### PR TITLE
댓글 UX 개선: 경로 링크 공백 허용, 자동 따옴표, 확장 유지, 필터 솔로 모드

### DIFF
--- a/docs/superpowers/mockups/filter-mockup.html
+++ b/docs/superpowers/mockups/filter-mockup.html
@@ -1,0 +1,414 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>사용자 필터 드롭다운 - 시안</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #1a1a2e;
+    color: #e0e0e0;
+    font-family: 'Segoe UI', -apple-system, sans-serif;
+    display: flex;
+    justify-content: center;
+    padding: 40px 20px;
+    min-height: 100vh;
+  }
+
+  .demo-container {
+    display: flex;
+    gap: 60px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .demo-section {
+    width: 320px;
+  }
+
+  .demo-section h2 {
+    font-size: 13px;
+    color: #888;
+    margin-bottom: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+
+  .demo-section .label {
+    font-size: 11px;
+    color: #666;
+    margin-top: 8px;
+    margin-bottom: 16px;
+    line-height: 1.5;
+  }
+
+  /* Filter dropdown styles - matching BAEFRAME's glassmorphism */
+  .filter-dropdown-wrapper {
+    position: relative;
+    display: inline-block;
+  }
+
+  .filter-chip {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 8px;
+    background: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 6px;
+    color: #ccc;
+    cursor: pointer;
+    font-size: 12px;
+    transition: all 0.15s;
+  }
+
+  .filter-chip:hover {
+    background: rgba(255,255,255,0.1);
+    color: #fff;
+  }
+
+  .filter-chip.active {
+    background: rgba(100, 180, 255, 0.15);
+    border-color: rgba(100, 180, 255, 0.3);
+    color: #8cc8ff;
+  }
+
+  .filter-dropdown-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    min-width: 220px;
+    background: rgba(30, 30, 50, 0.95);
+    backdrop-filter: blur(20px);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 8px;
+    padding: 4px;
+    z-index: 100;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+  }
+
+  .filter-dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 12px;
+    transition: background 0.1s;
+    user-select: none;
+  }
+
+  .filter-dropdown-item:hover {
+    background: rgba(255,255,255,0.08);
+  }
+
+  .filter-dropdown-check {
+    width: 14px;
+    height: 14px;
+    border: 1.5px solid rgba(255,255,255,0.25);
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: all 0.15s;
+  }
+
+  .filter-dropdown-check.checked {
+    background: #5b9cf6;
+    border-color: #5b9cf6;
+  }
+
+  .filter-dropdown-check svg {
+    display: none;
+  }
+
+  .filter-dropdown-check.checked svg {
+    display: block;
+  }
+
+  .filter-dropdown-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .filter-dropdown-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .filter-dropdown-name:hover {
+    text-decoration: underline;
+  }
+
+  .filter-dropdown-badge {
+    font-size: 10px;
+    color: #666;
+    min-width: 18px;
+    text-align: right;
+  }
+
+  .filter-dropdown-divider {
+    height: 1px;
+    background: rgba(255,255,255,0.08);
+    margin: 4px 8px;
+  }
+
+  /* Solo indicator */
+  .solo-hint {
+    font-size: 9px;
+    color: #5b9cf6;
+    margin-left: 4px;
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  .filter-dropdown-item:hover .solo-hint {
+    opacity: 1;
+  }
+
+  /* Interaction hint */
+  .interaction-hint {
+    display: flex;
+    gap: 16px;
+    margin-top: 6px;
+    padding: 6px 8px;
+    font-size: 10px;
+    color: #555;
+    border-top: 1px solid rgba(255,255,255,0.05);
+  }
+
+  .interaction-hint span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  /* Arrow labels */
+  .arrow-label {
+    position: absolute;
+    font-size: 11px;
+    color: #f0a050;
+    white-space: nowrap;
+  }
+
+  .click-zone {
+    position: relative;
+  }
+
+  .zone-label {
+    position: absolute;
+    right: -120px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 10px;
+    color: #f0a050;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    white-space: nowrap;
+  }
+
+  .zone-label::before {
+    content: '←';
+  }
+</style>
+</head>
+<body>
+
+<div class="demo-container">
+
+  <!-- 현재 상태: 전체 선택 -->
+  <div class="demo-section">
+    <h2>기본 상태 (전체 선택)</h2>
+    <p class="label">모든 사용자 체크됨. 체크박스로 개별 토글, 이름 클릭으로 솔로 모드.</p>
+
+    <div class="filter-dropdown-wrapper">
+      <button class="filter-chip">
+        <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/>
+          <circle cx="12" cy="7" r="4"/>
+        </svg>
+        <svg viewBox="0 0 24 24" width="8" height="8" fill="none" stroke="currentColor" stroke-width="2.5">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </button>
+
+      <div class="filter-dropdown-menu">
+        <div class="filter-dropdown-item" style="position:relative">
+          <div class="filter-dropdown-check checked">
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="white" stroke-width="2"><polyline points="2 6 5 9 10 3"/></svg>
+          </div>
+          <div class="filter-dropdown-dot" style="background:#4fc3f7"></div>
+          <div class="filter-dropdown-name">배한솔</div>
+          <span class="solo-hint">솔로</span>
+          <div class="filter-dropdown-badge">12</div>
+          <div class="zone-label" style="right:-140px">이름 클릭 = 솔로</div>
+        </div>
+
+        <div class="filter-dropdown-item">
+          <div class="filter-dropdown-check checked">
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="white" stroke-width="2"><polyline points="2 6 5 9 10 3"/></svg>
+          </div>
+          <div class="filter-dropdown-dot" style="background:#f06292"></div>
+          <div class="filter-dropdown-name">김지은</div>
+          <span class="solo-hint">솔로</span>
+          <div class="filter-dropdown-badge">8</div>
+          <div class="zone-label" style="right:-140px">체크박스 = 토글</div>
+        </div>
+
+        <div class="filter-dropdown-item">
+          <div class="filter-dropdown-check checked">
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="white" stroke-width="2"><polyline points="2 6 5 9 10 3"/></svg>
+          </div>
+          <div class="filter-dropdown-dot" style="background:#aed581"></div>
+          <div class="filter-dropdown-name">이정민</div>
+          <span class="solo-hint">솔로</span>
+          <div class="filter-dropdown-badge">5</div>
+        </div>
+
+        <div class="filter-dropdown-divider"></div>
+
+        <div class="filter-dropdown-item">
+          <div class="filter-dropdown-check checked">
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="white" stroke-width="2"><polyline points="2 6 5 9 10 3"/></svg>
+          </div>
+          <div class="filter-dropdown-name" style="color:#999">전체 선택</div>
+        </div>
+
+        <div class="interaction-hint">
+          <span>☑ 체크박스 = 토글</span>
+          <span>👤 이름 = 솔로</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 솔로 모드 -->
+  <div class="demo-section">
+    <h2>솔로 모드 (이름 클릭 후)</h2>
+    <p class="label">"배한솔" 이름을 클릭 → 배한솔만 체크. 다시 이름 클릭 → 전체 복원.</p>
+
+    <div class="filter-dropdown-wrapper">
+      <button class="filter-chip active">
+        <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/>
+          <circle cx="12" cy="7" r="4"/>
+        </svg>
+        <svg viewBox="0 0 24 24" width="8" height="8" fill="none" stroke="currentColor" stroke-width="2.5">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </button>
+
+      <div class="filter-dropdown-menu">
+        <div class="filter-dropdown-item" style="background:rgba(91,156,246,0.1)">
+          <div class="filter-dropdown-check checked">
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="white" stroke-width="2"><polyline points="2 6 5 9 10 3"/></svg>
+          </div>
+          <div class="filter-dropdown-dot" style="background:#4fc3f7"></div>
+          <div class="filter-dropdown-name" style="color:#8cc8ff; font-weight:600">배한솔</div>
+          <span class="solo-hint" style="opacity:1">솔로</span>
+          <div class="filter-dropdown-badge" style="color:#8cc8ff">12</div>
+        </div>
+
+        <div class="filter-dropdown-item" style="opacity:0.5">
+          <div class="filter-dropdown-check"></div>
+          <div class="filter-dropdown-dot" style="background:#f06292"></div>
+          <div class="filter-dropdown-name">김지은</div>
+          <div class="filter-dropdown-badge">8</div>
+        </div>
+
+        <div class="filter-dropdown-item" style="opacity:0.5">
+          <div class="filter-dropdown-check"></div>
+          <div class="filter-dropdown-dot" style="background:#aed581"></div>
+          <div class="filter-dropdown-name">이정민</div>
+          <div class="filter-dropdown-badge">5</div>
+        </div>
+
+        <div class="filter-dropdown-divider"></div>
+
+        <div class="filter-dropdown-item">
+          <div class="filter-dropdown-check">
+          </div>
+          <div class="filter-dropdown-name" style="color:#999">전체 선택</div>
+        </div>
+
+        <div class="interaction-hint">
+          <span>☑ 체크박스 = 토글</span>
+          <span>👤 이름 = 솔로</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 개별 토글 모드 -->
+  <div class="demo-section">
+    <h2>개별 토글 (체크박스 클릭)</h2>
+    <p class="label">체크박스를 클릭하여 여러 명을 조합. 드롭다운은 닫히지 않음.</p>
+
+    <div class="filter-dropdown-wrapper">
+      <button class="filter-chip active">
+        <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/>
+          <circle cx="12" cy="7" r="4"/>
+        </svg>
+        <svg viewBox="0 0 24 24" width="8" height="8" fill="none" stroke="currentColor" stroke-width="2.5">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </button>
+
+      <div class="filter-dropdown-menu">
+        <div class="filter-dropdown-item">
+          <div class="filter-dropdown-check checked">
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="white" stroke-width="2"><polyline points="2 6 5 9 10 3"/></svg>
+          </div>
+          <div class="filter-dropdown-dot" style="background:#4fc3f7"></div>
+          <div class="filter-dropdown-name">배한솔</div>
+          <span class="solo-hint">솔로</span>
+          <div class="filter-dropdown-badge">12</div>
+        </div>
+
+        <div class="filter-dropdown-item">
+          <div class="filter-dropdown-check"></div>
+          <div class="filter-dropdown-dot" style="background:#f06292"></div>
+          <div class="filter-dropdown-name">김지은</div>
+          <span class="solo-hint">솔로</span>
+          <div class="filter-dropdown-badge">8</div>
+        </div>
+
+        <div class="filter-dropdown-item">
+          <div class="filter-dropdown-check checked">
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="white" stroke-width="2"><polyline points="2 6 5 9 10 3"/></svg>
+          </div>
+          <div class="filter-dropdown-dot" style="background:#aed581"></div>
+          <div class="filter-dropdown-name">이정민</div>
+          <span class="solo-hint">솔로</span>
+          <div class="filter-dropdown-badge">5</div>
+        </div>
+
+        <div class="filter-dropdown-divider"></div>
+
+        <div class="filter-dropdown-item">
+          <div class="filter-dropdown-check">
+          </div>
+          <div class="filter-dropdown-name" style="color:#999">전체 선택</div>
+        </div>
+
+        <div class="interaction-hint">
+          <span>☑ 체크박스 = 토글</span>
+          <span>👤 이름 = 솔로</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/docs/superpowers/plans/2026-03-23-comment-ux-improvements.md
+++ b/docs/superpowers/plans/2026-03-23-comment-ux-improvements.md
@@ -1,0 +1,466 @@
+# 댓글 UX 개선 구현 계획
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 댓글 경로 링크 공백 허용, 붙여넣기 자동 따옴표, 답글 후 확장 유지, 사용자 필터 UX 개선
+
+**Architecture:** `renderer/scripts/app.js`의 4개 독립 영역을 수정. 경로 렌더링(regex), 입력 이벤트(paste), 댓글 목록 렌더링(확장 보존), 필터 드롭다운(솔로/토글 + overflow). CSS는 필터 관련 스타일만 추가.
+
+**Tech Stack:** Vanilla JS, CSS, Electron renderer process
+
+**Spec:** `docs/superpowers/specs/2026-03-23-comment-ux-improvements-design.md`
+
+---
+
+## Chunk 1: 경로 링크 공백 허용 + 붙여넣기 자동 따옴표
+
+### Task 1: Stage 2b regex 공백 허용
+
+**Files:**
+- Modify: `renderer/scripts/app.js:5438-5444`
+
+- [ ] **Step 1: Stage 2b regex 수정 — `\s`를 `\n\r`로 변경**
+
+`renderer/scripts/app.js:5440`에서 현재 regex:
+```javascript
+html = html.replace(/(G:[/\\](?:[^\s<"'&\x00]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi, (match) => {
+```
+
+수정:
+```javascript
+html = html.replace(/(G:[/\\](?:[^\n\r<"'&\x00]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi, (match) => {
+```
+
+- [ ] **Step 2: 매치 결과 trailing whitespace trim 추가**
+
+같은 콜백 내부에서 `match`를 trim 처리. `app.js:5440-5444`를 다음으로 교체:
+```javascript
+html = html.replace(/(G:[/\\](?:[^\n\r<"'&\x00]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi, (match) => {
+  if (match.includes('gdrive-link-btn')) return match;
+  const trimmed = match.replace(/\s+$/, '');
+  return makeBtn(trimmed, trimmed);
+});
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add renderer/scripts/app.js
+git commit -m "fix: 경로 링크 regex에서 공백 허용 (줄바꿈에서 끊기)"
+```
+
+---
+
+### Task 2: 붙여넣기 시 자동 따옴표 감싸기
+
+**Files:**
+- Modify: `renderer/scripts/app.js:1259-1266` (commentInput paste 핸들러)
+- Modify: `renderer/scripts/app.js:7789-7796` (threadEditor paste 핸들러)
+
+경로 감지 유틸 함수를 먼저 정의하고, 기존 paste 핸들러에 통합한다.
+
+- [ ] **Step 1: 경로 paste 처리 헬퍼 함수 작성**
+
+`renderGDriveLinks()` 함수 바로 위 (app.js:5410 부근)에 헬퍼 함수 추가:
+```javascript
+/**
+ * paste 이벤트에서 드라이브 경로를 감지하여 첫 줄에 따옴표를 감싸는 헬퍼.
+ * 이미지 paste가 아닌 텍스트 paste에서만 동작.
+ * @returns {boolean} 경로가 감지되어 처리된 경우 true
+ */
+function handleDrivePathPaste(e) {
+  // 이미지 데이터가 있으면 무시 (기존 이미지 paste 우선)
+  if (e.clipboardData?.files?.length > 0) return false;
+  if (e.clipboardData?.types?.includes('image/png')) return false;
+
+  const text = e.clipboardData?.getData('text');
+  if (!text) return false;
+
+  const trimmed = text.trim();
+  // 드라이브 경로 패턴: C:\ D:\ G:/ 등
+  if (!/^[A-Z]:[/\\]/i.test(trimmed)) return false;
+
+  // 이미 따옴표로 감싸져 있으면 무시
+  if (/^["']/.test(trimmed) && /["']$/.test(trimmed)) return false;
+
+  e.preventDefault();
+
+  const target = e.target;
+  const lines = text.split('\n');
+  // 첫 줄(경로)만 따옴표 감싸기, 나머지 줄은 그대로
+  lines[0] = `"${lines[0].trim()}"`;
+  const result = lines.join('\n');
+
+  // textarea/input에 삽입
+  const start = target.selectionStart;
+  const end = target.selectionEnd;
+  const value = target.value;
+  target.value = value.slice(0, start) + result + value.slice(end);
+  target.selectionStart = target.selectionEnd = start + result.length;
+
+  // input 이벤트 트리거 (auto-resize 등)
+  target.dispatchEvent(new Event('input', { bubbles: true }));
+
+  return true;
+}
+```
+
+- [ ] **Step 2: commentInput paste 핸들러에 통합**
+
+`app.js:1259-1266`을 수정. 기존 이미지 paste 로직 앞에 경로 감지 추가:
+```javascript
+elements.commentInput.addEventListener('paste', async (e) => {
+  // 드라이브 경로 자동 따옴표
+  if (handleDrivePathPaste(e)) return;
+
+  const imageData = await getImageFromClipboard(e);
+  if (imageData) {
+    e.preventDefault();
+    showCommentImagePreview(imageData);
+    showToast('이미지가 첨부되었습니다', 'success');
+  }
+});
+```
+
+- [ ] **Step 3: threadEditor paste 핸들러에 통합**
+
+`app.js:7789-7796`을 수정:
+```javascript
+threadEditor?.addEventListener('paste', async (e) => {
+  // 드라이브 경로 자동 따옴표
+  if (handleDrivePathPaste(e)) return;
+
+  const imageData = await getImageFromClipboard(e);
+  if (imageData) {
+    e.preventDefault();
+    showThreadImagePreview(imageData);
+    showToast('이미지가 첨부되었습니다', 'success');
+  }
+});
+```
+
+- [ ] **Step 4: 동적 reply-input에 이벤트 위임 추가**
+
+댓글 패널 컨테이너에 paste 이벤트 위임 추가. `app.js`에서 기존 댓글 목록 이벤트 바인딩 후(약 5283줄 이후 근처), 혹은 초기화 영역에 다음 추가:
+
+```javascript
+// 동적 답글 입력의 경로 paste 처리 (이벤트 위임)
+elements.commentsList?.addEventListener('paste', (e) => {
+  if (e.target.closest('.comment-reply-input')) {
+    handleDrivePathPaste(e);
+  }
+});
+```
+
+**주의**: 이 위임 리스너는 한 번만 등록하면 되므로 `updateCommentListImmediate()` 바깥의 초기화 영역에 둔다. `elements.commentsList`를 참조하는 초기화 코드 근처(app.js:1259 이미지 paste 핸들러 바로 뒤)에 배치.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add renderer/scripts/app.js
+git commit -m "feat: 댓글에 드라이브 경로 붙여넣기 시 자동 따옴표 감싸기"
+```
+
+---
+
+## Chunk 2: 답글 후 확장 상태 유지
+
+### Task 3: 확장 상태 및 스크롤 보존
+
+**Files:**
+- Modify: `renderer/scripts/app.js:4889-4891` (updateCommentListImmediate 시작부)
+- Modify: `renderer/scripts/app.js:5024-5036` (스레드 토글/답글 HTML 템플릿)
+
+- [ ] **Step 1: 확장 ID 수집 + 스크롤 위치 저장**
+
+`updateCommentListImmediate()` 함수 시작부 (app.js:4891 `if (!container) return;` 바로 뒤)에 추가:
+
+```javascript
+// 확장 상태 및 스크롤 위치 보존
+const expandedIds = new Set(
+  [...container.querySelectorAll('.comment-thread-toggle.expanded')]
+    .map(el => el.dataset.markerId)
+);
+const savedScrollTop = container.scrollTop;
+```
+
+- [ ] **Step 2: HTML 템플릿에 확장 상태 반영**
+
+`app.js:5024-5029` 스레드 토글 버튼 부분을 수정:
+```javascript
+${replyCount > 0 ? `
+<button class="comment-thread-toggle${expandedIds.has(marker.id) ? ' expanded' : ''}" data-marker-id="${marker.id}">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+  답글 ${replyCount}개
+</button>
+` : ''}
+```
+
+`app.js:5030` 답글 컨테이너 부분을 수정:
+```javascript
+<div class="comment-replies${expandedIds.has(marker.id) ? ' expanded' : ''}" data-marker-id="${marker.id}">
+```
+
+- [ ] **Step 3: 스크롤 위치 복원**
+
+`updateCommentListImmediate()` 함수 맨 마지막 (app.js:5283 `});` 바로 뒤, 함수 닫기 전)에 추가:
+
+```javascript
+// 스크롤 위치 복원
+container.scrollTop = savedScrollTop;
+```
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add renderer/scripts/app.js
+git commit -m "fix: 답글 작성 후 스레드 확장 상태 및 스크롤 위치 유지"
+```
+
+---
+
+## Chunk 3: 사용자 필터 드롭다운 UX 개선
+
+### Task 4: 드롭다운 HTML 구조 변경 + 솔로/토글 로직
+
+**Files:**
+- Modify: `renderer/scripts/app.js:1493-1532` (updateAuthorFilterMenu)
+- Modify: `renderer/scripts/app.js:1601-1643` (필터 클릭 핸들러)
+
+- [ ] **Step 1: updateAuthorFilterMenu() 리팩토링 — 이름을 span으로 감싸기 + 솔로 힌트 + 안내 텍스트 추가**
+
+`app.js:1511-1531` 전체를 다음으로 교체:
+
+```javascript
+let html = '';
+for (const [authorId, info] of authors) {
+  const color = getAuthorColor(authorId);
+  const isChecked = selectedAll || commentFilterState.authors.includes(authorId);
+  html += `
+    <div class="filter-dropdown-item" data-author-id="${escapeHtml(authorId)}">
+      <div class="filter-dropdown-check ${isChecked ? 'checked' : ''}">${isChecked ? '✓' : ''}</div>
+      <div class="filter-dropdown-dot" style="background: ${color.color}"></div>
+      <span class="filter-dropdown-name">${escapeHtml(info.name)}</span>
+      <span class="filter-dropdown-solo-hint">솔로</span>
+      <span class="filter-dropdown-badge">${info.count}</span>
+    </div>`;
+}
+
+html += '<div class="filter-dropdown-divider"></div>';
+html += `
+  <div class="filter-dropdown-item" data-author-id="__all__">
+    <div class="filter-dropdown-check ${selectedAll ? 'checked' : ''}">${selectedAll ? '✓' : ''}</div>
+    <span class="filter-dropdown-name">전체 선택/해제</span>
+  </div>`;
+html += `<div class="filter-dropdown-hint">☑ 체크박스 = 토글 &nbsp; 👤 이름 = 솔로</div>`;
+
+menu.innerHTML = html;
+```
+
+- [ ] **Step 2: 클릭 핸들러 리팩토링 — 체크박스/이름 분리 + 드롭다운 유지 + stopPropagation**
+
+`app.js:1601-1643` 전체를 다음으로 교체:
+
+```javascript
+// 작성자 선택/해제 (체크박스 토글 + 이름 솔로)
+document.getElementById('authorFilterMenu')?.addEventListener('click', (e) => {
+  e.stopPropagation(); // 드롭다운 닫힘 방지
+
+  const item = e.target.closest('.filter-dropdown-item');
+  if (!item) return;
+
+  const authorId = item.dataset.authorId;
+  const clickedName = e.target.closest('.filter-dropdown-name');
+  const clickedCheck = e.target.closest('.filter-dropdown-check');
+
+  // 전체 선택/해제
+  if (authorId === '__all__') {
+    commentFilterState.authors = commentFilterState.authors === null ? [] : null;
+  }
+  // 이름 클릭 → 솔로 모드
+  else if (clickedName) {
+    const isSolo = (
+      commentFilterState.authors !== null &&
+      commentFilterState.authors.length === 1 &&
+      commentFilterState.authors[0] === authorId
+    );
+    commentFilterState.authors = isSolo ? null : [authorId];
+  }
+  // 체크박스 클릭 → 개별 토글
+  else {
+    if (commentFilterState.authors === null) {
+      // 전체 선택 → 이 작성자만 해제
+      const allMarkers = commentManager.getAllMarkers();
+      const uniqueAuthors = new Set(
+        allMarkers.filter(m => !m.deleted).map(m => m.authorId || m.author || 'unknown')
+      );
+      commentFilterState.authors = [...uniqueAuthors].filter(id => id !== authorId);
+    } else {
+      const idx = commentFilterState.authors.indexOf(authorId);
+      if (idx !== -1) {
+        commentFilterState.authors.splice(idx, 1);
+      } else {
+        commentFilterState.authors.push(authorId);
+      }
+      // 모든 작성자가 선택되면 null(전체)로 리셋
+      const allMarkers = commentManager.getAllMarkers();
+      const uniqueAuthors = new Set(
+        allMarkers.filter(m => !m.deleted).map(m => m.authorId || m.author || 'unknown')
+      );
+      if (commentFilterState.authors.length >= uniqueAuthors.size) {
+        commentFilterState.authors = null;
+      }
+    }
+  }
+
+  updateAuthorFilterMenu();
+  applyCommentFilters();
+
+  const btn = document.getElementById('authorFilterBtn');
+  if (btn) {
+    btn.classList.toggle('active', commentFilterState.authors !== null);
+  }
+});
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add renderer/scripts/app.js
+git commit -m "feat: 사용자 필터 드롭다운 솔로/토글 듀얼 인터랙션 구현"
+```
+
+---
+
+### Task 5: 드롭다운 overflow 방지 + CSS 스타일
+
+**Files:**
+- Modify: `renderer/scripts/app.js:1561-1571` (드롭다운 열기 로직)
+- Modify: `renderer/styles/main.css:3699` 이후 (새 스타일 추가)
+
+- [ ] **Step 1: 드롭다운 열기 시 overflow 위치 보정**
+
+`app.js:1561-1571`을 다음으로 교체:
+
+```javascript
+document.getElementById('authorFilterBtn')?.addEventListener('click', (e) => {
+  e.stopPropagation();
+  const menu = document.getElementById('authorFilterMenu');
+  const isOpen = menu.classList.contains('open');
+  if (isOpen) {
+    menu.classList.remove('open');
+    // 위치 리셋
+    menu.style.top = '';
+    menu.style.bottom = '';
+    menu.style.left = '';
+    menu.style.right = '';
+  } else {
+    updateAuthorFilterMenu();
+    // 위치 리셋 후 열기
+    menu.style.top = '';
+    menu.style.bottom = '';
+    menu.style.left = '';
+    menu.style.right = '';
+    menu.classList.add('open');
+
+    // 레이아웃 확정 후 overflow 보정
+    requestAnimationFrame(() => {
+      const rect = menu.getBoundingClientRect();
+      if (rect.bottom > window.innerHeight) {
+        menu.style.top = 'auto';
+        menu.style.bottom = 'calc(100% + 4px)';
+      }
+      if (rect.right > window.innerWidth) {
+        menu.style.left = 'auto';
+        menu.style.right = '0';
+      }
+    });
+  }
+});
+```
+
+- [ ] **Step 2: CSS 스타일 추가 — 솔로 힌트, 인터랙션 힌트**
+
+`renderer/styles/main.css`에서 `.filter-dropdown-badge` (line 3699) 바로 뒤에 다음 추가:
+
+```css
+.filter-dropdown-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.filter-dropdown-name:hover {
+  text-decoration: underline;
+}
+
+.filter-dropdown-solo-hint {
+  font-size: 9px;
+  color: var(--accent-primary);
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+  margin-left: -4px;
+}
+
+.filter-dropdown-item:hover .filter-dropdown-solo-hint {
+  opacity: 0.7;
+}
+
+.filter-dropdown-hint {
+  padding: 4px 10px 6px;
+  font-size: 10px;
+  color: var(--text-tertiary);
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 2px;
+}
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add renderer/scripts/app.js renderer/styles/main.css
+git commit -m "feat: 필터 드롭다운 overflow 방지 + 솔로 힌트 스타일 추가"
+```
+
+---
+
+## Chunk 4: 수동 테스트 및 최종 커밋
+
+### Task 6: 수동 테스트 검증
+
+- [ ] **Step 1: 경로 링크 공백 테스트**
+
+앱 실행 후 (`npm run dev`) 댓글에 다음 입력:
+```
+G:\공유 드라이브\사우스 코리안 파크\232_친모1\출력\B파트 한솔전달용
+파일 전달드립니다!
+```
+→ 첫 줄 전체가 하나의 버튼으로 렌더링되는지 확인
+
+- [ ] **Step 2: 경로 붙여넣기 자동 따옴표 테스트**
+
+Windows 탐색기에서 `G:\공유 드라이브\폴더` 경로를 복사 → 댓글 입력창에 Ctrl+V
+→ `"G:\공유 드라이브\폴더"` 형태로 따옴표가 자동 추가되는지 확인
+→ 이미 따옴표가 있는 경우 중복 추가 안 되는지 확인
+→ 이미지 붙여넣기가 여전히 동작하는지 확인
+
+- [ ] **Step 3: 답글 확장 유지 테스트**
+
+답글이 있는 댓글의 스레드를 펼친 상태에서 답글 작성
+→ 스레드가 펼쳐진 상태 유지되는지 확인
+→ 스크롤 위치가 유지되는지 확인
+
+- [ ] **Step 4: 사용자 필터 테스트**
+
+필터 드롭다운 열기 → 체크박스 클릭 (드롭다운 유지) → 이름 클릭 (솔로 모드)
+→ 같은 이름 다시 클릭 (전체 복원)
+→ 화면 하단 근처에서 열기 (위로 열리는지 확인)
+
+- [ ] **Step 5: lint 실행**
+
+```bash
+npm run lint
+```
+에러가 있으면 수정 후 추가 커밋.

