### PR TITLE
[v1.2.0-beta] 코멘트 클러스터 UX 재작업 — 편집 regression 복구·줌 반응형·썸네일 정확-프레임

### DIFF
--- a/DEVLOG/2026-04-20-코멘트-클러스터-UX-재작업.md
+++ b/DEVLOG/2026-04-20-코멘트-클러스터-UX-재작업.md
@@ -1,0 +1,77 @@
+# 코멘트 클러스터 UX 재작업
+
+> PR #112로 도입된 Mode C 하이브리드 펼침 UI의 후속 개선
+
+## 요약
+
+| 항목 | 수정 파일 | 이유 | 우선순위 | 상태 |
+|------|----------|------|---------|------|
+| Phase 1 | comment-cluster.js, test | 픽셀 간격 기반 split 순수 함수 | 높음 | ✅ 완료 |
+| Phase 2 | main.css | 배지/접기/툴팁 CSS 재설계 (세로줄 제거, +N 강조) | 높음 | ✅ 완료 |
+| Phase 3 | timeline.js | DOM 구조 변경 + split 파이프라인 통합 | 높음 | ✅ 완료 |
+| Phase 4 | timeline.js, app.js | 이벤트 위임 + 드래그 편집 regression 복구 | 높음 | ✅ 완료 |
+| Phase 5 | app.js | 접힌 배지 호버 팝업 (세로 리스트) | 중간 | ✅ 완료 |
+| Phase 6 | thumbnail-generator.js, app.js | 댓글 썸네일 정확-프레임 (온디맨드 캡처) | 중간 | ✅ 완료 |
+
+## 배경 및 목적
+
+PR #112에서 **구간 코멘트 중첩 시 하이브리드 펼침 UI (Mode C)** 가 병합된 후 다음 이슈가 발견됐다:
+
+- **A. 편집 regression**: 펼친 클러스터 내부 코멘트의 드래그/리사이즈 편집이 안 됨
+- **B. 펼친 상태 즉시 닫힘**: 편집하려 `mousedown`하면 클러스터가 바로 접힘
+- **C. 배지 시각 혼잡**: 세로 3색 스트라이프가 시선 분산
+- **D. 호버 피드백 부재**: 접힌 배지에는 단일 코멘트와 달리 툴팁이 없음
+- **E. 접기 버튼 가시성 낮음**: "▲ 접기" 칩이 작고 눈에 안 띔
+- **F. 줌 무시 클러스터링**: 확대해도 이미 묶인 클러스터는 유지
+- **G. 댓글 썸네일 근사치**: 사이드바가 `startFrame` 정확 프레임이 아닌 근사 썸네일 표시
+
+## 아키텍처 (핵심 변경)
+
+### 이벤트 위임
+
+**기존**: `setupCommentRangeInteractions()`가 `.comment-range-item` DOM마다 개별 리스너를 바인딩. PR #112로 클러스터 펼침 시 DOM이 재생성되는데 함수가 재호출되지 않아 이벤트가 비었음.
+
+**전환**: `commentTrack` 컨테이너 1곳에 `click` / `mousedown` / `mouseover` / `mouseout` 위임 리스너 1회 바인딩. 타깃 식별은 `e.target.closest(...)`.
+
+### 픽셀 기반 클러스터 분리
+
+`findRangeClusters()` (프레임 기반, 유지) 다음 단계에 `splitClustersByPixelGap(clusters, { pxPerFrame, minGapPx: 8 })` 추가. 줌인될수록 `pxPerFrame ↑` → 같은 프레임 클러스터도 자연스럽게 분리.
+
+### 썸네일 온디맨드 캡처
+
+`thumbnailGenerator.getThumbnailUrlAtExact(time)`로 정확 매칭 우선 → 없으면 `requestExactCapture(time)` 큐에 등록 + 근사치 폴백. `pause` 시 `_drainExactQueue()`, `play` 시 `_abortExactDrain()`. Phase 2 완료 후 비디오가 해제돼도 lazy 재생성하여 캡처.
+
+## 수동 QA 체크리스트
+
+1. [ ] 겹친 코멘트 2/3/5개 → 각각 `+2`/`+3`/`+5` 배지 표시
+2. [ ] 배지 호버 (접힌 상태) → 300ms 후 세로 리스트 팝업 (색 점·작성자·프레임 범위·본문 1줄)
+3. [ ] 팝업 위치 top/bottom 폴백 (뷰포트 상단 근처에서 아래로)
+4. [ ] 배지 클릭 → 펼침, 오른쪽 상단에 "× 접기" 배지 명확히 표시
+5. [ ] **펼친 클러스터 내부 코멘트 바 중앙 드래그 → 이동**, 펼친 상태 유지 (핵심 regression 복구)
+6. [ ] 좌/우 핸들 드래그 → `startFrame`/`endFrame` 변경, 펼친 상태 유지
+7. [ ] 3px 미만 드래그 = 단순 클릭 처리 (프레임 이동/하이라이트만, 데이터 변경 無)
+8. [ ] 트랙 빈 영역 클릭 → 펼친 클러스터 접힘
+9. [ ] 드래그 직후 접힘 시도 → 차단 (50ms `commentJustDragged` 플래그)
+10. [ ] 줌 1× 8px 이내 코멘트 → 클러스터 묶음; **줌 300% 확대 → 자연스레 분리**
+11. [ ] 댓글 클릭 → 사이드바 썸네일이 근사치 먼저, 일시정지 시 ≤1초 후 **정확한 프레임으로 교체**
+12. [ ] 재생 중에는 온디맨드 캡처 대기, 일시정지 시 드레인
+13. [ ] Phase 2 완료 후 (`this.video === null`) 새 댓글 달기 → 정확 프레임 캡처 동작
+14. [ ] Regression: 비클러스터 단일 코멘트 편집 정상 동작
+15. [ ] 실시간 동기화 이벤트 드래그 중 수신돼도 펼친 상태 유지
+16. [ ] 펼친 상태에서 줌 변경 → 구성원 동일하면 유지, split으로 구성원 변하면 접힘
+
+## 테스트 결과
+
+- 단위 테스트: `npm run test:cluster` — **28/28 통과** (기존 18 + 신규 10)
+- ESLint 오류: **0건** (경고는 기존 코드의 미사용 변수로 이번 PR과 무관)
+
+## 스펙·플랜 참조
+
+- Spec: [docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md](../docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md)
+- Plan: [docs/superpowers/plans/2026-04-20-comment-cluster-ux-rework.md](../docs/superpowers/plans/2026-04-20-comment-cluster-ux-rework.md)
+
+## 후속 과제
+
+- [ ] 웹 뷰어(`web-viewer/`)에도 동일 UX 반영 (별도 PR)
+- [ ] ESC 키로 펼친 클러스터 접기 (선택적 개선)
+- [ ] 온디맨드 캡처 큐 상한 (현재 Set 중복 방지만, 극단적 누적 방지용 상한 미설정)

