### PR TITLE
fix: 댓글 답글 @멘션/수정·삭제/이미지 + 썸네일 오버레이 개선 + 실시간 동기화 버그 수정

### DIFF
--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -4919,9 +4919,21 @@ async function initApp() {
 
   function highlightMentions(html) {
     if (!html) return html;
-    // replace는 stateful하지 않도록 lastIndex 리셋
+
+    // HTML 태그를 플레이스홀더로 치환 (태그 내부 속성 값이 매칭되는 것 방지)
+    const tagPlaceholders = [];
+    let protectedHtml = html.replace(/<[^>]+>/g, (tag) => {
+      const placeholder = `\x00TAG_${tagPlaceholders.length}\x00`;
+      tagPlaceholders.push(tag);
+      return placeholder;
+    });
+
+    // 태그 밖의 텍스트에서만 멘션 하이라이팅
     _MENTION_PATTERN.lastIndex = 0;
-    return html.replace(_MENTION_PATTERN, '<span class="mention-highlight">@$1</span>');
+    protectedHtml = protectedHtml.replace(_MENTION_PATTERN, '<span class="mention-highlight">@$1</span>');
+
+    // 태그 복원
+    return protectedHtml.replace(/\x00TAG_(\d+)\x00/g, (_, i) => tagPlaceholders[Number(i)]);
   }
 
   /**
@@ -5150,7 +5162,8 @@ async function initApp() {
             </div>
             ` : ''}
           </div>
-          <p class="comment-reply-text">${highlightMentions(renderGDriveLinks(highlightCommentSearchMatches(reply.text, normalizedSearch)))}</p>
+          ${reply.text ? `<p class="comment-reply-text">${highlightMentions(renderGDriveLinks(highlightCommentSearchMatches(reply.text, normalizedSearch)))}</p>` : ''}
+          ${reply.image ? `<div class="comment-attached-image"><img src="${reply.image}" alt="첨부 이미지" data-full-image="${reply.image}"></div>` : ''}
         </div>
       `;
       }).join('');

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -4907,6 +4907,16 @@ async function initApp() {
     return result;
   }
 
+  /**
+   * HTML 문자열 내 @멘션을 하이라이팅
+   * 이미 이스케이프된 HTML에서 동작 (태그 내부는 건드리지 않음)
+   */
+  function highlightMentions(html) {
+    if (!html) return html;
+    // HTML 태그 밖에서만 @이름 패턴을 매칭
+    return html.replace(/(@(?:[\p{L}\p{N}]+))(?![^<]*>)/gu, '<span class="mention-highlight">$1</span>');
+  }
+
   function updateFeedbackProgress(total, resolved) {
     if (!elements.feedbackProgress) return;
 
@@ -5026,7 +5036,7 @@ async function initApp() {
             <span class="comment-reply-author ${getAuthorColorClass(reply.author)}" ${getAuthorColorStyle(reply.author)}>${highlightCommentSearchMatches(reply.author, normalizedSearch)}</span>
             <span class="comment-reply-time">${formatRelativeTime(reply.createdAt)}</span>
           </div>
-          <p class="comment-reply-text">${renderGDriveLinks(highlightCommentSearchMatches(reply.text, normalizedSearch))}</p>
+          <p class="comment-reply-text">${highlightMentions(renderGDriveLinks(highlightCommentSearchMatches(reply.text, normalizedSearch)))}</p>
         </div>
       `).join('');
 
@@ -5060,7 +5070,7 @@ async function initApp() {
           <span class="comment-timecode">${highlightCommentSearchMatches(marker.startTimecode, normalizedSearch)}</span>
         </div>
         <div class="comment-content">
-          <p class="comment-text">${renderGDriveLinks(highlightCommentSearchMatches(marker.text, normalizedSearch))}</p>
+          <p class="comment-text">${highlightMentions(renderGDriveLinks(highlightCommentSearchMatches(marker.text, normalizedSearch)))}</p>
           ${marker.image ? `<div class="comment-attached-image"><img src="${marker.image}" alt="첨부 이미지" data-full-image="${marker.image}"></div>` : ''}
         </div>
         <div class="comment-edit-form" style="display: none;">
@@ -5300,6 +5310,9 @@ async function initApp() {
       const replyInput = item.querySelector('.comment-reply-input');
       const replySubmit = item.querySelector('.comment-reply-submit');
 
+      // 인라인 답글 textarea에 멘션 자동완성 부착
+      if (replyInput) mentionManager.attach(replyInput);
+
       // 스레드 토글 버튼
       threadToggle?.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -5330,7 +5343,7 @@ async function initApp() {
 
       // Enter로 답글 제출
       replyInput?.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
+        if (e.key === 'Enter' && !e.shiftKey && !mentionManager.isVisible) {
           e.preventDefault();
           e.stopPropagation();
           replySubmit?.click();
@@ -7580,19 +7593,38 @@ async function initApp() {
     threadReplyCount.style.display = replyCount > 0 ? 'flex' : 'none';
 
     // 답글들 렌더링 (XSS 방지: author 필드 이스케이프)
-    threadReplies.innerHTML = (marker.replies || []).map(reply => `
-      <div class="thread-reply-item">
+    threadReplies.innerHTML = (marker.replies || []).map(reply => {
+      const canEditReply = commentManager.canEdit(reply);
+      return `
+      <div class="thread-reply-item" data-reply-id="${reply.id}">
         <div class="thread-reply-avatar">${escapeHtml(reply.author.charAt(0))}</div>
         <div class="thread-reply-content">
           <div class="thread-reply-header">
             <span class="thread-reply-author" ${getAuthorColorStyle(reply.author)}>${escapeHtml(reply.author)}</span>
             <span class="thread-reply-time">${formatRelativeTime(reply.createdAt)}</span>
+            ${canEditReply ? `
+            <div class="thread-reply-actions">
+              <button class="thread-reply-action-btn thread-reply-edit-btn" title="수정">수정</button>
+              <button class="thread-reply-action-btn thread-reply-delete-btn" title="삭제">삭제</button>
+            </div>
+            ` : ''}
           </div>
           <div class="thread-reply-text">${formatMarkdown(reply.text)}</div>
+          <div class="thread-reply-edit-form" style="display: none;">
+            <div class="thread-reply-edit-editor" contenteditable="true">${escapeHtml(reply.text)}</div>
+            <div class="thread-reply-edit-actions">
+              <button class="thread-reply-edit-save">저장</button>
+              <button class="thread-reply-edit-cancel">취소</button>
+            </div>
+          </div>
           ${reply.image ? `<div class="thread-reply-image"><img src="${reply.image}" alt="첨부 이미지" data-full-image="${reply.image}"></div>` : ''}
         </div>
       </div>
-    `).join('');
+    `;
+    }).join('');
+
+    // 답글 수정/삭제 이벤트 바인딩
+    bindThreadReplyActions(markerId);
 
     // 에디터 초기화
     threadEditor.innerHTML = '';
@@ -7616,6 +7648,81 @@ async function initApp() {
     threadEditor.innerHTML = '';
     clearThreadImage();
     restoreFocus();
+  }
+
+  /**
+   * 스레드 답글 수정/삭제 이벤트 바인딩
+   */
+  function bindThreadReplyActions(markerId) {
+    threadReplies.querySelectorAll('.thread-reply-item').forEach(replyItem => {
+      const replyId = replyItem.dataset.replyId;
+      if (!replyId) return;
+
+      // 이미 바인딩된 요소 건너뛰기
+      if (replyItem.dataset.bound) return;
+      replyItem.dataset.bound = 'true';
+
+      const editBtn = replyItem.querySelector('.thread-reply-edit-btn');
+      const deleteBtn = replyItem.querySelector('.thread-reply-delete-btn');
+      const textEl = replyItem.querySelector('.thread-reply-text');
+      const editForm = replyItem.querySelector('.thread-reply-edit-form');
+      const editEditor = replyItem.querySelector('.thread-reply-edit-editor');
+      const saveBtn = replyItem.querySelector('.thread-reply-edit-save');
+      const cancelBtn = replyItem.querySelector('.thread-reply-edit-cancel');
+
+      // 수정 버튼
+      editBtn?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        textEl.style.display = 'none';
+        editForm.style.display = 'block';
+        // 멘션 자동완성 부착
+        mentionManager.attach(editEditor);
+        editEditor.focus();
+      });
+
+      // 수정 저장
+      saveBtn?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const newText = editEditor.innerText.trim();
+        if (!newText) return;
+
+        const success = commentManager.updateReply(markerId, replyId, { text: newText });
+        if (success) {
+          textEl.innerHTML = formatMarkdown(newText);
+          editForm.style.display = 'none';
+          textEl.style.display = '';
+          showToast('답글이 수정되었습니다.', 'success');
+        }
+      });
+
+      // 수정 취소
+      cancelBtn?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        editForm.style.display = 'none';
+        textEl.style.display = '';
+        // 원래 텍스트로 복원
+        const marker = commentManager.getMarker(markerId);
+        const reply = marker?.replies?.find(r => r.id === replyId);
+        if (reply) editEditor.textContent = reply.text;
+      });
+
+      // 삭제 버튼
+      deleteBtn?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (!confirm('이 답글을 삭제하시겠습니까?')) return;
+
+        const success = commentManager.deleteReply(markerId, replyId);
+        if (success) {
+          replyItem.remove();
+          // 답글 개수 업데이트
+          const marker = commentManager.getMarker(markerId);
+          const replyCount = marker?.replies?.length || 0;
+          threadReplyCount.textContent = replyCount > 0 ? `${replyCount}개의 댓글` : '';
+          threadReplyCount.style.display = replyCount > 0 ? 'flex' : 'none';
+          showToast('답글이 삭제되었습니다.', 'success');
+        }
+      });
+    });
   }
 
   /**
@@ -7663,6 +7770,9 @@ async function initApp() {
     html = html.replace(/(<li>.*<\/li>)/gs, '<ul>$1</ul>');
     // Clean up consecutive ul tags
     html = html.replace(/<\/ul>\s*<ul>/g, '');
+
+    // @멘션 하이라이팅
+    html = html.replace(/@([\p{L}\p{N}]+)/gu, '<span class="mention-highlight">@$1</span>');
 
     // Line breaks
     html = html.replace(/\n/g, '<br>');
@@ -7779,18 +7889,32 @@ async function initApp() {
 
     // UI 업데이트 - 새 답글 추가 (XSS 방지: author 필드 이스케이프)
     threadReplies.innerHTML += `
-      <div class="thread-reply-item">
+      <div class="thread-reply-item" data-reply-id="${newReply.id}">
         <div class="thread-reply-avatar">${escapeHtml(newReply.author.charAt(0))}</div>
         <div class="thread-reply-content">
           <div class="thread-reply-header">
             <span class="thread-reply-author" ${getAuthorColorStyle(newReply.author)}>${escapeHtml(newReply.author)}</span>
             <span class="thread-reply-time">${formatRelativeTime(newReply.createdAt)}</span>
+            <div class="thread-reply-actions">
+              <button class="thread-reply-action-btn thread-reply-edit-btn" title="수정">수정</button>
+              <button class="thread-reply-action-btn thread-reply-delete-btn" title="삭제">삭제</button>
+            </div>
           </div>
           <div class="thread-reply-text">${formatMarkdown(newReply.text)}</div>
+          <div class="thread-reply-edit-form" style="display: none;">
+            <div class="thread-reply-edit-editor" contenteditable="true">${escapeHtml(newReply.text)}</div>
+            <div class="thread-reply-edit-actions">
+              <button class="thread-reply-edit-save">저장</button>
+              <button class="thread-reply-edit-cancel">취소</button>
+            </div>
+          </div>
           ${newReply.image ? `<div class="thread-reply-image"><img src="${newReply.image}" alt="첨부 이미지" data-full-image="${newReply.image}"></div>` : ''}
         </div>
       </div>
     `;
+
+    // 새 답글 수정/삭제 이벤트 바인딩
+    bindThreadReplyActions(currentThreadMarkerId);
 
     // 에디터 및 이미지 초기화
     threadEditor.innerHTML = '';

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5031,15 +5031,31 @@ async function initApp() {
       const markerAuthorColor = getAuthorColor(marker.authorId || marker.author || 'unknown');
       const replyCount = marker.replies?.length || 0;
       const avatarImage = userSettings.getAvatarForName(marker.author);
-      const repliesHtml = (marker.replies || []).map(reply => `
-        <div class="comment-reply">
+      const repliesHtml = (marker.replies || []).map(reply => {
+        const canEditReply = commentManager.canEdit(reply);
+        return `
+        <div class="comment-reply" data-reply-id="${reply.id}" data-marker-id="${marker.id}">
           <div class="comment-reply-header">
             <span class="comment-reply-author ${getAuthorColorClass(reply.author)}" ${getAuthorColorStyle(reply.author)}>${highlightCommentSearchMatches(reply.author, normalizedSearch)}</span>
             <span class="comment-reply-time">${formatRelativeTime(reply.createdAt)}</span>
+            ${canEditReply ? `
+            <div class="comment-reply-actions">
+              <button class="comment-reply-action-btn comment-reply-edit-btn" title="수정">수정</button>
+              <button class="comment-reply-action-btn comment-reply-delete-btn" title="삭제">삭제</button>
+            </div>
+            ` : ''}
           </div>
           <p class="comment-reply-text">${highlightMentions(renderGDriveLinks(highlightCommentSearchMatches(reply.text, normalizedSearch)))}</p>
+          <div class="comment-reply-edit-form" style="display: none;">
+            <textarea class="comment-reply-edit-textarea" rows="2">${escapeHtml(reply.text)}</textarea>
+            <div class="comment-reply-edit-actions">
+              <button class="comment-reply-edit-save">저장</button>
+              <button class="comment-reply-edit-cancel">취소</button>
+            </div>
+          </div>
         </div>
-      `).join('');
+      `;
+      }).join('');
 
       // 썸네일 URL 가져오기
       const markerTime = marker.startFrame / videoPlayer.fps;
@@ -5349,6 +5365,59 @@ async function initApp() {
           e.stopPropagation();
           replySubmit?.click();
         }
+      });
+
+      // 답글 수정/삭제 이벤트 바인딩
+      item.querySelectorAll('.comment-reply').forEach(replyEl => {
+        const replyId = replyEl.dataset.replyId;
+        const markerId = replyEl.dataset.markerId;
+        if (!replyId) return;
+
+        const replyTextEl = replyEl.querySelector('.comment-reply-text');
+        const editForm = replyEl.querySelector('.comment-reply-edit-form');
+        const editTextarea = replyEl.querySelector('.comment-reply-edit-textarea');
+
+        // 수정 버튼
+        replyEl.querySelector('.comment-reply-edit-btn')?.addEventListener('click', (e) => {
+          e.stopPropagation();
+          replyTextEl.style.display = 'none';
+          editForm.style.display = 'block';
+          mentionManager.attach(editTextarea);
+          editTextarea.focus();
+        });
+
+        // 수정 저장
+        replyEl.querySelector('.comment-reply-edit-save')?.addEventListener('click', (e) => {
+          e.stopPropagation();
+          const newText = editTextarea.value.trim();
+          if (!newText) return;
+          const success = commentManager.updateReply(markerId, replyId, { text: newText });
+          if (success) {
+            updateCommentList(getActiveCommentFilter());
+            showToast('답글이 수정되었습니다.', 'success');
+          }
+        });
+
+        // 수정 취소
+        replyEl.querySelector('.comment-reply-edit-cancel')?.addEventListener('click', (e) => {
+          e.stopPropagation();
+          editForm.style.display = 'none';
+          replyTextEl.style.display = '';
+          const marker = commentManager.getMarker(markerId);
+          const reply = marker?.replies?.find(r => r.id === replyId);
+          if (reply) editTextarea.value = reply.text;
+        });
+
+        // 삭제 버튼
+        replyEl.querySelector('.comment-reply-delete-btn')?.addEventListener('click', (e) => {
+          e.stopPropagation();
+          if (!confirm('이 답글을 삭제하시겠습니까?')) return;
+          const success = commentManager.deleteReply(markerId, replyId);
+          if (success) {
+            updateCommentList(getActiveCommentFilter());
+            showToast('답글이 삭제되었습니다.', 'success');
+          }
+        });
       });
     });
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -25,6 +25,7 @@ import { getPlaylistManager } from './modules/playlist-manager.js';
 import { getAudioWaveform } from './modules/audio-waveform.js';
 import { getPlaybackSync } from './modules/playback-sync.js';
 import { getMentionManager } from './modules/mention-manager.js';
+import { TEAM_MEMBERS } from './modules/team-members.js';
 import { getSlackNotifier } from './modules/slack-notifier.js';
 
 const log = createLogger('App');
@@ -4908,13 +4909,13 @@ async function initApp() {
   }
 
   /**
-   * HTML 문자열 내 @멘션을 하이라이팅
-   * 이미 이스케이프된 HTML에서 동작 (태그 내부는 건드리지 않음)
+   * HTML 문자열 내 @멘션을 하이라이팅 (TEAM_MEMBERS 이름만)
    */
   function highlightMentions(html) {
     if (!html) return html;
-    // HTML 태그 밖에서만 @이름 패턴을 매칭
-    return html.replace(/(@(?:[\p{L}\p{N}]+))(?![^<]*>)/gu, '<span class="mention-highlight">$1</span>');
+    const names = TEAM_MEMBERS.map(m => m.name).sort((a, b) => b.length - a.length);
+    const pattern = new RegExp(`@(${names.join('|')})(?![\\p{L}\\p{N}])`, 'gu');
+    return html.replace(pattern, '<span class="mention-highlight">@$1</span>');
   }
 
   function updateFeedbackProgress(total, resolved) {
@@ -7776,8 +7777,10 @@ async function initApp() {
     // Clean up consecutive ul tags
     html = html.replace(/<\/ul>\s*<ul>/g, '');
 
-    // @멘션 하이라이팅
-    html = html.replace(/@([\p{L}\p{N}]+)/gu, '<span class="mention-highlight">@$1</span>');
+    // @멘션 하이라이팅 (TEAM_MEMBERS 이름만)
+    const names = TEAM_MEMBERS.map(m => m.name).sort((a, b) => b.length - a.length);
+    const mentionPattern = new RegExp(`@(${names.join('|')})(?![\\p{L}\\p{N}])`, 'gu');
+    html = html.replace(mentionPattern, '<span class="mention-highlight">@$1</span>');
 
     // 코드 블록 복원
     codePlaceholders.forEach((code, i) => {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -4910,12 +4910,112 @@ async function initApp() {
 
   /**
    * HTML 문자열 내 @멘션을 하이라이팅 (TEAM_MEMBERS 이름만)
+   * 정규식은 모듈 로드 시 1회만 빌드 (성능 최적화)
    */
+  const _MENTION_PATTERN = (() => {
+    const names = TEAM_MEMBERS.map(m => m.name).sort((a, b) => b.length - a.length);
+    return new RegExp(`@(${names.join('|')})(?![\\p{L}\\p{N}])`, 'gu');
+  })();
+
   function highlightMentions(html) {
     if (!html) return html;
-    const names = TEAM_MEMBERS.map(m => m.name).sort((a, b) => b.length - a.length);
-    const pattern = new RegExp(`@(${names.join('|')})(?![\\p{L}\\p{N}])`, 'gu');
-    return html.replace(pattern, '<span class="mention-highlight">@$1</span>');
+    // replace는 stateful하지 않도록 lastIndex 리셋
+    _MENTION_PATTERN.lastIndex = 0;
+    return html.replace(_MENTION_PATTERN, '<span class="mention-highlight">@$1</span>');
+  }
+
+  /**
+   * 답글 수정 모드 시작 (편집 폼을 on-demand로 생성)
+   * @param {HTMLElement} replyItem - 답글 DOM 요소
+   * @param {string} markerId
+   * @param {string} replyId
+   * @param {object} config - UI 구성
+   * @param {Function} onSaved - 저장 성공 후 콜백 (newText: string) => void
+   */
+  function startReplyEdit(replyItem, markerId, replyId, config, onSaved) {
+    const textEl = replyItem.querySelector(config.textSelector);
+    if (!textEl) return;
+
+    // 이미 편집 중이면 무시
+    if (replyItem.querySelector('.' + config.formClass)) return;
+
+    const marker = commentManager.getMarker(markerId);
+    const reply = marker?.replies?.find(r => r.id === replyId);
+    if (!reply) return;
+
+    // 편집 폼 동적 생성
+    const form = document.createElement('div');
+    form.className = config.formClass;
+
+    let editor;
+    if (config.editorType === 'textarea') {
+      editor = document.createElement('textarea');
+      editor.rows = 2;
+      editor.value = reply.text;
+    } else {
+      editor = document.createElement('div');
+      editor.contentEditable = 'true';
+      editor.textContent = reply.text;
+    }
+    editor.className = config.editorClass;
+
+    const actions = document.createElement('div');
+    actions.className = config.actionsClass;
+
+    const saveBtn = document.createElement('button');
+    saveBtn.className = config.saveClass;
+    saveBtn.textContent = '저장';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = config.cancelClass;
+    cancelBtn.textContent = '취소';
+
+    actions.appendChild(saveBtn);
+    actions.appendChild(cancelBtn);
+    form.appendChild(editor);
+    form.appendChild(actions);
+
+    // 텍스트 숨기고 폼 삽입
+    textEl.style.display = 'none';
+    textEl.insertAdjacentElement('afterend', form);
+
+    mentionManager.attach(editor);
+    editor.focus();
+
+    const cleanup = () => {
+      mentionManager.detach(editor);
+      form.remove();
+      textEl.style.display = '';
+    };
+
+    saveBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const newText = (config.editorType === 'textarea' ? editor.value : editor.innerText).trim();
+      if (!newText) return;
+      const success = commentManager.updateReply(markerId, replyId, { text: newText });
+      if (success) {
+        cleanup();
+        onSaved(newText);
+        showToast('답글이 수정되었습니다.', 'success');
+      }
+    });
+
+    cancelBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      cleanup();
+    });
+  }
+
+  /**
+   * 답글 삭제 (확인 후 실행)
+   */
+  function handleReplyDelete(markerId, replyId, onDeleted) {
+    if (!confirm('이 답글을 삭제하시겠습니까?')) return;
+    const success = commentManager.deleteReply(markerId, replyId);
+    if (success) {
+      onDeleted();
+      showToast('답글이 삭제되었습니다.', 'success');
+    }
   }
 
   function updateFeedbackProgress(total, resolved) {
@@ -5051,13 +5151,6 @@ async function initApp() {
             ` : ''}
           </div>
           <p class="comment-reply-text">${highlightMentions(renderGDriveLinks(highlightCommentSearchMatches(reply.text, normalizedSearch)))}</p>
-          <div class="comment-reply-edit-form" style="display: none;">
-            <textarea class="comment-reply-edit-textarea" rows="2">${escapeHtml(reply.text)}</textarea>
-            <div class="comment-reply-edit-actions">
-              <button class="comment-reply-edit-save">저장</button>
-              <button class="comment-reply-edit-cancel">취소</button>
-            </div>
-          </div>
         </div>
       `;
       }).join('');
@@ -5444,56 +5537,35 @@ async function initApp() {
         }
       });
 
-      // 답글 수정/삭제 이벤트 바인딩
+      // 답글 수정/삭제 이벤트 바인딩 (공통 헬퍼 사용)
+      const inlineEditConfig = {
+        textSelector: '.comment-reply-text',
+        editorType: 'textarea',
+        editorClass: 'comment-reply-edit-textarea',
+        formClass: 'comment-reply-edit-form',
+        actionsClass: 'comment-reply-edit-actions',
+        saveClass: 'comment-reply-edit-save',
+        cancelClass: 'comment-reply-edit-cancel'
+      };
+
       item.querySelectorAll('.comment-reply').forEach(replyEl => {
         const replyId = replyEl.dataset.replyId;
         const markerId = replyEl.dataset.markerId;
         if (!replyId) return;
 
-        const replyTextEl = replyEl.querySelector('.comment-reply-text');
-        const editForm = replyEl.querySelector('.comment-reply-edit-form');
-        const editTextarea = replyEl.querySelector('.comment-reply-edit-textarea');
-
-        // 수정 버튼
         replyEl.querySelector('.comment-reply-edit-btn')?.addEventListener('click', (e) => {
           e.stopPropagation();
-          replyTextEl.style.display = 'none';
-          editForm.style.display = 'block';
-          mentionManager.attach(editTextarea);
-          editTextarea.focus();
+          startReplyEdit(replyEl, markerId, replyId, inlineEditConfig, () => {
+            // commentManager가 markersChanged 이벤트를 발생시켜
+            // 댓글 목록이 자동 재렌더링되므로 별도 호출 불필요
+          });
         });
 
-        // 수정 저장
-        replyEl.querySelector('.comment-reply-edit-save')?.addEventListener('click', (e) => {
-          e.stopPropagation();
-          const newText = editTextarea.value.trim();
-          if (!newText) return;
-          const success = commentManager.updateReply(markerId, replyId, { text: newText });
-          if (success) {
-            updateCommentList(getActiveCommentFilter());
-            showToast('답글이 수정되었습니다.', 'success');
-          }
-        });
-
-        // 수정 취소
-        replyEl.querySelector('.comment-reply-edit-cancel')?.addEventListener('click', (e) => {
-          e.stopPropagation();
-          editForm.style.display = 'none';
-          replyTextEl.style.display = '';
-          const marker = commentManager.getMarker(markerId);
-          const reply = marker?.replies?.find(r => r.id === replyId);
-          if (reply) editTextarea.value = reply.text;
-        });
-
-        // 삭제 버튼
         replyEl.querySelector('.comment-reply-delete-btn')?.addEventListener('click', (e) => {
           e.stopPropagation();
-          if (!confirm('이 답글을 삭제하시겠습니까?')) return;
-          const success = commentManager.deleteReply(markerId, replyId);
-          if (success) {
-            updateCommentList(getActiveCommentFilter());
-            showToast('답글이 삭제되었습니다.', 'success');
-          }
+          handleReplyDelete(markerId, replyId, () => {
+            // markersChanged 이벤트로 자동 재렌더링
+          });
         });
       });
     });
@@ -7757,13 +7829,6 @@ async function initApp() {
             ` : ''}
           </div>
           <div class="thread-reply-text">${formatMarkdown(reply.text)}</div>
-          <div class="thread-reply-edit-form" style="display: none;">
-            <div class="thread-reply-edit-editor" contenteditable="true">${escapeHtml(reply.text)}</div>
-            <div class="thread-reply-edit-actions">
-              <button class="thread-reply-edit-save">저장</button>
-              <button class="thread-reply-edit-cancel">취소</button>
-            </div>
-          </div>
           ${reply.image ? `<div class="thread-reply-image"><img src="${reply.image}" alt="첨부 이미지" data-full-image="${reply.image}"></div>` : ''}
         </div>
       </div>
@@ -7798,8 +7863,25 @@ async function initApp() {
   }
 
   /**
-   * 스레드 답글 수정/삭제 이벤트 바인딩
+   * 스레드 답글 수정/삭제 이벤트 바인딩 (공통 헬퍼 사용)
    */
+  const _threadEditConfig = {
+    textSelector: '.thread-reply-text',
+    editorType: 'contenteditable',
+    editorClass: 'thread-reply-edit-editor',
+    formClass: 'thread-reply-edit-form',
+    actionsClass: 'thread-reply-edit-actions',
+    saveClass: 'thread-reply-edit-save',
+    cancelClass: 'thread-reply-edit-cancel'
+  };
+
+  function updateThreadReplyCount(markerId) {
+    const marker = commentManager.getMarker(markerId);
+    const replyCount = marker?.replies?.length || 0;
+    threadReplyCount.textContent = replyCount > 0 ? `${replyCount}개의 댓글` : '';
+    threadReplyCount.style.display = replyCount > 0 ? 'flex' : 'none';
+  }
+
   function bindThreadReplyActions(markerId) {
     threadReplies.querySelectorAll('.thread-reply-item').forEach(replyItem => {
       const replyId = replyItem.dataset.replyId;
@@ -7809,65 +7891,23 @@ async function initApp() {
       if (replyItem.dataset.bound) return;
       replyItem.dataset.bound = 'true';
 
-      const editBtn = replyItem.querySelector('.thread-reply-edit-btn');
-      const deleteBtn = replyItem.querySelector('.thread-reply-delete-btn');
-      const textEl = replyItem.querySelector('.thread-reply-text');
-      const editForm = replyItem.querySelector('.thread-reply-edit-form');
-      const editEditor = replyItem.querySelector('.thread-reply-edit-editor');
-      const saveBtn = replyItem.querySelector('.thread-reply-edit-save');
-      const cancelBtn = replyItem.querySelector('.thread-reply-edit-cancel');
-
       // 수정 버튼
-      editBtn?.addEventListener('click', (e) => {
+      replyItem.querySelector('.thread-reply-edit-btn')?.addEventListener('click', (e) => {
         e.stopPropagation();
-        textEl.style.display = 'none';
-        editForm.style.display = 'block';
-        // 멘션 자동완성 부착
-        mentionManager.attach(editEditor);
-        editEditor.focus();
-      });
-
-      // 수정 저장
-      saveBtn?.addEventListener('click', (e) => {
-        e.stopPropagation();
-        const newText = editEditor.innerText.trim();
-        if (!newText) return;
-
-        const success = commentManager.updateReply(markerId, replyId, { text: newText });
-        if (success) {
-          textEl.innerHTML = formatMarkdown(newText);
-          editForm.style.display = 'none';
-          textEl.style.display = '';
-          showToast('답글이 수정되었습니다.', 'success');
-        }
-      });
-
-      // 수정 취소
-      cancelBtn?.addEventListener('click', (e) => {
-        e.stopPropagation();
-        editForm.style.display = 'none';
-        textEl.style.display = '';
-        // 원래 텍스트로 복원
-        const marker = commentManager.getMarker(markerId);
-        const reply = marker?.replies?.find(r => r.id === replyId);
-        if (reply) editEditor.textContent = reply.text;
+        startReplyEdit(replyItem, markerId, replyId, _threadEditConfig, (newText) => {
+          // 스레드 팝업은 별도 렌더링 경로라서 수동으로 텍스트 갱신
+          const textEl = replyItem.querySelector('.thread-reply-text');
+          if (textEl) textEl.innerHTML = formatMarkdown(newText);
+        });
       });
 
       // 삭제 버튼
-      deleteBtn?.addEventListener('click', (e) => {
+      replyItem.querySelector('.thread-reply-delete-btn')?.addEventListener('click', (e) => {
         e.stopPropagation();
-        if (!confirm('이 답글을 삭제하시겠습니까?')) return;
-
-        const success = commentManager.deleteReply(markerId, replyId);
-        if (success) {
+        handleReplyDelete(markerId, replyId, () => {
           replyItem.remove();
-          // 답글 개수 업데이트
-          const marker = commentManager.getMarker(markerId);
-          const replyCount = marker?.replies?.length || 0;
-          threadReplyCount.textContent = replyCount > 0 ? `${replyCount}개의 댓글` : '';
-          threadReplyCount.style.display = replyCount > 0 ? 'flex' : 'none';
-          showToast('답글이 삭제되었습니다.', 'success');
-        }
+          updateThreadReplyCount(markerId);
+        });
       });
     });
   }
@@ -8060,13 +8100,6 @@ async function initApp() {
             </div>
           </div>
           <div class="thread-reply-text">${formatMarkdown(newReply.text)}</div>
-          <div class="thread-reply-edit-form" style="display: none;">
-            <div class="thread-reply-edit-editor" contenteditable="true">${escapeHtml(newReply.text)}</div>
-            <div class="thread-reply-edit-actions">
-              <button class="thread-reply-edit-save">저장</button>
-              <button class="thread-reply-edit-cancel">취소</button>
-            </div>
-          </div>
           ${newReply.image ? `<div class="thread-reply-image"><img src="${newReply.image}" alt="첨부 이미지" data-full-image="${newReply.image}"></div>` : ''}
         </div>
       </div>

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5112,9 +5112,18 @@ async function initApp() {
         ` : ''}
         <div class="comment-replies${expandedIds.has(marker.id) ? ' expanded' : ''}" data-marker-id="${marker.id}">
           ${repliesHtml}
+          <div class="comment-reply-image-preview" style="display: none;">
+            <img class="comment-reply-preview-img" src="" alt="첨부 이미지">
+            <button class="comment-reply-image-remove" title="이미지 제거">✕</button>
+          </div>
           <div class="comment-reply-input-wrapper">
-            <textarea class="comment-reply-input" placeholder="답글 입력..." rows="1"></textarea>
-            <button class="comment-reply-submit">전송</button>
+            <textarea class="comment-reply-input" placeholder="답글 입력... (Ctrl+V로 이미지 붙여넣기)" rows="1"></textarea>
+            <div class="comment-reply-input-actions">
+              <button class="comment-reply-image-btn" title="이미지 첨부">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+              </button>
+              <button class="comment-reply-submit">전송</button>
+            </div>
           </div>
         </div>
       </div>
@@ -5326,9 +5335,54 @@ async function initApp() {
       const replyBtn = item.querySelector('.reply-btn');
       const replyInput = item.querySelector('.comment-reply-input');
       const replySubmit = item.querySelector('.comment-reply-submit');
+      const replyImageBtn = item.querySelector('.comment-reply-image-btn');
+      const replyImagePreview = item.querySelector('.comment-reply-image-preview');
+      const replyPreviewImg = item.querySelector('.comment-reply-preview-img');
+      const replyImageRemove = item.querySelector('.comment-reply-image-remove');
+
+      // 인라인 답글 이미지 상태
+      let pendingReplyImage = null;
+
+      function showReplyImagePreview(imageData) {
+        pendingReplyImage = imageData;
+        replyPreviewImg.src = imageData.base64;
+        replyImagePreview.style.display = 'block';
+      }
+
+      function clearReplyImage() {
+        pendingReplyImage = null;
+        if (replyPreviewImg) replyPreviewImg.src = '';
+        if (replyImagePreview) replyImagePreview.style.display = 'none';
+      }
 
       // 인라인 답글 textarea에 멘션 자동완성 부착
       if (replyInput) mentionManager.attach(replyInput);
+
+      // 답글 이미지 버튼 클릭
+      replyImageBtn?.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const imageData = await selectImageFile();
+        if (imageData) {
+          showReplyImagePreview(imageData);
+          showToast('이미지가 첨부되었습니다', 'success');
+        }
+      });
+
+      // 답글 이미지 제거
+      replyImageRemove?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        clearReplyImage();
+      });
+
+      // 답글 이미지 붙여넣기
+      replyInput?.addEventListener('paste', async (e) => {
+        const imageData = await getImageFromClipboard(e);
+        if (imageData) {
+          e.preventDefault();
+          showReplyImagePreview(imageData);
+          showToast('이미지가 첨부되었습니다', 'success');
+        }
+      });
 
       // 스레드 토글 버튼
       threadToggle?.addEventListener('click', (e) => {
@@ -5347,15 +5401,33 @@ async function initApp() {
         replyInput?.focus();
       });
 
-      // 답글 제출
+      // 답글 제출 (이미지 포함)
       replySubmit?.addEventListener('click', (e) => {
         e.stopPropagation();
         const replyText = replyInput.value.trim();
-        if (replyText) {
-          commentManager.addReplyToMarker(item.dataset.markerId, replyText);
-          replyInput.value = '';
-          showToast('답글이 추가되었습니다.', 'success');
+        const hasImage = pendingReplyImage && pendingReplyImage.base64;
+        if (!replyText && !hasImage) return;
+
+        const marker = commentManager.getMarker(item.dataset.markerId);
+        if (!marker) return;
+
+        const replyData = {
+          text: replyText || '',
+          author: commentManager.getAuthor()
+        };
+        if (hasImage) {
+          replyData.image = pendingReplyImage.base64;
+          replyData.imageWidth = pendingReplyImage.width;
+          replyData.imageHeight = pendingReplyImage.height;
         }
+
+        const newReply = marker.addReply(replyData);
+        commentManager._emit('replyAdded', { marker, reply: newReply });
+        commentManager._emit('markersChanged');
+
+        replyInput.value = '';
+        clearReplyImage();
+        showToast('답글이 추가되었습니다.', 'success');
       });
 
       // Enter로 답글 제출

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -4019,7 +4019,7 @@ async function initApp() {
         loadingProgress.style.width = `${progress * 100}%`;
 
         if (phase === 1) {
-          loadingText.textContent = `썸네일 빠른 생성 중... (${current}/${total})`;
+          loadingText.textContent = `썸네일 생성 중... (${current}/${total})`;
         } else {
           loadingText.textContent = `썸네일 세부 생성 중... (${current}/${total})`;
         }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5025,6 +5025,11 @@ async function initApp() {
     const thumbnailScale = userSettings.getCommentThumbnailScale();
     const thumbnailGenerator = getThumbnailGenerator();
 
+    // 재렌더링 전: 기존 요소들의 mentionManager 핸들러 정리 (메모리 누수 방지)
+    container.querySelectorAll('.comment-reply-input, .comment-reply-edit-textarea').forEach(el => {
+      mentionManager.detach(el);
+    });
+
     container.innerHTML = markers.map(marker => {
       const authorClass = getAuthorColorClass(marker.author);
       const authorStyle = getAuthorColorStyle(marker.author);

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -16,7 +16,7 @@ import { getUserSettings } from './modules/user-settings.js';
 import { getAuthManager } from './modules/auth-manager.js';
 import { getThumbnailGenerator } from './modules/thumbnail-generator.js';
 import { PlexusEffect } from './modules/plexus.js';
-import { getImageFromClipboard, selectImageFile, isValidImageBase64 } from './modules/image-utils.js';
+import { getImageFromClipboard, hasImageInClipboard, selectImageFile, isValidImageBase64 } from './modules/image-utils.js';
 import { parseVersion, toVersionInfo } from './modules/version-parser.js';
 import { getVersionManager } from './modules/version-manager.js';
 import { getVersionDropdown } from './modules/version-dropdown.js';
@@ -1257,13 +1257,16 @@ async function initApp() {
   }
 
   // 댓글 입력창 이미지 붙여넣기
+  // 이미지가 있으면 동기적으로 preventDefault (async await 이후엔 이미 늦음)
   elements.commentInput.addEventListener('paste', async (e) => {
     // 드라이브 경로 자동 따옴표
     if (handleDrivePathPaste(e)) return;
 
+    if (!hasImageInClipboard(e)) return;
+    e.preventDefault();
+
     const imageData = await getImageFromClipboard(e);
     if (imageData) {
-      e.preventDefault();
       showCommentImagePreview(imageData);
       showToast('이미지가 첨부되었습니다', 'success');
     }
@@ -5486,10 +5489,13 @@ async function initApp() {
       });
 
       // 답글 이미지 붙여넣기
+      // 주의: async 핸들러의 await 이후 preventDefault는 이미 늦어서 무효함
+      //       → 이미지 유무를 먼저 동기 체크 후 즉시 preventDefault
       replyInput?.addEventListener('paste', async (e) => {
+        if (!hasImageInClipboard(e)) return;
+        e.preventDefault();
         const imageData = await getImageFromClipboard(e);
         if (imageData) {
-          e.preventDefault();
           showReplyImagePreview(imageData);
           showToast('이미지가 첨부되었습니다', 'success');
         }
@@ -8215,13 +8221,16 @@ async function initApp() {
   });
 
   // 스레드 에디터 이미지 붙여넣기
+  // 이미지가 있으면 동기적으로 preventDefault (async await 이후엔 이미 늦음)
   threadEditor?.addEventListener('paste', async (e) => {
     // 드라이브 경로 자동 따옴표
     if (handleDrivePathPaste(e)) return;
 
+    if (!hasImageInClipboard(e)) return;
+    e.preventDefault();
+
     const imageData = await getImageFromClipboard(e);
     if (imageData) {
-      e.preventDefault();
       showThreadImagePreview(imageData);
       showToast('이미지가 첨부되었습니다', 'success');
     }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -7762,8 +7762,13 @@ async function initApp() {
     // Strikethrough: ~text~
     html = html.replace(/~(.+?)~/g, '<s>$1</s>');
 
-    // Code: `code`
-    html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+    // Code: `code` — 플레이스홀더로 보호 (멘션 하이라이팅 방지)
+    const codePlaceholders = [];
+    html = html.replace(/`([^`]+)`/g, (_, code) => {
+      const placeholder = `\x00CODE_${codePlaceholders.length}\x00`;
+      codePlaceholders.push(`<code>${code}</code>`);
+      return placeholder;
+    });
 
     // Bullet list: - item
     html = html.replace(/^- (.+)$/gm, '<li>$1</li>');
@@ -7773,6 +7778,11 @@ async function initApp() {
 
     // @멘션 하이라이팅
     html = html.replace(/@([\p{L}\p{N}]+)/gu, '<span class="mention-highlight">@$1</span>');
+
+    // 코드 블록 복원
+    codePlaceholders.forEach((code, i) => {
+      html = html.replace(`\x00CODE_${i}\x00`, code);
+    });
 
     // Line breaks
     html = html.replace(/\n/g, '<br>');

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5165,7 +5165,7 @@ async function initApp() {
             </div>
             ` : ''}
           </div>
-          ${reply.text ? `<p class="comment-reply-text">${highlightMentions(renderGDriveLinks(highlightCommentSearchMatches(reply.text, normalizedSearch)))}</p>` : ''}
+          <p class="comment-reply-text">${reply.text ? highlightMentions(renderGDriveLinks(highlightCommentSearchMatches(reply.text, normalizedSearch))) : ''}</p>
           ${reply.image ? `<div class="comment-attached-image"><img src="${reply.image}" alt="첨부 이미지" data-full-image="${reply.image}"></div>` : ''}
         </div>
       `;
@@ -8106,7 +8106,10 @@ async function initApp() {
     threadReplyCount.style.display = 'flex';
 
     // UI 업데이트 - 새 답글 추가 (XSS 방지: author 필드 이스케이프)
-    threadReplies.innerHTML += `
+    // 주의: innerHTML += 를 쓰면 기존 DOM이 재파싱되면서 이벤트 리스너가
+    //       사라지고 data-bound 속성은 남아 이전 답글의 수정/삭제가 먹통됨
+    //       → insertAdjacentHTML로 기존 노드를 건드리지 않고 append
+    threadReplies.insertAdjacentHTML('beforeend', `
       <div class="thread-reply-item" data-reply-id="${newReply.id}">
         <div class="thread-reply-avatar">${escapeHtml(newReply.author.charAt(0))}</div>
         <div class="thread-reply-content">
@@ -8122,9 +8125,9 @@ async function initApp() {
           ${newReply.image ? `<div class="thread-reply-image"><img src="${newReply.image}" alt="첨부 이미지" data-full-image="${newReply.image}"></div>` : ''}
         </div>
       </div>
-    `;
+    `);
 
-    // 새 답글 수정/삭제 이벤트 바인딩
+    // 새 답글에만 이벤트 바인딩 (기존 답글은 data-bound로 스킵)
     bindThreadReplyActions(currentThreadMarkerId);
 
     // 에디터 및 이미지 초기화

--- a/renderer/scripts/modules/comment-sync.js
+++ b/renderer/scripts/modules/comment-sync.js
@@ -139,7 +139,9 @@ export class CommentSync {
 
   _onReplyAdded(e) {
     if (this._isRemoteUpdate) return;
-    const { markerId, reply } = e.detail || {};
+    const detail = e.detail || {};
+    const markerId = detail.markerId || detail.marker?.id;
+    const reply = detail.reply;
     if (!markerId || !reply) return;
 
     this._lm.broadcastEvent({
@@ -159,7 +161,10 @@ export class CommentSync {
 
   _onReplyUpdated(e) {
     if (this._isRemoteUpdate) return;
-    const { markerId, replyId, updates } = e.detail || {};
+    const detail = e.detail || {};
+    const markerId = detail.markerId || detail.marker?.id;
+    const replyId = detail.replyId;
+    const updates = detail.updates;
     if (!markerId || !replyId) return;
 
     this._lm.broadcastEvent({
@@ -172,7 +177,9 @@ export class CommentSync {
 
   _onReplyDeleted(e) {
     if (this._isRemoteUpdate) return;
-    const { markerId, replyId } = e.detail || {};
+    const detail = e.detail || {};
+    const markerId = detail.markerId || detail.marker?.id;
+    const replyId = detail.replyId;
     if (!markerId || !replyId) return;
 
     this._lm.broadcastEvent({

--- a/renderer/scripts/modules/image-utils.js
+++ b/renderer/scripts/modules/image-utils.js
@@ -169,6 +169,21 @@ export async function createThumbnail(base64, size = IMAGE_CONFIG.thumbnailSize)
 }
 
 /**
+ * 클립보드 이벤트에 이미지가 포함되어 있는지 동기적으로 확인
+ * paste 이벤트 핸들러에서 preventDefault를 즉시 호출하기 위해 사용
+ * @param {ClipboardEvent} event
+ * @returns {boolean}
+ */
+export function hasImageInClipboard(event) {
+  const items = event.clipboardData?.items;
+  if (!items) return false;
+  for (const item of items) {
+    if (item.type.startsWith('image/')) return true;
+  }
+  return false;
+}
+
+/**
  * 클립보드에서 이미지 가져오기
  * @param {ClipboardEvent} event - 붙여넣기 이벤트
  * @returns {Promise<{base64: string, width: number, height: number}|null>}

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -147,6 +147,8 @@ export class ReviewDataManager extends EventTarget {
       this.commentManager.addEventListener('markerUpdated', this._onDataChanged);
       this.commentManager.addEventListener('markerDeleted', this._onDataChanged);
       this.commentManager.addEventListener('replyAdded', this._onDataChanged);
+      this.commentManager.addEventListener('replyUpdated', this._onDataChanged);
+      this.commentManager.addEventListener('replyDeleted', this._onDataChanged);
       this.commentManager.addEventListener('layerAdded', this._onDataChanged);
       this.commentManager.addEventListener('layerRemoved', this._onDataChanged);
     }
@@ -178,6 +180,8 @@ export class ReviewDataManager extends EventTarget {
       this.commentManager.removeEventListener('markerUpdated', this._onDataChanged);
       this.commentManager.removeEventListener('markerDeleted', this._onDataChanged);
       this.commentManager.removeEventListener('replyAdded', this._onDataChanged);
+      this.commentManager.removeEventListener('replyUpdated', this._onDataChanged);
+      this.commentManager.removeEventListener('replyDeleted', this._onDataChanged);
       this.commentManager.removeEventListener('layerAdded', this._onDataChanged);
       this.commentManager.removeEventListener('layerRemoved', this._onDataChanged);
     }

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -7161,6 +7161,96 @@ body.resizing .comment-panel {
   padding-left: 16px;
 }
 
+/* 답글 수정/삭제 버튼 */
+.thread-reply-actions {
+  display: none;
+  margin-left: auto;
+  gap: 4px;
+}
+
+.thread-reply-item:hover .thread-reply-actions {
+  display: flex;
+}
+
+.thread-reply-action-btn {
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  padding: 2px 6px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.thread-reply-action-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+
+.thread-reply-delete-btn:hover {
+  color: #ff5555;
+}
+
+/* 답글 수정 폼 */
+.thread-reply-edit-form {
+  margin-top: 4px;
+}
+
+.thread-reply-edit-editor {
+  background: var(--bg-secondary, #2a2a2a);
+  border: 1px solid var(--border-primary, #444);
+  border-radius: 6px;
+  padding: 8px;
+  font-size: 13px;
+  color: var(--text-primary);
+  min-height: 40px;
+  max-height: 120px;
+  overflow-y: auto;
+  outline: none;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.thread-reply-edit-editor:focus {
+  border-color: var(--accent-primary, #ffd000);
+}
+
+.thread-reply-edit-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+  justify-content: flex-end;
+}
+
+.thread-reply-edit-actions button {
+  padding: 4px 12px;
+  font-size: 12px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.thread-reply-edit-save {
+  background: var(--accent-primary, #ffd000);
+  color: var(--bg-primary, #1a1a1a);
+  font-weight: 600;
+}
+
+.thread-reply-edit-save:hover {
+  background: var(--accent-hover, #ffe44d);
+}
+
+.thread-reply-edit-cancel {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-secondary);
+}
+
+.thread-reply-edit-cancel:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
 /* Thread Input Area */
 .thread-input-area {
   border-top: 1px solid var(--border-subtle);
@@ -10281,6 +10371,11 @@ body.audio-mode .frame-indicator {
 
 .mention-item-name {
   font-weight: 500;
+}
+
+.mention-highlight {
+  color: var(--accent-primary, #ffd000);
+  font-weight: 600;
 }
 
 /* ==========================================

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -230,7 +230,7 @@
 
 /* 로딩 오버레이 */
 .light-mode .video-loading-overlay {
-  background: rgba(245, 245, 245, 0.85);
+  background: rgba(245, 245, 245, 0.8);
 }
 
 /* 코덱 에러 오버레이 */
@@ -6324,19 +6324,21 @@ body.resizing .comment-panel {
 
 .video-loading-overlay {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.85);
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.75);
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  gap: 10px;
+  padding: 8px 16px;
+  border-radius: 8px;
   z-index: 100;
   opacity: 0;
   visibility: hidden;
+  pointer-events: none;
   transition: all 0.3s ease;
+  backdrop-filter: blur(4px);
 }
 
 .video-loading-overlay.active {
@@ -6345,13 +6347,13 @@ body.resizing .comment-panel {
 }
 
 .loading-spinner {
-  width: 48px;
-  height: 48px;
-  border: 3px solid var(--border-subtle);
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border-subtle);
   border-top-color: var(--accent-primary);
   border-radius: 50%;
   animation: spin 1s linear infinite;
-  margin-bottom: 16px;
+  flex-shrink: 0;
 }
 
 @keyframes spin {
@@ -6361,17 +6363,18 @@ body.resizing .comment-panel {
 }
 
 .loading-text {
-  font-size: 14px;
+  font-size: 12px;
   color: var(--text-secondary);
-  margin-bottom: 12px;
+  white-space: nowrap;
 }
 
 .loading-progress-bar {
-  width: 200px;
-  height: 4px;
+  width: 80px;
+  height: 3px;
   background: var(--bg-tertiary);
   border-radius: 2px;
   overflow: hidden;
+  flex-shrink: 0;
 }
 
 .loading-progress-fill {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -6219,6 +6219,12 @@ body.resizing .comment-panel {
   white-space: pre-wrap;
 }
 
+/* 이미지만 있는 답글: 빈 텍스트 컨테이너는 높이를 차지하지 않음 */
+/* (수정 시 startReplyEdit가 querySelector로 찾을 수 있도록 DOM에는 존재) */
+.comment-reply-text:empty {
+  display: none;
+}
+
 /* 댓글 패널 답글 수정/삭제 버튼 */
 .comment-reply-actions {
   display: none;

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -6219,6 +6219,94 @@ body.resizing .comment-panel {
   white-space: pre-wrap;
 }
 
+/* 댓글 패널 답글 수정/삭제 버튼 */
+.comment-reply-actions {
+  display: none;
+  margin-left: auto;
+  gap: 4px;
+}
+
+.comment-reply:hover .comment-reply-actions {
+  display: flex;
+}
+
+.comment-reply-action-btn {
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  padding: 1px 5px;
+  cursor: pointer;
+  border-radius: 3px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.comment-reply-action-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+
+.comment-reply-delete-btn:hover {
+  color: #ff5555;
+}
+
+/* 댓글 패널 답글 수정 폼 */
+.comment-reply-edit-form {
+  margin-top: 6px;
+}
+
+.comment-reply-edit-textarea {
+  width: 100%;
+  background: var(--bg-secondary, #2a2a2a);
+  border: 1px solid var(--border-primary, #444);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 12px;
+  color: var(--text-primary);
+  resize: vertical;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.comment-reply-edit-textarea:focus {
+  border-color: var(--accent-primary, #ffd000);
+  outline: none;
+}
+
+.comment-reply-edit-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+  justify-content: flex-end;
+}
+
+.comment-reply-edit-actions button {
+  padding: 3px 10px;
+  font-size: 11px;
+  border-radius: 3px;
+  border: none;
+  cursor: pointer;
+}
+
+.comment-reply-edit-save {
+  background: var(--accent-primary, #ffd000);
+  color: var(--bg-primary, #1a1a1a);
+  font-weight: 600;
+}
+
+.comment-reply-edit-save:hover {
+  background: var(--accent-hover, #ffe44d);
+}
+
+.comment-reply-edit-cancel {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-secondary);
+}
+
+.comment-reply-edit-cancel:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
 .comment-reply-input-wrapper {
   margin-top: 10px;
   display: flex;

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -6307,12 +6307,6 @@ body.resizing .comment-panel {
   background: rgba(255, 255, 255, 0.15);
 }
 
-.comment-reply-input-wrapper {
-  margin-top: 10px;
-  display: flex;
-  gap: 8px;
-}
-
 .comment-reply-input {
   flex: 1;
   padding: 8px 10px;
@@ -6344,6 +6338,77 @@ body.resizing .comment-panel {
 
 .comment-reply-submit:hover {
   background: var(--accent-secondary);
+}
+
+/* 인라인 답글 이미지 첨부 */
+.comment-reply-input-wrapper {
+  margin-top: 10px;
+  display: flex;
+  gap: 6px;
+  align-items: flex-end;
+}
+
+.comment-reply-input-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.comment-reply-image-btn {
+  padding: 6px;
+  background: none;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+}
+
+.comment-reply-image-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--accent-primary);
+}
+
+.comment-reply-image-preview {
+  position: relative;
+  margin-bottom: 6px;
+  max-width: 120px;
+}
+
+.comment-reply-preview-img {
+  max-width: 120px;
+  max-height: 80px;
+  border-radius: 6px;
+  border: 1px solid var(--border-subtle);
+  object-fit: cover;
+}
+
+.comment-reply-image-remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 18px;
+  height: 18px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 50%;
+  color: var(--text-secondary);
+  font-size: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  line-height: 1;
+}
+
+.comment-reply-image-remove:hover {
+  background: #ff5555;
+  color: white;
+  border-color: #ff5555;
 }
 
 /* 마커 답글 표시 */


### PR DESCRIPTION
## 요약

- 댓글 답글에 @멘션 태그 및 수정/삭제 기능 추가 (스레드 팝업 + 인라인)
- 인라인 답글에 이미지 첨부 기능 추가 (스레드 팝업과 동일)
- 답글 추가/삭제 실시간 동기화가 안 되던 기존 버그 수정
- 썸네일 생성 중 전체 화면을 덮던 오버레이를 비차단형으로 변경
- @멘션 하이라이팅을 TEAM_MEMBERS 등록 이름만 매칭하도록 제한

## 변경 내용

### 답글 @멘션 태그 기능
- `formatMarkdown`, 댓글 패널 텍스트에 `<span class="mention-highlight">` 하이라이팅 추가
- TEAM_MEMBERS에 등록된 이름만 매칭 (임의 `@문자열` 매칭 방지)
- 코드 블록(`` `code` ``) 안의 @멘션은 플레이스홀더로 보호하여 하이라이팅 제외
- 인라인 답글 textarea에 `mentionManager.attach()` 적용 (자동완성 드롭다운)
- 멘션 드롭다운 열린 상태에서 Enter 키 전송 방지

### 답글 수정/삭제 버튼
- **스레드 팝업**(더블클릭) 답글에 수정/삭제 버튼 추가 (hover 시 표시)
- **댓글 패널 사이드바** 인라인 답글에도 수정/삭제 버튼 추가
- 수정: 인라인 에디터 + 멘션 자동완성 지원
- 삭제: 확인 다이얼로그 + `commentManager.canEdit` 권한 체크
- 기존 `commentManager.updateReply` / `deleteReply` API 활용

### 인라인 답글 이미지 첨부
- 이미지 버튼 클릭 또는 `Ctrl+V` 붙여넣기로 첨부
- 미리보기 + ✕ 제거 버튼
- 텍스트만/이미지만/텍스트+이미지 모두 전송 가능
- 스레드 팝업과 동일한 `addReply` 데이터 형식 사용

### 답글 실시간 동기화 버그 수정
- `comment-sync.js`의 `replyAdded`, `replyDeleted` Broadcast가 전송되지 않던 기존 버그 수정
- 원인: CommentManager가 `{ marker }` (객체)를 보내는데 CommentSync가 `{ markerId }` (문자열)를 기대 → 항상 `undefined`로 early return
- `detail.markerId || detail.marker?.id`로 양쪽 모두 대응하도록 수정
- `replyUpdated`도 동일 패턴으로 방어적 수정

### 썸네일 생성 오버레이 비차단형 변경
- 전체 비디오 영역을 85% 불투명 배경으로 덮던 오버레이 → 하단 중앙 소형 인디케이터로 변경
- `pointer-events: none` 적용으로 재생/코멘트 등 모든 조작 가능
- 스피너(16px) + 텍스트 + 진행률 바를 한 줄로 정리
- backdrop-filter blur 적용으로 가독성 확보
- 썸네일은 별도 hidden video에서 생성되므로 메인 재생에 영향 없음 확인

## 변경 파일

- `renderer/scripts/app.js` — 답글 UI/이벤트, 멘션 하이라이팅, 썸네일 오버레이 진행률 텍스트
- `renderer/styles/main.css` — 답글 수정/삭제/이미지 스타일, 멘션 하이라이팅, 썸네일 오버레이
- `renderer/scripts/modules/comment-sync.js` — 답글 Broadcast 이벤트 detail 호환성

## 테스트

- [x] 답글에서 `@이름` 입력 → 드롭다운 표시 및 하이라이팅 확인
- [x] `@등록된이름` vs `@아무거나` 구분 (후자는 하이라이팅 안 됨)
- [x] `` `@이름` `` 코드 블록 내 하이라이팅 제외 확인
- [x] 스레드 팝업 답글 hover → 수정/삭제 버튼 표시
- [x] 댓글 패널 사이드바 답글 hover → 수정/삭제 버튼 표시
- [x] 인라인 답글 이미지 첨부 (버튼/붙여넣기) 및 전송
- [ ] 답글 추가/삭제가 다른 클라이언트에 실시간 반영되는지 확인
- [x] 썸네일 생성 중 재생 및 코멘트 작성 가능 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)