### PR TITLE
[v1.2.1-beta] 축소 상태 영상 이동과 화면 중앙 고정 토글 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "1.2.0-beta",
+  "version": "1.2.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "1.2.0-beta",
+      "version": "1.2.1-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "1.2.0-beta",
+  "version": "1.2.1-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {
@@ -18,6 +18,7 @@
     "test:playlist-continuous": "node --test scripts/tests/playlist-continuous-core.test.js",
     "test:playlist-comments": "node --test scripts/tests/playlist-comment-index.test.js",
     "test:playlist": "node --test scripts/tests/playlist-ordering.test.js scripts/tests/playlist-continuous-core.test.js scripts/tests/playlist-continuous-runtime.test.js scripts/tests/playlist-comment-index.test.js",
+    "test:video-pan": "node --test scripts/tests/video-pan-controls.test.js",
     "test:toast-stack": "node --test scripts/tests/toast-stack-core.test.js",
     "bundle:liveblocks": "esbuild ./node_modules/@liveblocks/client/dist/index.js --bundle --format=esm --outfile=renderer/scripts/lib/liveblocks-client.js",
     "postinstall": "npm run bundle:liveblocks"

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -436,6 +436,12 @@
             <button class="video-zoom-btn" id="btnVideoZoomReset" title="원본 크기 (100%)">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/></svg>
             </button>
