### PR TITLE
fix: 타임라인 마커 색상 및 UI 버그 수정 (4건)

### DIFF
--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -2445,12 +2445,14 @@ async function initApp() {
       const marker = commentManager.getMarker(markerId);
       const layer = commentManager.layers.find(l => l.id === layerId);
       if (marker && layer) {
+        // 마커 개별 색상 사용 (없으면 레이어 색상)
+        const markerColor = marker.colorInfo?.color || layer.color;
         timeline.updateCommentRangeElement({
           layerId,
           markerId,
           startFrame: marker.startFrame,
           endFrame: marker.endFrame,
-          color: layer.color,
+          color: markerColor,
           text: marker.text,
           resolved: marker.resolved
         });
@@ -3769,6 +3771,13 @@ async function initApp() {
 
       // 우측 댓글 패널로 스크롤 및 글로우 효과
       scrollToCommentWithGlow(marker.id);
+    });
+
+    // 우클릭 - 마커 색상 팝업
+    markerEl.addEventListener('contextmenu', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      showMarkerPopup(marker.id, e.clientX, e.clientY);
     });
 
     // 해결 버튼

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -4,6 +4,7 @@
  */
 
 import { createLogger } from '../logger.js';
+import { MARKER_COLORS } from './comment-manager.js';
 
 const log = createLogger('Timeline');
 
@@ -1593,20 +1594,28 @@ export class Timeline extends EventTarget {
       const allResolved = cluster.markers.every(m => m.resolved);
       // 대표 프레임 (첫 번째 마커의 프레임)
       const representativeFrame = cluster.markers[0].frame;
+      // 대표 색상 (첫 번째 마커의 colorKey 사용)
+      const representativeColorKey = allInfos[0]?.colorKey || 'default';
 
-      this._addClusteredMarker(centerTime, allResolved, representativeFrame, allInfos, count);
+      this._addClusteredMarker(centerTime, allResolved, representativeFrame, allInfos, count, representativeColorKey);
     });
   }
 
   /**
    * 클러스터된 마커 추가 (내부용)
    */
-  _addClusteredMarker(time, resolved, frame, markerInfos, clusterCount) {
+  _addClusteredMarker(time, resolved, frame, markerInfos, clusterCount, colorKey = 'default') {
     const percent = (time / this.duration) * 100;
     const marker = document.createElement('div');
     marker.className = `comment-marker-track${resolved ? ' resolved' : ''}`;
     marker.style.left = `${percent}%`;
     marker.dataset.time = time;
+
+    // 마커 색상 적용 (resolved가 아닌 경우에만)
+    if (!resolved) {
+      const markerColor = MARKER_COLORS[colorKey]?.color || MARKER_COLORS.default.color;
+      marker.style.backgroundColor = markerColor;
+    }
     marker.dataset.frame = frame;
 
     // 클러스터 카운트가 2 이상이면 배지 표시

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -303,6 +303,8 @@ body {
   font-weight: 500;
   cursor: pointer;
   transition: all var(--transition-fast);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .btn-secondary {


### PR DESCRIPTION
- 타임라인 세로선이 마커 색상과 동일하게 표시되도록 수정
- 링크 복사 등 버튼이 창 크기 조절 시 글자가 밀리지 않도록 CSS 수정
- 프리뷰 창에서 마커 우클릭으로 색상 지정 가능하도록 추가
- 마커 드래그 시 색상이 기본색상으로 변하는 버그 수정

https://claude.ai/code/session_01KoH2KSvXsDaTuovWqzVvjE