### PR TITLE
[v1.2.2-beta] 오디오 파형 오버레이 댓글 마커 입력 충돌 수정

### DIFF
--- a/DEVLOG/2026-05-15-오디오-댓글마커-핫픽스.md
+++ b/DEVLOG/2026-05-15-오디오-댓글마커-핫픽스.md
@@ -1,0 +1,21 @@
+# 2026-05-15 오디오 댓글 마커 핫픽스
+
+## 배경
+
+- 오디오 파일을 열었을 때 웨이브폼 오버레이가 화면 전체에서 마우스 호버와 드래그 커서를 잡았다.
+- 그 영향으로 댓글 모드에서 화면을 클릭해 댓글 마커를 입력하기 어려웠다.
+
+## 수정
+
+- 웨이브폼 시각화 캔버스는 화면 전체에 그대로 그리되, 마우스 이벤트는 별도 `audio-waveform-hit-area`에서만 받도록 분리했다.
+- hit area를 실제 파형이 보이는 영역으로 제한했다.
+- 댓글 모드에서는 웨이브폼 hit area가 마우스 이벤트를 받지 않도록 막아 댓글 마커 입력이 우선 동작하게 했다.
+- 회귀 방지를 위해 `test:audio-waveform` 테스트를 추가했다.
+
+## 검증
+
+- `npm run test:audio-waveform`
+- `npm run test:video-pan`
+- `npm run test:cluster`
+- `node_modules\.bin\eslint.cmd renderer/scripts/modules/audio-waveform.js scripts/tests/audio-waveform-hit-area.test.js`
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "1.2.1-beta",
+  "version": "1.2.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "1.2.1-beta",
+      "version": "1.2.2-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "1.2.1-beta",
+  "version": "1.2.2-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {
@@ -19,6 +19,7 @@
     "test:playlist-comments": "node --test scripts/tests/playlist-comment-index.test.js",
     "test:playlist": "node --test scripts/tests/playlist-ordering.test.js scripts/tests/playlist-continuous-core.test.js scripts/tests/playlist-continuous-runtime.test.js scripts/tests/playlist-comment-index.test.js",
     "test:video-pan": "node --test scripts/tests/video-pan-controls.test.js",
+    "test:audio-waveform": "node --test scripts/tests/audio-waveform-hit-area.test.js",
     "test:toast-stack": "node --test scripts/tests/toast-stack-core.test.js",
     "bundle:liveblocks": "esbuild ./node_modules/@liveblocks/client/dist/index.js --bundle --format=esm --outfile=renderer/scripts/lib/liveblocks-client.js",
     "postinstall": "npm run bundle:liveblocks"