--- a/docs/superpowers/specs/2026-03-23-comment-ux-improvements-design.md
+++ b/docs/superpowers/specs/2026-03-23-comment-ux-improvements-design.md
@@ -38,6 +38,9 @@ G:\공유 드라이브\사우스 코리안 파크\232_친모1\출력\B파트 한
 파일 전달드립니다!
 ```
 
+### 알려진 한계
+같은 줄에 경로와 텍스트가 섞인 경우 (예: `G:\공유 드라이브\폴더 여기 확인`) 텍스트까지 경로로 인식될 수 있음. 사용자 패턴상 경로는 항상 단독 줄에 입력되고, Section 2의 자동 따옴표가 이를 이중으로 방지하므로 허용 가능한 트레이드오프.
+
 ---
 
 ## 2. 경로 붙여넣기 - 자동 따옴표 감싸기
@@ -48,21 +51,28 @@ G:\공유 드라이브\사우스 코리안 파크\232_친모1\출력\B파트 한
 ### 구현
 댓글 입력 textarea/input에 `paste` 이벤트 리스너 추가:
 1. `event.clipboardData.getData('text')` 확인
-2. `G:\` 또는 `G:/`로 시작하는 텍스트인지 검사
-3. 이미 따옴표로 감싸져 있으면 무시
-4. 감싸져 있지 않으면 앞뒤에 `"` 추가하여 삽입
-5. `event.preventDefault()`로 기본 붙여넣기 차단
+2. 이미지 데이터가 있으면 무시 (기존 이미지 paste 핸들러 우선)
+3. `G:\` 또는 `G:/`로 시작하는 텍스트인지 검사
+4. 이미 따옴표로 감싸져 있으면 무시
+5. 감싸져 있지 않으면 **첫 줄(경로)만** 따옴표로 감싸고 나머지 줄은 그대로 유지
+6. `event.preventDefault()`로 기본 붙여넣기 차단
+
+### 기존 paste 핸들러와의 공존
+- `commentInput` (app.js:1259)과 `threadEditor` (app.js:7789)에 이미 이미지 paste 핸들러 존재
+- 새 로직을 기존 핸들러 **내부에 통합**: 이미지가 아닌 텍스트 paste일 때만 경로 감지 분기
+- 별도 리스너를 추가하지 않아 순서/충돌 문제 방지
 
 ### 대상 입력 요소
 - 댓글 작성 textarea (`#commentInput` 또는 동적 생성 요소)
 - 답글 작성 입력 (스레드 팝업 내)