--- a/docs/superpowers/plans/2026-04-20-comment-cluster-ux-rework.md
+++ b/docs/superpowers/plans/2026-04-20-comment-cluster-ux-rework.md
@@ -1,0 +1,1248 @@
+# 코멘트 클러스터 UX 재작업 구현 계획
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PR #112에서 도입된 Mode C 하이브리드 펼침 UI의 후속 개선 — 이벤트 위임 기반 상호작용 엔진, 픽셀 기반 클러스터 해제, 배지/접기/호버 팝업 재설계, 댓글 썸네일 정확-프레임 캡처.
+
+**Architecture:** 기존 `.comment-range-item` 개별 리스너 방식을 `commentTrack` 컨테이너 1개에 위임하는 구조로 전환. 순수 함수 `splitClustersByPixelGap`을 기존 `findRangeClusters` 파이프라인에 추가. 썸네일은 EventTarget `exactCaptured` 이벤트로 진적 갱신.
+
+**Tech Stack:** Electron + vanilla JS ES modules, node-tap(`npm run test:*`), ESLint, Prettier.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md`
+
+---
+
+## 파일 구조
+
+| 파일 | 변경 유형 | 책임 |
+|------|----------|------|
+| `renderer/scripts/modules/comment-cluster.js` | 추가 | 클러스터링 순수 함수 모음 — `splitClustersByPixelGap` 추가 |
+| `scripts/tests/comment-cluster.test.js` | 추가 | 클러스터링 순수 함수 단위 테스트 |
+| `renderer/scripts/modules/timeline.js` | 개편 | 이벤트 위임 엔진, 드래그 엔진, split 호출, DOM 구조 변경 |
+| `renderer/scripts/app.js` | 삭제+수정 | `setupCommentRangeInteractions` 삭제, 썸네일 호출부 수정, `exactCaptured` 리스너 |
+| `renderer/scripts/modules/thumbnail-generator.js` | 추가 | 온디맨드 정확-프레임 API |
+| `renderer/styles/main.css` | 개편 | stack-hint 제거, label/close-badge/tooltip 추가 |
+| `DEVLOG/2026-04-20-코멘트-클러스터-UX-재작업.md` | 신규 | 작업 로그 + QA 체크리스트 |
+
+---
+
+## Chunk 1: Phase 1 — 클러스터 split 로직 (TDD)
+
+### Task 1.1: `splitClustersByPixelGap` 실패 테스트 작성
+
+**Files:**
+- Modify: `scripts/tests/comment-cluster.test.js`
+
+- [ ] **Step 1: 기존 테스트 파일 확인**
+
+Run: `cat scripts/tests/comment-cluster.test.js | head -30`
+Expected: 기존 `findRangeClusters`, `assignLanes`, `clusterKey` 테스트 확인
+
+- [ ] **Step 2: `splitClustersByPixelGap` import 및 기본 케이스 테스트 추가**
+
+파일 상단 import:
+```js
+import { splitClustersByPixelGap } from '../../renderer/scripts/modules/comment-cluster.js';
+```
+
+파일 하단 새 describe 블록:
+```js
+describe('splitClustersByPixelGap', () => {
+  test('빈 배열 입력 → 빈 배열 반환', () => {
+    const result = splitClustersByPixelGap([], { pxPerFrame: 1, minGapPx: 8 });
+    expect(result).toEqual([]);
+  });
+
+  test('단일 멤버 클러스터는 그대로 통과', () => {
+    const c = [{ markerId: 'a', startFrame: 0, endFrame: 10 }];
+    const result = splitClustersByPixelGap([c], { pxPerFrame: 1 });
+    expect(result).toEqual([c]);
+  });
+
+  test('모든 gap이 minGapPx 미만 → 원본 클러스터 그대로', () => {
+    const cluster = [
+      { markerId: 'a', startFrame: 0,  endFrame: 10 },
+      { markerId: 'b', startFrame: 12, endFrame: 20 }, // gap=2 frames * 1px = 2px < 8px
+    ];
+    const result = splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual(cluster);
+  });
+
+  test('한 지점만 gap ≥ minGapPx → 2개로 분리', () => {
+    const cluster = [
+      { markerId: 'a', startFrame: 0,  endFrame: 10 },
+      { markerId: 'b', startFrame: 20, endFrame: 30 }, // gap=10 frames * 1px = 10px ≥ 8px
+    ];
+    const result = splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+    expect(result.length).toBe(2);
+    expect(result[0]).toEqual([cluster[0]]);
+    expect(result[1]).toEqual([cluster[1]]);
+  });
+
+  test('여러 gap ≥ minGapPx → N+1개로 분리', () => {
+    const cluster = [
+      { markerId: 'a', startFrame: 0,  endFrame: 5  },
+      { markerId: 'b', startFrame: 15, endFrame: 20 }, // gap=10
+      { markerId: 'c', startFrame: 30, endFrame: 35 }, // gap=10
+    ];
+    const result = splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+    expect(result.length).toBe(3);
+  });
+
+  test('pxPerFrame = 0 → 원본 그대로 (안전 가드)', () => {
+    const cluster = [
+      { markerId: 'a', startFrame: 0,  endFrame: 10 },
+      { markerId: 'b', startFrame: 100, endFrame: 110 },
+    ];
+    const result = splitClustersByPixelGap([cluster], { pxPerFrame: 0, minGapPx: 8 });
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual(cluster);
+  });
+
+  test('pxPerFrame 음수 → 원본 그대로', () => {
+    const cluster = [
+      { markerId: 'a', startFrame: 0,  endFrame: 10 },
+      { markerId: 'b', startFrame: 100, endFrame: 110 },
+    ];
+    const result = splitClustersByPixelGap([cluster], { pxPerFrame: -1, minGapPx: 8 });
+    expect(result).toEqual([cluster]);
+  });
+
+  test('minGapPx 옵션 생략 → 기본 8px 적용', () => {
+    const cluster = [
+      { markerId: 'a', startFrame: 0,  endFrame: 10 },
+      { markerId: 'b', startFrame: 20, endFrame: 30 }, // gap=10px ≥ 8px
+    ];
+    const result = splitClustersByPixelGap([cluster], { pxPerFrame: 1 });
+    expect(result.length).toBe(2);
+  });
+
+  test('정렬되지 않은 멤버도 처리', () => {
+    const cluster = [
+      { markerId: 'b', startFrame: 20, endFrame: 30 },
+      { markerId: 'a', startFrame: 0,  endFrame: 10 },
+    ];
+    const result = splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+    expect(result.length).toBe(2);
+    expect(result[0][0].markerId).toBe('a');
+    expect(result[1][0].markerId).toBe('b');
+  });
+});
+```
+
+### Task 1.2: 테스트 실행하여 실패 확인
+
+- [ ] **Step 1: 테스트 실행**
+
+Run: `npm test -- --grep "splitClustersByPixelGap"` 또는 `npm run test`
+Expected: FAIL — `splitClustersByPixelGap is not defined` 또는 import 에러
+
+### Task 1.3: `splitClustersByPixelGap` 함수 구현
+
+**Files:**
+- Modify: `renderer/scripts/modules/comment-cluster.js`
+
+- [ ] **Step 1: 파일 끝에 함수 추가**
+
+```js
+/**
+ * 클러스터 내부에서 이웃 간 픽셀 거리가 minGapPx 이상이면 분리한다.
+ * 줌에 따라 pxPerFrame이 커지면 같은 클러스터가 자연스럽게 분리된다.
+ *
+ * @param {Array<Array<Comment>>} clusters - findRangeClusters의 반환값
+ * @param {{pxPerFrame: number, minGapPx?: number}} opts
+ * @returns {Array<Array<Comment>>} 분리된 클러스터 배열 (단일 멤버도 포함 가능)
+ */
+export function splitClustersByPixelGap(clusters, { pxPerFrame, minGapPx = 8 } = {}) {
+  if (!pxPerFrame || pxPerFrame <= 0) return clusters;
+  const result = [];
+  for (const cluster of clusters) {
+    if (!cluster || cluster.length < 2) {
+      result.push(cluster);
+      continue;
+    }
+    const sorted = [...cluster].sort((a, b) => a.startFrame - b.startFrame);
+    let current = [sorted[0]];
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1];
+      const curr = sorted[i];
+      const gapFrames = curr.startFrame - prev.endFrame;
+      const gapPx = gapFrames * pxPerFrame;
+      if (gapPx >= minGapPx) {
+        result.push(current);
+        current = [curr];
+      } else {
+        current.push(curr);
+      }
+    }
+    result.push(current);
+  }
+  return result;
+}
+```
+
+### Task 1.4: 테스트 통과 확인
+
+- [ ] **Step 1: 테스트 재실행**
+
+Run: `npm test`
+Expected: PASS — 신규 9개 케이스 모두 통과
+
+### Task 1.5: 커밋
+
+- [ ] **Step 1: 변경 확인**
+
+Run: `git status`
+Expected: `renderer/scripts/modules/comment-cluster.js` + `scripts/tests/comment-cluster.test.js` 수정 표시
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add renderer/scripts/modules/comment-cluster.js scripts/tests/comment-cluster.test.js
+git commit -m "feat: 픽셀 간격 기반 클러스터 분리 순수 함수 추가
+
+splitClustersByPixelGap(clusters, {pxPerFrame, minGapPx=8})
+- 줌에 따라 pxPerFrame이 커지면 같은 프레임 클러스터를 자연스럽게 분리
+- 단위 테스트 9건 추가 (엣지 케이스 포함)"
+```
+
+---
+
+## Chunk 2: Phase 2 — 배지/접기/툴팁 CSS + DOM
+
+### Task 2.1: 기존 stack-hint 스타일 제거 및 label 추가
+
+**Files:**
+- Modify: `renderer/styles/main.css` (라인 ~3041-3062)
+
+- [ ] **Step 1: 기존 스타일 확인**
+
+Read `renderer/styles/main.css:3040-3065`로 기존 `.comment-cluster-stack-hint`, `.comment-cluster-count` 규칙 파악.
+
+- [ ] **Step 2: `.comment-cluster-stack-hint` 블록 삭제**
+
+- [ ] **Step 3: `.comment-cluster-count` 블록을 `.comment-cluster-badge-label`로 교체**
+
+```css
+.comment-cluster-badge-label {
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+  pointer-events: none;
+}
+```
+
+- [ ] **Step 4: `.comment-cluster-badge` 자체 강화 (음영 강화)**
+
+기존 `.comment-cluster-badge` 블록의 `box-shadow`를 살짝 강화:
+```css
+box-shadow: 0 2px 6px rgba(245, 158, 11, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.1) inset;
+```
+
+### Task 2.2: 접기 배지 (close-badge) 스타일 추가
+
+**Files:**
+- Modify: `renderer/styles/main.css` (기존 `.comment-collapse-chip` 블록 근처)
+
+- [ ] **Step 1: 기존 `.comment-collapse-chip` 블록 삭제**
+
+- [ ] **Step 2: `.comment-cluster-close-badge` 블록 추가**
+
+```css
+.comment-cluster-close-badge {
+  position: absolute;
+  top: -22px;
+  right: 0;
+  height: 20px;
+  padding: 0 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 10px;
+  box-shadow: 0 2px 6px rgba(245, 158, 11, 0.5);
+  cursor: pointer;
+  z-index: 25;
+  user-select: none;
+  transition: filter 0.15s ease, transform 0.15s ease;
+}
+.comment-cluster-close-badge:hover {
+  filter: brightness(1.15);
+  transform: translateY(-1px);
+}
+.comment-cluster-close-badge::before {
+  content: '×';
+  font-size: 14px;
+  line-height: 1;
+}
+```
+
+### Task 2.3: 호버 툴팁 스타일 추가
+
+**Files:**
+- Modify: `renderer/styles/main.css` (파일 끝 또는 comment-cluster 근처)
+
+- [ ] **Step 1: 툴팁 스타일 블록 추가**
+
+```css
+.comment-cluster-tooltip {
+  position: fixed;
+  z-index: 10000;
+  max-width: 360px;
+  min-width: 200px;
+  padding: 8px 0;
+  background: rgba(30, 30, 30, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5);
+  color: #e0e0e0;
+  font-size: 12px;
+  line-height: 1.4;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.comment-cluster-tooltip.visible {
+  opacity: 1;
+}
+.comment-cluster-tooltip .tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.comment-cluster-tooltip .tooltip-row + .tooltip-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+.comment-cluster-tooltip .tooltip-color-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.comment-cluster-tooltip .tooltip-author {
+  font-weight: 600;
+  color: #ffffff;
+  flex-shrink: 0;
+}
+.comment-cluster-tooltip .tooltip-range {
+  color: #888;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.comment-cluster-tooltip .tooltip-text {
+  color: #bbb;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+```
+
+### Task 2.4: 커밋
+
+- [ ] **Step 1: 커밋**
+
+```bash
+git add renderer/styles/main.css
+git commit -m "style: 코멘트 클러스터 배지/접기/툴팁 CSS 재설계
+
+- comment-cluster-stack-hint(세로 3색 스트라이프) 제거
+- comment-cluster-badge-label: '+N' 텍스트 강조 스타일
+- comment-cluster-close-badge: 펼친 클러스터 오른쪽 상단 고정 배지형 접기
+- comment-cluster-tooltip: 접힌 배지 호버용 세로 리스트 팝업"
+```
+
+---
+
+## Chunk 3: Phase 3 — DOM 구조 변경 + split 호출
+
+### Task 3.1: `_createClusterBadgeElement` DOM 구조 변경
+
+**Files:**
+- Modify: `renderer/scripts/modules/timeline.js` (라인 ~2065-2109)
+
+- [ ] **Step 1: 기존 함수 Read로 확인**
+
+- [ ] **Step 2: 함수 내부의 `.comment-cluster-stack-hint` DOM 생성 제거**
+
+- [ ] **Step 3: `.comment-cluster-count` → `.comment-cluster-badge-label`로 변경, 내용을 `+${count}`로**
+
+구체 예시 (기존 구조에 맞춰 Edit):
+```js
+// 기존: 스택 힌트 3개 stripe DOM 생성 블록 제거
+
+const label = document.createElement('span');
+label.className = 'comment-cluster-badge-label';
+label.textContent = `+${cluster.length}`;
+badge.appendChild(label);
+```
+
+- [ ] **Step 4: 기존에 달려 있던 `badge.addEventListener('click', ...)` 제거**
+
+위임 핸들러가 담당하므로 제거. `badge.dataset.clusterKey = clusterKey(cluster)`는 **반드시 유지**.
+
+### Task 3.2: `_createCollapseChip` → `_createClusterCloseBadge` 리네임 및 구조 변경
+
+**Files:**
+- Modify: `renderer/scripts/modules/timeline.js` (라인 ~2114-2133)
+
+- [ ] **Step 1: 함수 이름 `_createCollapseChip` → `_createClusterCloseBadge`**
+
+- [ ] **Step 2: 반환 DOM 클래스명 `.comment-collapse-chip` → `.comment-cluster-close-badge`**
+
+```js
+_createClusterCloseBadge() {
+  const el = document.createElement('div');
+  el.className = 'comment-cluster-close-badge';
+  el.textContent = '접기';
+  return el;
+}
+```
+
+- [ ] **Step 3: 기존 `addEventListener('click', ...)` 제거**
+
+- [ ] **Step 4: 호출부 검색 후 리네임 반영**
+
+Grep `_createCollapseChip` → 호출부를 `_createClusterCloseBadge`로 교체.
+
+### Task 3.3: `renderCommentRanges`에 split 적용 + 검증 순서 이동
+
+**Files:**
+- Modify: `renderer/scripts/modules/timeline.js` (라인 ~1945-1968)
+
+- [ ] **Step 1: 파일 상단 import에 `splitClustersByPixelGap` 추가**
+
+```js
+import { findRangeClusters, assignLanes, clusterKey, splitClustersByPixelGap } from './comment-cluster.js';
+```
+
+- [ ] **Step 2: `renderCommentRanges` 내 클러스터링 흐름 수정**
+
+```js
+// 1) 프레임 기반 클러스터링
+const rawClusters = findRangeClusters(comments);
+
+// 1b) 픽셀 기반 split (줌 반응형)
+const trackRect = this.commentTrack.getBoundingClientRect();
+const pxPerFrame = this.totalFrames > 0 ? trackRect.width / this.totalFrames : 0;
+const clusters = splitClustersByPixelGap(rawClusters, { pxPerFrame, minGapPx: 8 });
+
+// 2) 펼침 유효성 검증 — 반드시 split 후!
+if (this.expandedClusterId !== null) {
+  const stillExists = clusters.some(c =>
+    clusterKey(c) === this.expandedClusterId && c.length > 1
+  );
+  if (!stillExists) {
+    this.expandedClusterId = null;
+  }
+}
+// ... 이하 기존 로직 유지 (maxLanes 계산, 렌더)
+```
+
+### Task 3.4: 수동 동작 확인
+
+- [ ] **Step 1: 앱 실행**
+
+Run: `npm run dev`
+Expected: 앱 정상 실행, 에러 없음
+
+- [ ] **Step 2: 배지 시각 확인**
+
+- 겹친 코멘트 2개 이상 만들기 → `+N` 텍스트 배지가 주황 그라디언트로 표시, 세로줄 없음
+- 펼쳤을 때 오른쪽 상단에 "× 접기" 배지 명확히 표시
+
+- [ ] **Step 3: 줌 변경 확인**
+
+- 겹친 코멘트 상태에서 타임라인 줌인 → 일정 줌 이후 클러스터 해제되어 개별 코멘트로 전환
+
+### Task 3.5: 커밋
+
+```bash
+git add renderer/scripts/modules/timeline.js
+git commit -m "feat: 클러스터 DOM 구조 변경 + 픽셀 기반 split 적용
+
+- _createClusterBadgeElement: 세로 stripe 제거, '+N' 텍스트 라벨
+- _createCollapseChip → _createClusterCloseBadge 리네임 + 배지 구조
+- renderCommentRanges: splitClustersByPixelGap 파이프라인 통합
+- 펼침 유효성 검증을 split 결과 기준으로 수행"
+```
+
+---
+
+## Chunk 4: Phase 4 — 이벤트 위임 엔진 + 드래그 복구
+
+### Task 4.1: 상태 필드 추가
+
+**Files:**
+- Modify: `renderer/scripts/modules/timeline.js` (constructor)
+
+- [ ] **Step 1: `constructor` 내 기존 `expandedClusterId` 아래에 필드 추가**
+
+```js
+this.isDraggingComment = false;
+this.dragContext = null;
+this.justDragged = false;
+this.clusterTooltipTimer = null;
+this.clusterTooltipEl = null;
+this._delegationBound = false;
+```
+
+### Task 4.2: `setCommentTrack` 기존 click 리스너 제거 + 위임 바인딩 호출
+
+**Files:**
+- Modify: `renderer/scripts/modules/timeline.js` (라인 ~1900-1912)
+
+- [ ] **Step 1: 기존 `setCommentTrack` 내 `click` addEventListener 블록 삭제**
+
+- [ ] **Step 2: `setCommentTrack` 끝에 위임 바인딩 호출 추가**
+
+```js
+setCommentTrack(trackElement, layerHeaderElement = null) {
+  this.commentTrack = trackElement;
+  this.commentLayerHeader = layerHeaderElement;
+  this._bindCommentTrackDelegation();
+}
+```
+
+### Task 4.3: 위임 핸들러 메서드 추가
+
+**Files:**
+- Modify: `renderer/scripts/modules/timeline.js` (클래스 내부 적절한 위치, 예: `setCommentTrack` 다음)
+
+- [ ] **Step 1: `_bindCommentTrackDelegation` 메서드 추가**
+
+```js
+_bindCommentTrackDelegation() {
+  if (this._delegationBound || !this.commentTrack) return;
+  this._delegationBound = true;
+
+  this.commentTrack.addEventListener('mousedown', (e) => this._onCommentTrackMousedown(e));
+  this.commentTrack.addEventListener('click',     (e) => this._onCommentTrackClick(e));
+  this.commentTrack.addEventListener('mouseover', (e) => this._onCommentTrackMouseover(e));
+  this.commentTrack.addEventListener('mouseout',  (e) => this._onCommentTrackMouseout(e));
+}
+```
+
+- [ ] **Step 2: `_onCommentTrackMousedown` 라우팅 추가**
+
+```js
+_onCommentTrackMousedown(e) {
+  if (e.button !== 0) return;
+
+  const handle     = e.target.closest('.comment-handle');
+  const rangeItem  = e.target.closest('.comment-range-item');
+  const closeBadge = e.target.closest('.comment-cluster-close-badge');
+  const badge      = e.target.closest('.comment-cluster-badge');
+
+  if (handle && rangeItem) {
+    this._startResizeDrag(rangeItem, handle.dataset.handle, e);
+  } else if (rangeItem) {
+    this._startMoveDrag(rangeItem, e);
+  } else if (closeBadge) {
+    this.expandedClusterId = null;
+    this.renderCommentRanges(this._lastComments || []);
+  } else if (badge) {
+    const key = badge.dataset.clusterKey;
+    this.expandedClusterId = (this.expandedClusterId === key) ? null : key;
+    this.renderCommentRanges(this._lastComments || []);
+  }
+}
+```
+
+- [ ] **Step 3: `_onCommentTrackClick` (닫힘 가드)**
+
+```js
+_onCommentTrackClick(e) {
+  if (this.isDraggingComment || this.justDragged) {
+    this.justDragged = false;
+    return;
+  }
+  // 트랙 배경 클릭 (다른 요소 위가 아님)
+  if (e.target === this.commentTrack && this.expandedClusterId !== null) {
+    this.expandedClusterId = null;
+    this.renderCommentRanges(this._lastComments || []);
+  }
+}
+```
+
+### Task 4.4: 드래그 엔진 구현
+
+**Files:**
+- Modify: `renderer/scripts/modules/timeline.js`
+
+- [ ] **Step 1: `_pxToFrameDelta` 헬퍼**
+
+```js
+_pxToFrameDelta(dx) {
+  const rect = this.commentTrack.getBoundingClientRect();
+  if (rect.width <= 0 || !this.totalFrames) return 0;
+  return Math.round((dx / rect.width) * this.totalFrames);
+}
+```
+
+- [ ] **Step 2: `_startMoveDrag` 구현**
+
+```js
+_startMoveDrag(element, e) {
+  const markerId = element.dataset.markerId;
+  const layerId  = element.dataset.layerId;
+  if (!markerId) return;
+
+  const marker = this._getMarkerForRange?.(layerId, markerId);
+  if (!marker) return;
+
+  this.dragContext = {
+    mode: 'move',
+    element, markerId, layerId,
+    startX: e.clientX,
+    origStartFrame: marker.startFrame,
+    origEndFrame:   marker.endFrame,
+    dx: 0,
+    moved: false,
+  };
+  this.isDraggingComment = true;
+
+  this._attachDragWindowListeners();
+  e.preventDefault();
+}
+```
+
+- [ ] **Step 3: `_startResizeDrag` 구현**
+
+```js
+_startResizeDrag(element, side, e) {
+  const markerId = element.dataset.markerId;
+  const layerId  = element.dataset.layerId;
+  if (!markerId || (side !== 'left' && side !== 'right')) return;
+
+  const marker = this._getMarkerForRange?.(layerId, markerId);
+  if (!marker) return;
+
+  this.dragContext = {
+    mode: side === 'left' ? 'resize-left' : 'resize-right',
+    element, markerId, layerId,
+    startX: e.clientX,
+    origStartFrame: marker.startFrame,
+    origEndFrame:   marker.endFrame,
+    dx: 0,
+    moved: false,
+  };
+  this.isDraggingComment = true;
+
+  this._attachDragWindowListeners();
+  e.preventDefault();
+  e.stopPropagation();
+}
+```
+
+- [ ] **Step 4: `_attachDragWindowListeners` + `_onDragMove` + `_onDragEnd`**
+
+```js
+_attachDragWindowListeners() {
+  this._onDragMoveBound = (ev) => this._onDragMove(ev);
+  this._onDragEndBound  = (ev) => this._onDragEnd(ev);
+  window.addEventListener('mousemove', this._onDragMoveBound);
+  window.addEventListener('mouseup',   this._onDragEndBound);
+}
+
+_detachDragWindowListeners() {
+  if (this._onDragMoveBound) window.removeEventListener('mousemove', this._onDragMoveBound);
+  if (this._onDragEndBound)  window.removeEventListener('mouseup',   this._onDragEndBound);
+  this._onDragMoveBound = null;
+  this._onDragEndBound  = null;
+}
+
+_onDragMove(e) {
+  if (!this.dragContext) return;
+  const ctx = this.dragContext;
+  const dx = e.clientX - ctx.startX;
+  ctx.dx = dx;
+  if (Math.abs(dx) >= 3) ctx.moved = true;
+
+  const deltaFrames = this._pxToFrameDelta(dx);
+  let newStart = ctx.origStartFrame;
+  let newEnd   = ctx.origEndFrame;
+  const total  = this.totalFrames;
+
+  if (ctx.mode === 'move') {
+    let d = deltaFrames;
+    if (ctx.origStartFrame + d < 0) d = -ctx.origStartFrame;
+    if (ctx.origEndFrame   + d > total) d = total - ctx.origEndFrame;
+    newStart = ctx.origStartFrame + d;
+    newEnd   = ctx.origEndFrame   + d;
+  } else if (ctx.mode === 'resize-left') {
+    newStart = Math.max(0, Math.min(ctx.origEndFrame - 1, ctx.origStartFrame + deltaFrames));
+  } else if (ctx.mode === 'resize-right') {
+    newEnd = Math.min(total, Math.max(ctx.origStartFrame + 1, ctx.origEndFrame + deltaFrames));
+  }
+
+  // DOM 직접 업데이트 (재렌더 금지)
+  const leftPercent  = (newStart / total) * 100;
+  const widthPercent = ((newEnd - newStart) / total) * 100;
+  ctx.element.style.left  = `${leftPercent}%`;
+  ctx.element.style.width = `${Math.max(widthPercent, 0.5)}%`;
+}
+
+_onDragEnd(e) {
+  const ctx = this.dragContext;
+  this._detachDragWindowListeners();
+  this.isDraggingComment = false;
+  this.dragContext = null;
+
+  if (!ctx) return;
+
+  if (!ctx.moved) {
+    // 단순 클릭 — 데이터 변경 없음
+    this.justDragged = false;
+    return;
+  }
+
+  this.justDragged = true;
+  setTimeout(() => { this.justDragged = false; }, 50);
+
+  const deltaFrames = this._pxToFrameDelta(ctx.dx);
+  const total = this.totalFrames;
+  let newStart = ctx.origStartFrame;
+  let newEnd   = ctx.origEndFrame;
+
+  if (ctx.mode === 'move') {
+    let d = deltaFrames;
+    if (ctx.origStartFrame + d < 0) d = -ctx.origStartFrame;
+    if (ctx.origEndFrame   + d > total) d = total - ctx.origEndFrame;
+    newStart = ctx.origStartFrame + d;
+    newEnd   = ctx.origEndFrame   + d;
+  } else if (ctx.mode === 'resize-left') {
+    newStart = Math.max(0, Math.min(ctx.origEndFrame - 1, ctx.origStartFrame + deltaFrames));
+  } else if (ctx.mode === 'resize-right') {
+    newEnd = Math.min(total, Math.max(ctx.origStartFrame + 1, ctx.origEndFrame + deltaFrames));
+  }
+
+  if (newStart === ctx.origStartFrame && newEnd === ctx.origEndFrame) return;
+
+  // 외부 콜백으로 데이터 커밋 (timeline은 commentManager 직접 접근 금지)
+  if (typeof this.onCommentRangeUpdate === 'function') {
+    this.onCommentRangeUpdate({
+      layerId: ctx.layerId,
+      markerId: ctx.markerId,
+      startFrame: newStart,
+      endFrame: newEnd,
+    });
+  }
+}
+```
+
+### Task 4.5: `timeline.js`에 `onCommentRangeUpdate` / `_getMarkerForRange` 훅 정의
+
+- [ ] **Step 1: constructor 또는 초기화 지점에 기본값 설정**
+
+```js
+this.onCommentRangeUpdate = null;  // 외부에서 주입
+this._getMarkerForRange = null;     // 외부에서 주입 (layerId, markerId) => marker
+```
+
+- [ ] **Step 2: setter 메서드 추가**
+
+```js
+setCommentRangeCallbacks({ onUpdate, getMarker }) {
+  if (typeof onUpdate   === 'function') this.onCommentRangeUpdate = onUpdate;
+  if (typeof getMarker  === 'function') this._getMarkerForRange   = getMarker;
+}
+```
+
+### Task 4.6: `app.js`에서 콜백 주입 + 기존 `setupCommentRangeInteractions` 삭제
+
+**Files:**
+- Modify: `renderer/scripts/app.js` (라인 ~3095-3200)
+
+- [ ] **Step 1: 기존 `setupCommentRangeInteractions` 함수 전체 삭제**
+
+- [ ] **Step 2: 이 함수의 모든 호출부 삭제**
+
+Grep `setupCommentRangeInteractions` → 발견되는 모든 호출 제거.
+
+- [ ] **Step 3: timeline에 콜백 주입 코드 추가** (앱 초기화 지점)
+
+```js
+timeline.setCommentRangeCallbacks({
+  onUpdate: ({ layerId, markerId, startFrame, endFrame }) => {
+    const marker = commentManager.getMarker(markerId);
+    if (!marker) return;
+    commentManager.updateMarker(markerId, { startFrame, endFrame });
+  },
+  getMarker: (layerId, markerId) => commentManager.getMarker(markerId),
+});
+```
+
+적절한 위치는 `commentManager`가 초기화되고 `timeline`도 준비된 이후 — 기존 `setupCommentRangeInteractions` 호출 지점 근처.
+
+### Task 4.7: 수동 QA
+
+- [ ] **Step 1: 앱 실행**
+
+Run: `npm run dev`
+Expected: 정상 실행
+
+- [ ] **Step 2: 드래그/리사이즈 동작 확인**
+
+- 단일 코멘트 바 중앙 드래그 → 위치 이동 OK
+- 좌/우 핸들 드래그 → 크기 변경 OK
+- 3px 미만 클릭 → 데이터 변경 없음, 단순 클릭 동작만
+
+- [ ] **Step 3: 클러스터 펼친 상태 편집 확인 (핵심 regression)**
+
+- 겹친 코멘트 펼침 → 내부 개별 바 드래그 → 펼친 상태 **유지되며** 위치 이동
+- 핸들 드래그 → 크기 변경, 펼친 상태 유지
+- 접기 배지 클릭 → 정상 접힘
+- 빈 영역 클릭 → 접힘
+
+### Task 4.8: 커밋
+
+```bash
+git add renderer/scripts/modules/timeline.js renderer/scripts/app.js
+git commit -m "refactor: 코멘트 상호작용을 이벤트 위임으로 전환 + 드래그 편집 regression 수정
+
+- setupCommentRangeInteractions 삭제, commentTrack 1곳에 위임 리스너
+- _bindCommentTrackDelegation: mousedown/click/mouseover/mouseout 라우팅
+- _startMoveDrag/_startResizeDrag/_onDragMove/_onDragEnd 드래그 엔진
+- 드래그 중 재렌더 억제 (DOM 직접 스타일 업데이트)
+- 3px 미만 이동은 클릭, 이상이면 드래그 커밋 (justDragged 가드)
+- setCommentRangeCallbacks: timeline ↔ commentManager 경계 유지"
+```
+
+---
+
+## Chunk 5: Phase 5 — 호버 툴팁
+
+### Task 5.1: 툴팁 DOM 재사용 인스턴스 생성
+
+**Files:**
+- Modify: `renderer/scripts/modules/timeline.js`
+
+- [ ] **Step 1: `_ensureClusterTooltip` 헬퍼 추가**
+
+```js
+_ensureClusterTooltip() {
+  if (this.clusterTooltipEl) return this.clusterTooltipEl;
+  const el = document.createElement('div');
+  el.className = 'comment-cluster-tooltip';
+  el.setAttribute('role', 'tooltip');
+  document.body.appendChild(el);
+  this.clusterTooltipEl = el;
+  return el;
+}
+```
+
+### Task 5.2: 호버 이벤트 핸들러
+
+**Files:**
+- Modify: `renderer/scripts/modules/timeline.js`
+
+- [ ] **Step 1: `_onCommentTrackMouseover` / `_onCommentTrackMouseout`**
+
+```js
+_onCommentTrackMouseover(e) {
+  const badge = e.target.closest('.comment-cluster-badge');
+  if (!badge) return;
+  // 펼친 상태 배지에는 툴팁 띄우지 않음 (이미 펼쳐져 있으면 개별 코멘트가 보이므로)
+  if (this.expandedClusterId !== null) return;
+
+  this._cancelClusterTooltip();
+  this.clusterTooltipTimer = setTimeout(() => {
+    this._showClusterTooltip(badge);
+  }, 300);
+}
+
+_onCommentTrackMouseout(e) {
+  const badge = e.target.closest('.comment-cluster-badge');
+  if (!badge) return;
+  this._cancelClusterTooltip();
+  this._hideClusterTooltip();
+}
+
+_cancelClusterTooltip() {
+  if (this.clusterTooltipTimer) {
+    clearTimeout(this.clusterTooltipTimer);
+    this.clusterTooltipTimer = null;
+  }
+}
+
+_hideClusterTooltip() {
+  if (this.clusterTooltipEl) {
+    this.clusterTooltipEl.classList.remove('visible');
+  }
+}
+```
+
+### Task 5.3: 툴팁 표시 구현
+
+**Files:**
+- Modify: `renderer/scripts/modules/timeline.js`
+
+- [ ] **Step 1: `_showClusterTooltip` 구현**
+
+```js
+_showClusterTooltip(badge) {
+  const clusterKey = badge.dataset.clusterKey;
+  if (!clusterKey) return;
+
+  // clusterKey로 해당 cluster의 코멘트들 복구
+  const comments = this._findClusterCommentsByKey(clusterKey);
+  if (!comments || comments.length === 0) return;
+
+  const tooltip = this._ensureClusterTooltip();
+  tooltip.innerHTML = '';
+  comments.forEach(c => {
+    const row = document.createElement('div');
+    row.className = 'tooltip-row';
+    row.innerHTML = `
+      <span class="tooltip-color-dot" style="background:${c.color || '#4a9eff'}"></span>
+      <span class="tooltip-author">${this._escape(c.author || '익명')}</span>
+      <span class="tooltip-range">${c.startFrame}–${c.endFrame}</span>
+      <span class="tooltip-text">${this._escape((c.text || '').split('\n')[0].slice(0, 80))}</span>
+    `;
+    tooltip.appendChild(row);
+  });
+
+  // 위치 계산 (top placement 우선, 상단 근처면 bottom으로)
+  const badgeRect = badge.getBoundingClientRect();
+  tooltip.classList.add('visible');  // 측정 위해 먼저 visible
+  const tooltipRect = tooltip.getBoundingClientRect();
+
+  let top = badgeRect.top - tooltipRect.height - 8;
+  if (top < 10) top = badgeRect.bottom + 8;
+  let left = badgeRect.left + (badgeRect.width / 2) - (tooltipRect.width / 2);
+  left = Math.max(8, Math.min(window.innerWidth - tooltipRect.width - 8, left));
+
+  tooltip.style.top  = `${top}px`;
+  tooltip.style.left = `${left}px`;
+}
+
+_findClusterCommentsByKey(key) {
+  if (!this._lastComments) return [];
+  const rawClusters = findRangeClusters(this._lastComments);
+  const trackRect = this.commentTrack.getBoundingClientRect();
+  const pxPerFrame = this.totalFrames > 0 ? trackRect.width / this.totalFrames : 0;
+  const clusters = splitClustersByPixelGap(rawClusters, { pxPerFrame, minGapPx: 8 });
+  return clusters.find(c => clusterKey(c) === key) || [];
+}
+
+_escape(s) {
+  const d = document.createElement('div');
+  d.textContent = String(s);
+  return d.innerHTML;
+}
+```
+
+### Task 5.4: 수동 QA
+
+- [ ] **Step 1: 앱 실행**
+
+- [ ] **Step 2: 접힌 클러스터 배지에 마우스 호버 → 300ms 후 세로 리스트 팝업 표시**
+
+- [ ] **Step 3: 마우스 벗어나면 즉시 숨김**
+
+- [ ] **Step 4: 배지 클릭 후 펼친 상태 → 호버해도 팝업 안 뜸**
+
+- [ ] **Step 5: 뷰포트 상단 근처 배지 → 아래쪽에 팝업 표시**
+
+### Task 5.5: 커밋
+
+```bash
+git add renderer/scripts/modules/timeline.js
+git commit -m "feat: 접힌 클러스터 배지 호버 팝업 (세로 리스트)
+
+- 300ms 딜레이 후 표시, 마우스 벗어나면 즉시 숨김
+- 각 코멘트: 색 점 · 작성자 · 프레임 범위 · 본문 1줄 (80자 제한)
+- 위치: 배지 위쪽 우선, 상단 근처면 아래로 폴백
+- 펼친 상태에서는 팝업 비활성화 (개별 코멘트 표시로 충분)"
+```
+
+---
+
+## Chunk 6: Phase 6 — 썸네일 정확-프레임
+
+### Task 6.1: `thumbnail-generator.js`에 API 추가
+
+**Files:**
+- Modify: `renderer/scripts/modules/thumbnail-generator.js`
+
+- [ ] **Step 1: constructor 말미에 큐 상태 초기화**
+
+```js
+this._exactQueue = new Set();
+this._exactDraining = false;
+this._exactAborted = false;
+```
+
+- [ ] **Step 2: `getThumbnailUrlAtExact` 추가 (클래스 내 적절한 위치, `getThumbnailUrlAt` 근처)**
+
+```js
+getThumbnailUrlAtExact(time) {
+  const rounded = Math.round(time * 10) / 10;
+  return this.thumbnailMap.get(rounded) || null;
+}
+```
+
+- [ ] **Step 3: `requestExactCapture` 추가**
+
+```js
+requestExactCapture(time) {
+  if (typeof time !== 'number' || !isFinite(time) || time < 0) return;
+  const rounded = Math.round(time * 10) / 10;
+  if (this.thumbnailMap.has(rounded)) return;
+  if (this._exactQueue.has(rounded)) return;
+  this._exactQueue.add(rounded);
+  this._drainExactQueue();
+}
+```
+
+- [ ] **Step 4: `_drainExactQueue` 추가**
+
+```js
+async _drainExactQueue() {
+  if (this._exactDraining) return;
+  if (!this.videoSrc) return;
+  this._exactDraining = true;
+  this._exactAborted = false;
+
+  const needsVideo = !this.video;
+  try {
+    if (needsVideo) {
+      this.video = document.createElement('video');
+      this.video.muted = true;
+      this.video.preload = 'auto';
+      await this._loadVideo(this.videoSrc);
+    }
+
+    while (this._exactQueue.size > 0) {
+      if (this._exactAborted) break;
+      const t = this._exactQueue.values().next().value;
+      this._exactQueue.delete(t);
+      try {
+        await this._seekAndCapture(t);
+        const dataUrl = this.thumbnailMap.get(t);
+        if (dataUrl) this._emit('exactCaptured', { time: t, dataUrl });
+      } catch (err) {
+        log.warn('온디맨드 캡처 실패', { time: t, error: err?.message });
+      }
+    }
+  } finally {
+    if (needsVideo) {
+      this._cleanupVideo();
+      try { await this._saveToCache(); } catch (_) { /* ignore */ }
+    }
+    this._exactDraining = false;
+    this._exactAborted = false;
+  }
+}
+
+_abortExactDrain() {
+  this._exactAborted = true;
+}
+```
+
+### Task 6.2: `app.js` 댓글 렌더 수정
+
+**Files:**
+- Modify: `renderer/scripts/app.js` (라인 ~5299-5303)
+
+- [ ] **Step 1: 기존 썸네일 URL 획득 부분 교체**
+
+```js
+const markerTime = marker.startFrame / videoPlayer.fps;
+let thumbnailUrl = null;
+if (showThumbnails && thumbnailGenerator?.isReady) {
+  thumbnailUrl = thumbnailGenerator.getThumbnailUrlAtExact(markerTime);
+  if (!thumbnailUrl) {
+    thumbnailGenerator.requestExactCapture(markerTime);
+    thumbnailUrl = thumbnailGenerator.getThumbnailUrlAt(markerTime);
+  }
+}
+```
+
+### Task 6.3: `exactCaptured` 이벤트 리스너 + videoPlayer 훅
+
+**Files:**
+- Modify: `renderer/scripts/app.js`
+
+- [ ] **Step 1: thumbnailGenerator 초기화 근처에 리스너 추가**
+
+(Grep `thumbnailGenerator.addEventListener` 또는 `thumbnailGenerator = getThumbnailGenerator` 로 위치 찾기)
+
+```js
+thumbnailGenerator.addEventListener('exactCaptured', (e) => {
+  const { time, dataUrl } = e.detail || {};
+  if (!dataUrl || typeof time !== 'number') return;
+  const frame = Math.round(time * (videoPlayer.fps || 24));
+  document.querySelectorAll(
+    `.comment-item[data-start-frame="${frame}"] .comment-thumbnail`
+  ).forEach(img => { img.src = dataUrl; });
+});
+```
+
+- [ ] **Step 2: videoPlayer 이벤트 API 확인**
+
+Grep `videoPlayer.on\(` 또는 `videoPlayer.addEventListener` 또는 `player.on` — BAEFRAME의 videoPlayer 래퍼 API 파악.
+
+- [ ] **Step 3: pause/play 훅 추가**
+
+API 형태에 맞춰 (예시는 EventTarget 스타일):
+```js
+// 래퍼가 .on/.off 사용이면:
+videoPlayer.on?.('pause', () => thumbnailGenerator._drainExactQueue?.());
+videoPlayer.on?.('play',  () => thumbnailGenerator._abortExactDrain?.());
+
+// 혹은 DOM 이벤트면:
+videoPlayer.videoElement?.addEventListener('pause', () => thumbnailGenerator._drainExactQueue?.());
+videoPlayer.videoElement?.addEventListener('play',  () => thumbnailGenerator._abortExactDrain?.());
+```
+
+구체 구문은 실 API에 맞춰 선택.
+
+### Task 6.4: 수동 QA
+
+- [ ] **Step 1: 일시정지 상태에서 댓글 클릭** → 사이드바 썸네일이 근사치 → ≤1초 후 정확 프레임으로 교체
+
+- [ ] **Step 2: 재생 중 댓글 이동** → 근사치 유지, 일시정지 시 정확 프레임으로 교체
+
+- [ ] **Step 3: Phase 2 완료 후** (썸네일 캐시 전부 생성 완료) 새 댓글 달기 → 정확 프레임 캡처 동작
+
+### Task 6.5: 커밋
+
+```bash
+git add renderer/scripts/modules/thumbnail-generator.js renderer/scripts/app.js
+git commit -m "feat: 댓글 썸네일 온디맨드 정확-프레임 캡처
+
+- getThumbnailUrlAtExact: 정확한 시간 키가 맵에 있을 때만 반환
+- requestExactCapture + _drainExactQueue: 큐 기반 비동기 캡처
+- Phase 2 후 비디오가 해제된 경우 lazy 재생성
+- exactCaptured 이벤트로 img.src만 교체 (진적 갱신)
+- videoPlayer pause/play 훅으로 재생 방해 방지"
+```
+
+---
+
+## Chunk 7: Phase 7 — Lint · 테스트 · DEVLOG · PR
+
+### Task 7.1: Lint 및 포맷
+
+- [ ] **Step 1: ESLint 실행**
+
+Run: `npm run lint`
+Expected: 경고/에러 없음 (있으면 `npm run lint:fix`)
+
+- [ ] **Step 2: Prettier 실행**
+
+Run: `npm run format`
+Expected: 포맷 정리됨
+
+### Task 7.2: 단위 테스트 재실행
+
+- [ ] **Step 1: 전체 테스트 실행**
+
+Run: `npm test` 또는 해당 project의 test 커맨드
+Expected: 모든 테스트 통과
+
+### Task 7.3: DEVLOG 작성
+
+**Files:**
+- Create: `DEVLOG/2026-04-20-코멘트-클러스터-UX-재작업.md`
+
+- [ ] **Step 1: DEVLOG 파일 작성**
+
+```markdown
+# 코멘트 클러스터 UX 재작업
+
+## 요약
+
+| 항목 | 수정 파일 | 이유 | 우선순위 | 상태 |
+|------|----------|------|---------|------|
+| Phase 1 | comment-cluster.js, test | 픽셀 기반 split 순수 함수 | 높음 | ✅ 완료 |
+| Phase 2 | main.css | 배지/접기/툴팁 CSS 재설계 | 높음 | ✅ 완료 |
+| Phase 3 | timeline.js | DOM 구조 변경 + split 적용 | 높음 | ✅ 완료 |
+| Phase 4 | timeline.js, app.js | 이벤트 위임 + 드래그 복구 | 높음 | ✅ 완료 |
+| Phase 5 | timeline.js | 호버 툴팁 | 중간 | ✅ 완료 |
+| Phase 6 | thumbnail-generator.js, app.js | 정확-프레임 썸네일 | 중간 | ✅ 완료 |
+
+## 수동 QA 체크리스트
+
+(스펙 문서 6.2의 항목 16가지를 복사)
+
+## 스펙·플랜 참조
+
+- Spec: `docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md`
+- Plan: `docs/superpowers/plans/2026-04-20-comment-cluster-ux-rework.md`
+```
+
+### Task 7.4: 통합 QA
+
+QA 체크리스트 16개 항목을 순서대로 실제 앱에서 확인. 실패 항목은 해당 Phase로 돌아가 수정.
+
+### Task 7.5: 최종 커밋 + PR
+
+- [ ] **Step 1: DEVLOG 커밋**
+
+```bash
+git add DEVLOG/2026-04-20-코멘트-클러스터-UX-재작업.md
+git commit -m "docs: 코멘트 클러스터 UX 재작업 DEVLOG + QA 체크리스트"
+```
+
+- [ ] **Step 2: PR 생성**
+
+사용자가 PR 생성 요청 시 `anthropic-skills:pr-creator` 스킬 사용 또는:
+
+```bash
+gh pr create --title "feat: 코멘트 클러스터 UX 재작업 — 편집 regression 복구·줌 반응형·썸네일 정확-프레임" --body "$(cat <<'EOF'
+## 요약
+
+PR #112로 도입된 Mode C 하이브리드 펼침 UI의 후속 개선입니다.
+
+## 주요 변경
+
+- **편집 regression 복구**: 펼친 클러스터 내부 코멘트의 드래그/리사이즈 편집이 작동하지 않던 문제 수정 (이벤트 위임 전환)
+- **줌 반응형 클러스터링**: 타임라인 줌인 시 8px 이상 벌어진 코멘트는 클러스터 해제
+- **배지 UI 개선**: 세로 스트라이프 제거, "+N" 텍스트 강조, 접기 배지 오른쪽 상단 고정
+- **호버 팝업**: 접힌 클러스터 배지 호버 시 겹친 코멘트들을 세로 리스트로 프리뷰
+- **썸네일 정확-프레임**: 사이드바 댓글 썸네일이 `startFrame` 정확 프레임으로 진적 갱신
+
+## 설계·계획 문서
+
+- Spec: [docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md](docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md)
+- Plan: [docs/superpowers/plans/2026-04-20-comment-cluster-ux-rework.md](docs/superpowers/plans/2026-04-20-comment-cluster-ux-rework.md)
+- DEVLOG: [DEVLOG/2026-04-20-코멘트-클러스터-UX-재작업.md](DEVLOG/2026-04-20-코멘트-클러스터-UX-재작업.md)
+
+## Test plan
+
+- [ ] 단위 테스트 통과 (`splitClustersByPixelGap` 9케이스)
+- [ ] ESLint/Prettier 통과
+- [ ] 수동 QA 16개 항목 (DEVLOG 참조)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## 리스크 및 주의사항 요약
+
+| 리스크 | 완화 |
+|--------|------|
+| `window` 리스너 누수 | `_detachDragWindowListeners` 반드시 호출 |
+| 드래그 중 실시간 동기화 충돌 | `isDraggingComment === true`이면 해당 마커 DOM 업데이트 skip (commentManager 이벤트 핸들러에서 가드) |
+| 온디맨드 시크가 재생 방해 | videoPlayer pause/play 훅 |
+| split로 expandedClusterId 사라짐 | 스펙 4.3.4의 검증 순서 이동이 처리 |
+
+## 롤백 전략
+
+각 Phase는 별도 커밋으로 분리되어 있으므로 `git revert <커밋>`으로 Phase 단위 롤백 가능. 특히 Phase 4 (이벤트 위임) 이슈 발생 시 Phase 4·5 커밋만 revert하고 Phase 1-3은 유지할 수 있다.

--- a/docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md
+++ b/docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md
@@ -83,6 +83,27 @@ PR #112에서 타임라인 구간 코멘트가 겹칠 때 **클러스터 배지 
 | `mouseover` | `.comment-cluster-badge` | 호버 팝업 예약 (300ms 후 표시) |
 | `mouseout` | `.comment-cluster-badge` | 호버 팝업 타이머 취소 / 즉시 숨김 |
 
+#### 4.1.1a 기존 리스너 정리 (중요)
+
+`timeline.js:1906-1911` `setCommentTrack()`에 이미 다음 `click` 리스너가 존재한다:
+
+```js
+this.commentTrack.addEventListener('click', (e) => {
+  if (e.target === this.commentTrack && this.expandedClusterId !== null) {
+    this.expandedClusterId = null;
+    this.renderCommentRanges(this._lastComments || []);
+  }
+});
+```
+
+이 리스너는 **드래그 가드가 없어** 이슈 B의 원인 중 하나다. **교체 방침**:
+
+1. `setCommentTrack()` 내부의 기존 `click` 리스너 **삭제**
+2. 같은 위치에서 `_bindCommentTrackDelegation()`을 호출
+3. 새 위임 `click` 핸들러가 `isDraggingComment`/`justDragged` 가드와 함께 동일 동작 수행
+
+또한 `_createClusterBadgeElement()`(라인 2065-2109), `_createCollapseChip()`(라인 2114-2133)에 현재 달려 있는 개별 `addEventListener` 호출도 **모두 제거**한다. 이벤트 라우팅은 위임 핸들러가 전담.
+
 #### 4.1.2 상태 필드 (timeline.js)
 
 ```js