--- a/renderer/scripts/modules/audio-waveform.js
+++ b/renderer/scripts/modules/audio-waveform.js
@@ -26,6 +26,7 @@ export class AudioWaveform extends EventTarget {
     this.ctx = null;
     this.overlayCanvas = null;
     this.overlayCtx = null;
+    this.hitArea = null;
 
     // 오디오 데이터
     this.waveformData = null; // Main Process에서 생성된 웨이브폼 데이터
@@ -88,6 +89,9 @@ export class AudioWaveform extends EventTarget {
     this.overlayCanvas.className = 'audio-waveform-overlay';
     this.overlayCtx = this.overlayCanvas.getContext('2d');
 
+    this.hitArea = document.createElement('div');
+    this.hitArea.className = 'audio-waveform-hit-area';
+
     // 시간 표시 엘리먼트
     this._timeDisplay = document.createElement('div');
     this._timeDisplay.className = 'audio-waveform-time';
@@ -102,15 +106,16 @@ export class AudioWaveform extends EventTarget {
 
     container.appendChild(this.canvas);
     container.appendChild(this.overlayCanvas);
+    container.appendChild(this.hitArea);
     container.appendChild(this._timeDisplay);
     container.appendChild(this._hoverLabel);
     container.appendChild(this._zoomIndicator);
 
     // 이벤트 리스너
-    this.overlayCanvas.addEventListener('mousedown', this._onMouseDown);
-    this.overlayCanvas.addEventListener('mousemove', this._onMouseMove);
-    this.overlayCanvas.addEventListener('mouseleave', this._onMouseLeave);
-    this.overlayCanvas.addEventListener('wheel', this._onWheel, { passive: false });
+    this.hitArea.addEventListener('mousedown', this._onMouseDown);
+    this.hitArea.addEventListener('mousemove', this._onMouseMove);
+    this.hitArea.addEventListener('mouseleave', this._onMouseLeave);
+    this.hitArea.addEventListener('wheel', this._onWheel, { passive: false });
     window.addEventListener('mouseup', this._onMouseUp);
     window.addEventListener('resize', this._onResize);
 
@@ -124,11 +129,11 @@ export class AudioWaveform extends EventTarget {
   unmount() {
     this.stopAnimation();
 
-    if (this.overlayCanvas) {
-      this.overlayCanvas.removeEventListener('mousedown', this._onMouseDown);
-      this.overlayCanvas.removeEventListener('mousemove', this._onMouseMove);
-      this.overlayCanvas.removeEventListener('mouseleave', this._onMouseLeave);
-      this.overlayCanvas.removeEventListener('wheel', this._onWheel);
+    if (this.hitArea) {
+      this.hitArea.removeEventListener('mousedown', this._onMouseDown);
+      this.hitArea.removeEventListener('mousemove', this._onMouseMove);
+      this.hitArea.removeEventListener('mouseleave', this._onMouseLeave);
+      this.hitArea.removeEventListener('wheel', this._onWheel);
     }
     window.removeEventListener('mouseup', this._onMouseUp);
     window.removeEventListener('resize', this._onResize);
@@ -141,6 +146,7 @@ export class AudioWaveform extends EventTarget {
     this.ctx = null;
     this.overlayCanvas = null;
     this.overlayCtx = null;
+    this.hitArea = null;
     this._timeDisplay = null;
     this._hoverLabel = null;
     this.waveformData = null;
@@ -705,13 +711,14 @@ export class AudioWaveform extends EventTarget {
 
     this._isDragging = true;
     this._seekFromEvent(e);
-    this.overlayCanvas.style.cursor = 'grabbing';
+    this.hitArea.style.cursor = 'grabbing';
   }
 
   _onMouseMove(e) {
     if (!this.waveformData || this.duration <= 0) return;
 
-    const rect = this.overlayCanvas.getBoundingClientRect();
+    const rect = this._getInteractionRect();
+    if (!rect || rect.width <= 0) return;
     const x = e.clientX - rect.left;
 
     // 줌/스크롤 반영
@@ -738,8 +745,8 @@ export class AudioWaveform extends EventTarget {
   _onMouseUp() {
     if (this._isDragging) {
       this._isDragging = false;
-      if (this.overlayCanvas) {
-        this.overlayCanvas.style.cursor = '';
+      if (this.hitArea) {
+        this.hitArea.style.cursor = '';
       }
     }
   }
@@ -752,7 +759,8 @@ export class AudioWaveform extends EventTarget {
   }
 
   _seekFromEvent(e) {
-    const rect = this.overlayCanvas.getBoundingClientRect();
+    const rect = this._getInteractionRect();
+    if (!rect || rect.width <= 0) return;
     const x = e.clientX - rect.left;
 
     // 줌/스크롤 반영: 화면 x → 전체 비율
@@ -775,7 +783,8 @@ export class AudioWaveform extends EventTarget {
     if (!this.waveformData || this.duration <= 0) return;
     e.preventDefault();
 
-    const rect = this.overlayCanvas.getBoundingClientRect();
+    const rect = this._getInteractionRect();
+    if (!rect || rect.width <= 0) return;
     const mouseX = e.clientX - rect.left;
     const mouseRatio = mouseX / rect.width; // 마우스가 보이는 영역의 어디인지 (0~1)
 
@@ -838,6 +847,10 @@ export class AudioWaveform extends EventTarget {
     this.canvas.height = rect.height;
     this.overlayCanvas.width = rect.width;
     this.overlayCanvas.height = rect.height;
+  }
+
+  _getInteractionRect() {
+    return (this.hitArea || this.overlayCanvas)?.getBoundingClientRect() || null;
   }
 
   // ====== 유틸리티 ======
@@ -904,9 +917,9 @@ export class AudioWaveform extends EventTarget {
     const hue2rgb = (p, q, t) => {
       if (t < 0) t += 1;
       if (t > 1) t -= 1;
-      if (t < 1/6) return p + (q - p) * 6 * t;
-      if (t < 1/2) return q;
-      if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
       return p;
     };
 
@@ -915,9 +928,9 @@ export class AudioWaveform extends EventTarget {
     } else {
       const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
       const p = 2 * l - q;
-      r = hue2rgb(p, q, h + 1/3);
+      r = hue2rgb(p, q, h + 1 / 3);
       g = hue2rgb(p, q, h);
-      b = hue2rgb(p, q, h - 1/3);
+      b = hue2rgb(p, q, h - 1 / 3);
     }
 
     return '#' +

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -9805,7 +9805,8 @@ body.app-fullscreen .video-wrapper.comment-mode::after {
   right: 0;
   bottom: 0;
   z-index: 5;
-  cursor: pointer;
+  cursor: default;
+  pointer-events: none;
 }
 
 .audio-waveform-container.active {
@@ -9848,15 +9849,31 @@ body.app-fullscreen .video-wrapper.comment-mode::after {
 
 .audio-waveform-overlay {
   z-index: 2;
+  pointer-events: none;
+}
+
+.audio-waveform-hit-area {
+  position: absolute;
+  top: 30%;
+  left: 0;
+  width: 100%;
+  height: 52%;
+  z-index: 4;
+  pointer-events: auto;
   cursor: pointer;
 }
 
-.audio-waveform-overlay:hover {
+.audio-waveform-hit-area:hover {
   cursor: grab;
 }
 
-.audio-waveform-overlay:active {
+.audio-waveform-hit-area:active {
   cursor: grabbing;
+}
+
+.video-wrapper.comment-mode .audio-waveform-hit-area {
+  pointer-events: none;
+  cursor: crosshair;
 }
 
 .audio-waveform-time {

--- a/scripts/tests/audio-waveform-hit-area.test.js
+++ b/scripts/tests/audio-waveform-hit-area.test.js
@@ -1,0 +1,25 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const rootDir = path.resolve(__dirname, '..', '..');
+const sourcePath = path.join(rootDir, 'renderer', 'scripts', 'modules', 'audio-waveform.js');
+const cssPath = path.join(rootDir, 'renderer', 'styles', 'main.css');
+
+const source = fs.readFileSync(sourcePath, 'utf8');
+const css = fs.readFileSync(cssPath, 'utf8');
+
+test('audio waveform uses a constrained hit area for pointer interaction', () => {
+  assert.match(source, /this\.hitArea\s*=\s*document\.createElement\('div'\)/);
+  assert.match(source, /this\.hitArea\.className\s*=\s*'audio-waveform-hit-area'/);
+  assert.doesNotMatch(source, /this\.overlayCanvas\.addEventListener\('mousedown', this\._onMouseDown\)/);
+  assert.match(source, /this\.hitArea\.addEventListener\('mousedown', this\._onMouseDown\)/);
+  assert.match(source, /const rect = this\._getInteractionRect\(\)/);
+});
+
+test('audio waveform overlay is visual-only and comment mode can receive marker clicks', () => {
+  assert.match(css, /\.audio-waveform-overlay\s*\{[\s\S]*?pointer-events:\s*none;/);
+  assert.match(css, /\.audio-waveform-hit-area\s*\{[\s\S]*?top:\s*30%;[\s\S]*?height:\s*52%;/);
+  assert.match(css, /\.video-wrapper\.comment-mode\s+\.audio-waveform-hit-area\s*\{[\s\S]*?pointer-events:\s*none;/);
+});


### PR DESCRIPTION
## 📋 업데이트 요약

- 🛠️ 오디오 파일을 열었을 때 댓글 마커를 찍기 어려웠던 문제를 고쳤습니다.
- 🎧 파형 위에서만 마우스 호버/드래그가 반응하고, 파형 밖 화면은 댓글 마커 입력을 방해하지 않습니다.
- 💬 댓글 모드에서는 화면 클릭이 댓글 마커 입력으로 우선 동작합니다.
- 🚚 핫픽스 배포 버전을 `1.2.2-beta`로 올렸습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/audio-waveform.js`
  - 기존에는 `audio-waveform-overlay` 캔버스가 화면 전체에서 `mousedown`, `mousemove`, `mouseleave`, `wheel` 이벤트를 직접 받았습니다.
  - 새 `audio-waveform-hit-area` div를 추가해 이벤트 수신 영역을 시각용 캔버스와 분리했습니다.
  - `_getInteractionRect()`를 통해 스크러빙/호버/휠 줌 좌표 계산을 hit area 기준으로 통일했습니다.

- `renderer/styles/main.css`
  - `.audio-waveform-container`와 `.audio-waveform-overlay`는 시각 표시만 담당하도록 `pointer-events: none`을 적용했습니다.
  - `.audio-waveform-hit-area`를 `top: 30%`, `height: 52%`로 제한해 실제 파형 영역에서만 `grab` 호버가 뜨게 했습니다.
  - `.video-wrapper.comment-mode .audio-waveform-hit-area`에서는 이벤트를 꺼서 댓글 마커 입력이 우선되게 했습니다.

- `scripts/tests/audio-waveform-hit-area.test.js`
  - 오디오 파형 이벤트가 hit area로 분리되었는지, 댓글 모드에서 웨이브폼이 마커 클릭을 막지 않는지 확인하는 회귀 테스트를 추가했습니다.

- `package.json`, `package-lock.json`
  - 핫픽스 버전을 `1.2.2-beta`로 반영하고 `test:audio-waveform` 스크립트를 추가했습니다.

## 🚧 개발 난항

- 증상만 보면 댓글 마커 쪽 클릭 문제처럼 보였지만, 실제 원인은 오디오 웨이브폼 오버레이가 화면 전체의 마우스 이벤트를 잡고 있던 구조였습니다.
- 전체 `npm run lint`는 기존 저장소의 CRLF 줄바꿈 파일들까지 검사하면서 대량 실패했습니다. 이번 수정 파일은 로컬 ESLint로 범위를 좁혀 별도 검증했습니다.
- `npm ci` 후 postinstall이 `liveblocks-client.js` 번들을 다시 생성했지만 내용 해시는 동일해, 이번 변경 범위에서는 제외했습니다.

## ✅ 테스트 가이드

### 실사용자용

1. 오디오 파일을 엽니다.
2. 파형 위에 마우스를 올리면 기존처럼 호버/드래그 커서가 보이는지 확인합니다.
3. 파형 밖 화면에서는 `grab` 커서가 뜨지 않는지 확인합니다.
4. 댓글 모드로 전환한 뒤 화면을 클릭해 댓글 마커가 바로 찍히는지 확인합니다.

### 개발자용

- `npm run test:audio-waveform`
- `npm run test:video-pan`
- `npm run test:cluster`
- `node_modules\.bin\eslint.cmd renderer/scripts/modules/audio-waveform.js scripts/tests/audio-waveform-hit-area.test.js`
- `npm run build`