+- 동적 생성되는 `.comment-reply-input`: 이벤트 위임 사용 (댓글 패널 컨테이너에 paste 이벤트 위임)
 
 ### 경로 판별 조건
 ```javascript
 /^[A-Z]:[/\\]/.test(text.trim())
 ```
 - 드라이브 문자 + `:` + 경로 구분자로 시작하는 텍스트
-- 여러 줄이면 각 줄을 개별 검사하지 않고, 첫 줄이 경로면 전체를 따옴표로 감싸기 (경로 뒤 줄바꿈 + 설명 텍스트 패턴 대응)
+- 여러 줄 paste 시 첫 줄만 따옴표 감싸기 (설명 텍스트가 따옴표 안에 포함되는 것 방지)
 
 ---
 
@@ -90,6 +100,8 @@ const isExpanded = expandedIds.has(marker.id);
 // replies container: class="comment-replies${isExpanded ? ' expanded' : ''}"
 ```
 
+또한 `container.scrollTop`을 재렌더링 전에 저장하고, 렌더링 후 복원하여 스크롤 위치도 보존.
+
 ---
 
 ## 4. 사용자 필터 드롭다운 UX 개선
@@ -116,9 +128,25 @@ const isExpanded = expandedIds.has(marker.id);
 - 이미 솔로 상태에서 같은 이름 클릭 → 전체 복원 (`authors = null`)
 
 **구현**:
+- `updateAuthorFilterMenu()`에서 작성자 이름을 `<span class="filter-dropdown-name">` 요소로 감싸기 (현재는 bare text)
 - `.filter-dropdown-check` 클릭 → 체크박스 토글 로직
 - `.filter-dropdown-name` 클릭 → 솔로 로직
-- 이벤트 위임으로 클릭 대상 구분
+- 이벤트 위임으로 클릭 대상 구분 (`.filter-dropdown-item`에 단일 리스너, `e.target.closest()`로 분기)
+- 메뉴 내부 클릭 시 `e.stopPropagation()` 추가 (document click 핸들러가 닫지 않도록)
+
+**솔로 모드 감지 알고리즘**:
+```javascript
+const isSolo = (
+  commentFilterState.authors !== null &&
+  commentFilterState.authors.length === 1 &&
+  commentFilterState.authors[0] === clickedAuthorId
+);
+if (isSolo) {
+  commentFilterState.authors = null; // 전체 복원
+} else {
+  commentFilterState.authors = [clickedAuthorId]; // 솔로 진입
+}
+```
 
 **UI 힌트**:
 - 이름 hover 시 "솔로" 텍스트 표시 (opacity 전환)
@@ -147,7 +175,7 @@ if (rect.right > viewportW) {
 }
 ```
 
