### PR TITLE
feat: 웹 뷰어 성능 및 UI 개선, 슬랙 웹 링크 지원

### DIFF
--- a/web-viewer/index.html
+++ b/web-viewer/index.html
@@ -117,12 +117,11 @@
             </div>
             <div class="playhead" id="playhead"></div>
           </div>
-        </div>
-
-        <!-- 타임라인 썸네일 미리보기 -->
-        <div id="timelineThumbnail" class="timeline-thumbnail hidden">
-          <canvas id="thumbnailCanvas"></canvas>
-          <span id="thumbnailTime">00:00:00</span>
+          <!-- 타임라인 썸네일 미리보기 (timeline 내부로 이동) -->
+          <div id="timelineThumbnail" class="timeline-thumbnail hidden">
+            <canvas id="thumbnailCanvas"></canvas>
+            <span id="thumbnailTime">00:00:00</span>
+          </div>
         </div>
 
         <div class="controls-row">

--- a/web-viewer/styles/main.css
+++ b/web-viewer/styles/main.css
@@ -444,6 +444,7 @@ body {
 }
 
 .timeline-container {
+  position: relative;
   margin-bottom: 0.75rem;
 }
 
@@ -582,15 +583,17 @@ body {
 /* 타임라인 썸네일 미리보기 */
 .timeline-thumbnail {
   position: absolute;
-  bottom: calc(100% + 10px);
-  left: 50%;
-  transform: translateX(-50%);
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 8px;
   background: var(--bg-secondary);
   border: 2px solid var(--accent-color);
   border-radius: 8px;
   padding: 4px;
   z-index: 100;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  /* 위치는 JS에서 동적으로 설정 */
 }
 
 .timeline-thumbnail.hidden {


### PR DESCRIPTION
웹 뷰어 개선:
- 모바일 전체화면 지원 개선 (iOS Safari, CSS 폴백)
- 타임라인 썸네일 미리보기 위치 수정
- 스트리밍 + 백그라운드 다운로드 방식으로 변경
  - 처음 1MB 다운로드 후 즉시 재생 시작
  - 백그라운드에서 나머지 영상 다운로드
  - MediaSource API 지원 시 청크 스트리밍 사용

데스크톱 앱 개선:
- 링크 복사 시 웹 뷰어 링크도 함께 생성
- 클립보드 포맷: "경로|웹URL|파일명"
- AutoHotkey에서 파싱하여 슬랙 메시지 생성 가능