@@ -180,6 +201,33 @@ for (const group of splitClusters) {
 }
 ```
 
+#### 4.3.4 펼친 상태 유효성 검증 — split 결과 반영 (중요)
+
+기존 `renderCommentRanges` (timeline.js:1948-1956)에 `expandedClusterId` 유효성 검증이 있다:
+
+```js
+if (this.expandedClusterId !== null) {
+  const stillExists = clusters.some(c =>
+    clusterKey(c) === this.expandedClusterId && c.length > 1
+  );
+  if (!stillExists) {
+    this.expandedClusterId = null;
+  }
+}
+```
+
+**split 도입 후 수정**: 이 검증은 `rawClusters`가 아닌 **split 결과**(`splitClusters`)에 대해 수행해야 한다. 줌 변경으로 split 결과가 달라져 펼친 클러스터의 구성원이 쪼개지면 `clusterKey`가 달라지고, 조용히 접힘 상태로 복귀한다 — 이건 의도된 동작이며 UX상 허용된다. 그러나 검증 순서를 반드시 split **이후**로 이동해야 한다.
+
+```js
+const splitClusters = splitClustersByPixelGap(rawClusters, { pxPerFrame, minGapPx: 8 });
+if (this.expandedClusterId !== null) {
+  const stillExists = splitClusters.some(c =>
+    clusterKey(c) === this.expandedClusterId && c.length > 1
+  );
+  if (!stillExists) this.expandedClusterId = null;
+}
+```
+
 ### 4.4 배지/팝업 DOM 구조
 
 #### 4.4.1 배지 (접힌 상태)
@@ -233,6 +281,8 @@ for (const group of splitClusters) {
 
 #### 4.5.1 `thumbnail-generator.js` 신규 API
 
+**실제 속성명**: 클래스는 `extends EventTarget`이며, 내부 비디오 요소의 속성명은 `this.video`(라인 44, 136)다. Phase 2가 완료되면 `_cleanupVideo()`(라인 174)가 `this.video = null`로 설정해 **해제**한다 — 따라서 온디맨드 캡처는 비디오가 해제된 후에도 작동해야 한다.
+
 ```js
 getThumbnailUrlAtExact(time) {
   const rounded = Math.round(time * 10) / 10;
@@ -250,9 +300,23 @@ requestExactCapture(time) {
 
 async _drainExactQueue() {
   if (this._exactDraining) return;
-  if (this.videoElement?.paused !== true) return;  // 재생 중이면 대기
+  if (!this.videoSrc) return;  // 아직 영상 로드 전
+
+  // 원본 영상이 재생 중이면 방해하지 않기 위해 대기
+  // (메인 player는 timeline.js가 보유하며 여기선 알 수 없으므로, 앱 측에서
+  //  pause 훅을 통해 trigger를 넣어준다 — 4.5.1a 참고)
+
   this._exactDraining = true;
   try {
+    // 비디오 요소가 없으면 온디맨드 캡처용으로 재생성 (기존 `generate()` 경로 재사용 금지)
+    const needsVideo = !this.video;
+    if (needsVideo) {
+      this.video = document.createElement('video');
+      this.video.muted = true;
+      this.video.preload = 'auto';
+      await this._loadVideo(this.videoSrc);
+    }
+
     while (this._exactQueue.size > 0) {
       const t = this._exactQueue.values().next().value;
       this._exactQueue.delete(t);
@@ -260,13 +324,40 @@ async _drainExactQueue() {
       const dataUrl = this.thumbnailMap.get(t);
       if (dataUrl) this._emit('exactCaptured', { time: t, dataUrl });
     }
+
+    // 임시 비디오였으면 정리 (캐시 재저장 포함)
+    if (needsVideo) {
+      this._cleanupVideo();
+      await this._saveToCache();
+    }
   } finally {
     this._exactDraining = false;
   }
 }
+
+// 재생 시작 시 앱에서 호출 — 진행 중 while 루프를 다음 iteration에서 중단
+_abortExactDrain() {
+  this._exactAborted = true;
+}
+// (while 루프 내에서 `if (this._exactAborted) { this._exactAborted = false; break; }` 체크)
 ```
 
-재생 중 캡처 방지: `videoElement`에 `pause` 이벤트 리스너 등록 → 일시정지 시 `_drainExactQueue()` 호출.
+#### 4.5.1a 재생 중 캡처 방지 — 앱 측 훅
+
+`thumbnail-generator.js`는 메인 `videoPlayer` 인스턴스에 접근하지 않는다(책임 분리). 따라서 **앱 계층에서 트리거**한다:
+
+- **요청만 쌓기**: `requestExactCapture(time)`은 `_drainExactQueue()`를 즉시 호출하지만, 내부에서 `_exactDraining` 가드로 중복 방지
+- **앱 측 drain 조건**: `app.js`에서 `videoPlayer`에 `pause` 이벤트 훅을 추가해 `thumbnailGenerator._drainExactQueue()`를 명시 호출하고, `play` 이벤트에서는 `_exactDraining` 플래그로 진행 중 드레인을 abort (안전하게 현재 `_seekAndCapture` 하나만 끝나고 큐 정지)
+
+간단화를 위해 이번 스코프에서는 **앱 측 조건부 호출**로 구현 (아래는 **의사코드** — 구현 시 `videoPlayer` 래퍼의 실제 이벤트 API를 확인해 `addEventListener`/`on`/직접 콜백 중 적합한 것을 선택):
+
+```js
+// app.js 기존 videoPlayer 이벤트 훅 근처에 추가 — 실 API 확인 후 적용
+videoPlayerBindOnPause(() => thumbnailGenerator._drainExactQueue?.());
+videoPlayerBindOnPlay (() => thumbnailGenerator._abortExactDrain?.());
+```
+
+`videoPlayer`가 HTML `<video>` 엘리먼트면 `addEventListener('pause'|'play', ...)`, 자체 래퍼면 래퍼의 구독 메서드를 사용. 구현 단계 첫 태스크에서 확인.
 
 #### 4.5.2 `app.js` 호출부 수정 (라인 ~5300)
 
@@ -284,8 +375,11 @@ if (showThumbnails && thumbnailGenerator?.isReady) {
 
 #### 4.5.3 정확 캡처 완료 이벤트 처리
 
+`ThumbnailGenerator`는 `extends EventTarget`이며 이벤트 발행은 `dispatchEvent(new CustomEvent(type, { detail }))` (라인 514-518). 따라서 소비자는 **`addEventListener` + `e.detail`** 패턴을 사용한다 (기존 `'progress'` 리스너와 동일한 방식, `app.js:4191-4193` 참고).
+
 ```js
-thumbnailGenerator.on('exactCaptured', ({ time, dataUrl }) => {
+thumbnailGenerator.addEventListener('exactCaptured', (e) => {
+  const { time, dataUrl } = e.detail;
   const frame = Math.round(time * videoPlayer.fps);
   document.querySelectorAll(
     `.comment-item[data-start-frame="${frame}"] .comment-thumbnail`
@@ -342,6 +436,8 @@ thumbnailGenerator.on('exactCaptured', ({ time, dataUrl }) => {
 12. Regression: 비클러스터 단일 코멘트 편집 정상 동작
 13. 실시간 동기화 이벤트 드래그 중 수신돼도 펼친 상태 유지
 14. ESC 키로도 클러스터 접힘 (선택적 기능)
+15. **펼친 상태에서 줌 변경** → 구성원 동일하면 펼친 상태 유지; split으로 구성원 변하면 자연스럽게 접힘 (regression 없음)
+16. Phase 2 완료 후 (`this.video === null` 상태)에도 온디맨드 캡처가 정상 동작 (재생성 경로)
 
 ### 6.3 Regression 확인
 

--- a/docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md
+++ b/docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md
@@ -1,0 +1,387 @@
+# 코멘트 클러스터 UX 재작업 설계
+
+- **작성일**: 2026-04-20
+- **작성자**: Claude Code (baehandoridori 협업)
+- **상태**: Draft
+- **관련 선행 작업**: PR #112 (Mode C 하이브리드 펼침 UI)
+
+---
+
+## 1. 배경 및 목적
+
+PR #112에서 타임라인 구간 코멘트가 겹칠 때 **클러스터 배지 → 펼침 UI (Mode C)**가 도입되었다. 병합 후 후속 사용에서 다음 UX 이슈와 regression이 발견되었다.
+
+### 1.1 관찰된 이슈
+
+| # | 이슈 | 증상 |
+|---|------|------|
+| A | **코멘트 편집 regression** | 펼친 클러스터 내부의 개별 코멘트에 대해 타임라인 바에서의 드래그/리사이즈 편집이 동작하지 않는다. |
+| B | **펼친 상태 즉시 닫힘** | 펼친 클러스터의 개별 코멘트를 이동/리사이즈하려고 `mousedown`하면 클러스터가 즉시 접힌다. |
+| C | **배지 시각 혼잡** | 접힌 배지의 세로 3색 스트라이프(`.comment-cluster-stack-hint`)가 시선을 분산시키고, 겹침 개수 숫자가 잘 안 보인다. |
+| D | **호버 피드백 부재** | 단일 코멘트 마커에는 호버 툴팁이 있지만, 접힌 클러스터 배지에는 없다 — 내용을 미리 볼 수 없다. |
+| E | **접기 버튼 가시성 낮음** | 펼친 상태의 `▲ 접기` 칩이 작고 눈에 띄지 않는다. |
+| F | **줌 무시 클러스터링** | 현재 `findRangeClusters`는 프레임 기반만 사용하므로, 타임라인을 많이 확대해도 이미 묶인 클러스터가 그대로 유지된다 (시각적으로 충분히 떨어져 있어도). |
+
+### 1.2 추가 개선 요구
+
+| # | 항목 | 목표 |
+|---|------|------|
+| G | **댓글 썸네일 정확-프레임** | 사이드바 댓글 목록의 썸네일이 `markerTime`의 가장 가까운 근사 프레임이 아닌 **정확한 startFrame**의 썸네일을 표시. |
+
+---
+
+## 2. 범위
+
+### 2.1 In-Scope
+
+- 이벤트 위임 기반 상호작용 엔진 전환 (A·B·E 해결)
+- 클러스터 해제 픽셀 임계값 적용 (F 해결)
+- 배지/접기/호버 팝업 재설계 (C·D·E 해결)
+- 댓글 썸네일 온디맨드 정확-프레임 캡처 (G 해결)
+- 단위 테스트 + 수동 QA 체크리스트
+
+### 2.2 Out-of-Scope
+
+- PR #111 (최근 연 파일) 관련 작업 — 코드는 이미 main에 적용되어 있음
+- 클러스터 설정을 사용자가 조정하는 UI
+- 마커(점) 클러스터링 (본 스펙은 **구간** 코멘트 클러스터 전용)
+- 웹 뷰어(`web-viewer/`) 반영 — 별도 작업
+
+---
+
+## 3. 설계 결정 (요약)
+
+| 결정 | 선택 | 이유 |
+|------|------|------|
+| 상호작용 아키텍처 | **이벤트 위임** | 재렌더 친화적, 중복 바인딩 무, 클러스터/배지/호버를 한 곳에서 관리 |
+| 픽셀 임계값 | **8px** | 코멘트 바 높이보다 약간 작은 균형적 값 |
+| 배지 디자인 | **"+N" 텍스트 강조 + 세로줄 제거** | 숫자 가독성 최우선, 시각 잡음 감소 |
+| 접기 버튼 | **배지 스타일, 클러스터 오른쪽 상단 고정** | 가시성 확보, 펼침 영역과 명확한 연관 |
+| 드래그 중 닫힘 방지 | **`isDraggingComment` 플래그 + 드래그 중 재렌더 억제** | 펼친 상태를 무조건 유지, 사용자 의도 보존 |
+| 호버 팝업 적용 범위 | **접힌 배지에만** | 펼친 상태에서는 개별 코멘트 호버로 충분 |
+| 썸네일 정확-프레임 | **온디맨드 seek+capture, 재생 중 큐 대기** | 초기 렌더 블로킹 없음, 재생 방해 방지 |
+
+---
+
+## 4. 아키텍처
+
+### 4.1 이벤트 위임 전환
+
+**기존 문제**: `setupCommentRangeInteractions()` (`renderer/scripts/app.js:3097`)가 `.comment-range-item` DOM마다 리스너를 바인딩한다. PR #112 이후 클러스터 펼침 시 DOM이 재생성되는데, 이 함수가 재호출되지 않으면 이벤트가 비어 regression이 발생한다.
+
+**전환**: `commentTrack` 컨테이너 단 1개에 위임 리스너를 단다. 타깃 식별은 `e.target.closest(...)`.
+
+#### 4.1.1 분기 테이블 (위임 핸들러)
+
+| 이벤트 | 대상 셀렉터 | 동작 |
+|--------|------------|------|
+| `mousedown` | `.comment-handle-left/right` | 리사이즈 드래그 시작 (`isDraggingComment = true`) |
+| `mousedown` | `.comment-range-item` (핸들 外) | 이동 드래그 시작 (`isDraggingComment = true`) |
+| `mousedown` | `.comment-cluster-badge` | 클러스터 펼침 |
+| `mousedown` | `.comment-cluster-close-badge` | 클러스터 접힘 |
+| `click` | 트랙 빈 영역 | `!isDraggingComment && !justDragged`일 때만 `expandedClusterId = null` |
+| `mouseover` | `.comment-cluster-badge` | 호버 팝업 예약 (300ms 후 표시) |
+| `mouseout` | `.comment-cluster-badge` | 호버 팝업 타이머 취소 / 즉시 숨김 |
+
+#### 4.1.2 상태 필드 (timeline.js)
+
+```js
+this.expandedClusterId    = null;   // 기존 유지
+this.isDraggingComment    = false;  // 신규
+this.dragContext          = null;   // 신규
+this.justDragged          = false;  // 신규 (click 차단용 1-tick 플래그)
+this.clusterTooltipTimer  = null;   // 신규
+this.clusterTooltipEl     = null;   // 신규 (body에 1개 유지, 재사용)
+```
+
+`dragContext` 형태:
+```js
+{
+  mode: 'move' | 'resize-left' | 'resize-right',
+  markerId: string,
+  layerId: string,
+  startX: number,           // clientX 기록
+  origStartFrame: number,
+  origEndFrame: number,
+  element: HTMLElement,     // 드래그 대상 DOM (재렌더 대신 직접 조작)
+}
+```
+
+### 4.2 드래그 엔진 (재렌더 억제)
+
+**핵심 원칙**: 드래그 **중** 에는 `renderCommentRanges()`를 **절대 호출하지 않는다**.
+
+| 단계 | 동작 |
+|------|------|
+| `mousedown` | `dragContext` 세팅, `window`에 `mousemove`/`mouseup` 임시 바인딩, `e.preventDefault()` |
+| `mousemove` | `Δframe = pxToFrameDelta(clientX - startX)` 계산, `element.style.left/width`만 직접 업데이트 (DOM 교체 금지) |
+| `mouseup` (3px 미만 이동) | 클릭으로 처리, `commentManager` 변경 **안 함**, `justDragged = false` |
+| `mouseup` (3px 이상 이동) | `commentManager.updateMarker(...)` 호출 → 데이터 이벤트 → 일반 재렌더 경로로 동기화. `justDragged = true`로 1-tick 설정 |
+| cleanup | `window`의 `mousemove`/`mouseup` 해제, `isDraggingComment = false`, `dragContext = null` |
+
+### 4.3 클러스터링 로직 확장
+
+#### 4.3.1 기존 파이프라인
+
+```
+findRangeClusters(comments)  →  [cluster1, cluster2, ...]
+assignLanes(cluster)         →  각 comment._lane 할당
+```
+
+#### 4.3.2 신규 순수 함수 추가
+
+```js
+// renderer/scripts/modules/comment-cluster.js
+
+/**
+ * 클러스터 내부에서 이웃 간 픽셀 거리가 minGapPx 이상이면 분리한다.
+ * @param {Array<Array<Comment>>} clusters - findRangeClusters의 반환값
+ * @param {{pxPerFrame: number, minGapPx?: number}} opts
+ * @returns {Array<Array<Comment>>} 분리된 클러스터 배열 (단일 멤버도 포함 가능)
+ */
+export function splitClustersByPixelGap(clusters, { pxPerFrame, minGapPx = 8 }) {
+  if (!pxPerFrame || pxPerFrame <= 0) return clusters;  // 안전 가드
+  const result = [];
+  for (const cluster of clusters) {
+    if (cluster.length < 2) { result.push(cluster); continue; }
+    const sorted = [...cluster].sort((a, b) => a.startFrame - b.startFrame);
+    let current = [sorted[0]];
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1];
+      const curr = sorted[i];
+      const gapPx = (curr.startFrame - prev.endFrame) * pxPerFrame;
+      if (gapPx >= minGapPx) {
+        result.push(current);
+        current = [curr];
+      } else {
+        current.push(curr);
+      }
+    }
+    result.push(current);
+  }
+  return result;
+}
+```
+
+#### 4.3.3 호출부 (timeline.js `renderCommentRanges`)
+
+```js
+const rawClusters = findRangeClusters(comments);
+const trackRect = this.commentTrack.getBoundingClientRect();
+const pxPerFrame = trackRect.width / this.totalFrames;
+const splitClusters = splitClustersByPixelGap(rawClusters, { pxPerFrame, minGapPx: 8 });
+
+for (const group of splitClusters) {
+  if (group.length === 1) {
+    // 단일 코멘트 (배지 아님) 렌더
+  } else {
+    // 클러스터 배지 또는 펼침 렌더
+  }
+}
+```
+
+### 4.4 배지/팝업 DOM 구조
+
+#### 4.4.1 배지 (접힌 상태)
+
+**기존** (제거):
+```html
+<div class="comment-cluster-badge">
+  <div class="comment-cluster-stack-hint">
+    <div class="stripe" style="background:#f00"></div>
+    <div class="stripe" style="background:#0f0"></div>
+    <div class="stripe" style="background:#00f"></div>
+  </div>
+  <div class="comment-cluster-count">⊕3</div>
+</div>
+```
+
+**신규**:
+```html
+<div class="comment-cluster-badge" data-cluster-key="...">
+  <span class="comment-cluster-badge-label">+3</span>
+</div>
+```
+
+#### 4.4.2 접기 배지 (펼친 상태)
+
+```html
+<div class="comment-cluster-close-badge">× 접기</div>
+```
+
+위치: `position: absolute; top: -20px; right: 0; z-index: 25;`
+
+#### 4.4.3 호버 툴팁 (body 레벨)
+
+`body`에 단일 `<div class="comment-cluster-tooltip">`를 유지하고 재사용 (메모리/GC 효율). 내용 구조:
+
+```html
+<div class="comment-cluster-tooltip" role="tooltip">
+  <div class="tooltip-row">
+    <span class="tooltip-color-dot" style="background:#4a9eff"></span>
+    <span class="tooltip-author">김민수</span>
+    <span class="tooltip-range">120–145</span>
+    <span class="tooltip-text">수정 필요한 부분…</span>
+  </div>
+  <!-- 반복 -->
+</div>
+```
+
+위치 계산: 배지 `getBoundingClientRect()` 기준 top placement, 뷰포트 상단 160px 미만이면 bottom placement로 폴백.
+
+### 4.5 썸네일 온디맨드 정확-프레임
+
+#### 4.5.1 `thumbnail-generator.js` 신규 API
+
+```js
+getThumbnailUrlAtExact(time) {
+  const rounded = Math.round(time * 10) / 10;
+  return this.thumbnailMap.get(rounded) || null;
+}
+
+requestExactCapture(time) {
+  const rounded = Math.round(time * 10) / 10;
+  if (this.thumbnailMap.has(rounded)) return;
+  if (!this._exactQueue) this._exactQueue = new Set();
+  if (this._exactQueue.has(rounded)) return;
+  this._exactQueue.add(rounded);
+  this._drainExactQueue();
+}
+
+async _drainExactQueue() {
+  if (this._exactDraining) return;
+  if (this.videoElement?.paused !== true) return;  // 재생 중이면 대기
+  this._exactDraining = true;
+  try {
+    while (this._exactQueue.size > 0) {
+      const t = this._exactQueue.values().next().value;
+      this._exactQueue.delete(t);
+      await this._seekAndCapture(t);
+      const dataUrl = this.thumbnailMap.get(t);
+      if (dataUrl) this._emit('exactCaptured', { time: t, dataUrl });
+    }
+  } finally {
+    this._exactDraining = false;
+  }
+}
+```
+
+재생 중 캡처 방지: `videoElement`에 `pause` 이벤트 리스너 등록 → 일시정지 시 `_drainExactQueue()` 호출.
+
+#### 4.5.2 `app.js` 호출부 수정 (라인 ~5300)
+
+```js
+const markerTime = marker.startFrame / videoPlayer.fps;
+let thumbnailUrl = null;
+if (showThumbnails && thumbnailGenerator?.isReady) {
+  thumbnailUrl = thumbnailGenerator.getThumbnailUrlAtExact(markerTime);
+  if (!thumbnailUrl) {
+    thumbnailGenerator.requestExactCapture(markerTime);
+    thumbnailUrl = thumbnailGenerator.getThumbnailUrlAt(markerTime);  // 근사 폴백
+  }
+}
+```
+
+#### 4.5.3 정확 캡처 완료 이벤트 처리
+
+```js
+thumbnailGenerator.on('exactCaptured', ({ time, dataUrl }) => {
+  const frame = Math.round(time * videoPlayer.fps);
+  document.querySelectorAll(
+    `.comment-item[data-start-frame="${frame}"] .comment-thumbnail`
+  ).forEach(img => { img.src = dataUrl; });
+});
+```
+
+전체 재렌더가 아닌 **해당 요소의 `img.src`만 교체**하여 부드러운 진적 갱신.
+
+---
+
+## 5. 영향받는 파일
+
+| 파일 | 변경 유형 | 주요 수정 |
+|------|----------|----------|
+| `renderer/scripts/modules/comment-cluster.js` | 추가 | `splitClustersByPixelGap` 함수 추가 |
+| `scripts/tests/comment-cluster.test.js` | 추가 | `splitClustersByPixelGap` 단위 테스트 |
+| `renderer/scripts/modules/timeline.js` | 개편 | 위임 핸들러 도입, 드래그 엔진 구현, 클러스터 split 호출, 배지/접기/툴팁 DOM 구조 변경, 상태 필드 추가 |
+| `renderer/scripts/app.js` | 삭제+수정 | `setupCommentRangeInteractions` 삭제, 호출부 제거; 썸네일 렌더 부분 수정; `exactCaptured` 이벤트 수신 |
+| `renderer/scripts/modules/thumbnail-generator.js` | 추가 | `getThumbnailUrlAtExact`, `requestExactCapture`, `_drainExactQueue` |
+| `renderer/styles/main.css` | 개편 | `.comment-cluster-stack-hint` 제거, `.comment-cluster-badge-label` 추가, `.comment-cluster-close-badge` 추가, `.comment-cluster-tooltip` 추가 |
+
+---
+
+## 6. 테스트 전략
+
+### 6.1 단위 테스트 (`scripts/tests/comment-cluster.test.js`)
+
+| 케이스 | 입력 | 기대 |
+|--------|------|------|
+| 빈 클러스터 목록 | `[]` | `[]` |
+| 단일 멤버 클러스터 통과 | `[[c1]]` | `[[c1]]` |
+| 모든 gap < 8px | 3개 코멘트, pxPerFrame=1, 모두 간격 5px | 원본 클러스터 그대로 |
+| gap 한 지점만 ≥ 8px | 3개 코멘트, 중간만 10px gap | 2개 그룹 분리 |
+| 여러 gap ≥ 8px | 4개 코멘트, 2곳 gap 10px | 3개 그룹 분리 |
+| 단일 멤버로 쪼개짐 | 2개 코멘트, gap 10px | `[[c1], [c2]]` (각 단일) |
+| `pxPerFrame = 0` 방어 | 0 입력 | 원본 그대로 반환 |
+| `pxPerFrame` 음수 방어 | -1 입력 | 원본 그대로 반환 |
+| `minGapPx` 기본값 | 옵션 생략 | 8px 기준 적용 |
+
+### 6.2 수동 QA 체크리스트 (DEVLOG 첨부)
+
+1. 겹친 코멘트 2/3/5개 → 각각 `+2`/`+3`/`+5` 배지 표시
+2. 배지 호버 (접힌 상태) → 300ms 후 세로 리스트 팝업 (작성자 · 프레임 범위 · 본문 1줄)
+3. 팝업 위치 top/bottom 폴백 (뷰포트 상단 근처에서 아래로)
+4. 배지 클릭 → 펼침, 오른쪽 상단에 접기 배지 명확히 표시
+5. 펼친 클러스터 내부 코멘트 바 **중앙 드래그 → 이동**, 펼친 상태 유지
+6. 좌/우 핸들 드래그 → `startFrame`/`endFrame` 변경, 펼친 상태 유지
+7. 3px 미만 드래그 = 단순 클릭으로 처리 (패널 이동/하이라이트만)
+8. 빈 영역 클릭 → 펼친 클러스터 접힘
+9. 줌 1× 8px 이내 코멘트 → 클러스터 묶음; **줌 300% 확대 → 자연스레 분리**
+10. 댓글 클릭 → 사이드바 썸네일이 근사치 먼저, ≤ 1초 후 **정확한 프레임으로 교체**
+11. 재생 중에는 온디맨드 캡처 대기, **일시정지 시 드레인**
+12. Regression: 비클러스터 단일 코멘트 편집 정상 동작
+13. 실시간 동기화 이벤트 드래그 중 수신돼도 펼친 상태 유지
+14. ESC 키로도 클러스터 접힘 (선택적 기능)
+
+### 6.3 Regression 확인
+
+- 마커(점) 클러스터링 동작 유지 (기존 `marker.addEventListener` 경로)
+- 드로잉 모드/댓글 모드 전환 시 이벤트 충돌 없음
+- 타임라인 스크롤/줌 중 펼친 상태 유지
+- 다중 레이어 필터와의 상호작용
+
+---
+
+## 7. 리스크 및 완화
+
+| 리스크 | 심각도 | 완화 방안 |
+|--------|--------|----------|
+| `window` mousemove 리스너 누수 | 중 | `mouseup`/`cleanup`에서 반드시 `removeEventListener`; `init()`에 1회 플래그 |
+| 온디맨드 시크가 재생 방해 | 중 | `video.paused === true` 조건에서만 큐 드레인; `pause` 이벤트 훅 |
+| 호버 팝업 flicker | 낮 | `mouseover` 300ms 딜레이 + `mouseout` 즉시 타이머 취소 |
+| 이벤트 위임 전환이 기존 마커 드래그에 영향 | 중 | `markerTrack`과 `commentTrack`을 분리; 마커 경로는 건드리지 않음 |
+| 드래그 중 실시간 동기화 이벤트 수신 | 중 | `isDraggingComment === true`이면 해당 마커 DOM은 건드리지 않음 (다른 마커만 업데이트) |
+| 클러스터 split 후 레인 할당 재계산 비용 | 낮 | 분리된 각 그룹에 대해 `assignLanes` 별도 호출; 그룹 크기가 작아 부담 없음 |
+| 썸네일 캡처 큐 과다 적재 | 낮 | `Set`으로 중복 방지; 필요 시 상한(예: 100) 적용 |
+
+---
+
+## 8. 롤아웃 계획
+
+1. **단위 테스트 먼저** (`splitClustersByPixelGap` 테스트)
+2. **클러스터 로직 + 배지 DOM 구조** 변경 (C, F 해결)
+3. **이벤트 위임 엔진** 도입 (A, B, E 해결)
+4. **호버 팝업** 구현 (D 해결)
+5. **썸네일 정확-프레임** 구현 (G 해결)
+6. **수동 QA + DEVLOG 업데이트**
+7. 커밋 후 PR 생성
+
+각 단계 완료 시 `npm run lint` 및 관련 테스트 실행.
+
+---
+
+## 9. 참고
+
+- PR #112: [feat: 구간 코멘트 중첩 시 하이브리드 펼침 UI (Mode C)](https://github.com/baehandoridori/BAEFRAME/pull/112)
+- 기존 설계: `docs/superpowers/specs/2026-03-23-comment-ux-improvements-design.md`
+- 관련 모듈: `renderer/scripts/modules/comment-cluster.js`, `renderer/scripts/modules/timeline.js`

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -3264,7 +3264,8 @@ async function initApp() {
   function ensureClusterTooltip() {
     if (clusterTooltipEl) return clusterTooltipEl;
     const el = document.createElement('div');
-    el.className = 'comment-cluster-tooltip';
+    // 기존 단일 마커 툴팁과 동일한 시각 스타일 재사용
+    el.className = 'comment-marker-tooltip cluster-hover';
     el.setAttribute('role', 'tooltip');
     document.body.appendChild(el);
     clusterTooltipEl = el;
@@ -3280,28 +3281,41 @@ async function initApp() {
   function showClusterTooltip(badge) {
     const key = badge.dataset.clusterKey;
     if (!key) return;
-    // clusterKey로 해당 클러스터의 코멘트들 복구
     const members = key.split('|').map(id => commentManager.getMarker(id)).filter(Boolean);
     if (members.length === 0) return;
 
     const tooltip = ensureClusterTooltip();
-    tooltip.innerHTML = '';
-    members.forEach(m => {
-      const row = document.createElement('div');
-      row.className = 'tooltip-row';
-      const color = m.color || '#4a9eff';
-      const author = m.author || m.createdBy || '익명';
-      const text = (m.text || '').split('\n')[0].slice(0, 80);
-      row.innerHTML = `
-        <span class="tooltip-color-dot" style="background:${escapeTooltipText(color)}"></span>
-        <span class="tooltip-author">${escapeTooltipText(author)}</span>
-        <span class="tooltip-range">${m.startFrame}–${m.endFrame}</span>
-        <span class="tooltip-text">${escapeTooltipText(text)}</span>
-      `;
-      tooltip.appendChild(row);
-    });
 
-    // 위치: 배지 위쪽 우선, 상단 근처면 아래로 폴백
+    // 대표 시작 프레임과 타임코드 (최소 startFrame 기준)
+    const minStart = Math.min(...members.map(m => m.startFrame));
+    const repMember = members.find(m => m.startFrame === minStart) || members[0];
+    const startTimecode = repMember.startTimecode || '';
+
+    // 각 댓글 박스 (기존 .tooltip-comment 스타일: 왼쪽 accent border)
+    const commentsHtml = members.map(m => {
+      const text = m.text || '';
+      const hasImage = !!m.image;
+      const displayText = text === '(이미지)' ? '' : text;
+      const preview = displayText.length > 50
+        ? displayText.substring(0, 50) + '...'
+        : displayText;
+      const imageIcon = hasImage ? '<span class="tooltip-image-icon">🖼</span>' : '';
+      const textHtml = preview ? escapeTooltipText(preview) : '';
+      const body = textHtml || (hasImage ? '이미지' : '');
+      return `<div class="tooltip-comment">${imageIcon}${body}</div>`;
+    }).join('');
+
+    const headerHtml = startTimecode
+      ? `<div class="tooltip-header"><span class="tooltip-timecode">${escapeTooltipText(startTimecode)}</span><span class="tooltip-frame">${minStart}f</span></div>`
+      : `<div class="tooltip-frame">프레임 ${minStart}</div>`;
+
+    tooltip.innerHTML = `
+      ${headerHtml}
+      <div class="tooltip-comments">${commentsHtml}</div>
+      ${members.length > 1 ? `<div class="tooltip-count">${members.length}개 댓글</div>` : ''}
+    `;
+
+    // 위치: 배지 위쪽 우선, 상단 근처면 아래로 폴백 (translateY -50% 는 cluster-hover modifier로 무효화됨)
     tooltip.classList.add('visible');
     const badgeRect = badge.getBoundingClientRect();
     const tipRect = tooltip.getBoundingClientRect();

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -4274,6 +4274,9 @@ async function initApp() {
       if (thumbnailListeners.complete) {
         thumbnailGenerator.removeEventListener('complete', thumbnailListeners.complete);
       }
+      if (thumbnailListeners.exactCaptured) {
+        thumbnailGenerator.removeEventListener('exactCaptured', thumbnailListeners.exactCaptured);
+      }
 
       // 기존 썸네일 정리
       thumbnailGenerator.clear();
@@ -4333,12 +4336,8 @@ async function initApp() {
       thumbnailListeners.quickReady = onQuickReady;
       thumbnailListeners.complete = onComplete;
 
-      thumbnailGenerator.addEventListener('progress', onProgress);
-      thumbnailGenerator.addEventListener('quickReady', onQuickReady);
-      thumbnailGenerator.addEventListener('complete', onComplete);
-
       // 정확 프레임 온디맨드 캡처 완료 → 사이드바 댓글 썸네일 교체 (진적 갱신)
-      thumbnailGenerator.addEventListener('exactCaptured', (ev) => {
+      const onExactCaptured = (ev) => {
         const detail = ev.detail || {};
         const { time, dataUrl } = detail;
         if (!dataUrl || typeof time !== 'number') return;
@@ -4346,7 +4345,13 @@ async function initApp() {
         document.querySelectorAll(
           `.comment-item[data-start-frame="${frame}"] .comment-thumbnail`
         ).forEach(img => { img.src = dataUrl; });
-      });
+      };
+      thumbnailListeners.exactCaptured = onExactCaptured;
+
+      thumbnailGenerator.addEventListener('progress', onProgress);
+      thumbnailGenerator.addEventListener('quickReady', onQuickReady);
+      thumbnailGenerator.addEventListener('complete', onComplete);
+      thumbnailGenerator.addEventListener('exactCaptured', onExactCaptured);
 
       // 비디오 소스 경로 (file:// 프로토콜 추가)
       const videoSrc = filePath.startsWith('file://') ? filePath : `file://${filePath}`;

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -2932,6 +2932,8 @@ async function initApp() {
 
   // 댓글 드래그 상태
   let commentDragState = null;
+  let commentJustDragged = false; // 드래그 직후 click 차단용 1-tick 플래그
+  let commentInteractionsBound = false; // 위임 리스너 1회 바인딩 가드
 
   // ====== 비디오 댓글 범위 오버레이 ======
   const videoCommentRangeOverlay = document.getElementById('videoCommentRangeOverlay');
@@ -3093,48 +3095,116 @@ async function initApp() {
     renderVideoCommentRanges();
   }
 
-  // 댓글 범위 상호작용 설정 (드래그, 리사이즈, 클릭)
+  // 댓글 범위 상호작용 설정 — commentTrack 1곳에 이벤트 위임 (1회만 바인딩)
+  // 위임으로 전환한 이유: PR #112 이후 클러스터 펼침 시 .comment-range-item이 재생성되는데
+  // 요소별 바인딩 방식은 재렌더 후 이벤트가 비어 편집 regression이 발생했다.
   function setupCommentRangeInteractions() {
-    const items = commentTrack.querySelectorAll('.comment-range-item');
+    if (commentInteractionsBound) return;
+    if (!commentTrack) return;
+    commentInteractionsBound = true;
 
-    items.forEach(item => {
-      const layerId = item.dataset.layerId;
-      const markerId = item.dataset.markerId;
+    // 클릭 — 해당 댓글 선택 + 프레임 이동 + 댓글 하이라이트
+    // 트랙 배경 클릭은 펼친 클러스터 접기
+    commentTrack.addEventListener('click', (e) => {
+      if (commentDragState || commentJustDragged) return;
 
-      // 클릭 - 해당 댓글로 이동 및 선택 + 댓글 하이라이트
-      item.addEventListener('click', (e) => {
-        if (e.target.classList.contains('comment-handle')) return;
+      // 핸들/배지/접기 배지 클릭은 mousedown에서 처리하므로 무시
+      if (e.target.closest('.comment-handle')) return;
+      if (e.target.closest('.comment-cluster-badge')) return;
+      if (e.target.closest('.comment-cluster-close-badge')) return;
 
-        // 해당 프레임으로 이동
+      const item = e.target.closest('.comment-range-item');
+      if (item) {
+        const layerId = item.dataset.layerId;
+        const markerId = item.dataset.markerId;
         const marker = commentManager.getMarker(markerId);
         if (marker) {
           videoPlayer.seekToFrame(marker.startFrame);
           videoPlayer.pause();
-          // 프리뷰 마커 클릭과 동일한 효과
           scrollToCommentWithGlow(markerId);
         }
-
-        // 선택 표시
-        items.forEach(i => i.classList.remove('selected'));
+        commentTrack.querySelectorAll('.comment-range-item').forEach(i =>
+          i.classList.remove('selected')
+        );
         item.classList.add('selected');
         selectedCommentRange = { layerId, markerId };
-      });
+        return;
+      }
 
-      // 드래그 시작 (전체 이동)
-      item.addEventListener('mousedown', (e) => {
-        if (e.target.classList.contains('comment-handle')) return;
-        if (e.button !== 0) return;
+      // 트랙 배경 클릭 → 펼친 클러스터 접기
+      if (e.target === commentTrack && timeline.expandedClusterId !== null) {
+        timeline.expandedClusterId = null;
+        timeline.renderCommentRanges(timeline._lastComments || []);
+      }
+    });
 
+    // mousedown — 드래그/리사이즈/펼치기/접기 라우팅
+    commentTrack.addEventListener('mousedown', (e) => {
+      if (e.button !== 0) return;
+
+      // 1) 접기 배지 → 클러스터 접기
+      if (e.target.closest('.comment-cluster-close-badge')) {
         e.preventDefault();
+        e.stopPropagation();
+        timeline.expandedClusterId = null;
+        timeline.renderCommentRanges(timeline._lastComments || []);
+        return;
+      }
+
+      // 2) 클러스터 배지 → 펼치기 토글
+      const clusterBadge = e.target.closest('.comment-cluster-badge');
+      if (clusterBadge) {
+        e.preventDefault();
+        e.stopPropagation();
+        const key = clusterBadge.dataset.clusterKey;
+        timeline.expandedClusterId = (timeline.expandedClusterId === key) ? null : key;
+        timeline.renderCommentRanges(timeline._lastComments || []);
+        return;
+      }
+
+      // 3) 핸들 mousedown → 리사이즈 시작
+      const handle = e.target.closest('.comment-handle');
+      if (handle) {
+        const item = handle.closest('.comment-range-item');
+        if (!item) return;
+        const markerId = item.dataset.markerId;
+        const layerId = item.dataset.layerId;
         const marker = commentManager.getMarker(markerId);
         if (!marker) return;
-
-        // 권한 체크 (본인 코멘트만 이동 가능)
         if (!commentManager.canEdit(marker)) {
           showToast('본인 코멘트만 수정할 수 있습니다.', 'warning');
           return;
         }
+        e.preventDefault();
+        e.stopPropagation();
+        commentDragState = {
+          layerId,
+          markerId,
+          handle: handle.dataset.handle, // 'left' or 'right'
+          startX: e.clientX,
+          startFrame: marker.startFrame,
+          endFrame: marker.endFrame,
+          duration: marker.endFrame - marker.startFrame,
+          originalStartFrame: marker.startFrame,
+          originalEndFrame: marker.endFrame
+        };
+        item.classList.add('dragging');
+        document.body.style.cursor = 'ew-resize';
+        return;
+      }
 
+      // 4) 코멘트 바 본체 mousedown → 이동 드래그 시작
+      const item = e.target.closest('.comment-range-item');
+      if (item) {
+        const markerId = item.dataset.markerId;
+        const layerId = item.dataset.layerId;
+        const marker = commentManager.getMarker(markerId);
+        if (!marker) return;
+        if (!commentManager.canEdit(marker)) {
+          showToast('본인 코멘트만 수정할 수 있습니다.', 'warning');
+          return;
+        }
+        e.preventDefault();
         commentDragState = {
           layerId,
           markerId,
@@ -3143,48 +3213,12 @@ async function initApp() {
           startFrame: marker.startFrame,
           endFrame: marker.endFrame,
           duration: marker.endFrame - marker.startFrame,
-          // Undo용 원본 값 저장
           originalStartFrame: marker.startFrame,
           originalEndFrame: marker.endFrame
         };
-
         item.classList.add('dragging');
         document.body.style.cursor = 'grabbing';
-      });
-
-      // 핸들 드래그 시작 (리사이즈)
-      const handles = item.querySelectorAll('.comment-handle');
-      handles.forEach(handle => {
-        handle.addEventListener('mousedown', (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-
-          const marker = commentManager.getMarker(markerId);
-          if (!marker) return;
-
-          // 권한 체크 (본인 코멘트만 리사이즈 가능)
-          if (!commentManager.canEdit(marker)) {
-            showToast('본인 코멘트만 수정할 수 있습니다.', 'warning');
-            return;
-          }
-
-          commentDragState = {
-            layerId,
-            markerId,
-            handle: handle.dataset.handle, // 'left' or 'right'
-            startX: e.clientX,
-            startFrame: marker.startFrame,
-            endFrame: marker.endFrame,
-            duration: marker.endFrame - marker.startFrame,
-            // Undo용 원본 값 저장
-            originalStartFrame: marker.startFrame,
-            originalEndFrame: marker.endFrame
-          };
-
-          item.classList.add('dragging');
-          document.body.style.cursor = 'ew-resize';
-        });
-      });
+      }
     });
   }
 
@@ -3302,6 +3336,10 @@ async function initApp() {
 
       commentDragState = null;
       document.body.style.cursor = '';
+
+      // 드래그 직후 click 이벤트 차단 (클릭으로 오인한 접힘/선택 방지)
+      commentJustDragged = true;
+      setTimeout(() => { commentJustDragged = false; }, 50);
 
       // 데이터 저장
       reviewDataManager.save();

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -643,6 +643,8 @@ async function initApp() {
     getAudioWaveform()?.setPlaying(true);
     // 재생 시작 시 플레이헤드가 화면 밖에 있으면 스크롤
     timeline.scrollToPlayhead();
+    // 재생 중에는 온디맨드 썸네일 캡처를 중단해 재생 방해를 방지
+    getThumbnailGenerator()?._abortExactDrain?.();
   });
 
   videoPlayer.addEventListener('pause', () => {
@@ -650,6 +652,8 @@ async function initApp() {
     drawingManager.setPlaying(false);
     timeline.setPlayingState(false);
     getAudioWaveform()?.setPlaying(false);
+    // 일시정지 시점에 누적된 온디맨드 정확-프레임 큐를 소진
+    getThumbnailGenerator()?._drainExactQueue?.();
   });
 
   videoPlayer.addEventListener('ended', () => {
@@ -4319,6 +4323,17 @@ async function initApp() {
       thumbnailGenerator.addEventListener('quickReady', onQuickReady);
       thumbnailGenerator.addEventListener('complete', onComplete);
 
+      // 정확 프레임 온디맨드 캡처 완료 → 사이드바 댓글 썸네일 교체 (진적 갱신)
+      thumbnailGenerator.addEventListener('exactCaptured', (ev) => {
+        const detail = ev.detail || {};
+        const { time, dataUrl } = detail;
+        if (!dataUrl || typeof time !== 'number') return;
+        const frame = Math.round(time * (videoPlayer.fps || 24));
+        document.querySelectorAll(
+          `.comment-item[data-start-frame="${frame}"] .comment-thumbnail`
+        ).forEach(img => { img.src = dataUrl; });
+      });
+
       // 비디오 소스 경로 (file:// 프로토콜 추가)
       const videoSrc = filePath.startsWith('file://') ? filePath : `file://${filePath}`;
 
@@ -5423,11 +5438,16 @@ async function initApp() {
       `;
       }).join('');
 
-      // 썸네일 URL 가져오기
+      // 썸네일 URL 가져오기 — 정확 프레임 우선, 없으면 근사치 + 온디맨드 캡처 요청
       const markerTime = marker.startFrame / videoPlayer.fps;
-      const thumbnailUrl = showThumbnails && thumbnailGenerator?.isReady
-        ? thumbnailGenerator.getThumbnailUrlAt(markerTime)
-        : null;
+      let thumbnailUrl = null;
+      if (showThumbnails && thumbnailGenerator?.isReady) {
+        thumbnailUrl = thumbnailGenerator.getThumbnailUrlAtExact(markerTime);
+        if (!thumbnailUrl) {
+          thumbnailGenerator.requestExactCapture(markerTime);
+          thumbnailUrl = thumbnailGenerator.getThumbnailUrlAt(markerTime);
+        }
+      }
 
       const thumbnailHtml = thumbnailUrl ? `
         <div class="comment-thumbnail-wrapper" style="max-width: ${thumbnailScale}%;">

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -2935,6 +2935,10 @@ async function initApp() {
   let commentJustDragged = false; // 드래그 직후 click 차단용 1-tick 플래그
   let commentInteractionsBound = false; // 위임 리스너 1회 바인딩 가드
 
+  // 클러스터 호버 툴팁 상태
+  let clusterTooltipEl = null;
+  let clusterTooltipTimer = null;
+
   // ====== 비디오 댓글 범위 오버레이 ======
   const videoCommentRangeOverlay = document.getElementById('videoCommentRangeOverlay');
   const btnOverlayToggle = document.getElementById('btnOverlayToggle');
@@ -3220,6 +3224,91 @@ async function initApp() {
         document.body.style.cursor = 'grabbing';
       }
     });
+
+    // mouseover / mouseout — 접힌 클러스터 배지 호버 팝업
+    commentTrack.addEventListener('mouseover', (e) => {
+      const badge = e.target.closest('.comment-cluster-badge');
+      if (!badge) return;
+      if (timeline.expandedClusterId !== null) return; // 펼친 상태면 팝업 안 띄움
+      if (commentDragState) return;
+
+      cancelClusterTooltip();
+      clusterTooltipTimer = setTimeout(() => {
+        showClusterTooltip(badge);
+      }, 300);
+    });
+
+    commentTrack.addEventListener('mouseout', (e) => {
+      const badge = e.target.closest('.comment-cluster-badge');
+      if (!badge) return;
+      cancelClusterTooltip();
+      hideClusterTooltip();
+    });
+  }
+
+  function cancelClusterTooltip() {
+    if (clusterTooltipTimer) {
+      clearTimeout(clusterTooltipTimer);
+      clusterTooltipTimer = null;
+    }
+  }
+
+  function hideClusterTooltip() {
+    if (clusterTooltipEl) clusterTooltipEl.classList.remove('visible');
+  }
+
+  function ensureClusterTooltip() {
+    if (clusterTooltipEl) return clusterTooltipEl;
+    const el = document.createElement('div');
+    el.className = 'comment-cluster-tooltip';
+    el.setAttribute('role', 'tooltip');
+    document.body.appendChild(el);
+    clusterTooltipEl = el;
+    return el;
+  }
+
+  function escapeTooltipText(s) {
+    const d = document.createElement('div');
+    d.textContent = String(s ?? '');
+    return d.innerHTML;
+  }
+
+  function showClusterTooltip(badge) {
+    const key = badge.dataset.clusterKey;
+    if (!key) return;
+    // clusterKey로 해당 클러스터의 코멘트들 복구
+    const members = key.split('|').map(id => commentManager.getMarker(id)).filter(Boolean);
+    if (members.length === 0) return;
+
+    const tooltip = ensureClusterTooltip();
+    tooltip.innerHTML = '';
+    members.forEach(m => {
+      const row = document.createElement('div');
+      row.className = 'tooltip-row';
+      const color = m.color || '#4a9eff';
+      const author = m.author || m.createdBy || '익명';
+      const text = (m.text || '').split('\n')[0].slice(0, 80);
+      row.innerHTML = `
+        <span class="tooltip-color-dot" style="background:${escapeTooltipText(color)}"></span>
+        <span class="tooltip-author">${escapeTooltipText(author)}</span>
+        <span class="tooltip-range">${m.startFrame}–${m.endFrame}</span>
+        <span class="tooltip-text">${escapeTooltipText(text)}</span>
+      `;
+      tooltip.appendChild(row);
+    });
+
+    // 위치: 배지 위쪽 우선, 상단 근처면 아래로 폴백
+    tooltip.classList.add('visible');
+    const badgeRect = badge.getBoundingClientRect();
+    const tipRect = tooltip.getBoundingClientRect();
+
+    let top = badgeRect.top - tipRect.height - 8;
+    if (top < 10) top = badgeRect.bottom + 8;
+    let left = badgeRect.left + (badgeRect.width / 2) - (tipRect.width / 2);
+    left = Math.max(8, Math.min(window.innerWidth - tipRect.width - 8, left));
+
+    tooltip.style.top = `${top}px`;
+    tooltip.style.left = `${left}px`;
   }
 
   // 댓글 드래그 처리 (mousemove)

--- a/renderer/scripts/modules/comment-cluster.js
+++ b/renderer/scripts/modules/comment-cluster.js
@@ -73,3 +73,42 @@ export function clusterKey(cluster) {
   if (!cluster || cluster.length === 0) return null;
   return cluster.map(c => c.markerId).sort().join('|');
 }
+
+/**
+ * 클러스터 내부에서 이웃 간 픽셀 거리가 minGapPx 이상이면 분리한다.
+ * 줌에 따라 pxPerFrame이 커지면 같은 프레임 클러스터가 자연스럽게 분리된다.
+ *
+ * @param {Array<Array>} clusters - findRangeClusters의 반환값
+ * @param {{pxPerFrame: number, minGapPx?: number}} [opts]
+ * @returns {Array<Array>} 분리된 클러스터 배열 (단일 멤버도 포함 가능)
+ */
+export function splitClustersByPixelGap(clusters, opts = {}) {
+  const { pxPerFrame, minGapPx = 8 } = opts;
+  if (!Array.isArray(clusters)) return clusters;
+  if (typeof pxPerFrame !== 'number' || !isFinite(pxPerFrame) || pxPerFrame <= 0) {
+    return clusters;
+  }
+  const result = [];
+  for (const cluster of clusters) {
+    if (!cluster || cluster.length < 2) {
+      result.push(cluster);
+      continue;
+    }
+    const sorted = [...cluster].sort((a, b) => a.startFrame - b.startFrame);
+    let current = [sorted[0]];
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1];
+      const curr = sorted[i];
+      const gapFrames = curr.startFrame - prev.endFrame;
+      const gapPx = gapFrames * pxPerFrame;
+      if (gapPx >= minGapPx) {
+        result.push(current);
+        current = [curr];
+      } else {
+        current.push(curr);
+      }
+    }
+    result.push(current);
+  }
+  return result;
+}

--- a/renderer/scripts/modules/comment-cluster.js
+++ b/renderer/scripts/modules/comment-cluster.js
@@ -75,15 +75,19 @@ export function clusterKey(cluster) {
 }
 
 /**
- * 클러스터 내부에서 이웃 간 픽셀 거리가 minGapPx 이상이면 분리한다.
- * 줌에 따라 pxPerFrame이 커지면 같은 프레임 클러스터가 자연스럽게 분리된다.
+ * 클러스터 내부에서 이웃 구간의 `startFrame` 간격이 minSpacingPx 이상이면 분리한다.
+ *
+ * 기준이 `startFrame` 간격인 이유: 타임라인의 포인트 댓글 마커 클러스터링이 동일한
+ * "20px 미만 시작점 거리" 기준을 사용한다(timeline.js _renderClusteredMarkers).
+ * 구간 코멘트도 같은 기준으로 묶어야 포인트 마커의 "(N)" 복수 배지와 구간 배지가
+ * 시각적으로 일관되게 나타난다.
  *
  * @param {Array<Array>} clusters - findRangeClusters의 반환값
- * @param {{pxPerFrame: number, minGapPx?: number}} [opts]
+ * @param {{pxPerFrame: number, minSpacingPx?: number}} [opts]
  * @returns {Array<Array>} 분리된 클러스터 배열 (단일 멤버도 포함 가능)
  */
 export function splitClustersByPixelGap(clusters, opts = {}) {
-  const { pxPerFrame, minGapPx = 8 } = opts;
+  const { pxPerFrame, minSpacingPx = 20 } = opts;
   if (!Array.isArray(clusters)) return clusters;
   if (typeof pxPerFrame !== 'number' || !isFinite(pxPerFrame) || pxPerFrame <= 0) {
     return clusters;
@@ -99,9 +103,10 @@ export function splitClustersByPixelGap(clusters, opts = {}) {
     for (let i = 1; i < sorted.length; i++) {
       const prev = sorted[i - 1];
       const curr = sorted[i];
-      const gapFrames = curr.startFrame - prev.endFrame;
-      const gapPx = gapFrames * pxPerFrame;
-      if (gapPx >= minGapPx) {
+      // 포인트 마커 클러스터링과 동일: startFrame 간 픽셀 거리 기준
+      const spacingFrames = curr.startFrame - prev.startFrame;
+      const spacingPx = spacingFrames * pxPerFrame;
+      if (spacingPx >= minSpacingPx) {
         result.push(current);
         current = [curr];
       } else {

--- a/renderer/scripts/modules/thumbnail-generator.js
+++ b/renderer/scripts/modules/thumbnail-generator.js
@@ -563,8 +563,15 @@ export class ThumbnailGenerator extends EventTarget {
     if (this._exactDraining) return;
     if (!this.videoSrc) return;
     if (this._exactQueue.size === 0) return;
-    // Phase 1/2 진행 중이면 시크 경쟁 방지 위해 대기 (generate 완료 시 재시도됨)
-    if (this.isGenerating) return;
+    // 시크 경쟁 방지:
+    // - isGenerating: Phase 1 진행 중
+    // - isQuickReady && !isFullReady: Phase 1 끝난 뒤 Phase 2가 백그라운드에서
+    //   this.video에 seek 중인 창. (generate()에서 isGenerating은 Phase 1 직후
+    //   false로 바뀌지만 Phase 2는 계속 돌고 있어 여기가 누락되면 경쟁 발생.)
+    // 두 조건 모두 generate() 완료 시점에 해소되며, 완료 후 자동으로 drain 재시도.
+    const inBackgroundGeneration =
+      this.isGenerating || (this.isQuickReady && !this.isFullReady);
+    if (inBackgroundGeneration) return;
 
     this._exactDraining = true;
     this._exactAborted = false;

--- a/renderer/scripts/modules/thumbnail-generator.js
+++ b/renderer/scripts/modules/thumbnail-generator.js
@@ -46,6 +46,11 @@ export class ThumbnailGenerator extends EventTarget {
     // 백그라운드 생성 제어
     this.abortController = null;
 
+    // 온디맨드 정확-프레임 캡처 큐
+    this._exactQueue = new Set();
+    this._exactDraining = false;
+    this._exactAborted = false;
+
     log.info('ThumbnailGenerator 초기화됨', {
       thumbnailSize: `${this.thumbnailWidth}x${this.thumbnailHeight}`,
       quickInterval: this.quickInterval,
@@ -515,6 +520,83 @@ export class ThumbnailGenerator extends EventTarget {
    */
   _emit(type, detail = {}) {
     this.dispatchEvent(new CustomEvent(type, { detail }));
+  }
+
+  /**
+   * 정확한 시간의 썸네일만 반환 (근사 매칭 없음).
+   * 정확히 일치하는 키(roundedTime)가 맵에 없으면 null.
+   */
+  getThumbnailUrlAtExact(time) {
+    if (typeof time !== 'number' || !isFinite(time) || time < 0) return null;
+    const rounded = Math.round(time * 10) / 10;
+    return this.thumbnailMap.get(rounded) || null;
+  }
+
+  /**
+   * 특정 시간의 정확한 프레임 썸네일을 비동기로 캡처 요청.
+   * 이미 캐시에 있거나 큐에 있으면 no-op. 재생 중이더라도 큐에만 쌓이며,
+   * 앱이 _drainExactQueue를 호출해야 실제 캡처가 진행된다.
+   */
+  requestExactCapture(time) {
+    if (typeof time !== 'number' || !isFinite(time) || time < 0) return;
+    const rounded = Math.round(time * 10) / 10;
+    if (this.thumbnailMap.has(rounded)) return;
+    if (this._exactQueue.has(rounded)) return;
+    this._exactQueue.add(rounded);
+    // 기본 자동 드레인 — 앱 측 가드(pause 이벤트)가 있으면 덮어씀
+    this._drainExactQueue();
+  }
+
+  /**
+   * 정확 캡처 큐 소진. 재생 중 호출되면 Phase 2가 해제된 경우 비디오를
+   * 임시 재생성해 캡처하고, 완료 후 정리한다.
+   */
+  async _drainExactQueue() {
+    if (this._exactDraining) return;
+    if (!this.videoSrc) return;
+    if (this._exactQueue.size === 0) return;
+
+    this._exactDraining = true;
+    this._exactAborted = false;
+
+    const needsVideo = !this.video;
+    try {
+      if (needsVideo) {
+        this.video = document.createElement('video');
+        this.video.muted = true;
+        this.video.preload = 'auto';
+        await this._loadVideo(this.videoSrc);
+      }
+
+      while (this._exactQueue.size > 0) {
+        if (this._exactAborted) break;
+        const t = this._exactQueue.values().next().value;
+        this._exactQueue.delete(t);
+        try {
+          await this._seekAndCapture(t);
+          const dataUrl = this.thumbnailMap.get(t);
+          if (dataUrl) this._emit('exactCaptured', { time: t, dataUrl });
+        } catch (err) {
+          log.warn('온디맨드 캡처 실패', { time: t, error: err?.message });
+        }
+      }
+    } catch (err) {
+      log.warn('온디맨드 큐 드레인 오류', { error: err?.message });
+    } finally {
+      if (needsVideo) {
+        this._cleanupVideo();
+        try { await this._saveToCache(); } catch (_e) { /* 무시 */ }
+      }
+      this._exactDraining = false;
+      this._exactAborted = false;
+    }
+  }
+
+  /**
+   * 재생 시작 시 앱에서 호출 — 진행 중 드레인 루프를 다음 iteration에서 중단.
+   */
+  _abortExactDrain() {
+    this._exactAborted = true;
   }
 }
 

--- a/renderer/scripts/modules/thumbnail-generator.js
+++ b/renderer/scripts/modules/thumbnail-generator.js
@@ -46,8 +46,9 @@ export class ThumbnailGenerator extends EventTarget {
     // 백그라운드 생성 제어
     this.abortController = null;
 
-    // 온디맨드 정확-프레임 캡처 큐
-    this._exactQueue = new Set();
+    // 온디맨드 정확-프레임 캡처 큐 + 정확 프레임 전용 맵 (반올림 없음)
+    this._exactMap = new Map();       // 정확한 time(float) -> dataUrl
+    this._exactQueue = new Set();     // 정확한 time 요청 큐
     this._exactDraining = false;
     this._exactAborted = false;
 
@@ -183,6 +184,9 @@ export class ThumbnailGenerator extends EventTarget {
 
       log.info('모든 썸네일 생성 완료', { count: this.thumbnailMap.size });
       this._emit('complete', { count: this.thumbnailMap.size });
+
+      // 생성 중 대기시켰던 온디맨드 캡처 요청 소진
+      if (this._exactQueue.size > 0) this._drainExactQueue();
 
     } catch (error) {
       if (error.name === 'AbortError') {
@@ -508,6 +512,9 @@ export class ThumbnailGenerator extends EventTarget {
     this._cleanupVideo();
     this.thumbnailMap.clear();
     this.sortedTimes = [];
+    this._exactMap.clear();
+    this._exactQueue.clear();
+    this._exactAborted = true; // 진행 중 루프 중단 신호
     this.currentVideoHash = null;
     this.isQuickReady = false;
     this.isFullReady = false;
@@ -523,38 +530,41 @@ export class ThumbnailGenerator extends EventTarget {
   }
 
   /**
-   * 정확한 시간의 썸네일만 반환 (근사 매칭 없음).
-   * 정확히 일치하는 키(roundedTime)가 맵에 없으면 null.
+   * 요청된 **정확한 time**에 대해 캐시된 썸네일만 반환 (근사 매칭 없음).
+   * `_exactMap`은 온디맨드 캡처로 채워지며 0.1초 반올림을 거치지 않아
+   * 프레임 단위 정확도를 유지한다.
    */
   getThumbnailUrlAtExact(time) {
     if (typeof time !== 'number' || !isFinite(time) || time < 0) return null;
-    const rounded = Math.round(time * 10) / 10;
-    return this.thumbnailMap.get(rounded) || null;
+    return this._exactMap.get(time) || null;
   }
 
   /**
    * 특정 시간의 정확한 프레임 썸네일을 비동기로 캡처 요청.
-   * 이미 캐시에 있거나 큐에 있으면 no-op. 재생 중이더라도 큐에만 쌓이며,
-   * 앱이 _drainExactQueue를 호출해야 실제 캡처가 진행된다.
+   * 반올림하지 않은 정확한 time을 키로 사용해 frame precision 유지.
    */
   requestExactCapture(time) {
     if (typeof time !== 'number' || !isFinite(time) || time < 0) return;
-    const rounded = Math.round(time * 10) / 10;
-    if (this.thumbnailMap.has(rounded)) return;
-    if (this._exactQueue.has(rounded)) return;
-    this._exactQueue.add(rounded);
-    // 기본 자동 드레인 — 앱 측 가드(pause 이벤트)가 있으면 덮어씀
+    if (this._exactMap.has(time)) return;
+    if (this._exactQueue.has(time)) return;
+    this._exactQueue.add(time);
     this._drainExactQueue();
   }
 
   /**
-   * 정확 캡처 큐 소진. 재생 중 호출되면 Phase 2가 해제된 경우 비디오를
-   * 임시 재생성해 캡처하고, 완료 후 정리한다.
+   * 정확 캡처 큐 소진.
+   * - Phase 1/2 생성 중에는 `this.video`를 공유하면 시크 경쟁이 생기므로
+   *   **`isGenerating`일 땐 early return**하여 대기. `generate()` 완료 시점에
+   *   다시 호출되도록 연결돼 있다.
+   * - Phase 2 완료 후 `this.video`가 정리된 상태에서는 임시 비디오 요소를
+   *   생성해 캡처하고, 완료 후 정리.
    */
   async _drainExactQueue() {
     if (this._exactDraining) return;
     if (!this.videoSrc) return;
     if (this._exactQueue.size === 0) return;
+    // Phase 1/2 진행 중이면 시크 경쟁 방지 위해 대기 (generate 완료 시 재시도됨)
+    if (this.isGenerating) return;
 
     this._exactDraining = true;
     this._exactAborted = false;
@@ -573,9 +583,19 @@ export class ThumbnailGenerator extends EventTarget {
         const t = this._exactQueue.values().next().value;
         this._exactQueue.delete(t);
         try {
-          await this._seekAndCapture(t);
-          const dataUrl = this.thumbnailMap.get(t);
-          if (dataUrl) this._emit('exactCaptured', { time: t, dataUrl });
+          // 반올림 없이 정확한 t에 seek + 캡처
+          await this._seekTo(t);
+          const dataUrl = this._captureFrame();
+          this._exactMap.set(t, dataUrl);
+
+          // 0.1초 버킷 맵에도 기록해 근사 조회(getThumbnailUrlAt)에서 재사용
+          const bucket = Math.round(t * 10) / 10;
+          if (!this.thumbnailMap.has(bucket)) {
+            this.thumbnailMap.set(bucket, dataUrl);
+            this._insertSorted(bucket);
+          }
+
+          this._emit('exactCaptured', { time: t, dataUrl });
         } catch (err) {
           log.warn('온디맨드 캡처 실패', { time: t, error: err?.message });
         }

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -1937,12 +1937,12 @@ export class Timeline extends EventTarget {
     // 1) 프레임 기반 클러스터링
     const rawClusters = findRangeClusters(comments);
 
-    // 1b) 픽셀 기반 split — 줌 반응형 클러스터 해제
+    // 1b) 픽셀 기반 split — 줌 반응형. 포인트 마커 클러스터링과 동일한 20px 기준.
     const trackRect = this.commentTrack.getBoundingClientRect();
     const pxPerFrame = this.totalFrames > 0 && trackRect.width > 0
       ? trackRect.width / this.totalFrames
       : 0;
-    const clusters = splitClustersByPixelGap(rawClusters, { pxPerFrame, minGapPx: 8 });
+    const clusters = splitClustersByPixelGap(rawClusters, { pxPerFrame, minSpacingPx: 20 });
 
     // 2) 펼침 상태 유효성 검증 — split 후 clusterKey 기준으로 판정
     if (this.expandedClusterId !== null) {

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -1900,16 +1900,8 @@ export class Timeline extends EventTarget {
   setCommentTrack(trackElement, layerHeaderElement = null) {
     this.commentTrack = trackElement;
     this.commentLayerHeader = layerHeaderElement;
-
-    // 타임라인 배경 클릭 시 펼친 클러스터 접기
-    if (this.commentTrack) {
-      this.commentTrack.addEventListener('click', (e) => {
-        if (e.target === this.commentTrack && this.expandedClusterId !== null) {
-          this.expandedClusterId = null;
-          this.renderCommentRanges(this._lastComments || []);
-        }
-      });
-    }
+    // 트랙 배경 클릭으로 펼친 클러스터 접기 / 배지 펼치기 등은 app.js의
+    // setupCommentRangeInteractions()에서 드래그 가드와 함께 위임 처리한다.
   }
 
   /**
@@ -1997,7 +1989,7 @@ export class Timeline extends EventTarget {
           el.style.top = `${2 + c._lane * laneHeight}px`;
           this.commentTrack.appendChild(el);
         });
-        const closeBadge = this._createClusterCloseBadge(cluster, maxLanes);
+        const closeBadge = this._createClusterCloseBadge(cluster);
         this.commentTrack.appendChild(closeBadge);
       } else {
         // 접힌 클러스터 — 배지
@@ -2095,7 +2087,7 @@ export class Timeline extends EventTarget {
   /**
    * 펼친 클러스터의 접기 배지 DOM (오른쪽 상단 고정, 이벤트는 위임)
    */
-  _createClusterCloseBadge(cluster, maxLanes) {
+  _createClusterCloseBadge(cluster) {
     const totalFrames = this.totalFrames || 1;
     const minStart = Math.min(...cluster.map(c => c.startFrame));
     const maxEnd = Math.max(...cluster.map(c => c.endFrame));
@@ -2108,7 +2100,7 @@ export class Timeline extends EventTarget {
     el.dataset.clusterKey = clusterKey(cluster);
     // 클러스터 영역의 오른쪽 상단에 고정
     el.style.left = `calc(${leftPercent}% + ${widthPercent}% - 60px)`;
-    el.style.top = `-22px`;
+    el.style.top = '-22px';
     return el;
   }
 

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -6,7 +6,7 @@
 import { createLogger } from '../logger.js';
 import { MARKER_COLORS } from './comment-manager.js';
 import { resolveFrameGridTier } from './frame-grid-tiers.js';
-import { findRangeClusters, assignLanes, clusterKey } from './comment-cluster.js';
+import { findRangeClusters, assignLanes, clusterKey, splitClustersByPixelGap } from './comment-cluster.js';
 
 const log = createLogger('Timeline');
 
@@ -1942,10 +1942,17 @@ export class Timeline extends EventTarget {
       this.commentLayerHeader.style.display = 'flex';
     }
 
-    // 1) 클러스터링
-    const clusters = findRangeClusters(comments);
+    // 1) 프레임 기반 클러스터링
+    const rawClusters = findRangeClusters(comments);
 
-    // 2) 펼침 상태 유효성 검증 — 해당 clusterKey가 더 이상 존재하지 않으면 리셋
+    // 1b) 픽셀 기반 split — 줌 반응형 클러스터 해제
+    const trackRect = this.commentTrack.getBoundingClientRect();
+    const pxPerFrame = this.totalFrames > 0 && trackRect.width > 0
+      ? trackRect.width / this.totalFrames
+      : 0;
+    const clusters = splitClustersByPixelGap(rawClusters, { pxPerFrame, minGapPx: 8 });
+
+    // 2) 펼침 상태 유효성 검증 — split 후 clusterKey 기준으로 판정
     if (this.expandedClusterId !== null) {
       const stillExists = clusters.some(c =>
         clusterKey(c) === this.expandedClusterId && c.length > 1
@@ -1979,7 +1986,7 @@ export class Timeline extends EventTarget {
     // 5) 각 클러스터 렌더
     clusters.forEach(cluster => {
       if (cluster.length === 1) {
-        // 단일 댓글 — 기존처럼
+        // 단일 댓글 (또는 split 후 단일 멤버로 쪼개진 조각)
         const el = this._createCommentRangeElement(cluster[0]);
         el.style.top = '2px';
         this.commentTrack.appendChild(el);
@@ -1990,8 +1997,8 @@ export class Timeline extends EventTarget {
           el.style.top = `${2 + c._lane * laneHeight}px`;
           this.commentTrack.appendChild(el);
         });
-        const chip = this._createCollapseChip(cluster, maxLanes);
-        this.commentTrack.appendChild(chip);
+        const closeBadge = this._createClusterCloseBadge(cluster, maxLanes);
+        this.commentTrack.appendChild(closeBadge);
       } else {
         // 접힌 클러스터 — 배지
         const badge = this._createClusterBadgeElement(cluster);
@@ -2060,7 +2067,7 @@ export class Timeline extends EventTarget {
   }
 
   /**
-   * 접힌 클러스터의 배지 바 DOM 생성
+   * 접힌 클러스터의 배지 바 DOM 생성 (이벤트는 위임 핸들러가 처리)
    */
   _createClusterBadgeElement(cluster) {
     const totalFrames = this.totalFrames || 1;
@@ -2076,60 +2083,33 @@ export class Timeline extends EventTarget {
     el.style.width = `${Math.max(widthPercent, 3)}%`;
     el.style.top = '2px';
 
-    // 스택 힌트 (최대 3색)
-    const hint = document.createElement('div');
-    hint.className = 'comment-cluster-stack-hint';
-    cluster.slice(0, 3).forEach(c => {
-      const stripe = document.createElement('div');
-      stripe.style.background = c.color || '#4a9eff';
-      hint.appendChild(stripe);
-    });
-    el.appendChild(hint);
-
-    // 카운트 칩
-    const chip = document.createElement('span');
-    chip.className = 'comment-cluster-count';
-    chip.textContent = `⊕${cluster.length}`;
-    el.appendChild(chip);
-
-    // 라벨
+    // "+N" 숫자 강조 레이블만 표시 (세로 스트라이프/라벨 제거)
     const label = document.createElement('span');
-    label.className = 'comment-cluster-label';
-    label.textContent = '겹친 코멘트';
+    label.className = 'comment-cluster-badge-label';
+    label.textContent = `+${cluster.length}`;
     el.appendChild(label);
-
-    // 클릭 → 펼치기
-    el.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.expandedClusterId = clusterKey(cluster);
-      this.renderCommentRanges(this._lastComments || []);
-    });
 
     return el;
   }
 
   /**
-   * 펼친 클러스터를 접는 칩 DOM
+   * 펼친 클러스터의 접기 배지 DOM (오른쪽 상단 고정, 이벤트는 위임)
    */
-  _createCollapseChip(cluster, maxLanes) {
+  _createClusterCloseBadge(cluster, maxLanes) {
     const totalFrames = this.totalFrames || 1;
     const minStart = Math.min(...cluster.map(c => c.startFrame));
+    const maxEnd = Math.max(...cluster.map(c => c.endFrame));
     const leftPercent = (minStart / totalFrames) * 100;
+    const widthPercent = ((maxEnd - minStart) / totalFrames) * 100;
 
-    const chip = document.createElement('button');
-    chip.className = 'comment-collapse-chip';
-    chip.type = 'button';
-    chip.textContent = '▲ 접기';
-    chip.style.left = `${leftPercent}%`;
-    chip.style.top = `${24 * maxLanes + 2}px`;
-
-    chip.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.expandedClusterId = null;
-      this.renderCommentRanges(this._lastComments || []);
-    });
-
-    return chip;
+    const el = document.createElement('div');
+    el.className = 'comment-cluster-close-badge';
+    el.textContent = '접기';
+    el.dataset.clusterKey = clusterKey(cluster);
+    // 클러스터 영역의 오른쪽 상단에 고정
+    el.style.left = `calc(${leftPercent}% + ${widthPercent}% - 60px)`;
+    el.style.top = `-22px`;
+    return el;
   }
 
   /**

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -3051,14 +3051,14 @@ body.app-fullscreen .video-comment-overlay-controls {
   pointer-events: none;
 }
 
-/* 접기 배지 (펼친 상태) */
+/* 접기 배지 (펼친 상태) — position은 JS에서 left만 설정, right/width는 content-driven */
 .comment-cluster-close-badge {
   position: absolute;
   top: -22px;
-  right: 0;
   height: 20px;
   padding: 0 10px;
   display: inline-flex;
+  width: auto;
   align-items: center;
   gap: 4px;
   background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
@@ -3070,6 +3070,7 @@ body.app-fullscreen .video-comment-overlay-controls {
   cursor: pointer;
   z-index: 25;
   user-select: none;
+  white-space: nowrap;
   transition: filter 0.15s ease, transform 0.15s ease;
 }
 
@@ -3085,70 +3086,13 @@ body.app-fullscreen .video-comment-overlay-controls {
   transform: translateY(-1px);
 }
 
-/* 클러스터 호버 툴팁 (접힌 배지 전용) */
-.comment-cluster-tooltip {
-  position: fixed;
-  z-index: 10000;
-  max-width: 360px;
-  min-width: 200px;
-  padding: 6px 0;
-  background: rgba(30, 30, 30, 0.97);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 6px;
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5);
-  color: #e0e0e0;
-  font-size: 12px;
-  line-height: 1.4;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.15s ease;
+/* 클러스터 호버 툴팁 — .comment-marker-tooltip 스타일 재사용, 배지 위치 조정용 modifier */
+.comment-marker-tooltip.cluster-hover {
+  transform: none;
+}
+
+.comment-marker-tooltip.cluster-hover::before {
   display: none;
-}
-
-.comment-cluster-tooltip.visible {
-  opacity: 1;
-  display: block;
-}
-
-.comment-cluster-tooltip .tooltip-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 10px;
-  white-space: nowrap;
-  overflow: hidden;
-}
-
-.comment-cluster-tooltip .tooltip-row + .tooltip-row {
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.comment-cluster-tooltip .tooltip-color-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.comment-cluster-tooltip .tooltip-author {
-  font-weight: 600;
-  color: #ffffff;
-  flex-shrink: 0;
-}
-
-.comment-cluster-tooltip .tooltip-range {
-  color: #888;
-  font-variant-numeric: tabular-nums;
-  flex-shrink: 0;
-  font-family: ui-monospace, SFMono-Regular, monospace;
-  font-size: 11px;
-}
-
-.comment-cluster-tooltip .tooltip-text {
-  color: #bbb;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
 }
 
 /* ========================================

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -3015,77 +3015,140 @@ body.app-fullscreen .video-comment-overlay-controls {
 .comment-cluster-badge {
   position: absolute;
   height: 20px;
-  border-radius: 3px;
-  background: linear-gradient(180deg, rgba(245,158,11,0.9), rgba(217,119,6,0.85));
-  border-left: 2px solid var(--warning, #f59e0b);
-  border-right: 2px solid var(--warning, #f59e0b);
-  box-shadow: 0 2px 6px rgba(0,0,0,0.5), inset 0 0 0 1px rgba(255,255,255,0.08);
+  border-radius: 4px;
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  box-shadow:
+    0 2px 6px rgba(245, 158, 11, 0.5),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.1);
   cursor: pointer;
   display: flex;
   align-items: center;
-  padding: 0 10px 0 8px;
-  gap: 6px;
-  font-size: 10px;
+  justify-content: center;
+  padding: 0 8px;
   color: #fff;
-  font-weight: 600;
   overflow: hidden;
   white-space: nowrap;
-  transition: filter 0.15s, box-shadow 0.15s;
+  transition: filter 0.15s, box-shadow 0.15s, transform 0.15s;
 }
 
 .comment-cluster-badge:hover {
   filter: brightness(1.15);
-  box-shadow: 0 2px 10px rgba(245,158,11,0.35), inset 0 0 0 1px rgba(255,255,255,0.15);
+  transform: translateY(-1px);
+  box-shadow:
+    0 4px 12px rgba(245, 158, 11, 0.6),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.2);
 }
 
-.comment-cluster-stack-hint {
+/* "+N" 숫자 강조 레이블 */
+.comment-cluster-badge-label {
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+  pointer-events: none;
+}
+
+/* 접기 배지 (펼친 상태) */
+.comment-cluster-close-badge {
+  position: absolute;
+  top: -22px;
+  right: 0;
+  height: 20px;
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 10px;
+  box-shadow: 0 2px 6px rgba(245, 158, 11, 0.5);
+  cursor: pointer;
+  z-index: 25;
+  user-select: none;
+  transition: filter 0.15s ease, transform 0.15s ease;
+}
+
+.comment-cluster-close-badge::before {
+  content: '×';
+  font-size: 14px;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.comment-cluster-close-badge:hover {
+  filter: brightness(1.15);
+  transform: translateY(-1px);
+}
+
+/* 클러스터 호버 툴팁 (접힌 배지 전용) */
+.comment-cluster-tooltip {
+  position: fixed;
+  z-index: 10000;
+  max-width: 360px;
+  min-width: 200px;
+  padding: 6px 0;
+  background: rgba(30, 30, 30, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5);
+  color: #e0e0e0;
+  font-size: 12px;
+  line-height: 1.4;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  display: none;
+}
+
+.comment-cluster-tooltip.visible {
+  opacity: 1;
+  display: block;
+}
+
+.comment-cluster-tooltip .tooltip-row {
   display: flex;
-  flex-direction: column;
-  gap: 1px;
-  width: 3px;
-  height: 14px;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.comment-cluster-tooltip .tooltip-row + .tooltip-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.comment-cluster-tooltip .tooltip-color-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
   flex-shrink: 0;
 }
 
-.comment-cluster-stack-hint > div {
-  flex: 1;
-  border-radius: 1px;
+.comment-cluster-tooltip .tooltip-author {
+  font-weight: 600;
+  color: #ffffff;
+  flex-shrink: 0;
 }
 
-.comment-cluster-count {
-  background: rgba(0,0,0,0.35);
-  padding: 1px 6px;
-  border-radius: 8px;
+.comment-cluster-tooltip .tooltip-range {
+  color: #888;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
   font-family: ui-monospace, SFMono-Regular, monospace;
-  font-size: 10px;
-  flex-shrink: 0;
+  font-size: 11px;
 }
 
-.comment-cluster-label {
+.comment-cluster-tooltip .tooltip-text {
+  color: #bbb;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-/* 접기 칩 (펼친 상태) */
-.comment-collapse-chip {
-  position: absolute;
-  background: rgba(60, 60, 60, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 3px;
-  padding: 2px 8px;
-  font-size: 9px;
-  color: #ccc;
-  cursor: pointer;
-  font-family: ui-monospace, monospace;
-  height: 16px;
-  /* comment-range-item(z-index:10)보다 위에 표시되어야 접기 버튼이 가려지지 않음 */
-  z-index: 20;
-  transition: background 0.15s, color 0.15s;
-}
-
-.comment-collapse-chip:hover {
-  background: rgba(80, 80, 80, 0.9);
-  color: #fff;
+  min-width: 0;
 }
 
 /* ========================================

--- a/scripts/tests/comment-cluster.test.js
+++ b/scripts/tests/comment-cluster.test.js
@@ -130,3 +130,71 @@ test('clusterKey: 멤버 순서가 달라도 동일한 키 반환 (안정성)', 
   assert.equal(k1, k2);
   assert.equal(k1, 'alpha|beta');
 });
+
+// --- splitClustersByPixelGap ---
+
+test('split: 빈 배열 입력 → 빈 배열 반환', () => {
+  assert.deepEqual(mod.splitClustersByPixelGap([], { pxPerFrame: 1, minGapPx: 8 }), []);
+});
+
+test('split: 단일 멤버 클러스터는 그대로 통과', () => {
+  const cluster = [c('a', 0, 10)];
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].length, 1);
+  assert.equal(result[0][0].markerId, 'a');
+});
+
+test('split: 모든 gap이 minGapPx 미만 → 원본 클러스터 그대로', () => {
+  const cluster = [c('a', 0, 10), c('b', 12, 20)]; // gap=2 frames * 1px = 2px < 8px
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].length, 2);
+});
+
+test('split: 한 지점만 gap ≥ minGapPx → 2개로 분리', () => {
+  const cluster = [c('a', 0, 10), c('b', 20, 30)]; // gap=10 frames * 1px = 10px ≥ 8px
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+  assert.equal(result.length, 2);
+  assert.equal(result[0][0].markerId, 'a');
+  assert.equal(result[1][0].markerId, 'b');
+});
+
+test('split: 여러 gap ≥ minGapPx → N+1개로 분리', () => {
+  const cluster = [c('a', 0, 5), c('b', 15, 20), c('c', 30, 35)]; // 각 gap=10
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+  assert.equal(result.length, 3);
+});
+
+test('split: pxPerFrame = 0 → 원본 그대로 (안전 가드)', () => {
+  const cluster = [c('a', 0, 10), c('b', 100, 110)];
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 0, minGapPx: 8 });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].length, 2);
+});
+
+test('split: pxPerFrame 음수 → 원본 그대로', () => {
+  const cluster = [c('a', 0, 10), c('b', 100, 110)];
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: -1, minGapPx: 8 });
+  assert.equal(result.length, 1);
+});
+
+test('split: minGapPx 옵션 생략 → 기본 8px 적용', () => {
+  const cluster = [c('a', 0, 10), c('b', 20, 30)]; // gap=10px ≥ 8px
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1 });
+  assert.equal(result.length, 2);
+});
+
+test('split: 정렬되지 않은 멤버도 처리', () => {
+  const cluster = [c('b', 20, 30), c('a', 0, 10)]; // gap=10, 입력 역순
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+  assert.equal(result.length, 2);
+  assert.equal(result[0][0].markerId, 'a');
+  assert.equal(result[1][0].markerId, 'b');
+});
+
+test('split: pxPerFrame이 작으면 gap이 커도 묶임 유지 (줌 아웃)', () => {
+  const cluster = [c('a', 0, 10), c('b', 20, 30)]; // frame gap=10, pxPerFrame=0.1 → 1px < 8px
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 0.1, minGapPx: 8 });
+  assert.equal(result.length, 1);
+});

--- a/scripts/tests/comment-cluster.test.js
+++ b/scripts/tests/comment-cluster.test.js
@@ -132,69 +132,82 @@ test('clusterKey: 멤버 순서가 달라도 동일한 키 반환 (안정성)', 
 });
 
 // --- splitClustersByPixelGap ---
+// 기준: 이웃 구간의 startFrame 간격 (포인트 마커 클러스터링과 동일, 기본 20px)
 
 test('split: 빈 배열 입력 → 빈 배열 반환', () => {
-  assert.deepEqual(mod.splitClustersByPixelGap([], { pxPerFrame: 1, minGapPx: 8 }), []);
+  assert.deepEqual(mod.splitClustersByPixelGap([], { pxPerFrame: 1, minSpacingPx: 20 }), []);
 });
 
 test('split: 단일 멤버 클러스터는 그대로 통과', () => {
   const cluster = [c('a', 0, 10)];
-  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minSpacingPx: 20 });
   assert.equal(result.length, 1);
   assert.equal(result[0].length, 1);
   assert.equal(result[0][0].markerId, 'a');
 });
 
-test('split: 모든 gap이 minGapPx 미만 → 원본 클러스터 그대로', () => {
-  const cluster = [c('a', 0, 10), c('b', 12, 20)]; // gap=2 frames * 1px = 2px < 8px
-  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+test('split: 모든 spacing이 minSpacingPx 미만 → 원본 클러스터 그대로', () => {
+  // startFrame 0→15 = 15px < 20px
+  const cluster = [c('a', 0, 10), c('b', 15, 25)];
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minSpacingPx: 20 });
   assert.equal(result.length, 1);
   assert.equal(result[0].length, 2);
 });
 
-test('split: 한 지점만 gap ≥ minGapPx → 2개로 분리', () => {
-  const cluster = [c('a', 0, 10), c('b', 20, 30)]; // gap=10 frames * 1px = 10px ≥ 8px
-  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+test('split: 한 지점만 spacing ≥ minSpacingPx → 2개로 분리', () => {
+  // startFrame 0→25 = 25px ≥ 20px
+  const cluster = [c('a', 0, 10), c('b', 25, 35)];
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minSpacingPx: 20 });
   assert.equal(result.length, 2);
   assert.equal(result[0][0].markerId, 'a');
   assert.equal(result[1][0].markerId, 'b');
 });
 
-test('split: 여러 gap ≥ minGapPx → N+1개로 분리', () => {
-  const cluster = [c('a', 0, 5), c('b', 15, 20), c('c', 30, 35)]; // 각 gap=10
-  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+test('split: 여러 spacing ≥ minSpacingPx → N+1개로 분리', () => {
+  // startFrame 0→25→50, 각 25px 간격
+  const cluster = [c('a', 0, 5), c('b', 25, 30), c('c', 50, 55)];
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minSpacingPx: 20 });
   assert.equal(result.length, 3);
 });
 
 test('split: pxPerFrame = 0 → 원본 그대로 (안전 가드)', () => {
   const cluster = [c('a', 0, 10), c('b', 100, 110)];
-  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 0, minGapPx: 8 });
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 0, minSpacingPx: 20 });
   assert.equal(result.length, 1);
   assert.equal(result[0].length, 2);
 });
 
 test('split: pxPerFrame 음수 → 원본 그대로', () => {
   const cluster = [c('a', 0, 10), c('b', 100, 110)];
-  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: -1, minGapPx: 8 });
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: -1, minSpacingPx: 20 });
   assert.equal(result.length, 1);
 });
 
-test('split: minGapPx 옵션 생략 → 기본 8px 적용', () => {
-  const cluster = [c('a', 0, 10), c('b', 20, 30)]; // gap=10px ≥ 8px
+test('split: minSpacingPx 옵션 생략 → 기본 20px 적용', () => {
+  // startFrame 0→25 = 25px ≥ 20px
+  const cluster = [c('a', 0, 10), c('b', 25, 35)];
   const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1 });
   assert.equal(result.length, 2);
 });
 
 test('split: 정렬되지 않은 멤버도 처리', () => {
-  const cluster = [c('b', 20, 30), c('a', 0, 10)]; // gap=10, 입력 역순
-  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minGapPx: 8 });
+  const cluster = [c('b', 25, 35), c('a', 0, 10)]; // spacing=25px, 입력 역순
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minSpacingPx: 20 });
   assert.equal(result.length, 2);
   assert.equal(result[0][0].markerId, 'a');
   assert.equal(result[1][0].markerId, 'b');
 });
 
-test('split: pxPerFrame이 작으면 gap이 커도 묶임 유지 (줌 아웃)', () => {
-  const cluster = [c('a', 0, 10), c('b', 20, 30)]; // frame gap=10, pxPerFrame=0.1 → 1px < 8px
-  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 0.1, minGapPx: 8 });
+test('split: pxPerFrame이 작으면 spacing이 커도 묶임 유지 (줌 아웃)', () => {
+  // startFrame 차 100 * pxPerFrame 0.1 = 10px < 20px
+  const cluster = [c('a', 0, 10), c('b', 100, 110)];
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 0.1, minSpacingPx: 20 });
   assert.equal(result.length, 1);
+});
+
+test('split: 긴 구간이 중간에 있어도 startFrame만 가까우면 같은 클러스터', () => {
+  // A는 긴 구간 [0,1000], B는 A 시작점 근처 [5,10]
+  const cluster = [c('a', 0, 1000), c('b', 5, 10)];
+  const result = mod.splitClustersByPixelGap([cluster], { pxPerFrame: 1, minSpacingPx: 20 });
+  assert.equal(result.length, 1, 'startFrame 간격 5px이므로 묶임 유지');
 });


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 🐛 **겹친 코멘트를 펼친 뒤 길이/위치를 편집할 수 없던 문제**를 수정했습니다 (regression)
- 🐛 **겹친 코멘트를 열고 바로 닫히던 문제**를 해결했습니다 (드래그 중 접힘 방지)
- ✨ 타임라인을 많이 확대하면 **겹쳐 있던 코멘트가 자연스럽게 분리**되어 개별 편집이 가능합니다
- ✨ 겹친 코멘트 배지에 마우스를 올리면 **모든 코멘트 내용을 프리뷰**로 미리 볼 수 있습니다
- ⚡ 겹친 코멘트 표시가 더 깔끔해졌습니다 — 세로줄 없이 큼직한 **"+N"** 숫자로 표시
- ⚡ 펼친 상태에서 **"× 접기"** 버튼이 오른쪽 상단에 명확히 보입니다
- ⚡ 사이드바 댓글의 썸네일이 **정확한 프레임**으로 점진 갱신됩니다 (일시정지 상태에서 1초 이내)
- 🎯 겹침 판정 기준을 포인트 댓글 마커(흰 점)와 **동일한 20px**로 맞춰, 눈에 겹쳐 보일 때만 묶입니다

## 🔧 상세 기술 설명

### 이벤트 위임 전환 (편집 regression 원인 해결)
- 기존 `setupCommentRangeInteractions()`가 `.comment-range-item` DOM마다 이벤트를 개별 바인딩했는데, 클러스터 펼침 시 DOM이 재생성되며 이벤트가 비어버려 편집 불가 증상이 발생
- `commentTrack` 컨테이너 1곳에 위임 리스너(click / mousedown / mouseover / mouseout) 1회만 바인딩하도록 재작성
- `commentJustDragged` 1-tick 플래그로 드래그 직후 click 오인(접힘) 차단
- `timeline.setCommentTrack`의 기존 click-close 리스너 제거 (드래그 가드 없어 이슈의 원인이었음)
- 관련 파일: `renderer/scripts/app.js:3096-3224`, `renderer/scripts/modules/timeline.js:1900-1905`

### 픽셀 기반 클러스터 해제 (줌 반응형)
- `comment-cluster.js`에 순수 함수 `splitClustersByPixelGap(clusters, { pxPerFrame, minSpacingPx })` 추가
- `findRangeClusters` 다음 파이프라인 단계로 추가해, 줌인될수록 자연스럽게 분리
- 기준을 포인트 마커 클러스터링(`timeline.js:1553 minClusterDistance = 20`)과 **동일한 20px startFrame 거리**로 일치시켜, 시각적 일관성 확보
- 단위 테스트 10건 추가 (엣지 케이스 + 줌 시뮬레이션 포함) — 총 29/29 통과
- 관련 파일: `renderer/scripts/modules/comment-cluster.js`, `scripts/tests/comment-cluster.test.js`

### 배지/접기/툴팁 DOM·CSS 재설계
- `.comment-cluster-stack-hint` (세로 3색 스트라이프) 제거 → `+N` 텍스트 레이블로 교체
- `.comment-collapse-chip` → `.comment-cluster-close-badge`로 교체 (주황 그라디언트 · 오른쪽 상단 고정)
- 호버 팝업은 기존 `.comment-marker-tooltip` DOM 구조(헤더 + 타임코드 · 프레임 · 댓글 박스 · N개 댓글)를 그대로 재사용해 포인트 마커와 시각적으로 일관
- 접기 배지가 타임라인 끝까지 늘어지던 버그(`position: absolute`에서 `left`+`right` 동시 지정 시 width 자동 확장) 수정
- 관련 파일: `renderer/scripts/modules/timeline.js:2065-2105`, `renderer/styles/main.css`

### 댓글 썸네일 정확-프레임 온디맨드 캡처
- `thumbnail-generator.js`에 `getThumbnailUrlAtExact`, `requestExactCapture`, `_drainExactQueue`, `_abortExactDrain` 추가
- 댓글 렌더 시 정확 매칭이 없으면 근사치 먼저 표시 + 비동기 큐에 정확-프레임 요청
- Phase 2 완료 후 \`this.video\`가 해제된 상태에도 lazy 재생성으로 캡처 가능
- \`exactCaptured\` CustomEvent 수신 시 해당 \`comment-item\`의 \`img.src\`만 교체 (전체 재렌더 없이 진적 갱신)
- \`videoPlayer\` pause에서 drain, play에서 abort로 재생 방해 방지
- 관련 파일: \`renderer/scripts/modules/thumbnail-generator.js\`, \`renderer/scripts/app.js:639-656, 4322, 5427\`

### 스펙·플랜 문서화
- \`docs/superpowers/specs/2026-04-20-comment-cluster-ux-rework-design.md\` (2라운드 스펙 리뷰 반영 완료)
- \`docs/superpowers/plans/2026-04-20-comment-cluster-ux-rework.md\` (7-Chunk TDD 플랜)
- \`DEVLOG/2026-04-20-코멘트-클러스터-UX-재작업.md\` (QA 체크리스트 16건)

## 🚧 개발 난항

### 호버 팝업 스타일 불일치
- **문제**: 처음에 커스텀 \`.comment-cluster-tooltip\` 스타일로 작은 리스트 팝업을 만들었지만, 실제 앱의 단일 마커 호버 팝업과 시각적으로 달라 사용자가 어색함을 지적
- **시도**: 독립적 스타일 유지 vs 기존 스타일 재사용
- **해결**: 기존 \`.comment-marker-tooltip\` DOM 구조(\`tooltip-header/timecode/frame/comments/comment/count\`)를 그대로 재사용하고, \`cluster-hover\` modifier로 위치 조정만 override
- **교훈**: 기존에 같은 역할의 UI 요소가 있으면 새 스타일을 만들지 말고 재사용하는 것이 일관성 측면에서 훨씬 낫다

### 클러스터링 임계값을 몇 px로 둘 것인가
- **문제**: 처음 설계에서 \`minGapPx = 8\` (endFrame→startFrame 간격)로 잡았으나, 포인트 마커 클러스터링이 \`minClusterDistance = 20\` (startFrame→startFrame 거리)로 이미 구현되어 있어 기준이 달랐음. 사용자가 "포인트 마커의 \`(N)\` 복수 배지가 뜨는 조건과 동일하게 맞춰달라" 요청
- **시도**: gap 기반 유지 vs spacing 기반으로 변경
- **해결**: \`minGapPx\` → \`minSpacingPx\`, 기본값 8 → 20, 내부 계산을 \`curr.startFrame - prev.startFrame\`으로 변경. 테스트 전면 재작성(긴 구간이 중간에 있어도 startFrame만 가까우면 묶임 유지 케이스 추가)
- **교훈**: 비슷한 역할의 기존 클러스터링 로직이 있으면 기준을 먼저 확인하고 맞추기

### 접기 배지가 타임라인 끝까지 늘어남
- **문제**: CSS에 \`right: 0\`과 JS에서 \`el.style.left = calc(...)\`를 동시에 설정하면 \`position: absolute\` 요소의 width가 두 값 사이로 자동 확장되어 배지가 화면 끝까지 뻗음
- **해결**: CSS에서 \`right: 0\` 제거, \`width: auto\` + \`white-space: nowrap\` 명시로 content-driven 크기
- **교훈**: absolute 요소에 \`left\`/\`right\`/\`width\` 세 값의 상호작용을 항상 염두에 둬야 함

## ✅ 테스트 가이드

### 사용자 테스트
> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **겹친 코멘트 편집 (핵심 regression 복구 확인)**
   - 타임라인에 서로 겹치는 구간 코멘트 2~3개를 만듭니다 (예: 100~120, 105~125)
   - 주황색 \`+2\` 또는 \`+3\` 배지가 뜨면 클릭해서 펼칩니다
   - 펼쳐진 개별 코멘트 바의 **중앙을 잡고 좌우로 드래그** → 위치가 이동되고, 펼친 상태가 유지되어야 함 ✅
   - 좌/우 핸들을 잡고 드래그 → 크기가 변경되고, 펼친 상태 유지 ✅
   - 빈 영역을 클릭하면 접힘 ✅

2. **호버 팝업**
   - 접힌 \`+N\` 배지에 마우스를 올립니다
   - 약 0.3초 후 팝업이 뜨며 타임코드 + 프레임 + 각 댓글 본문이 박스로 표시되어야 함 ✅
   - 마우스를 벗어나면 즉시 사라져야 함

3. **줌 반응형 클러스터링**
   - 겹친 상태에서 **타임라인을 확대** → 일정 줌 이상에서 배지가 사라지고 개별 코멘트로 분리됨 ✅
   - 포인트 댓글 마커의 \`(2)\` 배지가 개별 마커로 분리되는 순간과 **같은 타이밍**에 구간 배지도 분리되어야 함

4. **접기 배지**
   - 펼친 상태에서 오른쪽 상단의 **"× 접기"** 배지가 **내용만큼의 너비**로 표시되어야 함 ✅
   - 타임라인 끝까지 늘어지면 ❌ (이전 버그)

5. **댓글 썸네일 정확도**
   - 사이드바에 댓글이 표시될 때 근사 썸네일이 먼저 뜨고, 앱을 일시정지 상태로 두면 **약 1초 이내에 정확한 프레임 썸네일**로 교체되어야 함 ✅

### 개발자 테스트
\`\`\`bash
# 클러스터링 순수 함수 단위 테스트 (29건)
npm run test:cluster
\`\`\`
> 수동 확인 사항:
> - \`commentDragState\`가 mouseup에서 null이 되고, \`commentJustDragged\`가 50ms 후 해제되는지
> - 펼친 상태에서 실시간 동기화 이벤트가 와도 드래그 중이면 DOM 업데이트 skip되는지
> - Phase 2 완료 후 \`this.video === null\`인 상태에서 새 댓글 작성 → 온디맨드 캡처가 \`_loadVideo\` 재호출로 동작하는지 (DevTools Network 탭 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)