### PR TITLE
feat: Slack 웹훅 알림 + @멘션 + G:/ 링크 + 단축키 설정

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -276,7 +276,29 @@ if (!gotTheLock) {
           }
         }
 
-        // baeframe:// URL이면 파일 경로로 변환
+        // baeframe://open?file=...&comment=... 형식 (Slack 딥링크)
+        const openMatch = arg.match(/^baeframe:\/\/open[?%]/i);
+        if (openMatch) {
+          const url = new URL(arg.replace(/\\/g, '/'));
+          const filePath = url.searchParams.get('file');
+          const commentId = url.searchParams.get('comment');
+          if (filePath) {
+            let resolved = filePath.replace(/\//g, '\\');
+            // Slack이 "G:/" → "G/" 로 변환하는 문제 수정
+            if (/^[A-Za-z][\/\\]/.test(resolved)) {
+              resolved = resolved[0] + ':' + resolved.slice(1);
+            }
+            log.info('Slack 딥링크 처리됨', { filePath: resolved, commentId });
+            if (hasExtension(resolved, '.bplaylist')) {
+              mainWindow.webContents.send('open-playlist', resolved);
+            } else {
+              mainWindow.webContents.send('open-from-protocol', resolved, commentId || null);
+            }
+            return;
+          }
+        }
+
+        // baeframe:// URL이면 파일 경로로 변환 (레거시)
         if (arg.startsWith('baeframe://')) {
           arg = parseBaeframeUrl(arg);
           log.info('프로토콜 URL 처리됨', { filePath: arg, commentId: parseBaeframeUrl._lastCommentId });
@@ -312,8 +334,27 @@ if (!gotTheLock) {
       } else if (hasExtension(fileArg, '.bplaylist')) {
         isPlaylistArg = true;
         log.info('재생목록 파일로 시작됨', { fileArg });
+      } else if (fileArg.match(/^baeframe:\/\/open[?%]/i)) {
+        // baeframe://open?file=...&comment=... 형식 (Slack 딥링크)
+        try {
+          const url = new URL(fileArg.replace(/\\/g, '/'));
+          const fp = url.searchParams.get('file');
+          if (fp) {
+            fileArg = fp.replace(/\//g, '\\');
+            if (/^[A-Za-z][\/\\]/.test(fileArg)) {
+              fileArg = fileArg[0] + ':' + fileArg.slice(1);
+            }
+            parseBaeframeUrl._lastCommentId = url.searchParams.get('comment') || null;
+            if (hasExtension(fileArg, '.bplaylist')) {
+              isPlaylistArg = true;
+            }
+            log.info('Slack 딥링크로 시작됨', { fileArg, commentId: parseBaeframeUrl._lastCommentId });
+          }
+        } catch (e) {
+          log.warn('Slack 딥링크 파싱 실패', { fileArg, error: e.message });
+        }
       } else if (fileArg.startsWith('baeframe://')) {
-        // baeframe://G:/path/file.bplaylist 형식 체크
+        // baeframe://G:/path/file.bplaylist 형식 체크 (레거시)
         const parsedPath = parseBaeframeUrl(fileArg);
         if (hasExtension(parsedPath, '.bplaylist')) {
           isPlaylistArg = true;

--- a/main/index.js
+++ b/main/index.js
@@ -277,13 +277,14 @@ if (!gotTheLock) {
         }
 
         // baeframe://open?file=...&comment=... 형식 (Slack 딥링크)
-        const openMatch = arg.match(/^baeframe:\/\/open[?%]/i);
-        if (openMatch) {
-          const url = new URL(arg.replace(/\\/g, '/'));
-          const filePath = url.searchParams.get('file');
-          const commentId = url.searchParams.get('comment');
-          if (filePath) {
-            let resolved = filePath.replace(/\//g, '\\');
+        if (arg.match(/^baeframe:\/\/open[?%]/i)) {
+          // new URL()은 커스텀 프로토콜에서 불안정하므로 정규식 사용
+          const fileMatch = arg.match(/[?&]file=([^&]+)/i) || arg.match(/[?%26]file[=%3D]([^&%]+)/i);
+          const commentMatch = arg.match(/[?&]comment=([^&]+)/i);
+          if (fileMatch) {
+            let resolved = decodeURIComponent(fileMatch[1]);
+            const commentId = commentMatch ? decodeURIComponent(commentMatch[1]) : null;
+            resolved = resolved.replace(/\//g, '\\');
             // Slack이 "G:/" → "G/" 로 변환하는 문제 수정
             if (/^[A-Za-z][\/\\]/.test(resolved)) {
               resolved = resolved[0] + ':' + resolved.slice(1);
@@ -336,22 +337,18 @@ if (!gotTheLock) {
         log.info('재생목록 파일로 시작됨', { fileArg });
       } else if (fileArg.match(/^baeframe:\/\/open[?%]/i)) {
         // baeframe://open?file=...&comment=... 형식 (Slack 딥링크)
-        try {
-          const url = new URL(fileArg.replace(/\\/g, '/'));
-          const fp = url.searchParams.get('file');
-          if (fp) {
-            fileArg = fp.replace(/\//g, '\\');
-            if (/^[A-Za-z][\/\\]/.test(fileArg)) {
-              fileArg = fileArg[0] + ':' + fileArg.slice(1);
-            }
-            parseBaeframeUrl._lastCommentId = url.searchParams.get('comment') || null;
-            if (hasExtension(fileArg, '.bplaylist')) {
-              isPlaylistArg = true;
-            }
-            log.info('Slack 딥링크로 시작됨', { fileArg, commentId: parseBaeframeUrl._lastCommentId });
+        const fileMatch = fileArg.match(/[?&]file=([^&]+)/i);
+        const commentMatch = fileArg.match(/[?&]comment=([^&]+)/i);
+        if (fileMatch) {
+          fileArg = decodeURIComponent(fileMatch[1]).replace(/\//g, '\\');
+          if (/^[A-Za-z][\/\\]/.test(fileArg)) {
+            fileArg = fileArg[0] + ':' + fileArg.slice(1);
           }
-        } catch (e) {
-          log.warn('Slack 딥링크 파싱 실패', { fileArg, error: e.message });
+          parseBaeframeUrl._lastCommentId = commentMatch ? decodeURIComponent(commentMatch[1]) : null;
+          if (hasExtension(fileArg, '.bplaylist')) {
+            isPlaylistArg = true;
+          }
+          log.info('Slack 딥링크로 시작됨', { fileArg, commentId: parseBaeframeUrl._lastCommentId });
         }
       } else if (fileArg.startsWith('baeframe://')) {
         // baeframe://G:/path/file.bplaylist 형식 체크 (레거시)

--- a/main/index.js
+++ b/main/index.js
@@ -395,10 +395,13 @@ if (!gotTheLock) {
     createMainWindow();
     debugLog('메인 윈도우 생성 완료');
 
-    // 파일 인자가 있으면 윈도우 로드 완료 후 파일 열기
+    // 파일 인자가 있으면 renderer 준비 완료 후 파일 열기
     if (fileArg) {
       const mainWindow = getMainWindow();
-      mainWindow.webContents.once('did-finish-load', () => {
+      // renderer에서 'renderer-ready' 신호를 보낼 때까지 대기
+      const { ipcMain } = require('electron');
+      ipcMain.once('renderer-ready', () => {
+        log.info('renderer 준비 완료, 파일 전송', { fileArg });
         if (isPlaylistArg) {
           // 재생목록 URL 또는 파일
           let playlistPath = fileArg;

--- a/main/index.js
+++ b/main/index.js
@@ -72,6 +72,15 @@ function parseBaeframeUrl(url) {
 
   // baeframe:// 제거
   let filePath = url.replace(/^baeframe:\/\//, '');
+
+  // ?comment=xxx 파라미터 추출 (코멘트 포커싱용)
+  let commentId = null;
+  const commentMatch = filePath.match(/[?&]comment=([^&]+)/);
+  if (commentMatch) {
+    commentId = decodeURIComponent(commentMatch[1]);
+    filePath = filePath.replace(/[?&]comment=[^&]+/, '');
+    log.info('코멘트 ID 추출', { commentId });
+  }
   log.info('baeframe:// 제거 후', { filePath });
 
   // URL 디코딩 (한글, 공백 등)
@@ -134,7 +143,9 @@ function parseBaeframeUrl(url) {
     filePath = filePath.replace(/\//g, '\\');
   }
 
-  log.debug('프로토콜 URL 파싱 완료', { filePath });
+  log.debug('프로토콜 URL 파싱 완료', { filePath, commentId });
+  // commentId를 마지막 파싱 결과로 저장 (open-from-protocol 시 전달용)
+  parseBaeframeUrl._lastCommentId = commentId;
   return filePath;
 }
 
@@ -268,14 +279,14 @@ if (!gotTheLock) {
         // baeframe:// URL이면 파일 경로로 변환
         if (arg.startsWith('baeframe://')) {
           arg = parseBaeframeUrl(arg);
-          log.info('프로토콜 URL 처리됨', { filePath: arg });
+          log.info('프로토콜 URL 처리됨', { filePath: arg, commentId: parseBaeframeUrl._lastCommentId });
         }
 
         // .bplaylist 파일이면 재생목록으로 열기
         if (hasExtension(arg, '.bplaylist')) {
           mainWindow.webContents.send('open-playlist', arg);
         } else {
-          mainWindow.webContents.send('open-from-protocol', arg);
+          mainWindow.webContents.send('open-from-protocol', arg, parseBaeframeUrl._lastCommentId || null);
         }
       }
     }
@@ -374,7 +385,7 @@ if (!gotTheLock) {
           log.info('재생목록 열기 이벤트 전송', { playlistPath });
           mainWindow.webContents.send('open-playlist', playlistPath);
         } else {
-          mainWindow.webContents.send('open-from-protocol', fileArg);
+          mainWindow.webContents.send('open-from-protocol', fileArg, parseBaeframeUrl._lastCommentId || null);
         }
       });
     }

--- a/main/index.js
+++ b/main/index.js
@@ -277,7 +277,7 @@ if (!gotTheLock) {
         }
 
         // baeframe://open?file=...&comment=... 형식 (Slack 딥링크)
-        if (arg.match(/^baeframe:\/\/open[?%]/i)) {
+        if (arg.match(/^baeframe:\/\/open\/?[?%]/i)) {
           // new URL()은 커스텀 프로토콜에서 불안정하므로 정규식 사용
           const fileMatch = arg.match(/[?&]file=([^&]+)/i) || arg.match(/[?%26]file[=%3D]([^&%]+)/i);
           const commentMatch = arg.match(/[?&]comment=([^&]+)/i);
@@ -337,7 +337,7 @@ if (!gotTheLock) {
       } else if (hasExtension(fileArg, '.bplaylist')) {
         isPlaylistArg = true;
         log.info('재생목록 파일로 시작됨', { fileArg });
-      } else if (fileArg.match(/^baeframe:\/\/open[?%]/i)) {
+      } else if (fileArg.match(/^baeframe:\/\/open\/?[?%]/i)) {
         // baeframe://open?file=...&comment=... 형식 (Slack 딥링크)
         const fileMatch = fileArg.match(/[?&]file=([^&]+)/i);
         const commentMatch = fileArg.match(/[?&]comment=([^&]+)/i);

--- a/main/index.js
+++ b/main/index.js
@@ -322,7 +322,9 @@ if (!gotTheLock) {
     log.info(`앱 준비 완료: ${Date.now() - appStartTime}ms`, { version: app.getVersion() });
 
     // 시작 시 전달된 파일/프로토콜 인자 확인
+    log.info('process.argv 전체', { argv: process.argv });
     let fileArg = process.argv.find(isLaunchArgument);
+    log.info('fileArg 결과', { fileArg: fileArg || '(없음)' });
 
     // 파일 인자가 있으면 로딩 창 먼저 표시
     // (재생목록 URL/파일은 제외 - 별도 처리)

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -741,6 +741,43 @@ function setupIpcHandlers() {
     }
   });
 
+  // Slack 웹훅 전송 (CSP 우회: 메인 프로세스에서 fetch)
+  ipcMain.handle('slack:send-webhook', async (event, url, payload) => {
+    const trace = log.trace('slack:send-webhook');
+    try {
+      const { net } = require('electron');
+      const request = net.request({
+        method: 'POST',
+        url: url
+      });
+
+      return new Promise((resolve) => {
+        request.setHeader('Content-Type', 'application/json');
+
+        request.on('response', (response) => {
+          let body = '';
+          response.on('data', (chunk) => { body += chunk.toString(); });
+          response.on('end', () => {
+            const success = response.statusCode >= 200 && response.statusCode < 300;
+            trace.end({ status: response.statusCode, body });
+            resolve({ success, status: response.statusCode, body });
+          });
+        });
+
+        request.on('error', (error) => {
+          trace.error(error);
+          resolve({ success: false, error: error.message });
+        });
+
+        request.write(JSON.stringify(payload));
+        request.end();
+      });
+    } catch (error) {
+      trace.error(error);
+      return { success: false, error: error.message };
+    }
+  });
+
   // 파일 위치 보기 (탐색기에서 파일 선택된 상태로 열기)
   ipcMain.handle('folder:show-item', async (event, filePath) => {
     const trace = log.trace('folder:show-item');

--- a/preload/preload.js
+++ b/preload/preload.js
@@ -116,6 +116,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   checkVideoThumbnail: (videoPath) => ipcRenderer.invoke('thumbnail:check-video-thumb', videoPath),
   getVideoThumbnailPath: (videoPath) => ipcRenderer.invoke('thumbnail:get-video-thumb-path', videoPath),
 
+  // ====== Slack 웹훅 ======
+  sendSlackWebhook: (url, payload) => ipcRenderer.invoke('slack:send-webhook', url, payload),
+
   // ====== 경로 유틸리티 ======
   pathDirname: (filePath) => ipcRenderer.invoke('path:dirname', filePath),
   pathBasename: (filePath) => ipcRenderer.invoke('path:basename', filePath),

--- a/preload/preload.js
+++ b/preload/preload.js
@@ -131,7 +131,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // ====== 이벤트 리스너 ======
   onOpenFromProtocol: (callback) => {
-    ipcRenderer.on('open-from-protocol', (event, arg) => callback(arg));
+    ipcRenderer.on('open-from-protocol', (event, arg, commentId) => callback(arg, commentId));
   },
   onRequestSaveBeforeQuit: (callback) => {
     ipcRenderer.on('app:request-save-before-quit', () => callback());

--- a/preload/preload.js
+++ b/preload/preload.js
@@ -129,6 +129,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   watchFileStop: (filePath) => ipcRenderer.invoke('file:watch-stop', filePath),
   watchFileStopAll: () => ipcRenderer.invoke('file:watch-stop-all'),
 
+  // renderer 초기화 완료 알림
+  notifyRendererReady: () => ipcRenderer.send('renderer-ready'),
+
   // ====== 이벤트 리스너 ======
   onOpenFromProtocol: (callback) => {
     ipcRenderer.on('open-from-protocol', (event, arg, commentId) => callback(arg, commentId));

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1204,6 +1204,7 @@
           <button class="app-settings-tab active" data-tab="profile">개인정보</button>
           <button class="app-settings-tab" data-tab="notification">알람</button>
           <button class="app-settings-tab" data-tab="theme">테마</button>
+          <button class="app-settings-tab" data-tab="shortcuts">단축키</button>
         </nav>
         <div class="app-settings-divider"></div>
         <div class="app-settings-content">
@@ -1319,6 +1320,19 @@
                 <span class="theme-color-swatch" style="background: #2ed573"></span>
                 <span class="theme-color-label">초록</span>
               </button>
+            </div>
+          </div>
+          <!-- 단축키 탭 -->
+          <div class="app-settings-panel" data-panel="shortcuts">
+            <h4 class="app-settings-section-title">단축키 설정</h4>
+            <div class="shortcut-actions">
+              <button class="app-settings-btn" id="resetAllShortcuts">
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+                전체 초기화
+              </button>
+            </div>
+            <div class="shortcut-list" id="shortcutList">
+              <!-- JS로 동적 생성 -->
             </div>
           </div>
         </div>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1326,12 +1326,12 @@
           <div class="app-settings-panel" data-panel="shortcuts">
             <h4 class="app-settings-section-title">단축키 설정</h4>
             <div class="shortcut-actions">
-              <button class="app-settings-btn" id="resetAllShortcuts">
+              <button class="app-settings-btn" id="settingsResetAllShortcuts">
                 <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
                 전체 초기화
               </button>
             </div>
-            <div class="shortcut-list" id="shortcutList">
+            <div class="shortcut-list" id="settingsShortcutList">
               <!-- JS로 동적 생성 -->
             </div>
           </div>

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5376,9 +5376,20 @@ async function initApp() {
       return placeholder;
     });
 
-    // 2단계: 따옴표 없는 경로 — 공백 불허, 경로 문자만
+    // 2단계: 따옴표 없는 경로
+    //   2a: 파일 확장자로 끝나는 경우 — 공백 허용 (확장자까지만 매칭)
+    //   영상/이미지/작업파일 확장자: mov, mp4, avi, mkv, psd, exr, png, jpg, jpeg, tif, tiff, bmp, gif,
+    //                              ae, aep, prproj, blend, ma, mb, fbx, obj, abc, hip, nk, bframe, pdf, zip
+    const FILE_EXT_RE = /\.(mov|mp4|avi|mkv|wmv|mxf|psd|exr|dpx|png|jpe?g|tiff?|bmp|gif|svg|ae[pt]?|prproj|blend|ma|mb|fbx|obj|abc|hip|nk|bframe|pdf|zip|rar|7z|wav|mp3|aif)/i;
+    html = html.replace(/(G:[/\\](?:[^<"'&\x00]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)*?\.(?:mov|mp4|avi|mkv|wmv|mxf|psd|exr|dpx|png|jpe?g|tiff?|bmp|gif|svg|ae[pt]?|prproj|blend|ma|mb|fbx|obj|abc|hip|nk|bframe|pdf|zip|rar|7z|wav|mp3|aif))/gi, (match) => {
+      return makeBtn(match, match);
+    });
+
+    //   2b: 확장자 없는 경로 (폴더) — 공백 불허
     //   <mark> 태그는 허용 (검색 하이라이트)
     html = html.replace(/(G:[/\\](?:[^\s<"'&\x00]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi, (match) => {
+      // 이미 버튼화된 경로 건너뛰기 (2a에서 처리된 것)
+      if (match.includes('gdrive-link-btn')) return match;
       return makeBtn(match, match);
     });
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5467,11 +5467,18 @@ async function initApp() {
     const idx = _toastState.toasts.indexOf(toast);
     if (idx !== -1) _toastState.toasts.splice(idx, 1);
 
-    // 퇴장 애니메이션 완료 후 DOM 제거 + 스택 재정렬
+    // 즉시 스택 재정렬 (남은 토스트가 부드럽게 위로 올라감)
+    _updateToastStack();
+
+    // 퇴장 애니메이션 완료 후 DOM 제거
     toast.addEventListener('animationend', () => {
       toast.remove();
-      _updateToastStack();
     }, { once: true });
+
+    // 안전장치: animationend 미발생 시 DOM 제거
+    setTimeout(() => {
+      if (toast.parentNode) toast.remove();
+    }, 500);
   }
 
   /**

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5545,29 +5545,45 @@ async function initApp() {
     clearTimeout(toast._autoTimer);
     cancelAnimationFrame(toast._progressRaf);
 
+    // 1단계: 페이드아웃 (opacity + transform)
+    toast.style.pointerEvents = 'none';
     if (swipeDir) {
-      toast.style.setProperty('--swipe-dir', swipeDir > 0 ? '120%' : '-120%');
-      toast.classList.add('toast-swipe-exit');
+      toast.style.transition = 'transform 0.25s ease-out, opacity 0.25s ease-out';
+      toast.style.transform = `translateX(${swipeDir > 0 ? '120%' : '-120%'})`;
+      toast.style.opacity = '0';
     } else {
-      toast.classList.add('toast-exit');
+      toast.style.transition = 'transform 0.2s ease-out, opacity 0.2s ease-out';
+      toast.style.transform = 'translateY(-8px) scale(0.96)';
+      toast.style.opacity = '0';
     }
 
-    // 배열에서 즉시 제거 (스택 계산에서 제외)
-    const idx = _toastState.toasts.indexOf(toast);
-    if (idx !== -1) _toastState.toasts.splice(idx, 1);
-
-    // 즉시 스택 재정렬 (남은 토스트가 부드럽게 위로 올라감)
-    _updateToastStack();
-
-    // 퇴장 애니메이션 완료 후 DOM 제거
-    toast.addEventListener('animationend', () => {
-      toast.remove();
-    }, { once: true });
-
-    // 안전장치: animationend 미발생 시 DOM 제거
+    // 2단계: 페이드아웃 완료 후 공간 축소 (Sonner 방식)
+    const fadeTime = swipeDir ? 250 : 200;
     setTimeout(() => {
-      if (toast.parentNode) toast.remove();
-    }, 600);
+      // 현재 높이를 고정한 뒤 0으로 transition
+      const h = toast.offsetHeight;
+      toast.style.height = h + 'px';
+      toast.style.overflow = 'hidden';
+      // force reflow
+      void toast.offsetHeight;
+      toast.style.transition = 'height 0.2s ease-out, margin 0.2s ease-out, padding 0.2s ease-out';
+      toast.style.height = '0';
+      toast.style.marginBottom = '0';
+      toast.style.marginTop = '0';
+      toast.style.paddingTop = '0';
+      toast.style.paddingBottom = '0';
+      toast.style.borderWidth = '0';
+
+      // 배열에서 제거 + 스택 재정렬
+      const idx = _toastState.toasts.indexOf(toast);
+      if (idx !== -1) _toastState.toasts.splice(idx, 1);
+      _updateToastStack();
+
+      // 공간 축소 완료 후 DOM 제거
+      setTimeout(() => {
+        toast.remove();
+      }, 220);
+    }, fadeTime);
   }
 
   /**

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5650,8 +5650,8 @@ async function initApp() {
       e.preventDefault();
       e.stopPropagation();
       const path = btn.dataset.path;
-      if (path && window.electronAPI?.openFolder) {
-        window.electronAPI.openFolder(path);
+      if (path && window.electronAPI?.showInFolder) {
+        window.electronAPI.showInFolder(path);
       }
     }
   });

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -824,6 +824,17 @@ async function initApp() {
   // 로드 완료
   reviewDataManager.addEventListener('loaded', (e) => {
     log.info('.bframe 로드됨', { path: e.detail.path });
+
+    // Slack 딥링크에서 코멘트 포커싱 요청이 있으면 처리
+    if (state.pendingCommentFocus) {
+      const commentId = state.pendingCommentFocus;
+      state.pendingCommentFocus = null;
+
+      // 댓글 목록 렌더링 완료 후 포커싱 (약간의 지연 필요)
+      setTimeout(() => {
+        focusComment(commentId);
+      }, 500);
+    }
   });
 
   // 로드 에러
@@ -5335,6 +5346,47 @@ async function initApp() {
   }
 
   /**
+   * Slack 딥링크에서 특정 코멘트로 포커싱
+   * - 댓글 패널 열기
+   * - 해당 코멘트로 스크롤 + 선택
+   * - 해당 프레임으로 이동
+   */
+  function focusComment(markerId) {
+    log.info('코멘트 포커싱', { markerId });
+
+    const marker = commentManager.getMarkerById(markerId);
+    if (!marker) {
+      log.warn('포커싱할 코멘트를 찾을 수 없음', { markerId });
+      showToast('해당 코멘트를 찾을 수 없습니다', 'warning');
+      return;
+    }
+
+    // 댓글 패널 열기
+    const commentPanel = document.getElementById('commentPanel');
+    if (commentPanel && !commentPanel.classList.contains('open')) {
+      commentPanel.classList.add('open');
+    }
+
+    // 해당 프레임으로 이동
+    videoPlayer.seekToFrame(marker.startFrame);
+
+    // 댓글 목록에서 해당 아이템 찾아서 선택 + 스크롤
+    const container = document.getElementById('commentList');
+    if (!container) return;
+
+    const commentItem = container.querySelector(`.comment-item[data-marker-id="${markerId}"]`);
+    if (commentItem) {
+      container.querySelectorAll('.comment-item').forEach(i => i.classList.remove('selected'));
+      commentItem.classList.add('selected');
+      commentItem.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+      // 하이라이트 효과 (3초 후 제거)
+      commentItem.classList.add('focus-highlight');
+      setTimeout(() => commentItem.classList.remove('focus-highlight'), 3000);
+    }
+  }
+
+  /**
    * 상대 시간 포맷
    */
   function formatRelativeTime(date) {
@@ -6205,8 +6257,12 @@ async function initApp() {
   }
 
   // 프로토콜/파일 열기 이벤트 리스너
-  window.electronAPI.onOpenFromProtocol((arg) => {
-    log.info('프로토콜/파일 열기 이벤트 수신', { arg });
+  window.electronAPI.onOpenFromProtocol((arg, commentId) => {
+    log.info('프로토콜/파일 열기 이벤트 수신', { arg, commentId });
+    // commentId가 있으면 파일 로드 후 해당 코멘트로 포커싱
+    if (commentId) {
+      state.pendingCommentFocus = commentId;
+    }
     handleExternalFile(arg);
   });
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -825,29 +825,7 @@ async function initApp() {
   reviewDataManager.addEventListener('loaded', (e) => {
     log.info('.bframe 로드됨', { path: e.detail.path });
 
-    // Slack 딥링크에서 코멘트 포커싱 요청이 있으면 처리
-    if (state.pendingCommentFocus) {
-      const commentId = state.pendingCommentFocus;
-      state.pendingCommentFocus = null;
-
-      // 댓글 목록 렌더링 완료까지 재시도 (최대 5초)
-      let retries = 0;
-      const tryFocus = () => {
-        retries++;
-        log.info('코멘트 포커싱 시도', { commentId, retries });
-        const marker = commentManager.getMarkerById(commentId);
-        if (marker) {
-          // 댓글 목록 렌더링 보장
-          updateCommentList();
-          setTimeout(() => focusComment(commentId), 200);
-        } else if (retries < 10) {
-          setTimeout(tryFocus, 500);
-        } else {
-          log.warn('코멘트 포커싱 실패 (최대 재시도 초과)', { commentId });
-        }
-      };
-      setTimeout(tryFocus, 500);
-    }
+    // pendingCommentFocus는 updateCommentListImmediate에서 처리
   });
 
   // 로드 에러
@@ -5357,6 +5335,23 @@ async function initApp() {
       }, 1500);
     }
   }
+
+  // 댓글 목록이 렌더링될 때마다 pendingCommentFocus 체크
+  commentManager.addEventListener('markersChanged', () => {
+    if (state.pendingCommentFocus) {
+      const commentId = state.pendingCommentFocus;
+      const marker = commentManager.getMarkerById(commentId);
+      if (marker) {
+        state.pendingCommentFocus = null;
+        log.info('pendingCommentFocus 감지, 포커싱 실행', { commentId });
+        // 댓글 목록 렌더링 후 포커싱
+        setTimeout(() => {
+          updateCommentList();
+          setTimeout(() => focusComment(commentId), 300);
+        }, 200);
+      }
+    }
+  });
 
   /**
    * Slack 딥링크에서 특정 코멘트로 포커싱

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5369,29 +5369,11 @@ async function initApp() {
       return;
     }
 
-    // 댓글 패널 열기
-    const commentPanel = document.getElementById('commentPanel');
-    if (commentPanel && !commentPanel.classList.contains('open')) {
-      commentPanel.classList.add('open');
-    }
-
     // 해당 프레임으로 이동
     videoPlayer.seekToFrame(marker.startFrame);
 
-    // 댓글 목록에서 해당 아이템 찾아서 선택 + 스크롤
-    const container = document.getElementById('commentList');
-    if (!container) return;
-
-    const commentItem = container.querySelector(`.comment-item[data-marker-id="${markerId}"]`);
-    if (commentItem) {
-      container.querySelectorAll('.comment-item').forEach(i => i.classList.remove('selected'));
-      commentItem.classList.add('selected');
-      commentItem.scrollIntoView({ behavior: 'smooth', block: 'center' });
-
-      // 하이라이트 효과 (3초 후 제거)
-      commentItem.classList.add('focus-highlight');
-      setTimeout(() => commentItem.classList.remove('focus-highlight'), 3000);
-    }
+    // 기존 글로우 함수 재사용 (패널 열기 + 스크롤 + 선택 + 글로우)
+    scrollToCommentWithGlow(markerId);
   }
 
   /**

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5340,7 +5340,7 @@ async function initApp() {
   commentManager.addEventListener('markersChanged', () => {
     if (state.pendingCommentFocus) {
       const commentId = state.pendingCommentFocus;
-      const marker = commentManager.getMarkerById(commentId);
+      const marker = commentManager.getMarker(commentId);
       if (marker) {
         state.pendingCommentFocus = null;
         log.info('pendingCommentFocus 감지, 포커싱 실행', { commentId });
@@ -5362,7 +5362,7 @@ async function initApp() {
   function focusComment(markerId) {
     log.info('코멘트 포커싱', { markerId });
 
-    const marker = commentManager.getMarkerById(markerId);
+    const marker = commentManager.getMarker(markerId);
     if (!marker) {
       log.warn('포커싱할 코멘트를 찾을 수 없음', { markerId });
       showToast('해당 코멘트를 찾을 수 없습니다', 'warning');

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6270,6 +6270,10 @@ async function initApp() {
     handleExternalFile(arg);
   });
 
+  // renderer 초기화 완료 → main process에 알림 (파일 인자 전송 트리거)
+  window.electronAPI.notifyRendererReady?.();
+  log.info('renderer 초기화 완료, renderer-ready 전송');
+
   // ====== 앱 종료 전 저장 처리 ======
   window.electronAPI.onRequestSaveBeforeQuit(async () => {
     log.info('앱 종료 전 저장 요청 수신');

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -24,6 +24,8 @@ import { getSplitViewManager } from './modules/split-view-manager.js';
 import { getPlaylistManager } from './modules/playlist-manager.js';
 import { getAudioWaveform } from './modules/audio-waveform.js';
 import { getPlaybackSync } from './modules/playback-sync.js';
+import { getMentionManager } from './modules/mention-manager.js';
+import { getSlackNotifier } from './modules/slack-notifier.js';
 
 const log = createLogger('App');
 
@@ -357,6 +359,12 @@ async function initApp() {
     fps: 24,
     container: markerContainer
   });
+
+  // 멘션 매니저 (댓글 @멘션 자동완성)
+  const mentionManager = getMentionManager();
+
+  // Slack 알림 매니저
+  const slackNotifier = getSlackNotifier();
 
   // 하이라이트 매니저
   const highlightManager = new HighlightManager();
@@ -869,8 +877,15 @@ async function initApp() {
     updateCommentList();
     log.info('마커 추가됨', { id: marker.id, text: marker.text, remote: !!remote });
 
-    // 원격 변경은 Undo 스택에 넣지 않음
+    // 원격 변경은 알림/Undo 스킵
     if (remote) return;
+
+    // Slack 알림: @멘션 대상에게 웹훅 전송
+    slackNotifier.notifyNewComment(marker, commentManager.getAuthor(), {
+      filePath: state.currentFile,
+      fileName: elements.fileName?.textContent || '',
+      timecode: marker.startTimecode || ''
+    });
 
     // Undo 스택에 추가
     const markerData = marker.toJSON();
@@ -912,6 +927,16 @@ async function initApp() {
   commentManager.addEventListener('replyAdded', (e) => {
     renderVideoMarkers();
     updateCommentList();
+
+    // Slack 알림: 원작성자 + 스레드 참여자에게 웹훅 전송
+    const { marker, reply } = e.detail;
+    if (marker && reply) {
+      slackNotifier.notifyReply(marker, reply, commentManager.getAuthor(), {
+        filePath: state.currentFile,
+        fileName: elements.fileName?.textContent || '',
+        timecode: marker.startTimecode || ''
+      });
+    }
   });
 
   // 원격 동기화로 인한 전체 갱신 (CommentSync의 fromJSON 호출 시)
@@ -1143,8 +1168,16 @@ async function initApp() {
     }
   });
 
+  // 사이드바 댓글 입력에 멘션 자동완성 부착
+  mentionManager.attach(elements.commentInput);
+
+  // Slack 알림에 토스트 함수 주입
+  slackNotifier.setToastFunction(showToast);
+
   // 사이드바 댓글 입력 Enter 처리 (역순 플로우: 텍스트 입력 → 마커 찍기)
   elements.commentInput.addEventListener('keydown', (e) => {
+    // 멘션 드롭다운 열려있으면 Enter를 멘션 선택으로 처리 (댓글 제출 방지)
+    if (mentionManager.isVisible) return;
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       const text = elements.commentInput.value.trim();
@@ -4237,6 +4270,9 @@ async function initApp() {
     const textarea = inputWrapper.querySelector('textarea');
     setTimeout(() => textarea?.focus(), 50);
 
+    // 멘션 자동완성 부착
+    if (textarea) mentionManager.attach(textarea);
+
     // 자동 높이 조절 함수
     const autoResize = () => {
       textarea.style.height = 'auto';
@@ -4248,6 +4284,7 @@ async function initApp() {
 
     // Enter로 확정, Shift+Enter로 줄바꿈
     textarea?.addEventListener('keydown', (e) => {
+      if (mentionManager.isVisible) return;
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         const text = textarea.value.trim();
@@ -4362,7 +4399,7 @@ async function initApp() {
         <span class="tooltip-timecode">${marker.startTimecode}</span>
         <span class="tooltip-author ${authorClass}">${escapeHtml(marker.author)}</span>
       </div>
-      <div class="tooltip-text">${escapeHtml(marker.text)}</div>
+      <div class="tooltip-text">${renderGDriveLinks(escapeHtml(marker.text))}</div>
       <div class="tooltip-actions">
         <button class="tooltip-btn resolve" title="${marker.resolved ? '미해결로 변경' : '해결'}">
           ${marker.resolved ? '↩️' : '✓'}
@@ -4910,7 +4947,7 @@ async function initApp() {
             <span class="comment-reply-author ${getAuthorColorClass(reply.author)}" ${getAuthorColorStyle(reply.author)}>${highlightCommentSearchMatches(reply.author, normalizedSearch)}</span>
             <span class="comment-reply-time">${formatRelativeTime(reply.createdAt)}</span>
           </div>
-          <p class="comment-reply-text">${highlightCommentSearchMatches(reply.text, normalizedSearch)}</p>
+          <p class="comment-reply-text">${renderGDriveLinks(highlightCommentSearchMatches(reply.text, normalizedSearch))}</p>
         </div>
       `).join('');
 
@@ -4944,7 +4981,7 @@ async function initApp() {
           <span class="comment-timecode">${highlightCommentSearchMatches(marker.startTimecode, normalizedSearch)}</span>
         </div>
         <div class="comment-content">
-          <p class="comment-text">${highlightCommentSearchMatches(marker.text, normalizedSearch)}</p>
+          <p class="comment-text">${renderGDriveLinks(highlightCommentSearchMatches(marker.text, normalizedSearch))}</p>
           ${marker.image ? `<div class="comment-attached-image"><img src="${marker.image}" alt="첨부 이미지" data-full-image="${marker.image}"></div>` : ''}
         </div>
         <div class="comment-edit-form" style="display: none;">
@@ -5303,6 +5340,19 @@ async function initApp() {
   }
 
   /**
+   * G:/ 드라이브 경로를 클릭 가능한 버튼으로 변환
+   * escapeHtml 처리된 문자열에서 동작
+   */
+  function renderGDriveLinks(html) {
+    if (!html) return html;
+    // G:/ 또는 G:\ 뒤에 공백/태그시작/줄끝까지를 경로로 인식
+    return html.replace(/(G:[/\\][^\s<"']*)/gi, (match) => {
+      const normalizedPath = match.replace(/\//g, '\\');
+      return `<button class="gdrive-link-btn" data-path="${escapeHtml(normalizedPath)}" title="${escapeHtml(normalizedPath)}"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg> ${escapeHtml(match)}</button>`;
+    });
+  }
+
+  /**
    * 해결됨 날짜/시간 포맷 (예: 2월 9일 3:30 PM)
    */
   function formatResolvedDate(date) {
@@ -5592,6 +5642,19 @@ async function initApp() {
     }
   }
 
+  // G:/ 드라이브 경로 버튼 클릭 이벤트 위임 (전역)
+  document.body.addEventListener('click', (e) => {
+    const btn = e.target.closest('.gdrive-link-btn');
+    if (btn) {
+      e.preventDefault();
+      e.stopPropagation();
+      const path = btn.dataset.path;
+      if (path && window.electronAPI?.openFolder) {
+        window.electronAPI.openFolder(path);
+      }
+    }
+  });
+
   /**
    * 리사이저 설정 (마우스 커서 추적 개선)
    */
@@ -5717,27 +5780,40 @@ async function initApp() {
       break; // 다른 ESC 핸들러로 전달
 
     case 'KeyI':
-      // 시작점 설정
-      e.preventDefault();
-      btnSetInPoint.click();
+      // 시작점 설정 (수정자 키 없을 때만)
+      if (!e.ctrlKey && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        btnSetInPoint.click();
+      }
       return;
 
     case 'KeyO':
-      // 종료점 설정
-      e.preventDefault();
-      btnSetOutPoint.click();
+      // 종료점 설정 (수정자 키 없을 때만)
+      if (!e.ctrlKey && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        btnSetOutPoint.click();
+      }
       return;
 
     case 'KeyL':
-      // 구간 반복 토글
-      e.preventDefault();
-      btnLoopToggle.click();
+      // 구간 반복 토글 (Shift+L은 구간 해제)
+      if (!e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        if (e.shiftKey) {
+          // Shift+L: 구간 반복 해제
+          videoPlayer.clearLoop?.();
+        } else {
+          btnLoopToggle.click();
+        }
+      }
       return;
 
     case 'KeyH':
-      // 하이라이트 추가
-      e.preventDefault();
-      btnAddHighlight.click();
+      // 하이라이트 추가 (수정자 키 없을 때만)
+      if (!e.ctrlKey && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        btnAddHighlight.click();
+      }
       return;
 
     case 'Delete':
@@ -6406,6 +6482,9 @@ async function initApp() {
       pwWarning.style.display = showWarning ? 'flex' : 'none';
     }
 
+    // 단축키 설정 렌더링
+    renderShortcutSettings();
+
     appSettingsModal.classList.add('active');
   }
 
@@ -6444,6 +6523,141 @@ async function initApp() {
       if (panel) panel.classList.add('active');
     });
   });
+
+  // === 단축키 설정 UI ===
+  const SHORTCUT_CATEGORIES = {
+    '재생': ['playPause', 'prevFrame', 'nextFrame', 'prevFrameFast', 'nextFrameFast', 'prevSecond', 'nextSecond', 'goToStart', 'goToEnd'],
+    '모드': ['commentMode', 'drawMode', 'fullscreen'],
+    '구간 반복': ['setInPoint', 'setOutPoint', 'toggleLoop', 'clearLoop'],
+    '실행취소': ['undo', 'redo'],
+    '키프레임': ['keyframeAddWithCopy', 'keyframeAddBlank', 'keyframeAddBlank2', 'keyframeDelete', 'keyframeDeleteAlt', 'prevKeyframe', 'nextKeyframe'],
+    '프레임 편집': ['insertFrame', 'deleteFrame'],
+    '그리기 보조': ['onionSkinToggle', 'prevFrameDraw', 'nextFrameDraw']
+  };
+
+  let capturingShortcutAction = null;
+
+  function keyCodeToDisplay(code) {
+    const map = {
+      'Space': 'Space', 'ArrowLeft': '←', 'ArrowRight': '→', 'ArrowUp': '↑', 'ArrowDown': '↓',
+      'Home': 'Home', 'End': 'End', 'Delete': 'Del', 'Backspace': 'Back',
+      'Enter': 'Enter', 'Tab': 'Tab', 'Escape': 'Esc'
+    };
+    if (map[code]) return map[code];
+    if (code.startsWith('Key')) return code.slice(3);
+    if (code.startsWith('Digit')) return code.slice(5);
+    return code;
+  }
+
+  function formatShortcutDisplay(sc) {
+    const parts = [];
+    if (sc.ctrl) parts.push('Ctrl');
+    if (sc.shift) parts.push('Shift');
+    if (sc.alt) parts.push('Alt');
+    parts.push(keyCodeToDisplay(sc.key));
+    return parts.join(' + ');
+  }
+
+  function findShortcutConflict(newSc, excludeAction) {
+    const all = userSettings.getShortcuts();
+    for (const [action, sc] of Object.entries(all)) {
+      if (action === excludeAction) continue;
+      if (sc.key === newSc.key && sc.ctrl === newSc.ctrl && sc.shift === newSc.shift && sc.alt === newSc.alt) {
+        return { action, label: sc.label || action };
+      }
+    }
+    return null;
+  }
+
+  function renderShortcutSettings() {
+    const container = document.getElementById('shortcutList');
+    if (!container) return;
+
+    const shortcuts = userSettings.getShortcuts();
+    const customShortcuts = userSettings.settings?.customShortcuts || {};
+
+    container.innerHTML = Object.entries(SHORTCUT_CATEGORIES).map(([cat, actions]) => `
+      <div class="shortcut-category">
+        <h5 class="shortcut-category-title">${cat}</h5>
+        ${actions.filter(a => shortcuts[a]).map(action => {
+    const sc = shortcuts[action];
+    const isCustom = !!customShortcuts[action];
+    return `
+            <div class="shortcut-row ${isCustom ? 'custom' : ''}" data-action="${action}">
+              <span class="shortcut-label">${escapeHtml(sc.label || action)}</span>
+              <div class="shortcut-key-area">
+                <button class="shortcut-key-btn" data-action="${action}">${formatShortcutDisplay(sc)}</button>
+                ${isCustom ? `<button class="shortcut-reset-btn" data-action="${action}" title="기본값 복원">↩</button>` : ''}
+              </div>
+            </div>`;
+  }).join('')}
+      </div>
+    `).join('');
+
+    // 전체 초기화 버튼
+    document.getElementById('resetAllShortcuts')?.addEventListener('click', () => {
+      userSettings.resetAllShortcuts();
+      renderShortcutSettings();
+      showToast('모든 단축키가 초기화되었습니다.', 'success');
+    });
+  }
+
+  // 단축키 설정 패널 클릭 이벤트 위임
+  document.getElementById('shortcutList')?.addEventListener('click', (e) => {
+    // 키 바인딩 버튼 클릭 → 캡처 모드
+    const keyBtn = e.target.closest('.shortcut-key-btn');
+    if (keyBtn) {
+      capturingShortcutAction = keyBtn.dataset.action;
+      keyBtn.textContent = '키를 누르세요...';
+      keyBtn.classList.add('capturing');
+      return;
+    }
+
+    // 개별 초기화 버튼
+    const resetBtn = e.target.closest('.shortcut-reset-btn');
+    if (resetBtn) {
+      userSettings.resetShortcut(resetBtn.dataset.action);
+      renderShortcutSettings();
+      showToast('단축키가 초기화되었습니다.', 'success');
+    }
+  });
+
+  // 단축키 캡처 (capture phase)
+  document.addEventListener('keydown', (e) => {
+    if (!capturingShortcutAction) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Escape → 취소
+    if (e.key === 'Escape') {
+      capturingShortcutAction = null;
+      renderShortcutSettings();
+      return;
+    }
+
+    // 수정자 키만 누른 경우 무시
+    if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) return;
+
+    const newShortcut = {
+      key: e.code,
+      ctrl: e.ctrlKey,
+      shift: e.shiftKey,
+      alt: e.altKey
+    };
+
+    // 충돌 감지
+    const conflict = findShortcutConflict(newShortcut, capturingShortcutAction);
+    if (conflict) {
+      showToast(`"${conflict.label}"과(와) 충돌합니다.`, 'warning');
+      return;
+    }
+
+    userSettings.setShortcut(capturingShortcutAction, newShortcut);
+    capturingShortcutAction = null;
+    renderShortcutSettings();
+    showToast('단축키가 변경되었습니다.', 'success');
+  }, true); // capture phase
 
   // 개인정보 - 이름 변경 (blur 시 자동 저장)
   document.getElementById('appSettingsUserName')?.addEventListener('change', (e) => {
@@ -7142,6 +7356,9 @@ async function initApp() {
     threadEditor.innerHTML = '';
     updateSubmitButtonState();
 
+    // 멘션 자동완성 부착
+    mentionManager.attach(threadEditor);
+
     // 팝업 열기 (이전 포커스 저장)
     saveFocus();
     threadOverlay.classList.add('open');
@@ -7207,6 +7424,9 @@ async function initApp() {
 
     // Line breaks
     html = html.replace(/\n/g, '<br>');
+
+    // G:/ 경로 링크 변환
+    html = renderGDriveLinks(html);
 
     return html;
   }
@@ -7376,8 +7596,8 @@ async function initApp() {
       e.preventDefault();
       applyFormat('underline');
     }
-    // Enter: Submit (without Shift)
-    if (e.key === 'Enter' && !e.shiftKey) {
+    // Enter: Submit (without Shift) — 멘션 드롭다운 열려있으면 무시
+    if (e.key === 'Enter' && !e.shiftKey && !mentionManager.isVisible) {
       e.preventDefault();
       submitThreadReply();
     }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -872,19 +872,23 @@ async function initApp() {
 
   // 마커 추가됨
   commentManager.addEventListener('markerAdded', async (e) => {
-    const { marker, remote } = e.detail;
+    const { marker, remote, restored } = e.detail;
     removePendingMarkerUI();
     renderVideoMarkers();
     updateTimelineMarkers();
     updateCommentList();
     log.info('마커 추가됨', { id: marker.id, text: marker.text, remote: !!remote });
 
-    // 원격 변경은 알림/Undo 스킵
-    if (remote) return;
+    // 원격 변경 또는 Redo 복원은 알림/Undo 스킵
+    if (remote || restored) return;
 
     // Slack 알림: @멘션 대상에게 웹훅 전송 (딥링크 전에 저장하여 최신 상태 보장)
     if (reviewDataManager.getBframePath()) {
-      await reviewDataManager.save();
+      const saved = await reviewDataManager.save();
+      if (!saved) {
+        log.warn('bframe 저장 실패, Slack 알림 건너뜀');
+        return;
+      }
     }
     slackNotifier.notifyNewComment(marker, commentManager.getAuthor(), {
       filePath: state.currentFile,
@@ -941,7 +945,11 @@ async function initApp() {
       // 딥링크 전에 저장하여 최신 상태 보장
       const sendReplyNotification = async () => {
         if (reviewDataManager.getBframePath()) {
-          await reviewDataManager.save();
+          const saved = await reviewDataManager.save();
+          if (!saved) {
+            log.warn('bframe 저장 실패, 답글 Slack 알림 건너뜀');
+            return;
+          }
         }
         slackNotifier.notifyReply(marker, reply, commentManager.getAuthor(), {
           filePath: state.currentFile,

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -880,7 +880,10 @@ async function initApp() {
     // 원격 변경은 알림/Undo 스킵
     if (remote) return;
 
-    // Slack 알림: @멘션 대상에게 웹훅 전송
+    // Slack 알림: @멘션 대상에게 웹훅 전송 (딥링크 전에 저장하여 최신 상태 보장)
+    if (reviewDataManager.getBframePath()) {
+      await reviewDataManager.save();
+    }
     slackNotifier.notifyNewComment(marker, commentManager.getAuthor(), {
       filePath: state.currentFile,
       fileName: elements.fileName?.textContent || '',
@@ -932,11 +935,18 @@ async function initApp() {
     // remote: true인 경우(다른 사용자로부터 동기화된 답글)는 알림 전송 안 함
     const { marker, reply, remote } = e.detail;
     if (marker && reply && !remote) {
-      slackNotifier.notifyReply(marker, reply, commentManager.getAuthor(), {
-        filePath: state.currentFile,
-        fileName: elements.fileName?.textContent || '',
-        timecode: marker.startTimecode || ''
-      });
+      // 딥링크 전에 저장하여 최신 상태 보장
+      const sendReplyNotification = async () => {
+        if (reviewDataManager.getBframePath()) {
+          await reviewDataManager.save();
+        }
+        slackNotifier.notifyReply(marker, reply, commentManager.getAuthor(), {
+          filePath: state.currentFile,
+          fileName: elements.fileName?.textContent || '',
+          timecode: marker.startTimecode || ''
+        });
+      };
+      sendReplyNotification();
     }
   });
 
@@ -5347,16 +5357,29 @@ async function initApp() {
    */
   function renderGDriveLinks(html) {
     if (!html) return html;
-    // G:/ 또는 G:\ 뒤에 경로 문자를 인식 (공백 포함, <mark> 태그 허용)
-    // 검색 하이라이트의 <mark>/<\/mark> 태그가 경로 중간에 삽입되어도 무시
     const TAG_RE = /<\/?mark[^>]*>/gi;
-    return html.replace(/(G:[/\\](?:[^<"']|<\/?mark[^>]*>)*[^<"'\s])/gi, (match) => {
-      // 경로에서 mark 태그 제거하여 실제 경로 추출
-      const cleanPath = match.replace(TAG_RE, '');
-      const normalizedPath = cleanPath.replace(/\//g, '\\');
-      // 표시 텍스트에는 mark 태그 유지 (검색 하이라이트 보존)
-      return `<button class="gdrive-link-btn" data-path="${escapeHtml(normalizedPath)}" title="${escapeHtml(normalizedPath)}"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg> ${match}</button>`;
+
+    // 버튼 HTML 생성 헬퍼
+    function makeBtn(displayHtml, rawPath) {
+      const cleanPath = rawPath.replace(TAG_RE, '').replace(/\//g, '\\');
+      return `<button class="gdrive-link-btn" data-path="${escapeHtml(cleanPath)}" title="${escapeHtml(cleanPath)}"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg> ${displayHtml}</button>`;
+    }
+
+    // 1단계: 따옴표로 감싼 경로 (공백/한글 자유롭게 포함)
+    //   &quot;G:/경로&quot;  또는  &#39;G:/경로&#39;  (escapeHtml 후의 따옴표)
+    //   "G:/경로" 또는 'G:/경로' (원본 따옴표)
+    html = html.replace(/(?:&quot;|&amp;quot;|"|&#39;|')\s*(G:[/\\](?:[^<"'&]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)*?)(?:\s*(?:&quot;|&amp;quot;|"|&#39;|'))/gi, (match, path) => {
+      return makeBtn(path, path);
     });
+
+    // 2단계: 따옴표 없는 경로 — 공백 불허, 경로 문자만
+    //   G:/path/to/file.ext 또는 G:\path\to\file.ext
+    //   <mark> 태그는 허용 (검색 하이라이트)
+    html = html.replace(/(G:[/\\](?:[^\s<"'&]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi, (match) => {
+      return makeBtn(match, match);
+    });
+
+    return html;
   }
 
   /**
@@ -6567,7 +6590,27 @@ async function initApp() {
     return parts.join(' + ');
   }
 
+  // 시스템 예약 키 (handleKeydown에서 하드코딩, 사용자 설정보다 먼저 실행)
+  const RESERVED_SHORTCUTS = [
+    { key: 'Escape', ctrl: false, shift: false, alt: false, label: 'ESC (전체화면 해제)' },
+    { key: 'KeyS', ctrl: true, shift: false, alt: false, label: 'Ctrl+S (저장)' },
+    { key: 'Equal', ctrl: true, shift: false, alt: false, label: 'Ctrl++ (줌인)' },
+    { key: 'NumpadAdd', ctrl: true, shift: false, alt: false, label: 'Ctrl++ (줌인)' },
+    { key: 'Minus', ctrl: true, shift: false, alt: false, label: 'Ctrl+- (줌아웃)' },
+    { key: 'NumpadSubtract', ctrl: true, shift: false, alt: false, label: 'Ctrl+- (줌아웃)' },
+    { key: 'Slash', ctrl: false, shift: true, alt: false, label: 'Shift+/ (단축키 목록)' },
+    { key: 'Backslash', ctrl: false, shift: false, alt: false, label: '\\ (타임라인 맞춤)' },
+  ];
+
   function findShortcutConflict(newSc, excludeAction) {
+    // 시스템 예약 키 충돌 검사
+    for (const reserved of RESERVED_SHORTCUTS) {
+      if (newSc.key === reserved.key && newSc.ctrl === reserved.ctrl &&
+          newSc.shift === reserved.shift && newSc.alt === reserved.alt) {
+        return { action: '_reserved', label: `${reserved.label} [시스템 예약]` };
+      }
+    }
+    // 사용자 설정 간 충돌 검사
     const all = userSettings.getShortcuts();
     for (const [action, sc] of Object.entries(all)) {
       if (action === excludeAction) continue;

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -830,10 +830,23 @@ async function initApp() {
       const commentId = state.pendingCommentFocus;
       state.pendingCommentFocus = null;
 
-      // 댓글 목록 렌더링 완료 후 포커싱 (약간의 지연 필요)
-      setTimeout(() => {
-        focusComment(commentId);
-      }, 500);
+      // 댓글 목록 렌더링 완료까지 재시도 (최대 5초)
+      let retries = 0;
+      const tryFocus = () => {
+        retries++;
+        log.info('코멘트 포커싱 시도', { commentId, retries });
+        const marker = commentManager.getMarkerById(commentId);
+        if (marker) {
+          // 댓글 목록 렌더링 보장
+          updateCommentList();
+          setTimeout(() => focusComment(commentId), 200);
+        } else if (retries < 10) {
+          setTimeout(tryFocus, 500);
+        } else {
+          log.warn('코멘트 포커싱 실패 (최대 재시도 초과)', { commentId });
+        }
+      };
+      setTimeout(tryFocus, 500);
     }
   });
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5733,9 +5733,10 @@ async function initApp() {
     const splitViewManager = getSplitViewManager();
     if (splitViewManager.isOpen()) return;
 
-    // ====== 공통 단축키 ======
-    switch (e.code) {
-    case 'Space': {
+    // ====== 공통 단축키 (사용자 설정 기반) ======
+
+    // 재생/일시정지
+    if (userSettings.matchShortcut('playPause', e)) {
       e.preventDefault();
       const wasPlaying = videoPlayer.isPlaying;
       videoPlayer.togglePlay();
@@ -5747,31 +5748,71 @@ async function initApp() {
       return;
     }
 
-    case 'Home':
+    // 댓글 모드
+    if (userSettings.matchShortcut('commentMode', e)) {
+      e.preventDefault();
+      toggleCommentMode();
+      return;
+    }
+
+    // 전체화면
+    if (userSettings.matchShortcut('fullscreen', e)) {
+      e.preventDefault();
+      toggleFullscreen();
+      return;
+    }
+
+    // 시작점 설정
+    if (userSettings.matchShortcut('setInPoint', e)) {
+      e.preventDefault();
+      btnSetInPoint.click();
+      return;
+    }
+
+    // 종료점 설정
+    if (userSettings.matchShortcut('setOutPoint', e)) {
+      e.preventDefault();
+      btnSetOutPoint.click();
+      return;
+    }
+
+    // 구간 반복 토글
+    if (userSettings.matchShortcut('toggleLoop', e)) {
+      e.preventDefault();
+      btnLoopToggle.click();
+      return;
+    }
+
+    // 구간 반복 해제
+    if (userSettings.matchShortcut('clearLoop', e)) {
+      e.preventDefault();
+      videoPlayer.clearLoop?.();
+      return;
+    }
+
+    // 하이라이트 추가
+    if (userSettings.matchShortcut('addHighlight', e)) {
+      e.preventDefault();
+      btnAddHighlight.click();
+      return;
+    }
+
+    // 처음으로 이동
+    if (userSettings.matchShortcut('goToStart', e)) {
       e.preventDefault();
       videoPlayer.seekToStart();
       return;
+    }
 
-    case 'End':
+    // 끝으로 이동
+    if (userSettings.matchShortcut('goToEnd', e)) {
       e.preventDefault();
       videoPlayer.seekToEnd();
       return;
+    }
 
-    case 'KeyC':
-      if (!e.ctrlKey) {
-        e.preventDefault();
-        toggleCommentMode();
-      }
-      return;
-
-    case 'KeyF':
-      // F: 전체화면 토글
-      if (!e.ctrlKey) {
-        e.preventDefault();
-        toggleFullscreen();
-      }
-      return;
-
+    // ====== 하드코딩 유지 단축키 (시스템 조합키) ======
+    switch (e.code) {
     case 'Escape':
       // ESC: 전체화면 해제 (전체화면일 때)
       if (state.isFullscreen) {
@@ -5780,43 +5821,6 @@ async function initApp() {
         return;
       }
       break; // 다른 ESC 핸들러로 전달
-
-    case 'KeyI':
-      // 시작점 설정 (수정자 키 없을 때만)
-      if (!e.ctrlKey && !e.shiftKey && !e.altKey) {
-        e.preventDefault();
-        btnSetInPoint.click();
-      }
-      return;
-
-    case 'KeyO':
-      // 종료점 설정 (수정자 키 없을 때만)
-      if (!e.ctrlKey && !e.shiftKey && !e.altKey) {
-        e.preventDefault();
-        btnSetOutPoint.click();
-      }
-      return;
-
-    case 'KeyL':
-      // 구간 반복 토글 (Shift+L은 구간 해제)
-      if (!e.ctrlKey && !e.altKey) {
-        e.preventDefault();
-        if (e.shiftKey) {
-          // Shift+L: 구간 반복 해제
-          videoPlayer.clearLoop?.();
-        } else {
-          btnLoopToggle.click();
-        }
-      }
-      return;
-
-    case 'KeyH':
-      // 하이라이트 추가 (수정자 키 없을 때만)
-      if (!e.ctrlKey && !e.shiftKey && !e.altKey) {
-        e.preventDefault();
-        btnAddHighlight.click();
-      }
-      return;
 
     case 'Delete':
     case 'Backspace':
@@ -6542,7 +6546,7 @@ async function initApp() {
   const SHORTCUT_CATEGORIES = {
     '재생': ['playPause', 'prevFrame', 'nextFrame', 'prevFrameFast', 'nextFrameFast', 'prevSecond', 'nextSecond', 'goToStart', 'goToEnd'],
     '모드': ['commentMode', 'drawMode', 'fullscreen'],
-    '구간 반복': ['setInPoint', 'setOutPoint', 'toggleLoop', 'clearLoop'],
+    '구간 반복': ['setInPoint', 'setOutPoint', 'toggleLoop', 'clearLoop', 'addHighlight'],
     '실행취소': ['undo', 'redo'],
     '키프레임': ['keyframeAddWithCopy', 'keyframeAddBlank', 'keyframeAddBlank2', 'keyframeDelete', 'keyframeDeleteAlt', 'prevKeyframe', 'nextKeyframe'],
     '프레임 편집': ['insertFrame', 'deleteFrame'],

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5347,8 +5347,8 @@ async function initApp() {
    */
   function renderGDriveLinks(html) {
     if (!html) return html;
-    // G:/ 또는 G:\ 뒤에 공백/태그시작/줄끝까지를 경로로 인식
-    return html.replace(/(G:[/\\][^\s<"']*)/gi, (match) => {
+    // G:/ 또는 G:\ 뒤에 태그시작/따옴표/줄끝까지를 경로로 인식 (공백 포함)
+    return html.replace(/(G:[/\\][^<"']*[^<"'\s])/gi, (match) => {
       const normalizedPath = match.replace(/\//g, '\\');
       return `<button class="gdrive-link-btn" data-path="${escapeHtml(normalizedPath)}" title="${escapeHtml(normalizedPath)}"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg> ${escapeHtml(match)}</button>`;
     });
@@ -5818,28 +5818,18 @@ async function initApp() {
       return;
     }
 
-    // ====== 하드코딩 유지 단축키 (시스템 조합키) ======
+    // ====== 시스템 단축키 (변경 불가) ======
     switch (e.code) {
     case 'Escape':
-      // ESC: 전체화면 해제 (전체화면일 때)
       if (state.isFullscreen) {
         e.preventDefault();
         toggleFullscreen();
         return;
       }
-      break; // 다른 ESC 핸들러로 전달
-
-    case 'Delete':
-    case 'Backspace':
-      // 키프레임 삭제 (그리기 모드에서만)
-      if (state.isDrawMode && !e.ctrlKey) {
-        e.preventDefault();
-        drawingManager.removeKeyframe();
-      }
-      return;
+      break;
 
     case 'Slash':
-      if (e.shiftKey) { // ?
+      if (e.shiftKey) {
         e.preventDefault();
         elements.shortcutsToggle.click();
       }
@@ -5850,42 +5840,12 @@ async function initApp() {
       timeline.fitToView();
       return;
 
-    case 'KeyZ':
-      if (e.ctrlKey || e.metaKey) {
-        e.preventDefault();
-        if (e.shiftKey) {
-          // Ctrl+Shift+Z: Redo
-          if (await globalRedo()) {
-            showToast('다시 실행됨', 'info');
-          }
-        } else {
-          // Ctrl+Z: Undo
-          if (await globalUndo()) {
-            showToast('실행 취소됨', 'info');
-          }
-        }
-      }
-      return;
-
-    case 'KeyY':
-      if (e.ctrlKey || e.metaKey) {
-        // Ctrl+Y: Redo (alternative)
-        e.preventDefault();
-        if (await globalRedo()) {
-          showToast('다시 실행됨', 'info');
-        }
-      }
-      return;
-
     case 'KeyS':
       if (e.ctrlKey || e.metaKey) {
-        // Ctrl+S: 수동 저장
         e.preventDefault();
         if (reviewDataManager.getBframePath()) {
           reviewDataManager.save().then(saved => {
-            if (saved) {
-              showToast('저장되었습니다', 'success');
-            }
+            if (saved) showToast('저장되었습니다', 'success');
           });
         } else {
           showToast('저장할 파일이 없습니다', 'warn');
@@ -5908,130 +5868,162 @@ async function initApp() {
         timeline.zoomOut();
       }
       return;
-
-    // 사용자 정의 단축키 처리 (F6, F7 등)
-    default:
-      // 키프레임 추가 (복사) - F6
-      if (userSettings.matchShortcut('keyframeAddWithCopy', e)) {
-        e.preventDefault();
-        if (state.isDrawMode) {
-          drawingManager.addKeyframeWithContent();
-          showToast('키프레임 추가됨', 'success');
-        }
-        return;
-      }
-      // 빈 키프레임 추가 - F7
-      if (userSettings.matchShortcut('keyframeAddBlank', e)) {
-        e.preventDefault();
-        if (state.isDrawMode) {
-          drawingManager.addBlankKeyframe();
-          showToast('빈 키프레임 추가됨', 'success');
-        }
-        return;
-      }
-      break;
     }
 
-    // ====== 프레임 이동 및 그리기 모드 단축키 ======
-    switch (e.code) {
-    case 'ArrowLeft':
-      e.preventDefault();
-      if (e.ctrlKey) {
-        // Ctrl+←: 초 단위 뒤로 이동
-        const secondAmount = userSettings.getSecondSkipAmount();
-        const newTime = Math.max(0, (videoPlayer.currentTime || 0) - secondAmount);
-        videoPlayer.seek(newTime);
-        timeline.scrollToPlayhead();
-        log.info('초 단위 뒤로 이동 (단축키)', { seconds: secondAmount, newTime });
-      } else if (e.shiftKey) {
-        // Shift+←: 프레임 빨리 뒤로 이동
-        const frameAmount = userSettings.getFrameSkipAmount();
-        const currentFrame = videoPlayer.currentFrame || 0;
-        const newFrame = Math.max(0, currentFrame - frameAmount);
-        videoPlayer.seekToFrame(newFrame);
-        timeline.scrollToPlayhead();
-        log.info('프레임 빨리 뒤로 이동 (단축키)', { frames: frameAmount, newFrame });
-      } else if (e.altKey) {
-        // Alt+←: 이전 하이라이트로 이동
-        const prevHighlightTime = highlightManager.getPrevHighlightTime(videoPlayer.currentTime || 0);
-        if (prevHighlightTime !== null) {
-          videoPlayer.seek(prevHighlightTime);
-          timeline.scrollToPlayhead();
-          log.info('이전 하이라이트로 이동 (단축키)', { time: prevHighlightTime });
-        } else {
-          showToast('이전 하이라이트가 없습니다', 'info');
-        }
-      } else {
-        videoPlayer.prevFrame();
-      }
-      break;
+    // ====== 사용자 설정 기반 단축키 (변경 가능) ======
 
-    case 'ArrowRight':
+    // 실행취소/다시실행
+    if (userSettings.matchShortcut('undo', e)) {
       e.preventDefault();
-      if (e.ctrlKey) {
-        // Ctrl+→: 초 단위 앞으로 이동
-        const secondAmount = userSettings.getSecondSkipAmount();
-        const duration = videoPlayer.duration || 0;
-        const newTime = Math.min(duration, (videoPlayer.currentTime || 0) + secondAmount);
-        videoPlayer.seek(newTime);
-        timeline.scrollToPlayhead();
-        log.info('초 단위 앞으로 이동 (단축키)', { seconds: secondAmount, newTime });
-      } else if (e.shiftKey) {
-        // Shift+→: 프레임 빨리 앞으로 이동
-        const frameAmount = userSettings.getFrameSkipAmount();
-        const currentFrame = videoPlayer.currentFrame || 0;
-        const totalFrames = videoPlayer.totalFrames || 0;
-        const newFrame = Math.min(totalFrames - 1, currentFrame + frameAmount);
-        videoPlayer.seekToFrame(newFrame);
-        timeline.scrollToPlayhead();
-        log.info('프레임 빨리 앞으로 이동 (단축키)', { frames: frameAmount, newFrame });
-      } else if (e.altKey) {
-        // Alt+→: 다음 하이라이트로 이동
-        const nextHighlightTime = highlightManager.getNextHighlightTime(videoPlayer.currentTime || 0);
-        if (nextHighlightTime !== null) {
-          videoPlayer.seek(nextHighlightTime);
-          timeline.scrollToPlayhead();
-          log.info('다음 하이라이트로 이동 (단축키)', { time: nextHighlightTime });
-        } else {
-          showToast('다음 하이라이트가 없습니다', 'info');
-        }
-      } else {
-        videoPlayer.nextFrame();
-      }
-      break;
+      if (await globalUndo()) showToast('실행 취소됨', 'info');
+      return;
+    }
+    if (userSettings.matchShortcut('redo', e)) {
+      e.preventDefault();
+      if (await globalRedo()) showToast('다시 실행됨', 'info');
+      return;
+    }
+    // Ctrl+Shift+Z도 Redo로 동작 (Ctrl+Y 외 대안)
+    if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.code === 'KeyZ') {
+      e.preventDefault();
+      if (await globalRedo()) showToast('다시 실행됨', 'info');
+      return;
+    }
 
-    // 사용자 정의 단축키를 통한 처리
-    default:
-      // Shift+A: 1프레임 이전
-      if (userSettings.matchShortcut('prevFrameDraw', e)) {
+    // 키프레임 삭제 (그리기 모드에서만)
+    if (userSettings.matchShortcut('keyframeDelete', e)) {
+      if (state.isDrawMode) {
         e.preventDefault();
-        videoPlayer.prevFrame();
-        break;
+        drawingManager.removeKeyframe();
       }
-      // Shift+D: 1프레임 다음
-      if (userSettings.matchShortcut('nextFrameDraw', e)) {
-        e.preventDefault();
-        videoPlayer.nextFrame();
-        break;
+      return;
+    }
+
+    // 키프레임 추가 (복사)
+    if (userSettings.matchShortcut('keyframeAddWithCopy', e)) {
+      e.preventDefault();
+      if (state.isDrawMode) {
+        drawingManager.addKeyframeWithContent();
+        showToast('키프레임 추가됨', 'success');
       }
-      // A: 이전 키프레임으로 이동
-      if (userSettings.matchShortcut('prevKeyframe', e)) {
-        e.preventDefault();
-        const prevKf = drawingManager.getPrevKeyframeFrame();
-        if (prevKf !== null) {
-          videoPlayer.seekToFrame(prevKf);
-        }
-        break;
+      return;
+    }
+
+    // 빈 키프레임 추가
+    if (userSettings.matchShortcut('keyframeAddBlank', e)) {
+      e.preventDefault();
+      if (state.isDrawMode) {
+        drawingManager.addBlankKeyframe();
+        showToast('빈 키프레임 추가됨', 'success');
       }
-      // D: 다음 키프레임으로 이동
-      if (userSettings.matchShortcut('nextKeyframe', e)) {
-        e.preventDefault();
-        const nextKf = drawingManager.getNextKeyframeFrame();
-        if (nextKf !== null) {
-          videoPlayer.seekToFrame(nextKf);
-        }
-        break;
+      return;
+    }
+
+    // 프레임 이동 단축키
+    if (userSettings.matchShortcut('prevSecond', e)) {
+      e.preventDefault();
+      const secondAmount = userSettings.getSecondSkipAmount();
+      const newTime = Math.max(0, (videoPlayer.currentTime || 0) - secondAmount);
+      videoPlayer.seek(newTime);
+      timeline.scrollToPlayhead();
+      return;
+    }
+    if (userSettings.matchShortcut('nextSecond', e)) {
+      e.preventDefault();
+      const secondAmount = userSettings.getSecondSkipAmount();
+      const duration = videoPlayer.duration || 0;
+      const newTime = Math.min(duration, (videoPlayer.currentTime || 0) + secondAmount);
+      videoPlayer.seek(newTime);
+      timeline.scrollToPlayhead();
+      return;
+    }
+    if (userSettings.matchShortcut('prevFrameFast', e)) {
+      e.preventDefault();
+      const frameAmount = userSettings.getFrameSkipAmount();
+      const currentFrame = videoPlayer.currentFrame || 0;
+      const newFrame = Math.max(0, currentFrame - frameAmount);
+      videoPlayer.seekToFrame(newFrame);
+      timeline.scrollToPlayhead();
+      return;
+    }
+    if (userSettings.matchShortcut('nextFrameFast', e)) {
+      e.preventDefault();
+      const frameAmount = userSettings.getFrameSkipAmount();
+      const currentFrame = videoPlayer.currentFrame || 0;
+      const totalFrames = videoPlayer.totalFrames || 0;
+      const newFrame = Math.min(totalFrames - 1, currentFrame + frameAmount);
+      videoPlayer.seekToFrame(newFrame);
+      timeline.scrollToPlayhead();
+      return;
+    }
+    if (userSettings.matchShortcut('prevFrame', e)) {
+      e.preventDefault();
+      videoPlayer.prevFrame();
+      return;
+    }
+    if (userSettings.matchShortcut('nextFrame', e)) {
+      e.preventDefault();
+      videoPlayer.nextFrame();
+      return;
+    }
+
+    // Alt+Arrow: 하이라이트 이동 (설정 기반 아님, 하드코딩 유지)
+    if (e.altKey && e.code === 'ArrowLeft') {
+      e.preventDefault();
+      const prevHighlightTime = highlightManager.getPrevHighlightTime(videoPlayer.currentTime || 0);
+      if (prevHighlightTime !== null) {
+        videoPlayer.seek(prevHighlightTime);
+        timeline.scrollToPlayhead();
+      } else {
+        showToast('이전 하이라이트가 없습니다', 'info');
       }
+      return;
+    }
+    if (e.altKey && e.code === 'ArrowRight') {
+      e.preventDefault();
+      const nextHighlightTime = highlightManager.getNextHighlightTime(videoPlayer.currentTime || 0);
+      if (nextHighlightTime !== null) {
+        videoPlayer.seek(nextHighlightTime);
+        timeline.scrollToPlayhead();
+      } else {
+        showToast('다음 하이라이트가 없습니다', 'info');
+      }
+      return;
+    }
+
+    // 그리기 모드 토글
+    if (userSettings.matchShortcut('drawMode', e)) {
+      e.preventDefault();
+      if (!state.isDrawMode) {
+        toggleDrawMode();
+      }
+      // 브러시 도구 선택
+      const brushBtn = document.querySelector('.tool-btn[data-tool="brush"]');
+      if (brushBtn) brushBtn.click();
+      return;
+    }
+    if (userSettings.matchShortcut('prevFrameDraw', e)) {
+      e.preventDefault();
+      videoPlayer.prevFrame();
+      return;
+    }
+    if (userSettings.matchShortcut('nextFrameDraw', e)) {
+      e.preventDefault();
+      videoPlayer.nextFrame();
+      return;
+    }
+    if (userSettings.matchShortcut('prevKeyframe', e)) {
+      e.preventDefault();
+      const prevKf = drawingManager.getPrevKeyframeFrame();
+      if (prevKf !== null) videoPlayer.seekToFrame(prevKf);
+      return;
+    }
+    if (userSettings.matchShortcut('nextKeyframe', e)) {
+      e.preventDefault();
+      const nextKf = drawingManager.getNextKeyframeFrame();
+      if (nextKf !== null) videoPlayer.seekToFrame(nextKf);
+      return;
+    }
       // 1: 어니언 스킨 토글
       if (userSettings.matchShortcut('onionSkinToggle', e)) {
         e.preventDefault();
@@ -6065,19 +6057,6 @@ async function initApp() {
         e.preventDefault();
         drawingManager.deleteFrame();
         timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
-        break;
-      }
-      // B: 브러시 모드 (드로잉 모드 켜기 + 브러시 도구)
-      if (e.code === 'KeyB') {
-        e.preventDefault();
-        if (!state.isDrawMode) {
-          toggleDrawMode();
-        }
-        // 브러시 버튼 클릭으로 UI와 도구 함께 전환
-        const brushBtn = document.querySelector('.tool-btn[data-tool="brush"]');
-        if (brushBtn) {
-          brushBtn.click();
-        }
         break;
       }
       // E: 지우개 모드 (드로잉 모드에서만 작동)

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5347,10 +5347,15 @@ async function initApp() {
    */
   function renderGDriveLinks(html) {
     if (!html) return html;
-    // G:/ 또는 G:\ 뒤에 태그시작/따옴표/줄끝까지를 경로로 인식 (공백 포함)
-    return html.replace(/(G:[/\\][^<"']*[^<"'\s])/gi, (match) => {
-      const normalizedPath = match.replace(/\//g, '\\');
-      return `<button class="gdrive-link-btn" data-path="${escapeHtml(normalizedPath)}" title="${escapeHtml(normalizedPath)}"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg> ${escapeHtml(match)}</button>`;
+    // G:/ 또는 G:\ 뒤에 경로 문자를 인식 (공백 포함, <mark> 태그 허용)
+    // 검색 하이라이트의 <mark>/<\/mark> 태그가 경로 중간에 삽입되어도 무시
+    const TAG_RE = /<\/?mark[^>]*>/gi;
+    return html.replace(/(G:[/\\](?:[^<"']|<\/?mark[^>]*>)*[^<"'\s])/gi, (match) => {
+      // 경로에서 mark 태그 제거하여 실제 경로 추출
+      const cleanPath = match.replace(TAG_RE, '');
+      const normalizedPath = cleanPath.replace(/\//g, '\\');
+      // 표시 텍스트에는 mark 태그 유지 (검색 하이라이트 보존)
+      return `<button class="gdrive-link-btn" data-path="${escapeHtml(normalizedPath)}" title="${escapeHtml(normalizedPath)}"><svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg> ${match}</button>`;
     });
   }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -929,8 +929,9 @@ async function initApp() {
     updateCommentList();
 
     // Slack 알림: 원작성자 + 스레드 참여자에게 웹훅 전송
-    const { marker, reply } = e.detail;
-    if (marker && reply) {
+    // remote: true인 경우(다른 사용자로부터 동기화된 답글)는 알림 전송 안 함
+    const { marker, reply, remote } = e.detail;
+    if (marker && reply && !remote) {
       slackNotifier.notifyReply(marker, reply, commentManager.getAuthor(), {
         filePath: state.currentFile,
         fileName: elements.fileName?.textContent || '',
@@ -6491,6 +6492,18 @@ async function initApp() {
   function closeAppSettingsModal() {
     if (!appSettingsModal) return;
     appSettingsModal.classList.remove('active');
+
+    // 단축키 캡처 모드 해제 — 설정창 닫힐 때 캡처 중이면 원래 키 표시로 복원
+    if (capturingShortcutAction) {
+      const capturingBtn = document.querySelector(`.shortcut-key-btn.capturing[data-action="${capturingShortcutAction}"]`);
+      if (capturingBtn) {
+        const shortcuts = userSettings.getShortcuts();
+        const sc = shortcuts[capturingShortcutAction];
+        capturingBtn.textContent = sc ? formatShortcutDisplay(sc) : capturingShortcutAction;
+        capturingBtn.classList.remove('capturing');
+      }
+      capturingShortcutAction = null;
+    }
   }
 
   // 앱 설정 열기 버튼
@@ -6570,7 +6583,7 @@ async function initApp() {
   }
 
   function renderShortcutSettings() {
-    const container = document.getElementById('shortcutList');
+    const container = document.getElementById('settingsShortcutList');
     if (!container) return;
 
     const shortcuts = userSettings.getShortcuts();
@@ -6595,7 +6608,7 @@ async function initApp() {
     `).join('');
 
     // 전체 초기화 버튼
-    document.getElementById('resetAllShortcuts')?.addEventListener('click', () => {
+    document.getElementById('settingsResetAllShortcuts')?.addEventListener('click', () => {
       userSettings.resetAllShortcuts();
       renderShortcutSettings();
       showToast('모든 단축키가 초기화되었습니다.', 'success');
@@ -6603,7 +6616,7 @@ async function initApp() {
   }
 
   // 단축키 설정 패널 클릭 이벤트 위임
-  document.getElementById('shortcutList')?.addEventListener('click', (e) => {
+  document.getElementById('settingsShortcutList')?.addEventListener('click', (e) => {
     // 키 바인딩 버튼 클릭 → 캡처 모드
     const keyBtn = e.target.closest('.shortcut-key-btn');
     if (keyBtn) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6127,14 +6127,14 @@ async function initApp() {
       if (userSettings.matchShortcut('onionSkinToggle', e)) {
         e.preventDefault();
         toggleOnionSkinWithUI();
-        break;
+        return;
       }
       // 2: 빈 키프레임 삽입
       if (userSettings.matchShortcut('keyframeAddBlank2', e)) {
         e.preventDefault();
         drawingManager.addBlankKeyframe();
         timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
-        break;
+        return;
       }
       // Shift+3: 현재 키프레임 삭제
       if (userSettings.matchShortcut('keyframeDeleteAlt', e)) {
@@ -6142,35 +6142,33 @@ async function initApp() {
         drawingManager.removeKeyframe();
         showToast('키프레임이 삭제되었습니다.', 'info');
         timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
-        break;
+        return;
       }
       // 3: 프레임 삽입 (홀드 추가)
       if (userSettings.matchShortcut('insertFrame', e)) {
         e.preventDefault();
         drawingManager.insertFrame();
         timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
-        break;
+        return;
       }
       // 4: 프레임 삭제
       if (userSettings.matchShortcut('deleteFrame', e)) {
         e.preventDefault();
         drawingManager.deleteFrame();
         timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
-        break;
+        return;
       }
       // E: 지우개 모드 (드로잉 모드에서만 작동)
       if (e.code === 'KeyE') {
         // 드로잉 모드가 아니면 무시
-        if (!state.isDrawMode) {
-          break;
-        }
+        if (!state.isDrawMode) return;
         e.preventDefault();
         // 지우개 버튼 클릭으로 UI와 도구 함께 전환
         const eraserBtn = document.querySelector('.tool-btn[data-tool="eraser"]');
         if (eraserBtn) {
           eraserBtn.click();
         }
-        break;
+        return;
       }
       // V: 선택 모드 (드로잉 모드 끄기)
       if (e.code === 'KeyV') {
@@ -6178,9 +6176,8 @@ async function initApp() {
         if (state.isDrawMode) {
           toggleDrawMode();
         }
-        break;
+        return;
       }
-      break;
     }
   }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -886,6 +886,7 @@ async function initApp() {
     }
     slackNotifier.notifyNewComment(marker, commentManager.getAuthor(), {
       filePath: state.currentFile,
+      bframePath: reviewDataManager.getBframePath() || '',
       fileName: elements.fileName?.textContent || '',
       timecode: marker.startTimecode || ''
     });
@@ -942,6 +943,7 @@ async function initApp() {
         }
         slackNotifier.notifyReply(marker, reply, commentManager.getAuthor(), {
           filePath: state.currentFile,
+          bframePath: reviewDataManager.getBframePath() || '',
           fileName: elements.fileName?.textContent || '',
           timecode: marker.startTimecode || ''
         });
@@ -5366,17 +5368,23 @@ async function initApp() {
     }
 
     // 1단계: 따옴표로 감싼 경로 (공백/한글 자유롭게 포함)
-    //   &quot;G:/경로&quot;  또는  &#39;G:/경로&#39;  (escapeHtml 후의 따옴표)
-    //   "G:/경로" 또는 'G:/경로' (원본 따옴표)
+    //   플레이스홀더로 교체하여 2단계에서 재매칭 방지
+    const placeholders = [];
     html = html.replace(/(?:&quot;|&amp;quot;|"|&#39;|')\s*(G:[/\\](?:[^<"'&]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)*?)(?:\s*(?:&quot;|&amp;quot;|"|&#39;|'))/gi, (match, path) => {
-      return makeBtn(path, path);
+      const placeholder = `\x00GDRIVE_${placeholders.length}\x00`;
+      placeholders.push(makeBtn(path, path));
+      return placeholder;
     });
 
     // 2단계: 따옴표 없는 경로 — 공백 불허, 경로 문자만
-    //   G:/path/to/file.ext 또는 G:\path\to\file.ext
     //   <mark> 태그는 허용 (검색 하이라이트)
-    html = html.replace(/(G:[/\\](?:[^\s<"'&]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi, (match) => {
+    html = html.replace(/(G:[/\\](?:[^\s<"'&\x00]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi, (match) => {
       return makeBtn(match, match);
+    });
+
+    // 3단계: 플레이스홀더를 실제 버튼으로 복원
+    placeholders.forEach((btn, i) => {
+      html = html.replace(`\x00GDRIVE_${i}\x00`, btn);
     });
 
     return html;

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6178,7 +6178,6 @@ async function initApp() {
         }
         return;
       }
-    }
   }
 
   // 초기화 완료

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5021,6 +5021,7 @@ async function initApp() {
       // 클릭으로 해당 프레임 이동
       item.addEventListener('click', (e) => {
         if (e.target.closest('.comment-action-btn')) return;
+        if (e.target.closest('.gdrive-link-btn')) return;
         const frame = parseInt(item.dataset.startFrame);
         videoPlayer.seekToFrame(frame);
         container.querySelectorAll('.comment-item').forEach(i => i.classList.remove('selected'));
@@ -6607,13 +6608,14 @@ async function initApp() {
       </div>
     `).join('');
 
-    // 전체 초기화 버튼
-    document.getElementById('settingsResetAllShortcuts')?.addEventListener('click', () => {
-      userSettings.resetAllShortcuts();
-      renderShortcutSettings();
-      showToast('모든 단축키가 초기화되었습니다.', 'success');
-    });
   }
+
+  // 전체 초기화 버튼 (한 번만 등록)
+  document.getElementById('settingsResetAllShortcuts')?.addEventListener('click', () => {
+    userSettings.resetAllShortcuts();
+    renderShortcutSettings();
+    showToast('모든 단축키가 초기화되었습니다.', 'success');
+  });
 
   // 단축키 설정 패널 클릭 이벤트 위임
   document.getElementById('settingsShortcutList')?.addEventListener('click', (e) => {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -880,7 +880,7 @@ async function initApp() {
   });
 
   // 마커 추가됨
-  commentManager.addEventListener('markerAdded', (e) => {
+  commentManager.addEventListener('markerAdded', async (e) => {
     const { marker, remote } = e.detail;
     removePendingMarkerUI();
     renderVideoMarkers();

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5332,7 +5332,7 @@ async function initApp() {
       commentItem.classList.add('glow');
       setTimeout(() => {
         commentItem.classList.remove('glow');
-      }, 1500);
+      }, 2500);
     }
   }
 
@@ -5567,7 +5567,7 @@ async function initApp() {
     // 안전장치: animationend 미발생 시 DOM 제거
     setTimeout(() => {
       if (toast.parentNode) toast.remove();
-    }, 500);
+    }, 600);
   }
 
   /**

--- a/renderer/scripts/modules/comment-manager.js
+++ b/renderer/scripts/modules/comment-manager.js
@@ -596,7 +596,7 @@ export class CommentManager extends EventTarget {
     if (layer) {
       layer.addMarker(marker);
       log.info('마커 복원됨', { id: marker.id });
-      this._emit('markerAdded', { marker });
+      this._emit('markerAdded', { marker, restored: true });
       this._emit('markersChanged');
       return marker;
     }

--- a/renderer/scripts/modules/mention-manager.js
+++ b/renderer/scripts/modules/mention-manager.js
@@ -318,30 +318,82 @@ export class MentionManager {
    * contenteditable에 텍스트 삽입
    */
   _insertIntoContentEditable(element, replacement) {
-    const text = element.textContent || '';
     const sel = window.getSelection();
     if (!sel.rangeCount) return;
 
-    // 전체 텍스트에서 @부터 커서까지 교체
-    const range = document.createRange();
-    range.setStart(element, 0);
-    range.setEnd(sel.anchorNode, sel.anchorOffset);
-    const beforeCursorLen = range.toString().length;
+    // 현재 커서 위치 기준으로 @멘션 시작점부터 커서까지의 Range 생성
+    const cursorRange = document.createRange();
+    cursorRange.setStart(element, 0);
+    cursorRange.setEnd(sel.anchorNode, sel.anchorOffset);
+    const beforeCursorText = cursorRange.toString();
 
-    // textContent 기반으로 교체
-    const before = text.substring(0, this._mentionStart);
-    const after = text.substring(beforeCursorLen);
-    element.textContent = before + replacement + after;
+    // @멘션 시작 위치를 찾아서 해당 범위만 삭제 후 교체
+    // TreeWalker로 텍스트 노드를 순회하며 정확한 위치를 찾음
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null, false);
+    let charCount = 0;
+    let startNode = null, startOffset = 0;
+    let endNode = null, endOffset = 0;
+
+    // @멘션 시작 위치(mentionStart) 찾기
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      const nodeLen = node.textContent.length;
+
+      // 시작 노드 찾기
+      if (!startNode && charCount + nodeLen > this._mentionStart) {
+        startNode = node;
+        startOffset = this._mentionStart - charCount;
+      }
+
+      // 끝 노드 찾기 (커서 위치 = beforeCursorText.length)
+      if (!endNode && charCount + nodeLen >= beforeCursorText.length) {
+        endNode = node;
+        endOffset = beforeCursorText.length - charCount;
+        break;
+      }
+
+      charCount += nodeLen;
+    }
+
+    if (!startNode || !endNode) {
+      // 폴백: 텍스트 노드를 못 찾으면 기존 방식으로 처리
+      const text = element.textContent || '';
+      const before = text.substring(0, this._mentionStart);
+      const after = text.substring(beforeCursorText.length);
+      element.textContent = before + replacement + after;
+    } else {
+      // @멘션 범위만 선택해서 교체 (서식 보존)
+      const replaceRange = document.createRange();
+      replaceRange.setStart(startNode, startOffset);
+      replaceRange.setEnd(endNode, endOffset);
+      replaceRange.deleteContents();
+      replaceRange.insertNode(document.createTextNode(replacement));
+    }
 
     // 커서를 삽입 텍스트 끝으로 이동
+    const newSel = window.getSelection();
     const newRange = document.createRange();
-    const textNode = element.firstChild;
-    if (textNode) {
-      const newPos = before.length + replacement.length;
-      newRange.setStart(textNode, Math.min(newPos, textNode.length));
-      newRange.collapse(true);
-      sel.removeAllRanges();
-      sel.addRange(newRange);
+
+    // 삽입된 텍스트 노드 찾기 — 마지막으로 삽입한 노드 바로 뒤
+    const insertedWalker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null, false);
+    let targetNode = null;
+    let accumulated = 0;
+    const targetPos = this._mentionStart + replacement.length;
+
+    while (insertedWalker.nextNode()) {
+      const node = insertedWalker.currentNode;
+      if (accumulated + node.textContent.length >= targetPos) {
+        targetNode = node;
+        newRange.setStart(node, Math.min(targetPos - accumulated, node.textContent.length));
+        newRange.collapse(true);
+        break;
+      }
+      accumulated += node.textContent.length;
+    }
+
+    if (targetNode) {
+      newSel.removeAllRanges();
+      newSel.addRange(newRange);
     }
 
     element.focus();

--- a/renderer/scripts/modules/mention-manager.js
+++ b/renderer/scripts/modules/mention-manager.js
@@ -1,0 +1,427 @@
+/**
+ * baeframe - Mention Manager Module
+ * @멘션 자동완성 드롭다운 기능
+ */
+
+import { createLogger } from '../logger.js';
+import { TEAM_MEMBERS } from './team-members.js';
+
+const log = createLogger('MentionManager');
+
+let instance = null;
+
+/**
+ * 멘션 자동완성 매니저
+ */
+export class MentionManager {
+  constructor() {
+    this._attachedElements = new Map(); // element → { handlers, type }
+    this._dropdown = null;
+    this._activeElement = null;
+    this._activeIndex = 0;
+    this._filteredMembers = [];
+    this._mentionStart = -1; // @ 문자 시작 위치
+
+    this._createDropdown();
+  }
+
+  /**
+   * 드롭다운 DOM 생성 (한 번만)
+   */
+  _createDropdown() {
+    this._dropdown = document.createElement('div');
+    this._dropdown.className = 'mention-dropdown';
+    this._dropdown.style.display = 'none';
+    document.body.appendChild(this._dropdown);
+
+    // 클릭 이벤트 위임
+    this._dropdown.addEventListener('mousedown', (e) => {
+      e.preventDefault(); // blur 방지
+      const item = e.target.closest('.mention-item');
+      if (item) {
+        const index = parseInt(item.dataset.index, 10);
+        this._selectMember(index);
+      }
+    });
+  }
+
+  /**
+   * 요소에 멘션 기능 부착
+   * @param {HTMLElement} element - textarea 또는 contenteditable 요소
+   */
+  attach(element) {
+    if (this._attachedElements.has(element)) return;
+
+    const isContentEditable = element.getAttribute('contenteditable') === 'true';
+    const type = isContentEditable ? 'contenteditable' : 'textarea';
+
+    const onInput = () => this._handleInput(element, type);
+    const onKeyDown = (e) => this._handleKeyDown(e, element, type);
+    const onBlur = () => {
+      // 약간의 지연: 드롭다운 클릭이 blur보다 먼저 처리되도록
+      setTimeout(() => this.hide(), 150);
+    };
+
+    element.addEventListener('input', onInput);
+    element.addEventListener('keydown', onKeyDown);
+    element.addEventListener('blur', onBlur);
+
+    this._attachedElements.set(element, { handlers: { onInput, onKeyDown, onBlur }, type });
+  }
+
+  /**
+   * 요소에서 멘션 기능 해제
+   * @param {HTMLElement} element
+   */
+  detach(element) {
+    const entry = this._attachedElements.get(element);
+    if (!entry) return;
+
+    const { handlers } = entry;
+    element.removeEventListener('input', handlers.onInput);
+    element.removeEventListener('keydown', handlers.onKeyDown);
+    element.removeEventListener('blur', handlers.onBlur);
+
+    this._attachedElements.delete(element);
+
+    if (this._activeElement === element) {
+      this.hide();
+    }
+  }
+
+  /**
+   * 입력 이벤트 처리
+   */
+  _handleInput(element, type) {
+    const { text, cursorPos } = this._getTextAndCursor(element, type);
+    if (cursorPos < 0) {
+      this.hide();
+      return;
+    }
+
+    // 커서 앞에서 @ 찾기
+    const beforeCursor = text.substring(0, cursorPos);
+    const atIndex = beforeCursor.lastIndexOf('@');
+
+    if (atIndex < 0) {
+      this.hide();
+      return;
+    }
+
+    // @ 앞이 공백이거나 텍스트 시작이어야 유효한 멘션
+    if (atIndex > 0 && !/\s/.test(beforeCursor[atIndex - 1])) {
+      this.hide();
+      return;
+    }
+
+    // @ 뒤의 검색어
+    const query = beforeCursor.substring(atIndex + 1);
+
+    // 공백이 포함되면 멘션이 아님 (이름에 공백 없음)
+    if (/\s/.test(query)) {
+      this.hide();
+      return;
+    }
+
+    this._mentionStart = atIndex;
+    this._activeElement = element;
+
+    // 필터링
+    this._filteredMembers = query
+      ? TEAM_MEMBERS.filter(m => m.name.includes(query))
+      : [...TEAM_MEMBERS];
+
+    if (this._filteredMembers.length === 0) {
+      this.hide();
+      return;
+    }
+
+    this._activeIndex = 0;
+    this._renderDropdown();
+    this._positionDropdown(element, type, atIndex);
+  }
+
+  /**
+   * 키보드 이벤트 처리
+   */
+  _handleKeyDown(e, element, type) {
+    if (this._dropdown.style.display === 'none') return;
+    if (this._activeElement !== element) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        e.stopPropagation();
+        this._activeIndex = (this._activeIndex + 1) % this._filteredMembers.length;
+        this._renderDropdown();
+        break;
+
+      case 'ArrowUp':
+        e.preventDefault();
+        e.stopPropagation();
+        this._activeIndex = (this._activeIndex - 1 + this._filteredMembers.length) % this._filteredMembers.length;
+        this._renderDropdown();
+        break;
+
+      case 'Enter':
+        if (this._filteredMembers.length > 0) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          this._selectMember(this._activeIndex);
+        }
+        break;
+
+      case 'Escape':
+        e.preventDefault();
+        e.stopPropagation();
+        this.hide();
+        break;
+
+      case 'Tab':
+        if (this._filteredMembers.length > 0) {
+          e.preventDefault();
+          e.stopPropagation();
+          this._selectMember(this._activeIndex);
+        }
+        break;
+    }
+  }
+
+  /**
+   * 텍스트와 커서 위치 가져오기
+   */
+  _getTextAndCursor(element, type) {
+    if (type === 'textarea') {
+      return {
+        text: element.value,
+        cursorPos: element.selectionStart
+      };
+    }
+
+    // contenteditable
+    const sel = window.getSelection();
+    if (!sel.rangeCount || !element.contains(sel.anchorNode)) {
+      return { text: '', cursorPos: -1 };
+    }
+
+    const text = element.textContent || '';
+    // anchorNode 내에서의 offset을 전체 텍스트 내 위치로 변환
+    const range = document.createRange();
+    range.setStart(element, 0);
+    range.setEnd(sel.anchorNode, sel.anchorOffset);
+    const cursorPos = range.toString().length;
+
+    return { text, cursorPos };
+  }
+
+  /**
+   * 드롭다운 렌더링
+   */
+  _renderDropdown() {
+    this._dropdown.innerHTML = this._filteredMembers.map((member, i) => `
+      <div class="mention-item ${i === this._activeIndex ? 'active' : ''}" data-index="${i}">
+        <span class="mention-item-name">${this._escapeHtml(member.name)}</span>
+      </div>
+    `).join('');
+
+    this._dropdown.style.display = 'block';
+
+    // 활성 항목 스크롤
+    const activeItem = this._dropdown.querySelector('.mention-item.active');
+    if (activeItem) {
+      activeItem.scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  /**
+   * 드롭다운 위치 계산
+   */
+  _positionDropdown(element, type, atIndex) {
+    const rect = element.getBoundingClientRect();
+    let left, top;
+
+    if (type === 'textarea') {
+      // textarea: 요소 좌하단 기준
+      left = rect.left;
+      top = rect.bottom + 4;
+    } else {
+      // contenteditable: 커서 위치 기준
+      const sel = window.getSelection();
+      if (sel.rangeCount) {
+        const range = sel.getRangeAt(0);
+        const cursorRect = range.getBoundingClientRect();
+        left = cursorRect.left;
+        top = cursorRect.bottom + 4;
+      } else {
+        left = rect.left;
+        top = rect.bottom + 4;
+      }
+    }
+
+    // 뷰포트 경계 처리
+    const dropdownWidth = 200;
+    const dropdownHeight = Math.min(this._filteredMembers.length * 36, 200);
+
+    if (left + dropdownWidth > window.innerWidth) {
+      left = window.innerWidth - dropdownWidth - 8;
+    }
+
+    if (top + dropdownHeight > window.innerHeight) {
+      // 위쪽으로 표시
+      top = (type === 'textarea' ? rect.top : top - 8) - dropdownHeight - 4;
+    }
+
+    this._dropdown.style.left = `${Math.max(0, left)}px`;
+    this._dropdown.style.top = `${Math.max(0, top)}px`;
+  }
+
+  /**
+   * 멤버 선택 → 텍스트 삽입
+   */
+  _selectMember(index) {
+    const member = this._filteredMembers[index];
+    if (!member || !this._activeElement) return;
+
+    const entry = this._attachedElements.get(this._activeElement);
+    if (!entry) return;
+
+    const replacement = `@${member.name} `;
+
+    if (entry.type === 'textarea') {
+      this._insertIntoTextarea(this._activeElement, replacement);
+    } else {
+      this._insertIntoContentEditable(this._activeElement, replacement);
+    }
+
+    this.hide();
+  }
+
+  /**
+   * textarea에 텍스트 삽입
+   */
+  _insertIntoTextarea(textarea, replacement) {
+    const text = textarea.value;
+    const cursorPos = textarea.selectionStart;
+    const before = text.substring(0, this._mentionStart);
+    const after = text.substring(cursorPos);
+
+    textarea.value = before + replacement + after;
+    const newPos = before.length + replacement.length;
+    textarea.setSelectionRange(newPos, newPos);
+    textarea.focus();
+
+    // input 이벤트 발생시켜 외부 리스너에 알림
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  /**
+   * contenteditable에 텍스트 삽입
+   */
+  _insertIntoContentEditable(element, replacement) {
+    const text = element.textContent || '';
+    const sel = window.getSelection();
+    if (!sel.rangeCount) return;
+
+    // 전체 텍스트에서 @부터 커서까지 교체
+    const range = document.createRange();
+    range.setStart(element, 0);
+    range.setEnd(sel.anchorNode, sel.anchorOffset);
+    const beforeCursorLen = range.toString().length;
+
+    // textContent 기반으로 교체
+    const before = text.substring(0, this._mentionStart);
+    const after = text.substring(beforeCursorLen);
+    element.textContent = before + replacement + after;
+
+    // 커서를 삽입 텍스트 끝으로 이동
+    const newRange = document.createRange();
+    const textNode = element.firstChild;
+    if (textNode) {
+      const newPos = before.length + replacement.length;
+      newRange.setStart(textNode, Math.min(newPos, textNode.length));
+      newRange.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(newRange);
+    }
+
+    element.focus();
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  /**
+   * 드롭다운이 현재 표시 중인지 여부
+   */
+  get isVisible() {
+    return this._dropdown && this._dropdown.style.display !== 'none';
+  }
+
+  /**
+   * 드롭다운 숨기기
+   */
+  hide() {
+    if (this._dropdown) {
+      this._dropdown.style.display = 'none';
+    }
+    this._activeElement = null;
+    this._mentionStart = -1;
+    this._filteredMembers = [];
+  }
+
+  /**
+   * XSS 방지용 이스케이프
+   */
+  _escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  /**
+   * 텍스트에서 @멘션된 이름 추출
+   * @param {string} text - 파싱할 텍스트
+   * @returns {string[]} 멘션된 이름 배열 (TEAM_MEMBERS에 존재하는 이름만)
+   */
+  static parseMentions(text) {
+    if (!text) return [];
+
+    const mentions = [];
+    // @이름 패턴 매칭 (유니코드 문자 지원)
+    const regex = /@([\p{L}\p{N}]+)/gu;
+    let match;
+
+    while ((match = regex.exec(text)) !== null) {
+      const name = match[1];
+      if (TEAM_MEMBERS.some(m => m.name === name)) {
+        mentions.push(name);
+      }
+    }
+
+    // 중복 제거
+    return [...new Set(mentions)];
+  }
+
+  /**
+   * 파괴
+   */
+  destroy() {
+    for (const element of this._attachedElements.keys()) {
+      this.detach(element);
+    }
+    if (this._dropdown && this._dropdown.parentNode) {
+      this._dropdown.parentNode.removeChild(this._dropdown);
+    }
+    this._dropdown = null;
+    instance = null;
+  }
+}
+
+/**
+ * 싱글턴 인스턴스 반환
+ * @returns {MentionManager}
+ */
+export function getMentionManager() {
+  if (!instance) {
+    instance = new MentionManager();
+  }
+  return instance;
+}

--- a/renderer/scripts/modules/slack-notifier.js
+++ b/renderer/scripts/modules/slack-notifier.js
@@ -205,8 +205,11 @@ export class SlackNotifier {
    * 웹 뷰어 URL에 baeframe:// 경로를 hash로 인코딩
    */
   _buildDeepLink(videoInfo) {
-    if (!videoInfo || !videoInfo.filePath) return 'https://baeframe.vercel.app';
-    const baeframeUrl = `baeframe://${videoInfo.filePath}`;
+    if (!videoInfo) return 'https://baeframe.vercel.app';
+    // .bframe 경로 우선 사용 (댓글/리뷰 데이터 포함)
+    const targetPath = videoInfo.bframePath || videoInfo.filePath;
+    if (!targetPath) return 'https://baeframe.vercel.app';
+    const baeframeUrl = `baeframe://${targetPath}`;
     return `https://baeframe.vercel.app/open.html#open=${encodeURIComponent(baeframeUrl)}`;
   }
 

--- a/renderer/scripts/modules/slack-notifier.js
+++ b/renderer/scripts/modules/slack-notifier.js
@@ -209,12 +209,13 @@ export class SlackNotifier {
     // .bframe 경로 우선 사용 (댓글/리뷰 데이터 포함)
     const targetPath = videoInfo.bframePath || videoInfo.filePath;
     if (!targetPath) return '';
-    // HTTPS 리다이렉트 → baeframe:// (Slack 버튼/링크 호환)
-    let baeframeUrl = `baeframe://${targetPath}`;
+    // baeframe:// 직접 사용 (Bflow 방식 — Slack 버튼 호환)
+    // 경로를 encodeURIComponent로 인코딩하여 한글/공백/백슬래시 안전하게 전달
+    let url = `baeframe://open?file=${encodeURIComponent(targetPath)}`;
     if (markerId) {
-      baeframeUrl += `?comment=${encodeURIComponent(markerId)}`;
+      url += `&comment=${encodeURIComponent(markerId)}`;
     }
-    return `https://baeframe.vercel.app/open.html#open=${encodeURIComponent(baeframeUrl)}`;
+    return url;
   }
 
   /**

--- a/renderer/scripts/modules/slack-notifier.js
+++ b/renderer/scripts/modules/slack-notifier.js
@@ -152,9 +152,11 @@ export class SlackNotifier {
       log.info('웹훅 응답', JSON.stringify(result));
       if (!result.success) {
         log.warn('웹훅 응답 오류', { status: result.status, body: result.body, error: result.error });
+        throw new Error(`Slack 웹훅 실패 (${result.status || result.error || 'unknown'})`);
       }
     } else {
       log.warn('electronAPI.sendSlackWebhook 사용 불가');
+      throw new Error('electronAPI.sendSlackWebhook 사용 불가');
     }
   }
 

--- a/renderer/scripts/modules/slack-notifier.js
+++ b/renderer/scripts/modules/slack-notifier.js
@@ -209,12 +209,12 @@ export class SlackNotifier {
     // .bframe 경로 우선 사용 (댓글/리뷰 데이터 포함)
     const targetPath = videoInfo.bframePath || videoInfo.filePath;
     if (!targetPath) return '';
-    // baeframe:// 직접 사용 (Slack 메시지 본문에서 클릭 가능)
-    let url = `baeframe://${targetPath}`;
+    // HTTPS 리다이렉트 → baeframe:// (Slack 버튼/링크 호환)
+    let baeframeUrl = `baeframe://${targetPath}`;
     if (markerId) {
-      url += `?comment=${encodeURIComponent(markerId)}`;
+      baeframeUrl += `?comment=${encodeURIComponent(markerId)}`;
     }
-    return url;
+    return `https://baeframe.vercel.app/open.html#open=${encodeURIComponent(baeframeUrl)}`;
   }
 
   /**

--- a/renderer/scripts/modules/slack-notifier.js
+++ b/renderer/scripts/modules/slack-notifier.js
@@ -49,6 +49,7 @@ export class SlackNotifier {
         return;
       }
 
+      let failCount = 0;
       for (const name of mentionedNames) {
         // 본인 제외
         if (name === currentAuthor) continue;
@@ -66,10 +67,18 @@ export class SlackNotifier {
           target_comment: ''
         };
 
-        await this._sendWebhook(payload);
+        try {
+          await this._sendWebhook(payload);
+        } catch (err) {
+          log.warn(`댓글 알림 전송 실패 (${name})`, err);
+          failCount++;
+        }
+      }
+      if (failCount > 0) {
+        this._toast(`Slack 알림 ${failCount}건 전송 실패`, 'warning');
       }
     } catch (err) {
-      log.warn('댓글 알림 전송 실패', err);
+      log.warn('댓글 알림 처리 오류', err);
       this._toast('Slack 알림 전송 실패', 'warning');
     }
   }
@@ -119,6 +128,7 @@ export class SlackNotifier {
 
       if (targetNames.size === 0) return;
 
+      let failCount = 0;
       for (const name of targetNames) {
         const targetUid = getSlackUidByName(name);
         if (!targetUid) continue;
@@ -133,10 +143,18 @@ export class SlackNotifier {
           target_comment: marker.text
         };
 
-        await this._sendWebhook(payload);
+        try {
+          await this._sendWebhook(payload);
+        } catch (err) {
+          log.warn(`답글 알림 전송 실패 (${name})`, err);
+          failCount++;
+        }
+      }
+      if (failCount > 0) {
+        this._toast(`Slack 알림 ${failCount}건 전송 실패`, 'warning');
       }
     } catch (err) {
-      log.warn('답글 알림 전송 실패', err);
+      log.warn('답글 알림 처리 오류', err);
       this._toast('Slack 알림 전송 실패', 'warning');
     }
   }

--- a/renderer/scripts/modules/slack-notifier.js
+++ b/renderer/scripts/modules/slack-notifier.js
@@ -1,0 +1,215 @@
+/**
+ * baeframe - Slack Notifier Module
+ * Slack 워크플로 웹훅을 통한 알림 전송
+ */
+
+import { createLogger } from '../logger.js';
+import { TEAM_MEMBERS, getSlackUidByName } from './team-members.js';
+import { MentionManager } from './mention-manager.js';
+
+const log = createLogger('SlackNotifier');
+
+const WEBHOOK_URL = 'https://hooks.slack.com/triggers/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';
+
+let instance = null;
+
+/**
+ * Slack 웹훅 알림 매니저
+ */
+export class SlackNotifier {
+  constructor() {
+    this._enabled = true;
+    this._showToast = null; // app.js에서 주입
+  }
+
+  /**
+   * 토스트 함수 설정 (app.js에서 호출)
+   * @param {Function} toastFn - showToast 함수
+   */
+  setToastFunction(toastFn) {
+    this._showToast = toastFn;
+  }
+
+  /**
+   * 새 댓글 작성 시 @멘션 대상에게 알림
+   * @param {object} marker - CommentMarker 객체
+   * @param {string} currentAuthor - 현재 사용자 이름
+   * @param {object} videoInfo - { filePath, fileName, timecode }
+   */
+  async notifyNewComment(marker, currentAuthor, videoInfo) {
+    if (!this._enabled) return;
+
+    try {
+      const mentionedNames = MentionManager.parseMentions(marker.text);
+      if (mentionedNames.length === 0) return;
+
+      const senderUid = getSlackUidByName(currentAuthor);
+      if (!senderUid) {
+        log.warn('현재 사용자 Slack UID 없음', { currentAuthor });
+        return;
+      }
+
+      for (const name of mentionedNames) {
+        // 본인 제외
+        if (name === currentAuthor) continue;
+
+        const targetUid = getSlackUidByName(name);
+        if (!targetUid) continue;
+
+        const payload = {
+          your_name: senderUid,
+          target_name: targetUid,
+          time: this._formatTime(new Date()),
+          file_name: this._formatFileName(videoInfo),
+          deep_link: this._buildDeepLink(videoInfo),
+          comment: marker.text,
+          target_comment: ''
+        };
+
+        await this._sendWebhook(payload);
+      }
+    } catch (err) {
+      log.warn('댓글 알림 전송 실패', err);
+      this._toast('Slack 알림 전송 실패', 'warning');
+    }
+  }
+
+  /**
+   * 답글 작성 시 원작성자 + 스레드 참여자 + @멘션 대상에게 알림
+   * @param {object} marker - 원본 CommentMarker 객체
+   * @param {object} reply - 새로 추가된 Reply 객체
+   * @param {string} currentAuthor - 현재 사용자 이름
+   * @param {object} videoInfo - { filePath, fileName, timecode }
+   */
+  async notifyReply(marker, reply, currentAuthor, videoInfo) {
+    if (!this._enabled) return;
+
+    try {
+      const senderUid = getSlackUidByName(currentAuthor);
+      if (!senderUid) {
+        log.warn('현재 사용자 Slack UID 없음', { currentAuthor });
+        return;
+      }
+
+      // 알림 대상 수집 (Set으로 중복 제거)
+      const targetNames = new Set();
+
+      // 1. 원본 댓글 작성자
+      if (marker.author) {
+        targetNames.add(marker.author);
+      }
+
+      // 2. 기존 답글 작성자들
+      if (marker.replies) {
+        for (const r of marker.replies) {
+          if (r.author && r.id !== reply.id) {
+            targetNames.add(r.author);
+          }
+        }
+      }
+
+      // 3. 답글 내 @멘션 대상
+      const mentionedNames = MentionManager.parseMentions(reply.text);
+      for (const name of mentionedNames) {
+        targetNames.add(name);
+      }
+
+      // 본인 제외
+      targetNames.delete(currentAuthor);
+
+      if (targetNames.size === 0) return;
+
+      for (const name of targetNames) {
+        const targetUid = getSlackUidByName(name);
+        if (!targetUid) continue;
+
+        const payload = {
+          your_name: senderUid,
+          target_name: targetUid,
+          time: this._formatTime(new Date()),
+          file_name: this._formatFileName(videoInfo),
+          deep_link: this._buildDeepLink(videoInfo),
+          comment: reply.text,
+          target_comment: marker.text
+        };
+
+        await this._sendWebhook(payload);
+      }
+    } catch (err) {
+      log.warn('답글 알림 전송 실패', err);
+      this._toast('Slack 알림 전송 실패', 'warning');
+    }
+  }
+
+  /**
+   * 웹훅 HTTP POST (메인 프로세스 IPC 경유 — CSP 우회)
+   */
+  async _sendWebhook(payload) {
+    log.info('웹훅 전송 payload', JSON.stringify(payload, null, 2));
+
+    if (window.electronAPI?.sendSlackWebhook) {
+      const result = await window.electronAPI.sendSlackWebhook(WEBHOOK_URL, payload);
+      log.info('웹훅 응답', JSON.stringify(result));
+      if (!result.success) {
+        log.warn('웹훅 응답 오류', { status: result.status, body: result.body, error: result.error });
+      }
+    } else {
+      log.warn('electronAPI.sendSlackWebhook 사용 불가');
+    }
+  }
+
+  /**
+   * 시간 포맷팅 (한국어)
+   */
+  _formatTime(date) {
+    const y = date.getFullYear();
+    const M = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    const h = String(date.getHours()).padStart(2, '0');
+    const m = String(date.getMinutes()).padStart(2, '0');
+    return `${y}-${M}-${d} ${h}:${m}`;
+  }
+
+  /**
+   * 파일명 + 타임코드 포맷팅
+   */
+  _formatFileName(videoInfo) {
+    if (!videoInfo) return '';
+    const name = videoInfo.fileName || '';
+    const tc = videoInfo.timecode || '';
+    return tc ? `${name} (${tc})` : name;
+  }
+
+  /**
+   * 딥링크 생성 (Slack 버튼 URL은 https만 허용)
+   * 웹 뷰어 URL에 baeframe:// 경로를 hash로 인코딩
+   */
+  _buildDeepLink(videoInfo) {
+    if (!videoInfo || !videoInfo.filePath) return 'https://baeframe.vercel.app';
+    const baeframeUrl = `baeframe://${videoInfo.filePath}`;
+    return `https://baeframe.vercel.app/open.html#open=${encodeURIComponent(baeframeUrl)}`;
+  }
+
+  /**
+   * 토스트 알림 표시
+   */
+  _toast(message, type) {
+    if (this._showToast) {
+      this._showToast(message, type);
+    }
+  }
+
+  get enabled() { return this._enabled; }
+  set enabled(val) { this._enabled = !!val; }
+}
+
+/**
+ * 싱글턴 인스턴스 반환
+ * @returns {SlackNotifier}
+ */
+export function getSlackNotifier() {
+  if (!instance) {
+    instance = new SlackNotifier();
+  }
+  return instance;
+}

--- a/renderer/scripts/modules/slack-notifier.js
+++ b/renderer/scripts/modules/slack-notifier.js
@@ -62,7 +62,7 @@ export class SlackNotifier {
           target_name: targetUid,
           time: this._formatTime(new Date()),
           file_name: this._formatFileName(videoInfo),
-          deep_link: this._buildDeepLink(videoInfo),
+          deep_link: this._buildDeepLink(videoInfo, marker.id),
           comment: marker.text,
           target_comment: ''
         };
@@ -138,7 +138,7 @@ export class SlackNotifier {
           target_name: targetUid,
           time: this._formatTime(new Date()),
           file_name: this._formatFileName(videoInfo),
-          deep_link: this._buildDeepLink(videoInfo),
+          deep_link: this._buildDeepLink(videoInfo, marker.id),
           comment: reply.text,
           target_comment: marker.text
         };
@@ -204,13 +204,17 @@ export class SlackNotifier {
    * 딥링크 생성 (Slack 버튼 URL은 https만 허용)
    * 웹 뷰어 URL에 baeframe:// 경로를 hash로 인코딩
    */
-  _buildDeepLink(videoInfo) {
-    if (!videoInfo) return 'https://baeframe.vercel.app';
+  _buildDeepLink(videoInfo, markerId) {
+    if (!videoInfo) return '';
     // .bframe 경로 우선 사용 (댓글/리뷰 데이터 포함)
     const targetPath = videoInfo.bframePath || videoInfo.filePath;
-    if (!targetPath) return 'https://baeframe.vercel.app';
-    const baeframeUrl = `baeframe://${targetPath}`;
-    return `https://baeframe.vercel.app/open.html#open=${encodeURIComponent(baeframeUrl)}`;
+    if (!targetPath) return '';
+    // baeframe:// 직접 사용 (Slack 메시지 본문에서 클릭 가능)
+    let url = `baeframe://${targetPath}`;
+    if (markerId) {
+      url += `?comment=${encodeURIComponent(markerId)}`;
+    }
+    return url;
   }
 
   /**

--- a/renderer/scripts/modules/team-members.js
+++ b/renderer/scripts/modules/team-members.js
@@ -1,0 +1,55 @@
+/**
+ * baeframe - Team Members Module
+ * 팀 멤버 이름 ↔ Slack UID 매핑
+ */
+
+export const TEAM_MEMBERS = [
+  { name: '정영준', slackUid: 'U03LTQAAFSB' },
+  { name: '장삐쭈', slackUid: 'U03MM2C4F4Z' },
+  { name: '허혜원', slackUid: 'U03M1Q37LDU' },
+  { name: '지정민', slackUid: 'U03MAQGMEN8' },
+  { name: '안류천', slackUid: 'U03MAQH93BN' },
+  { name: '강선영', slackUid: 'U03M8AVUC1H' },
+  { name: '박정인', slackUid: 'U03M8AWB49Z' },
+  { name: '윤성원', slackUid: 'U03H7Q88E1M' },
+  { name: '원동우', slackUid: 'U03MM2B1W73' },
+  { name: '이혜민', slackUid: 'U03PN339U4E' },
+  { name: '배한솔', slackUid: 'U05DFV9UAN5' },
+  { name: '이다은', slackUid: 'U068C1BKPRT' },
+  { name: '장재영', slackUid: 'U0760LKJ5D4' },
+  { name: '김어진', slackUid: 'U090WLY7XLH' },
+  { name: '안지상', slackUid: 'U096RV2BLH4' },
+  { name: '류이레', slackUid: 'U0978NUD5L7' },
+  { name: '류성철', slackUid: 'U0A7KTD4Z4G' },
+  { name: '이승은', slackUid: 'U0A9FPUH3BQ' }
+];
+
+/**
+ * 이름으로 팀 멤버 찾기
+ * @param {string} name - 찾을 이름
+ * @returns {object|null} { name, slackUid } 또는 null
+ */
+export function findMemberByName(name) {
+  if (!name) return null;
+  return TEAM_MEMBERS.find(m => m.name === name) || null;
+}
+
+/**
+ * 이름으로 Slack UID 조회
+ * @param {string} name - 이름
+ * @returns {string|null} Slack UID 또는 null
+ */
+export function getSlackUidByName(name) {
+  const member = findMemberByName(name);
+  return member ? member.slackUid : null;
+}
+
+/**
+ * Slack UID로 팀 멤버 찾기
+ * @param {string} uid - Slack UID
+ * @returns {object|null} { name, slackUid } 또는 null
+ */
+export function findMemberBySlackUid(uid) {
+  if (!uid) return null;
+  return TEAM_MEMBERS.find(m => m.slackUid === uid) || null;
+}

--- a/renderer/scripts/modules/team-members.js
+++ b/renderer/scripts/modules/team-members.js
@@ -4,24 +4,24 @@
  */
 
 export const TEAM_MEMBERS = [
-  { name: '정영준', slackUid: 'U03LTQAAFSB' },
-  { name: '장삐쭈', slackUid: 'U03MM2C4F4Z' },
-  { name: '허혜원', slackUid: 'U03M1Q37LDU' },
-  { name: '지정민', slackUid: 'U03MAQGMEN8' },
-  { name: '안류천', slackUid: 'U03MAQH93BN' },
-  { name: '강선영', slackUid: 'U03M8AVUC1H' },
-  { name: '박정인', slackUid: 'U03M8AWB49Z' },
-  { name: '윤성원', slackUid: 'U03H7Q88E1M' },
-  { name: '원동우', slackUid: 'U03MM2B1W73' },
-  { name: '이혜민', slackUid: 'U03PN339U4E' },
-  { name: '배한솔', slackUid: 'U05DFV9UAN5' },
-  { name: '이다은', slackUid: 'U068C1BKPRT' },
-  { name: '장재영', slackUid: 'U0760LKJ5D4' },
-  { name: '김어진', slackUid: 'U090WLY7XLH' },
-  { name: '안지상', slackUid: 'U096RV2BLH4' },
-  { name: '류이레', slackUid: 'U0978NUD5L7' },
-  { name: '류성철', slackUid: 'U0A7KTD4Z4G' },
-  { name: '이승은', slackUid: 'U0A9FPUH3BQ' }
+  { name: '정영준', slackUid: 'U03LTQAAFSB', aliases: ['영준'] },
+  { name: '장삐쭈', slackUid: 'U03MM2C4F4Z', aliases: ['삐쭈'] },
+  { name: '허혜원', slackUid: 'U03M1Q37LDU', aliases: ['혜원', '모몽가'] },
+  { name: '지정민', slackUid: 'U03MAQGMEN8', aliases: ['정민'] },
+  { name: '안류천', slackUid: 'U03MAQH93BN', aliases: ['류천'] },
+  { name: '강선영', slackUid: 'U03M8AVUC1H', aliases: ['선영'] },
+  { name: '박정인', slackUid: 'U03M8AWB49Z', aliases: ['정인'] },
+  { name: '윤성원', slackUid: 'U03H7Q88E1M', aliases: ['성원', 'SW', 'sw'] },
+  { name: '원동우', slackUid: 'U03MM2B1W73', aliases: ['동우'] },
+  { name: '이혜민', slackUid: 'U03PN339U4E', aliases: ['혜민'] },
+  { name: '배한솔', slackUid: 'U05DFV9UAN5', aliases: ['한솔', '한솔쿤'] },
+  { name: '이다은', slackUid: 'U068C1BKPRT', aliases: ['다은'] },
+  { name: '장재영', slackUid: 'U0760LKJ5D4', aliases: ['재영'] },
+  { name: '김어진', slackUid: 'U090WLY7XLH', aliases: ['어진'] },
+  { name: '안지상', slackUid: 'U096RV2BLH4', aliases: ['지상'] },
+  { name: '류이레', slackUid: 'U0978NUD5L7', aliases: ['이레'] },
+  { name: '류성철', slackUid: 'U0A7KTD4Z4G', aliases: ['성철'] },
+  { name: '이승은', slackUid: 'U0A9FPUH3BQ', aliases: ['승은'] }
 ];
 
 /**
@@ -31,7 +31,12 @@ export const TEAM_MEMBERS = [
  */
 export function findMemberByName(name) {
   if (!name) return null;
-  return TEAM_MEMBERS.find(m => m.name === name) || null;
+  const trimmed = name.trim();
+  // 정확한 이름 매칭 우선
+  const exact = TEAM_MEMBERS.find(m => m.name === trimmed);
+  if (exact) return exact;
+  // 별명(aliases) 매칭
+  return TEAM_MEMBERS.find(m => m.aliases && m.aliases.some(a => a === trimmed)) || null;
 }
 
 /**

--- a/renderer/scripts/modules/user-settings.js
+++ b/renderer/scripts/modules/user-settings.js
@@ -34,6 +34,7 @@ const DEFAULT_SHORTCUTS = {
   setOutPoint: { key: 'KeyO', ctrl: false, shift: false, alt: false, label: '종료점 설정' },
   toggleLoop: { key: 'KeyL', ctrl: false, shift: false, alt: false, label: '구간 반복 토글' },
   clearLoop: { key: 'KeyL', ctrl: false, shift: true, alt: false, label: '구간 반복 해제' },
+  addHighlight: { key: 'KeyH', ctrl: false, shift: false, alt: false, label: '하이라이트 추가' },
 
   // 실행취소
   undo: { key: 'KeyZ', ctrl: true, shift: false, alt: false, label: '실행취소' },

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -4650,9 +4650,7 @@ body.app-fullscreen .video-comment-overlay-controls {
   line-height: 1.4;
   box-shadow:
     0 8px 40px rgba(0, 0, 0, 0.45),
-    0 2px 8px rgba(0, 0, 0, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  overflow: hidden;
+    0 2px 8px rgba(0, 0, 0, 0.25);
   cursor: grab;
   user-select: none;
   transition:
@@ -4662,6 +4660,8 @@ body.app-fullscreen .video-comment-overlay-controls {
     scale 0.4s cubic-bezier(0.22, 1, 0.36, 1);
   margin-bottom: 8px;
   will-change: transform, opacity;
+  /* 진행률 바가 border-radius를 넘지 않도록 격리 */
+  isolation: isolate;
 }
 
 .toast:active {
@@ -4755,7 +4755,7 @@ body.app-fullscreen .video-comment-overlay-controls {
   left: 0;
   height: 2px;
   background: var(--text-tertiary);
-  border-radius: 0 0 0 12px;
+  border-radius: 0 0 12px 12px;
   opacity: 0.4;
   transition: opacity 0.15s;
 }
@@ -4790,12 +4790,22 @@ body.app-fullscreen .video-comment-overlay-controls {
 .toast.toast-exit {
   animation: toastSlideOut 0.35s cubic-bezier(0.55, 0, 1, 0.45) forwards;
   pointer-events: none;
+  margin-bottom: 0;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-width: 0;
+  transition:
+    margin-bottom 0.35s cubic-bezier(0.55, 0, 1, 0.45),
+    max-height 0.35s cubic-bezier(0.55, 0, 1, 0.45),
+    padding 0.35s cubic-bezier(0.55, 0, 1, 0.45),
+    border-width 0.35s cubic-bezier(0.55, 0, 1, 0.45);
 }
 
 @keyframes toastSlideOut {
   from {
     opacity: 1;
-    transform: translateX(0) scale(1);
+    transform: scale(1);
   }
   to {
     opacity: 0;
@@ -4807,6 +4817,16 @@ body.app-fullscreen .video-comment-overlay-controls {
 .toast.toast-swipe-exit {
   animation: toastSwipeOut 0.3s cubic-bezier(0.55, 0, 1, 0.45) forwards;
   pointer-events: none;
+  margin-bottom: 0;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-width: 0;
+  transition:
+    margin-bottom 0.3s cubic-bezier(0.55, 0, 1, 0.45),
+    max-height 0.3s cubic-bezier(0.55, 0, 1, 0.45),
+    padding 0.3s cubic-bezier(0.55, 0, 1, 0.45),
+    border-width 0.3s cubic-bezier(0.55, 0, 1, 0.45);
 }
 
 @keyframes toastSwipeOut {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -3998,16 +3998,19 @@ body.app-fullscreen .video-comment-overlay-controls {
 
 /* Slack 딥링크 코멘트 포커싱 하이라이트 */
 .comment-item.focus-highlight {
-  animation: focusPulse 1.5s ease-in-out 2;
-  border-color: var(--accent-primary);
+  animation: focusPulse 1s ease-in-out 3;
+  border-color: #4a9eff;
+  background: rgba(74, 158, 255, 0.08);
 }
 
 @keyframes focusPulse {
   0%, 100% {
     box-shadow: 0 0 0 0 transparent;
+    border-color: #4a9eff;
   }
   50% {
-    box-shadow: 0 0 12px var(--accent-primary), 0 0 24px rgba(var(--accent-primary-rgb, 74, 158, 255), 0.3);
+    box-shadow: 0 0 12px #4a9eff, 0 0 28px rgba(74, 158, 255, 0.4);
+    border-color: #6db3ff;
   }
 }
 

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -10160,3 +10160,169 @@ body.audio-mode .frame-indicator {
   font-size: 11px;
   color: var(--text-tertiary);
 }
+
+/* ==========================================
+   @멘션 자동완성 드롭다운
+   ========================================== */
+.mention-dropdown {
+  position: fixed;
+  z-index: 10000;
+  background: var(--bg-secondary, #2a2a2a);
+  border: 1px solid var(--border-primary, #444);
+  border-radius: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+  min-width: 160px;
+  max-width: 220px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.mention-item {
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-primary, #eee);
+  transition: background 0.1s;
+}
+
+.mention-item:hover,
+.mention-item.active {
+  background: var(--accent-primary, #ffd000);
+  color: var(--bg-primary, #1a1a1a);
+}
+
+.mention-item-name {
+  font-weight: 500;
+}
+
+/* ==========================================
+   G:/ 드라이브 경로 링크 버튼
+   ========================================== */
+.gdrive-link-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  margin: 0 2px;
+  background: rgba(255, 208, 0, 0.15);
+  border: 1px solid rgba(255, 208, 0, 0.3);
+  border-radius: 4px;
+  color: var(--accent-primary, #ffd000);
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  word-break: break-all;
+  line-height: 1.4;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.gdrive-link-btn:hover {
+  background: rgba(255, 208, 0, 0.25);
+  border-color: rgba(255, 208, 0, 0.5);
+}
+
+.gdrive-link-btn svg {
+  flex-shrink: 0;
+}
+
+/* ==========================================
+   단축키 설정 패널
+   ========================================== */
+.shortcut-actions {
+  margin-bottom: 12px;
+}
+
+.shortcut-list {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.shortcut-category {
+  margin-bottom: 16px;
+}
+
+.shortcut-category-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary, #999);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 0 0 6px 0;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border-primary, #333);
+}
+
+.shortcut-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 0;
+  gap: 8px;
+}
+
+.shortcut-row.custom .shortcut-label {
+  color: var(--accent-primary, #ffd000);
+}
+
+.shortcut-label {
+  font-size: 13px;
+  color: var(--text-primary, #eee);
+  flex: 1;
+  min-width: 0;
+}
+
+.shortcut-key-area {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.shortcut-key-btn {
+  background: var(--bg-tertiary, #333);
+  border: 1px solid var(--border-primary, #444);
+  border-radius: 4px;
+  color: var(--text-primary, #eee);
+  font-size: 12px;
+  font-family: monospace;
+  padding: 3px 8px;
+  cursor: pointer;
+  min-width: 60px;
+  text-align: center;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.shortcut-key-btn:hover {
+  background: var(--bg-hover, #444);
+  border-color: var(--accent-primary, #ffd000);
+}
+
+.shortcut-key-btn.capturing {
+  background: var(--accent-primary, #ffd000);
+  color: var(--bg-primary, #1a1a1a);
+  border-color: var(--accent-primary, #ffd000);
+  font-family: inherit;
+  font-weight: 600;
+  animation: pulse-capture 1s ease-in-out infinite;
+}
+
+@keyframes pulse-capture {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+.shortcut-reset-btn {
+  background: none;
+  border: 1px solid var(--border-primary, #444);
+  border-radius: 4px;
+  color: var(--text-secondary, #999);
+  font-size: 14px;
+  padding: 2px 6px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.shortcut-reset-btn:hover {
+  color: var(--accent-primary, #ffd000);
+  border-color: var(--accent-primary, #ffd000);
+}

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -3984,7 +3984,7 @@ body.app-fullscreen .video-comment-overlay-controls {
 }
 
 .comment-item.glow {
-  animation: commentGlow 1.5s ease-out;
+  animation: commentGlow 2.5s ease-out;
 }
 
 @keyframes commentGlow {
@@ -4678,7 +4678,8 @@ body.app-fullscreen .video-comment-overlay-controls {
     scale 0.4s cubic-bezier(0.22, 1, 0.36, 1);
   margin-bottom: 8px;
   will-change: transform, opacity;
-  /* 진행률 바가 border-radius를 넘지 않도록 격리 */
+  /* 진행률 바가 border-radius를 넘지 않도록 */
+  overflow: hidden;
   isolation: isolate;
 }
 
@@ -4772,6 +4773,7 @@ body.app-fullscreen .video-comment-overlay-controls {
   bottom: 0;
   left: 0;
   height: 2px;
+  max-width: 100%;
   background: var(--text-tertiary);
   border-radius: 0 0 12px 12px;
   opacity: 0.4;
@@ -4806,51 +4808,67 @@ body.app-fullscreen .video-comment-overlay-controls {
 
 /* 퇴장 애니메이션 */
 .toast.toast-exit {
-  animation: toastSlideOut 0.35s cubic-bezier(0.55, 0, 1, 0.45) forwards;
+  animation: toastFadeCollapse 0.4s cubic-bezier(0.55, 0, 1, 0.45) forwards;
   pointer-events: none;
-  margin-bottom: 0;
-  max-height: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-width: 0;
-  transition:
-    margin-bottom 0.35s cubic-bezier(0.55, 0, 1, 0.45),
-    max-height 0.35s cubic-bezier(0.55, 0, 1, 0.45),
-    padding 0.35s cubic-bezier(0.55, 0, 1, 0.45),
-    border-width 0.35s cubic-bezier(0.55, 0, 1, 0.45);
 }
 
-@keyframes toastSlideOut {
-  from {
+@keyframes toastFadeCollapse {
+  0% {
     opacity: 1;
     transform: scale(1);
+    max-height: 80px;
+    margin-bottom: 8px;
+    padding-top: 14px;
+    padding-bottom: 14px;
   }
-  to {
+  50% {
     opacity: 0;
     transform: translateY(-8px) scale(0.96);
+    max-height: 80px;
+    margin-bottom: 8px;
+    padding-top: 14px;
+    padding-bottom: 14px;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.96);
+    max-height: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    border-width: 0;
   }
 }
 
 /* 스와이프 퇴장 */
 .toast.toast-swipe-exit {
-  animation: toastSwipeOut 0.3s cubic-bezier(0.55, 0, 1, 0.45) forwards;
+  animation: toastSwipeCollapse 0.4s cubic-bezier(0.55, 0, 1, 0.45) forwards;
   pointer-events: none;
-  margin-bottom: 0;
-  max-height: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-width: 0;
-  transition:
-    margin-bottom 0.3s cubic-bezier(0.55, 0, 1, 0.45),
-    max-height 0.3s cubic-bezier(0.55, 0, 1, 0.45),
-    padding 0.3s cubic-bezier(0.55, 0, 1, 0.45),
-    border-width 0.3s cubic-bezier(0.55, 0, 1, 0.45);
 }
 
-@keyframes toastSwipeOut {
-  to {
+@keyframes toastSwipeCollapse {
+  0% {
+    opacity: 1;
+    transform: translateX(0);
+    max-height: 80px;
+    margin-bottom: 8px;
+    padding-top: 14px;
+    padding-bottom: 14px;
+  }
+  50% {
     opacity: 0;
     transform: translateX(var(--swipe-dir, 100%));
+    max-height: 80px;
+    margin-bottom: 8px;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(var(--swipe-dir, 100%));
+    max-height: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    border-width: 0;
   }
 }
 

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -3996,6 +3996,21 @@ body.app-fullscreen .video-comment-overlay-controls {
   }
 }
 
+/* Slack 딥링크 코멘트 포커싱 하이라이트 */
+.comment-item.focus-highlight {
+  animation: focusPulse 1.5s ease-in-out 2;
+  border-color: var(--accent-primary);
+}
+
+@keyframes focusPulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+  50% {
+    box-shadow: 0 0 12px var(--accent-primary), 0 0 24px rgba(var(--accent-primary-rgb, 74, 158, 255), 0.3);
+  }
+}
+
 /* 컴팩트 뷰 */
 .comments-list.compact .comment-item {
   padding: 8px 12px;

--- a/web-viewer/open.html
+++ b/web-viewer/open.html
@@ -305,56 +305,9 @@
       }, 1500);
     }
 
-    // Slack 웹훅 딥링크 처리: #open=baeframe://... 형식
-    function handleSlackDeepLink() {
-      const hash = window.location.hash;
-      if (!hash || !hash.startsWith('#open=')) return false;
-
-      // hash에서 가져온 인코딩된 원본 유지 (브라우저 호환성)
-      const rawEncoded = hash.substring(6); // baeframe%3A%2F%2F...
-      const baeframeUrl = decodeURIComponent(rawEncoded);
-      if (!baeframeUrl.startsWith('baeframe://')) return false;
-
-      // 재시도 버튼용으로 원본 URL 저장
-      slackDeepLinkUrl = baeframeUrl;
-
-      // 디코딩된 URL에서 파일명 추출 (표시용)
-      const displayName = baeframeUrl.replace('baeframe://', '').split('?')[0].split(/[/\\]/).pop();
-
-      // href용: 경로 부분을 인코딩된 상태로 유지
-      // baeframe:// 프로토콜 + 인코딩된 경로
-      const pathPart = baeframeUrl.substring('baeframe://'.length);
-      const encodedHref = 'baeframe://' + encodeURI(pathPart).replace(/%5C/gi, '\\');
-
-      // 브라우저가 HTTPS→커스텀 프로토콜 이동을 차단하므로 복사 방식 사용
-      statusText.textContent = '아래 버튼으로 링크를 복사하세요';
-      statusDetail.textContent = displayName;
-
-      buttons.classList.remove('hidden');
-      btnOpenApp.href = '#';
-      btnOpenApp.textContent = '📋 링크 복사';
-      btnOpenApp.onclick = (e) => {
-        e.preventDefault();
-        navigator.clipboard.writeText(baeframeUrl).then(() => {
-          btnOpenApp.textContent = '✅ 복사됨! 주소창에 붙여넣기 (Ctrl+L → Ctrl+V → Enter)';
-          btnOpenApp.classList.add('copied');
-          setTimeout(() => {
-            btnOpenApp.textContent = '📋 다시 복사';
-            btnOpenApp.classList.remove('copied');
-          }, 5000);
-        });
-      };
-      btnOpenWeb.classList.add('hidden');
-
-      return true;
-    }
-
     // 메인 로직
     function main() {
       showPlatform();
-
-      // Slack 딥링크 처리 (#open=baeframe://...)
-      if (handleSlackDeepLink()) return;
 
       if (!validateUrls()) {
         return;
@@ -373,16 +326,8 @@
       }
     }
 
-    // Slack 딥링크 원본 URL 저장
-    let slackDeepLinkUrl = null;
-
     // 버튼 클릭 이벤트
     btnOpenApp.addEventListener('click', (e) => {
-      if (slackDeepLinkUrl) {
-        // Slack 딥링크: href에 baeframe:// 설정되어 있으므로 기본 동작 허용
-        // e.preventDefault() 호출하지 않음 → 브라우저가 프로토콜 핸들러 실행
-        return;
-      }
       e.preventDefault();
       window.location.href = getAppUrl();
     });

--- a/web-viewer/open.html
+++ b/web-viewer/open.html
@@ -305,9 +305,41 @@
       }, 1500);
     }
 
+    // Slack 웹훅 딥링크 처리: #open=baeframe://... 형식
+    function handleSlackDeepLink() {
+      const hash = window.location.hash;
+      if (!hash || !hash.startsWith('#open=')) return false;
+
+      const baeframeUrl = decodeURIComponent(hash.substring(6));
+      if (!baeframeUrl.startsWith('baeframe://')) return false;
+
+      statusText.textContent = 'BAEFRAME 앱 열기...';
+      statusDetail.textContent = baeframeUrl.replace('baeframe://', '');
+
+      // baeframe:// 프로토콜로 앱 열기 시도
+      window.location.href = baeframeUrl;
+
+      // 2초 후에도 페이지가 보이면 앱이 설치 안 된 상태
+      setTimeout(() => {
+        if (!document.hidden) {
+          statusText.textContent = 'BAEFRAME 앱을 찾을 수 없습니다';
+          statusDetail.textContent = '앱이 설치되어 있는지 확인해주세요';
+          buttons.classList.remove('hidden');
+          btnOpenApp.href = baeframeUrl;
+          btnOpenApp.textContent = '🖥️ 다시 시도';
+          btnOpenWeb.classList.add('hidden');
+        }
+      }, 2000);
+
+      return true;
+    }
+
     // 메인 로직
     function main() {
       showPlatform();
+
+      // Slack 딥링크 처리 (#open=baeframe://...)
+      if (handleSlackDeepLink()) return;
 
       if (!validateUrls()) {
         return;

--- a/web-viewer/open.html
+++ b/web-viewer/open.html
@@ -313,6 +313,9 @@
       const baeframeUrl = decodeURIComponent(hash.substring(6));
       if (!baeframeUrl.startsWith('baeframe://')) return false;
 
+      // 재시도 버튼용으로 원본 URL 저장
+      slackDeepLinkUrl = baeframeUrl;
+
       statusText.textContent = 'BAEFRAME 앱 열기...';
       statusDetail.textContent = baeframeUrl.replace('baeframe://', '');
 
@@ -358,10 +361,14 @@
       }
     }
 
+    // Slack 딥링크 원본 URL 저장
+    let slackDeepLinkUrl = null;
+
     // 버튼 클릭 이벤트
     btnOpenApp.addEventListener('click', (e) => {
       e.preventDefault();
-      window.location.href = getAppUrl();
+      // Slack 딥링크 모드면 원본 URL로 재시도, 아니면 웹 뷰어용 URL
+      window.location.href = slackDeepLinkUrl || getAppUrl();
     });
 
     btnOpenWeb.addEventListener('click', (e) => {

--- a/web-viewer/open.html
+++ b/web-viewer/open.html
@@ -310,29 +310,41 @@
       const hash = window.location.hash;
       if (!hash || !hash.startsWith('#open=')) return false;
 
-      const baeframeUrl = decodeURIComponent(hash.substring(6));
+      // hash에서 가져온 인코딩된 원본 유지 (브라우저 호환성)
+      const rawEncoded = hash.substring(6); // baeframe%3A%2F%2F...
+      const baeframeUrl = decodeURIComponent(rawEncoded);
       if (!baeframeUrl.startsWith('baeframe://')) return false;
 
       // 재시도 버튼용으로 원본 URL 저장
       slackDeepLinkUrl = baeframeUrl;
 
-      statusText.textContent = 'BAEFRAME 앱 열기...';
-      statusDetail.textContent = baeframeUrl.replace('baeframe://', '');
+      // 디코딩된 URL에서 파일명 추출 (표시용)
+      const displayName = baeframeUrl.replace('baeframe://', '').split('?')[0].split(/[/\\]/).pop();
 
-      // baeframe:// 프로토콜로 앱 열기 시도
-      window.location.href = baeframeUrl;
+      // href용: 경로 부분을 인코딩된 상태로 유지
+      // baeframe:// 프로토콜 + 인코딩된 경로
+      const pathPart = baeframeUrl.substring('baeframe://'.length);
+      const encodedHref = 'baeframe://' + encodeURI(pathPart).replace(/%5C/gi, '\\');
 
-      // 2초 후에도 페이지가 보이면 앱이 설치 안 된 상태
-      setTimeout(() => {
-        if (!document.hidden) {
-          statusText.textContent = 'BAEFRAME 앱을 찾을 수 없습니다';
-          statusDetail.textContent = '앱이 설치되어 있는지 확인해주세요';
-          buttons.classList.remove('hidden');
-          btnOpenApp.href = baeframeUrl;
-          btnOpenApp.textContent = '🖥️ 다시 시도';
-          btnOpenWeb.classList.add('hidden');
-        }
-      }, 2000);
+      // 브라우저가 HTTPS→커스텀 프로토콜 이동을 차단하므로 복사 방식 사용
+      statusText.textContent = '아래 버튼으로 링크를 복사하세요';
+      statusDetail.textContent = displayName;
+
+      buttons.classList.remove('hidden');
+      btnOpenApp.href = '#';
+      btnOpenApp.textContent = '📋 링크 복사';
+      btnOpenApp.onclick = (e) => {
+        e.preventDefault();
+        navigator.clipboard.writeText(baeframeUrl).then(() => {
+          btnOpenApp.textContent = '✅ 복사됨! 주소창에 붙여넣기 (Ctrl+L → Ctrl+V → Enter)';
+          btnOpenApp.classList.add('copied');
+          setTimeout(() => {
+            btnOpenApp.textContent = '📋 다시 복사';
+            btnOpenApp.classList.remove('copied');
+          }, 5000);
+        });
+      };
+      btnOpenWeb.classList.add('hidden');
 
       return true;
     }
@@ -366,9 +378,13 @@
 
     // 버튼 클릭 이벤트
     btnOpenApp.addEventListener('click', (e) => {
+      if (slackDeepLinkUrl) {
+        // Slack 딥링크: href에 baeframe:// 설정되어 있으므로 기본 동작 허용
+        // e.preventDefault() 호출하지 않음 → 브라우저가 프로토콜 핸들러 실행
+        return;
+      }
       e.preventDefault();
-      // Slack 딥링크 모드면 원본 URL로 재시도, 아니면 웹 뷰어용 URL
-      window.location.href = slackDeepLinkUrl || getAppUrl();
+      window.location.href = getAppUrl();
     });
 
     btnOpenWeb.addEventListener('click', (e) => {


### PR DESCRIPTION
## 요약

- Slack 워크플로 웹훅으로 @멘션/답글 시 자동 알림 전송
- 댓글 입력 시 @멘션 자동완성 드롭다운 (20명 팀원)
- 댓글 내 G:/ 경로 감지 → 파일탐색기 열기 버튼
- 앱 설정에 단축키 커스터마이즈 탭 추가 (50개+ 단축키)
- KeyI/KeyO/KeyL/KeyH 수정자 키 체크 누락 수정
- web-viewer/open.html에 Slack 딥링크 리다이렉트 추가

## 새 파일
- `renderer/scripts/modules/team-members.js` — 이름↔Slack UID 매핑
- `renderer/scripts/modules/mention-manager.js` — @멘션 자동완성
- `renderer/scripts/modules/slack-notifier.js` — Slack 웹훅 알림

## 수정 파일
- `renderer/scripts/app.js` — 통합 (멘션/웹훅/G링크/단축키)
- `renderer/index.html` — 단축키 설정 탭 추가
- `renderer/styles/main.css` — 멘션/G링크/단축키 스타일
- `main/ipc-handlers.js` — Slack 웹훅 IPC 핸들러
- `preload/preload.js` — sendSlackWebhook API 노출
- `web-viewer/open.html` — Slack 딥링크 → baeframe:// 리다이렉트

## 테스트
- [x] Slack 웹훅 전송 성공 확인
- [x] @멘션 드롭다운 동작 확인
- [ ] Vercel 배포 후 딥링크 리다이렉트 확인
- [ ] G:/ 경로 버튼 클릭 → 탐색기 열림
- [ ] 단축키 변경 → 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)