-메뉴가 `.open` 클래스를 받은 직후 위치를 계산하여 보정.
+메뉴에 `.open` 클래스 추가 후 `requestAnimationFrame()`으로 레이아웃이 확정된 뒤 위치를 계산하여 보정. (CSS transition 중 측정 오류 방지)
 
 ---
 
@@ -167,3 +195,25 @@ if (rect.right > viewportW) {
 ## 시안 참조
 
 `docs/superpowers/mockups/filter-mockup.html` - 필터 드롭다운 3가지 상태 비교
+
+---
+
+## 범위
+
+- **포함**: Desktop 앱 (`renderer/`) 전체
+- **제외**: Web Viewer (`web-viewer/`) - `renderGDriveLinks` 함수가 web-viewer에는 없음
+
+---
+
+## 수동 테스트 항목
+
+| # | 테스트 | 예상 결과 |
+|---|--------|----------|
+| 1 | 따옴표 없이 공백 포함 경로 입력 후 줄바꿈 | 전체 경로가 하나의 버튼으로 표시 |
+| 2 | 경로 붙여넣기 (클립보드) | 자동 따옴표 감싸기 |
+| 3 | 이미 따옴표 있는 경로 붙여넣기 | 중복 따옴표 없이 정상 처리 |
+| 4 | 이미지 붙여넣기 | 기존 이미지 paste 동작 유지 |
+| 5 | 답글 작성 후 스레드 확장 상태 | 확장 유지, 스크롤 위치 유지 |
+| 6 | 필터 체크박스 클릭 | 드롭다운 열린 채로 해당 사용자 토글 |
+| 7 | 필터 이름 클릭 (솔로) | 해당 사용자만 표시, 다시 클릭 시 전체 복원 |
+| 8 | 화면 하단 근처에서 필터 드롭다운 열기 | 위로 열림 (overflow 방지) |

--- a/docs/superpowers/specs/2026-03-23-comment-ux-improvements-design.md
+++ b/docs/superpowers/specs/2026-03-23-comment-ux-improvements-design.md
@@ -1,0 +1,169 @@
+# 댓글 UX 개선 설계 스펙
+
+## 요약
+
+| 항목 | 수정 파일 | 내용 | 우선순위 |
+|------|----------|------|---------|
+| 1. 경로 링크 공백 허용 | `renderer/scripts/app.js` | Stage 2b regex에서 공백 허용, 줄바꿈에서 끊기 | 높음 |
+| 2. 경로 붙여넣기 자동 따옴표 | `renderer/scripts/app.js` | paste 이벤트에서 G:\ 패턴 감지 → 따옴표 감싸기 | 높음 |
+| 3. 답글 후 확장 유지 | `renderer/scripts/app.js` | updateCommentList 시 확장 상태 보존 | 중간 |
+| 4. 사용자 필터 UX 개선 | `renderer/scripts/app.js`, `renderer/styles/main.css` | 드롭다운 유지 + 솔로/토글 모드 + overflow 방지 | 중간 |
+
+---
+
+## 1. 경로 링크 - 공백 허용
+
+### 배경
+댓글에 `G:공유 드라이브\JBBJ 자료실\폴더` 같은 경로를 따옴표 없이 입력하면, 공백에서 잘려서 `G:공유`까지만 버튼으로 처리됨.
+
+### 원인
+`renderGDriveLinks()` (app.js:5410-5452)의 Stage 2b regex:
+```regex
+/(G:[/\\](?:[^\s<"'&\x00]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi
+```
+문자 클래스 `[^\s<"'&\x00]`에서 `\s`가 공백을 제외함.
+
+### 수정
+Stage 2b regex의 `\s`를 `\n\r`로 변경하여 공백은 허용하되 줄바꿈에서 끊기:
+```regex
+/(G:[/\\](?:[^\n\r<"'&\x00]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi
+```
+
+매치된 경로의 trailing whitespace는 trim 처리.
+
+### 사용 패턴
+사용자들은 경로를 줄바꿈으로 구분하여 단독 입력:
+```
+G:\공유 드라이브\사우스 코리안 파크\232_친모1\출력\B파트 한솔전달용
+파일 전달드립니다!
+```
+
+---
+
+## 2. 경로 붙여넣기 - 자동 따옴표 감싸기
+
+### 배경
+경로는 대부분 클립보드에서 붙여넣기로 입력됨. 붙여넣기 시 자동으로 따옴표를 감싸면 Stage 1(따옴표 경로)에서 정확히 처리 가능.
+
+### 구현
+댓글 입력 textarea/input에 `paste` 이벤트 리스너 추가:
+1. `event.clipboardData.getData('text')` 확인
+2. `G:\` 또는 `G:/`로 시작하는 텍스트인지 검사
+3. 이미 따옴표로 감싸져 있으면 무시
+4. 감싸져 있지 않으면 앞뒤에 `"` 추가하여 삽입
+5. `event.preventDefault()`로 기본 붙여넣기 차단
+
+### 대상 입력 요소
+- 댓글 작성 textarea (`#commentInput` 또는 동적 생성 요소)
+- 답글 작성 입력 (스레드 팝업 내)
+
+### 경로 판별 조건
+```javascript
+/^[A-Z]:[/\\]/.test(text.trim())
+```
+- 드라이브 문자 + `:` + 경로 구분자로 시작하는 텍스트
+- 여러 줄이면 각 줄을 개별 검사하지 않고, 첫 줄이 경로면 전체를 따옴표로 감싸기 (경로 뒤 줄바꿈 + 설명 텍스트 패턴 대응)
+
+---
+
+## 3. 답글 후 확장 상태 유지
+
+### 배경
+답글 작성 후 `replyAdded`/`markersChanged` 이벤트 → `updateCommentList()` → 전체 HTML 재생성 → 확장 상태 소실.
+
+### 원인
+`updateCommentListImmediate()` (app.js:4889-5283)가 innerHTML을 완전히 재생성하면서 `.expanded` 클래스 정보를 보존하지 않음.
+
+### 수정
+`updateCommentListImmediate()` 시작부에서 현재 확장된 댓글 ID를 수집:
+```javascript
+const expandedIds = new Set(
+  [...container.querySelectorAll('.comment-thread-toggle.expanded')]
+    .map(el => el.dataset.markerId)
+);
+```
+
+HTML 렌더링 시 해당 ID의 toggle/replies에 `expanded` 클래스 부여:
+```javascript
+const isExpanded = expandedIds.has(marker.id);
+// thread toggle: class="comment-thread-toggle${isExpanded ? ' expanded' : ''}"
+// replies container: class="comment-replies${isExpanded ? ' expanded' : ''}"
+```
+
+---
+
+## 4. 사용자 필터 드롭다운 UX 개선
+
+### 4-1. 드롭다운 닫힘 방지
+
+**현재 동작**: 항목 클릭 시 드롭다운이 닫힘.
+**수정**: 항목 클릭 시 드롭다운 유지. 닫기는 다음 경우에만:
+- 드롭다운 바깥 클릭
+- 버튼 재클릭
+- mouseleave 300ms 타이머 (기존 동작 유지)
+
+### 4-2. 듀얼 인터랙션: 체크박스 토글 + 솔로 모드
+
+**기본 상태**: 전원 체크됨 (`commentFilterState.authors = null`)
+
+**체크박스 클릭** (개별 토글):
+- 해당 사용자만 on/off 토글
+- 여러 명 조합 가능
+- 전원 체크되면 `authors = null`로 리셋
+
+**이름 텍스트 클릭** (솔로 모드):
+- 해당 사용자만 체크, 나머지 해제
+- 이미 솔로 상태에서 같은 이름 클릭 → 전체 복원 (`authors = null`)
+
+**구현**:
+- `.filter-dropdown-check` 클릭 → 체크박스 토글 로직
+- `.filter-dropdown-name` 클릭 → 솔로 로직
+- 이벤트 위임으로 클릭 대상 구분
+
+**UI 힌트**:
+- 이름 hover 시 "솔로" 텍스트 표시 (opacity 전환)
+- 하단에 `☑ 체크박스 = 토글 | 👤 이름 = 솔로` 안내
+
+### 4-3. 드롭다운 overflow 방지
+
+드롭다운이 뷰포트 밖으로 나가지 않도록 위치 보정:
+
+**열릴 때** 위치 계산:
+```javascript
+const rect = menu.getBoundingClientRect();
+const viewportH = window.innerHeight;
+const viewportW = window.innerWidth;
+
+// 하단 넘침 → 위로 열기
+if (rect.bottom > viewportH) {
+  menu.style.top = 'auto';
+  menu.style.bottom = 'calc(100% + 4px)';
+}
+
+// 우측 넘침 → 왼쪽 정렬
+if (rect.right > viewportW) {
+  menu.style.left = 'auto';
+  menu.style.right = '0';
+}
+```
+
+메뉴가 `.open` 클래스를 받은 직후 위치를 계산하여 보정.
+
+---
+
+## 수정 대상 파일 요약
+
+| 파일 | 수정 내용 |
+|------|----------|
+| `renderer/scripts/app.js:5440` | Stage 2b regex 공백 허용 |
+| `renderer/scripts/app.js` (댓글 입력) | paste 이벤트 핸들러 추가 |
+| `renderer/scripts/app.js:4889-5283` | 확장 상태 보존 로직 |
+| `renderer/scripts/app.js:1493-1643` | 필터 드롭다운 솔로/토글 분리, 닫힘 방지 |
+| `renderer/scripts/app.js:1561-1571` | 드롭다운 열기 시 overflow 위치 보정 |
+| `renderer/styles/main.css:3647+` | 솔로 힌트 스타일, 인터랙션 힌트 |
+
+---
+
+## 시안 참조
+
+`docs/superpowers/mockups/filter-mockup.html` - 필터 드롭다운 3가지 상태 비교

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -4900,6 +4900,13 @@ async function initApp() {
     const container = elements.commentsList;
     if (!container) return;
 
+    // 확장 상태 및 스크롤 위치 보존
+    const expandedIds = new Set(
+      [...container.querySelectorAll('.comment-thread-toggle.expanded')]
+        .map(el => el.dataset.markerId)
+    );
+    const savedScrollTop = container.scrollTop;
+
     let markers = commentManager.getAllMarkers();
 
     // 필터 적용
@@ -5032,12 +5039,12 @@ async function initApp() {
           <button class="comment-action-btn delete-btn" title="삭제">삭제</button>
         </div>
         ${replyCount > 0 ? `
-        <button class="comment-thread-toggle" data-marker-id="${marker.id}">
+        <button class="comment-thread-toggle${expandedIds.has(marker.id) ? ' expanded' : ''}" data-marker-id="${marker.id}">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
           답글 ${replyCount}개
         </button>
         ` : ''}
-        <div class="comment-replies" data-marker-id="${marker.id}">
+        <div class="comment-replies${expandedIds.has(marker.id) ? ' expanded' : ''}" data-marker-id="${marker.id}">
           ${repliesHtml}
           <div class="comment-reply-input-wrapper">
             <textarea class="comment-reply-input" placeholder="답글 입력..." rows="1"></textarea>
@@ -5291,6 +5298,9 @@ async function initApp() {
         }
       });
     });