+            <button class="video-zoom-btn active" id="btnVideoCenterLock" title="화면 중앙 고정 켜짐" aria-label="화면 중앙 고정" aria-pressed="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="3"/>
+                <path d="M12 2v4M12 18v4M2 12h4M18 12h4"/>
+              </svg>
+            </button>
           </div>
 
           <!-- Zoom Indicator Overlay -->

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -154,6 +154,7 @@ async function initApp() {
     btnVideoZoomIn: document.getElementById('btnVideoZoomIn'),
     btnVideoZoomOut: document.getElementById('btnVideoZoomOut'),
     btnVideoZoomReset: document.getElementById('btnVideoZoomReset'),
+    btnVideoCenterLock: document.getElementById('btnVideoCenterLock'),
     videoZoomDisplay: document.getElementById('videoZoomDisplay'),
     zoomIndicatorOverlay: document.getElementById('zoomIndicatorOverlay'),
 
@@ -213,6 +214,9 @@ async function initApp() {
     recentFilesSection: document.getElementById('recentFilesSection')
   };
 
+  // 사용자 설정
+  const userSettings = getUserSettings();
+
   // 상태
   const state = {
     isDrawMode: false,
@@ -228,6 +232,7 @@ async function initApp() {
     // 비디오 패닝 상태
     videoPanX: 0,
     videoPanY: 0,
+    videoCenterLocked: userSettings.getVideoCenterLocked(),
     isPanningVideo: false,
     panStartX: 0,
     panStartY: 0,
@@ -491,9 +496,6 @@ async function initApp() {
     window.electronAPI.watchFileStopAll();
   });
 
-  // 사용자 설정
-  const userSettings = getUserSettings();
-
   // ====== 최근 파일 매니저 초기화 ======
   const recentFilesManager = getRecentFilesManager();
 
@@ -635,6 +637,9 @@ async function initApp() {
   userSettings.addEventListener('ready', () => {
     log.info('설정 파일 로드 완료, UI 업데이트');
     updateShortcutHints();
+    state.videoCenterLocked = userSettings.getVideoCenterLocked();
+    updateVideoCenterLockButton();
+    applyVideoZoom();
   });
 
   // ====== 모듈 이벤트 연결 ======
@@ -3599,11 +3604,24 @@ async function initApp() {
     }
   }
 
+  function shouldCenterVideo() {
+    return state.videoCenterLocked && state.videoZoom <= 100;
+  }
+
+  function canPanVideo() {
+    return !state.isDrawMode && (state.videoZoom > 100 || !state.videoCenterLocked);
+  }
+
   /**
    * 비디오 줌 적용
    */
   function applyVideoZoom() {
     const video = elements.videoPlayer;
+    if (shouldCenterVideo()) {
+      state.videoPanX = 0;
+      state.videoPanY = 0;
+    }
+
     const scale = state.videoZoom / 100;
 
     video.style.transform = `scale(${scale}) translate(${state.videoPanX}px, ${state.videoPanY}px)`;
@@ -3614,15 +3632,8 @@ async function initApp() {
       elements.videoZoomDisplay.textContent = `${Math.round(state.videoZoom)}%`;
     }
 
-    // 줌이 100%가 아니면 줌 상태 표시
-    if (state.videoZoom !== 100) {
-      elements.videoWrapper?.classList.add('zoomed');
-    } else {
-      elements.videoWrapper?.classList.remove('zoomed');
-      // 100%로 돌아오면 패닝도 리셋
-      state.videoPanX = 0;
-      state.videoPanY = 0;
-    }
+    elements.videoWrapper?.classList.toggle('zoomed', canPanVideo());
+    elements.videoWrapper?.classList.toggle('center-locked', shouldCenterVideo());
 
     // 캔버스도 동일하게 적용
     syncCanvasZoom();
@@ -3689,6 +3700,30 @@ async function initApp() {
     resetVideoZoom();
   });
 
+  function updateVideoCenterLockButton() {
+    const button = elements.btnVideoCenterLock;
+    if (!button) return;
+
+    button.classList.toggle('active', state.videoCenterLocked);
+    button.setAttribute('aria-pressed', String(state.videoCenterLocked));
+    button.title = state.videoCenterLocked
+      ? '화면 중앙 고정 켜짐'
+      : '화면 중앙 고정 꺼짐 - 축소 상태에서도 드래그 가능';
+  }
+
+  function setVideoCenterLocked(locked) {
+    state.videoCenterLocked = !!locked;
+    userSettings.setVideoCenterLocked(state.videoCenterLocked);
+    updateVideoCenterLockButton();
+    applyVideoZoom();
+  }
+
+  updateVideoCenterLockButton();
+
+  elements.btnVideoCenterLock?.addEventListener('click', () => {
+    setVideoCenterLocked(!state.videoCenterLocked);
+  });
+
   // 비디오 영역 휠 줌
   elements.viewerContainer?.addEventListener('wheel', (e) => {
     // 그리기 모드가 아닐 때만 줌 적용
@@ -3699,9 +3734,9 @@ async function initApp() {
     }
   }, { passive: false });
 
-  // 비디오 패닝 (줌이 100% 이상일 때)
+  // 비디오 패닝
   elements.videoWrapper?.addEventListener('mousedown', (e) => {
-    if (state.videoZoom > 100 && !state.isDrawMode && e.button === 0) {
+    if (canPanVideo() && e.button === 0) {
       state.isPanningVideo = true;
       state.panStartX = e.clientX;
       state.panStartY = e.clientY;

--- a/renderer/scripts/modules/user-settings.js
+++ b/renderer/scripts/modules/user-settings.js
@@ -184,7 +184,9 @@ export class UserSettings extends EventTarget {
       // 협업 플렉서스 패널 표시 여부
       showPlexusPanel: true,
       // 타임라인 프레임 격자 표시 여부
-      showFrameGrid: true
+      showFrameGrid: true,
+      // 100% 이하 줌에서 영상을 중앙에 고정할지 여부
+      videoCenterLocked: true
     };
 
     this._ready = false;
@@ -560,6 +562,17 @@ export class UserSettings extends EventTarget {
     // 향후 외부에서 설정 변경을 감지해야 할 경우를 위한 hook
     this._emit('showFrameGridChanged', { show: this.settings.showFrameGrid });
     log.info('프레임 격자 설정 변경됨', { show });
+  }
+
+  getVideoCenterLocked() {
+    return this.settings.videoCenterLocked !== false;
+  }
+
+  setVideoCenterLocked(locked) {
+    this.settings.videoCenterLocked = !!locked;
+    this._save();
+    this._emit('videoCenterLockedChanged', { locked: this.settings.videoCenterLocked });
+    log.info('비디오 중앙 고정 설정 변경됨', { locked: this.settings.videoCenterLocked });
   }
 
   getLightMode() {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -5221,6 +5221,12 @@ body.resizing .comment-panel {
   border-color: var(--border-default);
 }
 
+.video-zoom-btn.active {
+  background: var(--accent-glow);
+  color: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+
 .video-zoom-btn:active {
   transform: scale(0.95);
 }

--- a/scripts/tests/video-pan-controls.test.js
+++ b/scripts/tests/video-pan-controls.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
+const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
+const mainCss = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
+const userSettingsSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/user-settings.js'), 'utf8'));
+
+test('video center lock is exposed as a persisted zoom-control toggle', () => {
+  assert.match(indexSource, /id="btnVideoCenterLock"/);
+  assert.match(indexSource, /aria-label="화면 중앙 고정"/);
+  assert.match(mainCss, /\.video-zoom-btn\.active/);
+  assert.match(userSettingsSource, /videoCenterLocked: true/);
+  assert.match(userSettingsSource, /getVideoCenterLocked\(\)/);
+  assert.match(userSettingsSource, /setVideoCenterLocked\(locked\)/);
+});
+
+test('video can be panned at 100 percent or below when center lock is off', () => {
+  assert.match(appSource, /videoCenterLocked: userSettings\.getVideoCenterLocked\(\)/);
+  assert.match(appSource, /function canPanVideo\(\) \{[\s\S]*state\.videoZoom > 100 \|\| !state\.videoCenterLocked[\s\S]*\}/);
+  assert.match(appSource, /if \(canPanVideo\(\) && e\.button === 0\) \{/);
+  assert.doesNotMatch(appSource, /state\.videoZoom > 100 && !state\.isDrawMode && e\.button === 0/);
+});
+
+test('center lock keeps 100 percent and smaller zoom levels centered', () => {
+  assert.match(appSource, /function shouldCenterVideo\(\) \{[\s\S]*state\.videoCenterLocked && state\.videoZoom <= 100[\s\S]*\}/);
+  assert.match(appSource, /if \(shouldCenterVideo\(\)\) \{[\s\S]*state\.videoPanX = 0;[\s\S]*state\.videoPanY = 0;[\s\S]*\}/);
+  assert.match(appSource, /setVideoCenterLocked\(!state\.videoCenterLocked\)/);
+});


### PR DESCRIPTION
## 📋 업데이트 요약

- 🎛️ 영상 줌 컨트롤에 `화면 중앙 고정` 버튼을 추가했습니다.
- 🖱️ 이 버튼을 끄면 100% 이하로 축소한 상태에서도 영상을 드래그해서 원하는 위치로 옮길 수 있습니다.
- 📌 기본값은 기존처럼 중앙 고정 ON이라, 기존 사용자는 화면이 갑자기 달라지지 않습니다.
- 💾 사용자가 선택한 중앙 고정 상태는 저장되어 다음 실행 때도 유지됩니다.
- 🧪 테스트 빌드 구분을 위해 앱 버전을 `1.2.1-beta`로 올렸습니다.

## 🔧 상세 기술 설명

- `renderer/index.html`의 비디오 줌 컨트롤 영역에 `btnVideoCenterLock` 버튼을 추가했습니다.
- `renderer/scripts/app.js`에서 `videoCenterLocked` 상태를 추가하고, `shouldCenterVideo()` / `canPanVideo()`로 중앙 고정과 드래그 가능 조건을 분리했습니다.
- 기존에는 패닝 시작 조건이 `state.videoZoom > 100`에 묶여 있었는데, 이제 중앙 고정이 꺼져 있으면 `100% 이하`에서도 패닝이 시작됩니다.
- 중앙 고정이 켜져 있고 줌이 `100% 이하`이면 `videoPanX/Y`를 0으로 되돌려 기존 중앙 정렬 동작을 유지합니다.
- `renderer/scripts/modules/user-settings.js`에 `videoCenterLocked` 기본값과 getter/setter를 추가해 사용자 선택을 저장합니다.
- `renderer/styles/main.css`에 활성 토글 버튼 스타일을 추가해 기존 줌 컨트롤 톤 안에서 상태가 보이도록 했습니다.
- `scripts/tests/video-pan-controls.test.js`를 추가하고 `package.json`에 `test:video-pan` 스크립트를 등록했습니다.

## 🚧 개발 난항

- 기존 구조는 “줌이 100%가 아니면 이동 가능”처럼 보였지만, 실제 드래그 시작 조건은 `100% 초과`로 제한되어 있었습니다.
- 100%로 돌아올 때마다 위치값을 무조건 초기화하는 코드가 있어, 단순히 조건만 풀면 중앙 고정 UX와 자유 이동 UX가 섞일 위험이 있었습니다.
- 그래서 `화면 중앙 고정`이라는 사용자 선택을 별도 상태로 분리하고, 기본값은 기존 동작을 보존하는 방식으로 정리했습니다.

## ✅ 테스트 가이드

실사용자용:
- 영상을 연 뒤 우측 하단 줌 컨트롤에서 `-` 버튼 또는 마우스 휠로 75%, 50% 등으로 축소합니다.
- 중앙 고정 버튼이 켜져 있으면 영상이 중앙에 머뭅니다.
- 중앙 고정 버튼을 끄고 영상을 드래그하면 축소 상태에서도 위치가 이동해야 합니다.
- 다시 중앙 고정 버튼을 켜면 100% 이하 줌에서는 영상이 중앙으로 돌아와야 합니다.

개발자용:
- `npm run test:video-pan`
- `npm run test:playlist`
- `npm run test:toast-stack`
- `node --check renderer/scripts/app.js`
- `node --check renderer/scripts/modules/user-settings.js`
- `npm run build`