### PR TITLE
feat: 웹 뷰어 모바일 UI 개선

### DIFF
--- a/web-viewer/index.html
+++ b/web-viewer/index.html
@@ -119,10 +119,57 @@
           </div>
         </div>
 
+        <!-- 타임라인 썸네일 미리보기 -->
+        <div id="timelineThumbnail" class="timeline-thumbnail hidden">
+          <canvas id="thumbnailCanvas"></canvas>
+          <span id="thumbnailTime">00:00:00</span>
+        </div>
+
         <div class="controls-row">
-          <button id="btnPrevFrame" class="btn-control">◀◀</button>
-          <button id="btnPlayPause" class="btn-control btn-play">▶</button>
-          <button id="btnNextFrame" class="btn-control">▶▶</button>
+          <!-- 5초 뒤로 -->
+          <button id="btnSkipBack" class="btn-control btn-skip" title="5초 뒤로">
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+              <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>
+              <text x="12" y="15" text-anchor="middle" font-size="7" font-weight="bold">5</text>
+            </svg>
+          </button>
+
+          <!-- 이전 프레임 -->
+          <button id="btnPrevFrame" class="btn-control btn-frame" title="이전 프레임 (1프레임)">
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+              <rect x="4" y="6" width="3" height="12"/>
+              <path d="M20 6l-10 6 10 6V6z"/>
+            </svg>
+            <span class="frame-label">-1f</span>
+          </button>
+
+          <!-- 재생/일시정지 -->
+          <button id="btnPlayPause" class="btn-control btn-play" title="재생/일시정지">
+            <svg id="iconPlay" viewBox="0 0 24 24" width="28" height="28" fill="currentColor">
+              <path d="M8 5v14l11-7z"/>
+            </svg>
+            <svg id="iconPause" viewBox="0 0 24 24" width="28" height="28" fill="currentColor" class="hidden">
+              <path d="M6 4h4v16H6zM14 4h4v16h-4z"/>
+            </svg>
+          </button>
+
+          <!-- 다음 프레임 -->
+          <button id="btnNextFrame" class="btn-control btn-frame" title="다음 프레임 (1프레임)">
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+              <path d="M4 18l10-6-10-6v12z"/>
+              <rect x="17" y="6" width="3" height="12"/>
+            </svg>
+            <span class="frame-label">+1f</span>
+          </button>
+
+          <!-- 5초 앞으로 -->
+          <button id="btnSkipForward" class="btn-control btn-skip" title="5초 앞으로">
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+              <path d="M12 5V1l5 5-5 5V7c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6h2c0 4.42-3.58 8-8 8s-8-3.58-8-8 3.58-8 8-8z"/>
+              <text x="12" y="15" text-anchor="middle" font-size="7" font-weight="bold">5</text>
+            </svg>
+          </button>
+
           <span class="time-display" id="timeDisplay">00:00:00 / 00:00:00</span>
         </div>
       </div>

--- a/web-viewer/styles/main.css
+++ b/web-viewer/styles/main.css
@@ -522,10 +522,99 @@ body {
   height: 56px;
   background: var(--accent-color);
   font-size: 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn-play:hover {
   background: var(--accent-hover);
+}
+
+.btn-play svg {
+  width: 28px;
+  height: 28px;
+}
+
+.btn-play svg.hidden {
+  display: none;
+}
+
+/* 프레임 버튼 스타일 */
+.btn-frame {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  padding: 4px;
+}
+
+.btn-frame svg {
+  width: 20px;
+  height: 20px;
+}
+
+.frame-label {
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--accent-color);
+  font-family: monospace;
+}
+
+/* 5초 건너뛰기 버튼 */
+.btn-skip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-skip svg {
+  width: 24px;
+  height: 24px;
+}
+
+/* 컨트롤 버튼 내 SVG */
+.btn-control svg {
+  fill: currentColor;
+}
+
+/* 타임라인 썸네일 미리보기 */
+.timeline-thumbnail {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-secondary);
+  border: 2px solid var(--accent-color);
+  border-radius: 8px;
+  padding: 4px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.timeline-thumbnail.hidden {
+  display: none;
+}
+
+.timeline-thumbnail canvas {
+  display: block;
+  width: 160px;
+  height: 90px;
+  border-radius: 4px;
+  background: #000;
+}
+
+.timeline-thumbnail span {
+  display: block;
+  text-align: center;
+  font-size: 12px;
+  font-family: monospace;
+  color: var(--text-primary);
+  margin-top: 4px;
+  background: var(--bg-tertiary);
+  padding: 2px 6px;
+  border-radius: 4px;
 }
 
 .time-display {
@@ -1127,7 +1216,8 @@ body.fullscreen-mode .viewer-header {
   transition: opacity 0.3s;
 }
 
-body.fullscreen-mode #viewerScreen:hover .viewer-header {
+body.fullscreen-mode #viewerScreen:hover .viewer-header,
+body.fullscreen-mode.controls-visible .viewer-header {
   opacity: 1;
 }
 
@@ -1148,13 +1238,56 @@ body.fullscreen-mode .controls-bar {
   transition: opacity 0.3s;
 }
 
-body.fullscreen-mode #viewerScreen:hover .controls-bar {
+body.fullscreen-mode #viewerScreen:hover .controls-bar,
+body.fullscreen-mode.controls-visible .controls-bar {
   opacity: 1;
 }
 
 body.fullscreen-mode .bottom-tabs,
 body.fullscreen-mode .panel {
   display: none;
+}
+
+/* 모바일 전체화면 - 가로 강제 회전 */
+@media screen and (max-width: 768px) {
+  body.fullscreen-mode.landscape-lock {
+    /* 세로 모드일 때 가로로 회전 */
+  }
+
+  body.fullscreen-mode.landscape-lock #viewerScreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+  }
+
+  /* 세로 모드에서 가로로 강제 회전 (선택적) */
+  @media (orientation: portrait) {
+    body.fullscreen-mode.force-landscape #viewerScreen {
+      transform: rotate(90deg);
+      transform-origin: left top;
+      width: 100vh;
+      height: 100vw;
+      position: fixed;
+      top: 0;
+      left: 100%;
+    }
+
+    body.fullscreen-mode.force-landscape .controls-bar {
+      /* 터치 영역 조정 */
+    }
+  }
+}
+
+/* 모바일 전체화면 컨트롤 자동 숨김 */
+body.fullscreen-mode .controls-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 5;
 }
 
 /* 헤더 버튼 SVG 아이콘 */


### PR DESCRIPTION
- 재생/일시정지 버튼을 SVG 아이콘으로 변경
- 프레임 버튼에 -1f/+1f 레이블 추가 (가시성 향상)
- 5초 건너뛰기 버튼 추가 (앞으로/뒤로)
- 타임라인 썸네일 미리보기 기능 추가
- 모바일 전체화면 가로 회전 지원
- 전체화면 시 컨트롤 자동 숨김 (3초 후)
- 터치로 컨트롤 토글 기능