+
+    // 스크롤 위치 복원
+    container.scrollTop = savedScrollTop;
   }
 
   /**

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1526,7 +1526,8 @@ async function initApp() {
         <div class="filter-dropdown-item" data-author-id="${escapeHtml(authorId)}">
           <div class="filter-dropdown-check ${isChecked ? 'checked' : ''}">${isChecked ? '✓' : ''}</div>
           <div class="filter-dropdown-dot" style="background: ${color.color}"></div>
-          ${escapeHtml(info.name)}
+          <span class="filter-dropdown-name">${escapeHtml(info.name)}</span>
+          <span class="filter-dropdown-solo-hint">솔로</span>
           <span class="filter-dropdown-badge">${info.count}</span>
         </div>`;
     }
@@ -1535,8 +1536,9 @@ async function initApp() {
     html += `
       <div class="filter-dropdown-item" data-author-id="__all__">
         <div class="filter-dropdown-check ${selectedAll ? 'checked' : ''}">${selectedAll ? '✓' : ''}</div>
-        전체 선택/해제
+        <span class="filter-dropdown-name">전체 선택/해제</span>
       </div>`;
+    html += `<div class="filter-dropdown-hint">☑ 체크박스 = 토글 &nbsp; 👤 이름 = 솔로</div>`;
 
     menu.innerHTML = html;
   }
@@ -1607,18 +1609,33 @@ async function initApp() {
     }
   });
 
-  // 작성자 선택/해제
+  // 작성자 선택/해제 (체크박스 토글 + 이름 솔로)
   document.getElementById('authorFilterMenu')?.addEventListener('click', (e) => {
+    e.stopPropagation(); // 드롭다운 닫힘 방지
+
     const item = e.target.closest('.filter-dropdown-item');
     if (!item) return;
 
     const authorId = item.dataset.authorId;
+    const clickedName = e.target.closest('.filter-dropdown-name');
 
+    // 전체 선택/해제
     if (authorId === '__all__') {
-      commentFilterState.authors = null;
-    } else {
+      commentFilterState.authors = commentFilterState.authors === null ? [] : null;
+    }
+    // 이름 클릭 → 솔로 모드
+    else if (clickedName) {
+      const isSolo = (
+        commentFilterState.authors !== null &&
+        commentFilterState.authors.length === 1 &&
+        commentFilterState.authors[0] === authorId
+      );
+      commentFilterState.authors = isSolo ? null : [authorId];
+    }
+    // 체크박스 클릭 → 개별 토글
+    else {
       if (commentFilterState.authors === null) {
-        // 현재 전체 선택 → 이 작성자만 해제
+        // 전체 선택 → 이 작성자만 해제
         const allMarkers = commentManager.getAllMarkers();
         const uniqueAuthors = new Set(
           allMarkers.filter(m => !m.deleted).map(m => m.authorId || m.author || 'unknown')
@@ -1645,7 +1662,6 @@ async function initApp() {
     updateAuthorFilterMenu();
     applyCommentFilters();
 
-    // 작성자 필터 활성 상태 표시
     const btn = document.getElementById('authorFilterBtn');
     if (btn) {
       btn.classList.toggle('active', commentFilterState.authors !== null);

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5437,10 +5437,10 @@ async function initApp() {
 
     //   2b: 확장자 없는 경로 (폴더) — 공백 불허
     //   <mark> 태그는 허용 (검색 하이라이트)
-    html = html.replace(/(G:[/\\](?:[^\s<"'&\x00]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi, (match) => {
-      // 이미 버튼화된 경로 건너뛰기 (2a에서 처리된 것)
+    html = html.replace(/(G:[/\\](?:[^\n\r<"'&\x00]|&[^q#]|&q[^u]|&#[^3]|<\/?mark[^>]*>)+)/gi, (match) => {
       if (match.includes('gdrive-link-btn')) return match;
-      return makeBtn(match, match);
+      const trimmed = match.replace(/\s+$/, '');
+      return makeBtn(trimmed, trimmed);
     });
 
     // 3단계: 플레이스홀더를 실제 버튼으로 복원

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1257,11 +1257,21 @@ async function initApp() {
 
   // 댓글 입력창 이미지 붙여넣기
   elements.commentInput.addEventListener('paste', async (e) => {
+    // 드라이브 경로 자동 따옴표
+    if (handleDrivePathPaste(e)) return;
+
     const imageData = await getImageFromClipboard(e);
     if (imageData) {
       e.preventDefault();
       showCommentImagePreview(imageData);
       showToast('이미지가 첨부되었습니다', 'success');
+    }
+  });
+
+  // 동적 답글 입력의 경로 paste 처리 (이벤트 위임)
+  elements.commentsList?.addEventListener('paste', (e) => {
+    if (e.target.closest('.comment-reply-input')) {
+      handleDrivePathPaste(e);
     }
   });
 
@@ -5404,6 +5414,47 @@ async function initApp() {
   }
 
   /**
+   * paste 이벤트에서 드라이브 경로를 감지하여 첫 줄에 따옴표를 감싸는 헬퍼.
+   * 이미지 paste가 아닌 텍스트 paste에서만 동작.
+   * @returns {boolean} 경로가 감지되어 처리된 경우 true
+   */
+  function handleDrivePathPaste(e) {
+    // 이미지 데이터가 있으면 무시 (기존 이미지 paste 우선)
+    if (e.clipboardData?.files?.length > 0) return false;
+    if (e.clipboardData?.types?.includes('image/png')) return false;
+
+    const text = e.clipboardData?.getData('text');
+    if (!text) return false;
+
+    const trimmed = text.trim();
+    // 드라이브 경로 패턴: C:\ D:\ G:/ 등
+    if (!/^[A-Z]:[/\\]/i.test(trimmed)) return false;
+
+    // 이미 따옴표로 감싸져 있으면 무시
+    if (/^["']/.test(trimmed) && /["']$/.test(trimmed)) return false;
+
+    e.preventDefault();
+
+    const target = e.target;
+    const lines = text.split('\n');
+    // 첫 줄(경로)만 따옴표 감싸기, 나머지 줄은 그대로
+    lines[0] = `"${lines[0].trim()}"`;
+    const result = lines.join('\n');
+
+    // textarea/input에 삽입
+    const start = target.selectionStart;
+    const end = target.selectionEnd;
+    const value = target.value;
+    target.value = value.slice(0, start) + result + value.slice(end);
+    target.selectionStart = target.selectionEnd = start + result.length;
+
+    // input 이벤트 트리거 (auto-resize 등)
+    target.dispatchEvent(new Event('input', { bubbles: true }));
+
+    return true;
+  }
+
+  /**
    * G:/ 드라이브 경로를 클릭 가능한 버튼으로 변환
    * escapeHtml 처리된 문자열에서 동작
    */
@@ -7787,6 +7838,9 @@ async function initApp() {
 
   // 스레드 에디터 이미지 붙여넣기
   threadEditor?.addEventListener('paste', async (e) => {
+    // 드라이브 경로 자동 따옴표
+    if (handleDrivePathPaste(e)) return;
+
     const imageData = await getImageFromClipboard(e);
     if (imageData) {
       e.preventDefault();

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1576,9 +1576,32 @@ async function initApp() {
     const isOpen = menu.classList.contains('open');
     if (isOpen) {
       menu.classList.remove('open');
+      // 위치 리셋
+      menu.style.top = '';
+      menu.style.bottom = '';
+      menu.style.left = '';
+      menu.style.right = '';
     } else {
       updateAuthorFilterMenu();
+      // 위치 리셋 후 열기
+      menu.style.top = '';
+      menu.style.bottom = '';
+      menu.style.left = '';
+      menu.style.right = '';
       menu.classList.add('open');
+
+      // 레이아웃 확정 후 overflow 보정
+      requestAnimationFrame(() => {
+        const rect = menu.getBoundingClientRect();
+        if (rect.bottom > window.innerHeight) {
+          menu.style.top = 'auto';
+          menu.style.bottom = 'calc(100% + 4px)';
+        }
+        if (rect.right > window.innerWidth) {
+          menu.style.left = 'auto';
+          menu.style.right = '0';
+        }
+      });
     }
   });
 

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -3698,6 +3698,38 @@ body.app-fullscreen .video-comment-overlay-controls {
   margin-left: auto;
 }
 
+.filter-dropdown-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.filter-dropdown-name:hover {
+  text-decoration: underline;
+}
+
+.filter-dropdown-solo-hint {
+  font-size: 9px;
+  color: var(--accent-primary);
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+  margin-left: -4px;
+}
+
+.filter-dropdown-item:hover .filter-dropdown-solo-hint {
+  opacity: 0.7;
+}
+
+.filter-dropdown-hint {
+  padding: 4px 10px 6px;
+  font-size: 10px;
+  color: var(--text-tertiary);
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 2px;
+}
+
 .comment-search-bar {
   padding: 0;
   border-bottom: 0;


### PR DESCRIPTION
## 요약
- 댓글 내 Google Drive 경로 링크에서 공백 포함 경로가 잘리는 버그 수정
- 경로 붙여넣기 시 자동 따옴표 감싸기 기능 추가
- 답글 작성 후 스레드 확장 상태 및 스크롤 위치 유지
- 사용자 필터 드롭다운 UX 개선 (솔로/토글 모드, overflow 방지)

## 변경 내용

### 경로 링크 공백 허용
- Stage 2b regex에서 `\s`를 `\n\r`로 변경하여 공백 허용, 줄바꿈에서 끊기
- trailing whitespace trim 처리

### 붙여넣기 자동 따옴표
- paste 이벤트에서 드라이브 경로 감지 시 첫 줄에 자동 따옴표 감싸기
- 기존 이미지 paste 핸들러와 공존 (이미지 우선)
- 동적 reply-input에 이벤트 위임 적용

### 답글 후 확장 유지
- updateCommentListImmediate()에서 확장 ID 수집 후 재렌더링 시 복원
- scrollTop도 함께 보존

### 필터 드롭다운 UX
- 체크박스 클릭: 개별 토글 (드롭다운 유지)
- 이름 클릭: 솔로 모드 (해당 사용자만, 재클릭 시 전체 복원)
- 드롭다운 overflow 방지 (뷰포트 밖 나가지 않도록 위치 보정)
- 솔로 힌트 및 안내 텍스트 추가

## 테스트
- [x] 공백 포함 경로 버튼 렌더링 확인
- [x] 경로 붙여넣기 자동 따옴표 확인
- [x] 답글 후 스레드 확장 유지 확인
- [x] 필터 솔로/토글 동작 확인
- [x] 드롭다운 overflow 방지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)