### PR TITLE
fix: 플레이리스트 링크 공유 시 baeframe:// 프로토콜 지원 추가

### DIFF
--- a/JBBJ_작업도우미_배포용_v2_0.ahk
+++ b/JBBJ_작업도우미_배포용_v2_0.ahk
@@ -1460,14 +1460,17 @@ ClipboardPathConverter(clipType) {
         urlPath := StrReplace(cleanPath, "\", "/")
 
         ; ─────────────────────────────────────────────────────────────────
-        ; [BAEFRAME 연동] .bframe 파일 감지 시 baeframe:// 링크 생성
+        ; [BAEFRAME 연동] .bframe 또는 .bplaylist 파일 감지 시 baeframe:// 링크 생성
         ; ─────────────────────────────────────────────────────────────────
         SplitPath, cleanPath,,, ext
-        if (ext = "bframe")
+        if (ext = "bframe" || ext = "bplaylist")
         {
-            ; baeframe:// 링크 생성
-            ; 예: G:\공유\파일.bframe → baeframe://G:/공유/파일.bframe
-            protocolLink := "baeframe://" . urlPath
+            ; baeframe:// 링크 생성 (.bframe과 .bplaylist 동일한 형식)
+            ; G:/ → G/ 로 변환 (Slack이 G:를 보면 file:///로 변환하는 문제 방지)
+            ; 예: G:\공유\파일.bframe → baeframe://G/공유/파일.bframe
+            ; 예: G:\공유\재생목록.bplaylist → baeframe://G/공유/재생목록.bplaylist
+            urlPathNoColon := RegExReplace(urlPath, "^([A-Za-z]):", "$1")
+            protocolLink := "baeframe://" . urlPathNoColon
 
             ; 전역 변수에 저장 (Slack Ctrl+Shift+V용)
             ; g_LastOriginalPath = 표시 텍스트 (G:\...\파일.bframe)
@@ -1478,7 +1481,9 @@ ClipboardPathConverter(clipType) {
             g_LastWebUrl := webUrl  ; 웹 뷰어 URL 저장
 
             ; 사용자에게 감지됨 알림
-            if (webUrl != "") {
+            if (ext = "bplaylist") {
+                ToolTip, 📋 BAEFRAME 재생목록 감지됨`nSlack: Ctrl+Shift+V로 하이퍼링크 붙여넣기
+            } else if (webUrl != "") {
                 ToolTip, 🎬 BAEFRAME 경로 감지됨`nSlack: Ctrl+Shift+V로 하이퍼링크 + 웹링크 붙여넣기
             } else {
                 ToolTip, 🎬 BAEFRAME 경로 감지됨`nSlack: Ctrl+Shift+V로 하이퍼링크 붙여넣기

--- a/JBBJ_작업도우미_성원님버전.ahk
+++ b/JBBJ_작업도우미_성원님버전.ahk
@@ -1211,14 +1211,17 @@ ClipboardPathConverter(clipType) {
         urlPath := StrReplace(cleanPath, "\", "/")
 
         ; ─────────────────────────────────────────────────────────────────
-        ; [BAEFRAME 연동] .bframe 파일 감지 시 baeframe:// 링크 생성
+        ; [BAEFRAME 연동] .bframe 또는 .bplaylist 파일 감지 시 baeframe:// 링크 생성
         ; ─────────────────────────────────────────────────────────────────
         SplitPath, cleanPath,,, ext
-        if (ext = "bframe")
+        if (ext = "bframe" || ext = "bplaylist")
         {
-            ; baeframe:// 링크 생성
-            ; 예: G:\공유\파일.bframe → baeframe://G:/공유/파일.bframe
-            protocolLink := "baeframe://" . urlPath
+            ; baeframe:// 링크 생성 (.bframe과 .bplaylist 동일한 형식)
+            ; G:/ → G/ 로 변환 (Slack이 G:를 보면 file:///로 변환하는 문제 방지)
+            ; 예: G:\공유\파일.bframe → baeframe://G/공유/파일.bframe
+            ; 예: G:\공유\재생목록.bplaylist → baeframe://G/공유/재생목록.bplaylist
+            urlPathNoColon := RegExReplace(urlPath, "^([A-Za-z]):", "$1")
+            protocolLink := "baeframe://" . urlPathNoColon
 
             ; 전역 변수에 저장 (Slack Ctrl+Shift+V용)
             ; g_LastOriginalPath = 표시 텍스트 (G:\...\파일.bframe)
@@ -1229,7 +1232,9 @@ ClipboardPathConverter(clipType) {
             g_LastWebUrl := webUrl  ; 웹 뷰어 URL 저장
 
             ; 사용자에게 감지됨 알림
-            if (webUrl != "") {
+            if (ext = "bplaylist") {
+                ToolTip, 📋 BAEFRAME 재생목록 감지됨`nSlack: Ctrl+Shift+V로 하이퍼링크 붙여넣기
+            } else if (webUrl != "") {
                 ToolTip, 🎬 BAEFRAME 경로 감지됨`nSlack: Ctrl+Shift+V로 하이퍼링크 + 웹링크 붙여넣기
             } else {
                 ToolTip, 🎬 BAEFRAME 경로 감지됨`nSlack: Ctrl+Shift+V로 하이퍼링크 붙여넣기


### PR DESCRIPTION
- .bplaylist 확장자 감지 및 baeframe:// 링크 생성 로직 추가
- G:/ → G/ 변환으로 Slack file:/// 자동 변환 문제 방지
- 플레이리스트 감지 시 별도 툴팁 메시지 표시
- 배포용, 성원님버전 AHK 스크립트 모두 수정