### PR TITLE
fix: 마커 표시 오류 수정 및 기본 표시 시간 4초로 변경

### DIFF
--- a/renderer/scripts/modules/comment-manager.js
+++ b/renderer/scripts/modules/comment-manager.js
@@ -45,8 +45,9 @@ export class CommentMarker {
 
     // 시간 범위 (프레임 단위)
     this.startFrame = options.startFrame || 0;
-    this.endFrame = options.endFrame || (options.startFrame + options.fps || 24); // 기본 1초
-    this.fps = options.fps || 24;
+    const fps = options.fps || 24;
+    this.endFrame = options.endFrame || (this.startFrame + fps * 4); // 기본 4초
+    this.fps = fps;
 
     // 내용
     this.text = options.text || '';
@@ -375,7 +376,7 @@ export class CommentManager extends EventTarget {
       x,
       y,
       startFrame: this.currentFrame,
-      endFrame: this.currentFrame + this.fps, // 기본 1초
+      endFrame: this.currentFrame + this.fps * 4, // 기본 4초
       fps: this.fps,
       layerId: this.activeLayerId,
       author: this.author


### PR DESCRIPTION
웹 뷰어:
- drawings.find TypeError 수정 (Array.isArray 체크 추가)
- openThread/submitReply에서 layers 구조 지원
- 마커 기본 표시 시간 4초로 변경

데스크톱 앱:
- CommentMarker 기본 endFrame을 4초로 변경
- 새 마커 생성 시 기본 4초 적용