### PR TITLE
[v1.3.1-beta] 댓글 입력 안정화와 협업/재생 UX 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 *프레임 단위로 정확하게. 그림으로 직관적으로. 링크 하나로 간편하게.*
 
-[![Version](https://img.shields.io/badge/version-1.3.0--beta-0366d6?style=for-the-badge)](https://github.com/baehandoridori/BAEFRAME)
+[![Version](https://img.shields.io/badge/version-1.3.1--beta-0366d6?style=for-the-badge)](https://github.com/baehandoridori/BAEFRAME)
 [![Electron](https://img.shields.io/badge/Electron-28-47848F?style=for-the-badge&logo=electron&logoColor=white)](https://www.electronjs.org/)
 [![Platform](https://img.shields.io/badge/Windows-10%2F11-0078D6?style=for-the-badge&logo=windows&logoColor=white)](https://github.com/baehandoridori/BAEFRAME)
 [![License](https://img.shields.io/badge/License-MIT-2ea44f?style=for-the-badge)](LICENSE)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "1.3.0-beta",
+  "version": "1.3.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "1.3.0-beta",
+      "version": "1.3.1-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "1.3.0-beta",
+  "version": "1.3.1-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "test:recent": "node --test scripts/tests/recent-files-store.test.js",
+    "test:recent": "node --test scripts/tests/recent-files-store.test.js scripts/tests/recent-files-source.test.js",
     "test:frame-grid": "node --test scripts/tests/frame-grid-tiers.test.js",
     "test:cluster": "node --test scripts/tests/comment-cluster.test.js",
     "test:playlist-ordering": "node --test scripts/tests/playlist-ordering.test.js",
@@ -21,6 +21,8 @@
     "test:drawing": "node --test scripts/tests/drawing-stroke-records.test.js scripts/tests/drawing-runtime-source.test.js scripts/tests/keyframe-multi-select-source.test.js",
     "test:video-pan": "node --test scripts/tests/video-pan-controls.test.js",
     "test:audio-waveform": "node --test scripts/tests/audio-waveform-hit-area.test.js",
+    "test:collaboration": "node --test scripts/tests/collaboration-cursors-source.test.js",
+    "test:comment-input": "node --test scripts/tests/comment-input-focus-source.test.js",
     "test:toast-stack": "node --test scripts/tests/toast-stack-core.test.js",
     "bundle:liveblocks": "esbuild ./node_modules/@liveblocks/client/dist/index.js --bundle --format=esm --outfile=renderer/scripts/lib/liveblocks-client.js",
     "postinstall": "npm run bundle:liveblocks"

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -108,10 +108,16 @@
           <canvas class="collab-plexus-canvas" id="collabPlexusCanvas"></canvas>
           <div class="collab-plexus-footer">
             <span class="collab-plexus-label">실시간 협업 중</span>
-            <button class="collab-plexus-sync-btn" id="btnOpenSyncFromPlexus" title="동기화 작업 패널 열기">
-              <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
-              <span>동기화 작업</span>
-            </button>
+            <div class="collab-plexus-actions">
+              <button class="collab-plexus-action-btn collab-remote-cursor-btn" id="btnToggleRemoteCursors" title="다른 사람 커서 숨기기">
+                <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20C7 20 2.73 16.89 1 12a18.45 18.45 0 0 1 5.06-6.94"/><path d="M10.58 10.58A2 2 0 0 0 12 14a2 2 0 0 0 1.42-.58"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c5 0 9.27 3.11 11 8a18.5 18.5 0 0 1-2.16 3.19"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+                <span id="remoteCursorsToggleLabel">커서 숨기기</span>
+              </button>
+              <button class="collab-plexus-sync-btn" id="btnOpenSyncFromPlexus" title="동기화 작업 패널 열기">
+                <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
+                <span>동기화 작업</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -540,7 +546,7 @@
               </div>
 
               <!-- 색상 선택 -->
-              <div class="tools-section">
+              <div class="tools-section" id="colorSection">
                 <div class="section-label">색상</div>
                 <div class="colors-row">
                   <button class="color-btn active" data-color="red" style="background: #ff4757" title="빨강"></button>

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -217,6 +217,41 @@ async function initApp() {
   // 사용자 설정
   const userSettings = getUserSettings();
 
+  function getCommentEditableTarget(target) {
+    if (!(target instanceof Element)) return null;
+    return target.closest('.comment-input, .comment-marker-input, .comment-reply-input, .comment-edit-textarea, .comment-reply-edit-textarea, .thread-editor[contenteditable="true"]');
+  }
+
+  function installCommentEditableFocusRecovery() {
+    let pendingEditable = null;
+
+    document.addEventListener('pointerdown', handleEditablePointerDown, true);
+    document.addEventListener('mousedown', handleEditablePointerDown, true);
+
+    function handleEditablePointerDown(e) {
+      const editable = getCommentEditableTarget(e.target);
+      if (!editable || editable.disabled || editable.readOnly) return;
+
+      pendingEditable = editable;
+      window.setTimeout(() => {
+        if (pendingEditable !== editable) return;
+        pendingEditable = null;
+        if (!document.contains(editable) || document.activeElement === editable) return;
+
+        editable.focus({ preventScroll: true });
+        if (
+          (editable instanceof HTMLTextAreaElement || editable instanceof HTMLInputElement) &&
+          typeof editable.selectionStart === 'number'
+        ) {
+          const end = editable.value.length;
+          editable.setSelectionRange(end, end);
+        }
+      }, 0);
+    }
+  }
+
+  installCommentEditableFocusRecovery();
+
   // 상태
   const state = {
     isDrawMode: false,
@@ -258,6 +293,7 @@ async function initApp() {
     waiting: false,
     skippedBatch: [],
     preparePromises: new Map(),
+    preparedMediaPaths: new Map(),
     sessionId: 0
   };
 
@@ -2164,6 +2200,25 @@ async function initApp() {
     }
   });
 
+  // 다른 사람 협업 커서 표시 토글
+  const btnToggleRemoteCursors = document.getElementById('btnToggleRemoteCursors');
+  const remoteCursorsToggleLabel = document.getElementById('remoteCursorsToggleLabel');
+  function updateRemoteCursorToggleButton() {
+    const showRemoteCursors = userSettings.getShowRemoteCursors();
+    if (remoteCursorsToggleLabel) {
+      remoteCursorsToggleLabel.textContent = showRemoteCursors ? '커서 숨기기' : '커서 보이기';
+    }
+    if (btnToggleRemoteCursors) {
+      btnToggleRemoteCursors.classList.toggle('is-muted', !showRemoteCursors);
+      btnToggleRemoteCursors.setAttribute('title', showRemoteCursors ? '다른 사람 커서 숨기기' : '다른 사람 커서 보이기');
+      btnToggleRemoteCursors.setAttribute('aria-pressed', String(!showRemoteCursors));
+    }
+  }
+  updateRemoteCursorToggleButton();
+  btnToggleRemoteCursors?.addEventListener('click', () => {
+    userSettings.setShowRemoteCursors(!userSettings.getShowRemoteCursors());
+  });
+
   // 도구별 설정 저장 (크기, 불투명도)
   const toolSettings = {
     eraser: { size: 20 },      // 지우개는 기본 크기 더 크게
@@ -2179,6 +2234,8 @@ async function initApp() {
   const brushOpacitySlider = document.getElementById('brushOpacitySlider');
   const brushOpacityValue = document.getElementById('brushOpacityValue');
   const eraserModeSection = document.getElementById('eraserModeSection');
+  const colorSection = document.getElementById('colorSection');
+  const strokeSection = document.getElementById('strokeSection');
   const eraserModeButtons = document.querySelectorAll('.eraser-mode-btn[data-eraser-mode]');
 
   function applyEraserMode(mode, persist = false) {
@@ -2238,11 +2295,15 @@ async function initApp() {
       // 지우개일 때 불투명도 섹션 숨기기, 아니면 보이기
       if (newToolType === 'eraser') {
         opacitySection.style.display = 'none';
+        if (colorSection) colorSection.style.display = 'none';
+        if (strokeSection) strokeSection.style.display = 'none';
         if (eraserModeSection) eraserModeSection.hidden = false;
         applyEraserMode(currentEraserMode);
         drawingManager.setOpacity(1);  // 지우개는 항상 100%
       } else {
         opacitySection.style.display = 'block';
+        if (colorSection) colorSection.style.display = 'block';
+        if (strokeSection) strokeSection.style.display = 'block';
         if (eraserModeSection) eraserModeSection.hidden = true;
         brushOpacitySlider.value = toolSettings.brush.opacity;
         brushOpacityValue.textContent = `${toolSettings.brush.opacity}%`;
@@ -2284,6 +2345,7 @@ async function initApp() {
   function updateSizePreview() {
     const size = brushSizeSlider.value;
     brushSizeValue.textContent = `${size}px`;
+    sizePreview.classList.toggle('eraser-preview', currentToolType === 'eraser');
     sizePreview.style.setProperty('--preview-size', `${Math.min(size, 20)}px`);
     sizePreview.style.setProperty('--preview-color', currentColor);
   }
@@ -3276,10 +3338,15 @@ async function initApp() {
     renderVideoCommentRanges();
   }
 
-  async function refreshCommentRangesForCurrentMode() {
+  async function refreshCommentRangesForCurrentMode(options = {}) {
+    const { skipContinuousTimelineRefresh = false } = options;
     if (playlistUIState.mode === 'continuous') {
       setupCommentRangeInteractions();
       renderVideoCommentRanges();
+      if (skipContinuousTimelineRefresh && timeline.playlistDuration > 0) {
+        renderPlaylistContinuousCommentList(commentFilterState.status);
+        return;
+      }
       await updatePlaylistContinuousTimeline();
       return;
     }
@@ -3806,6 +3873,7 @@ async function initApp() {
 
   // 비디오 패닝
   elements.videoWrapper?.addEventListener('mousedown', (e) => {
+    if (getCommentEditableTarget(e.target)) return;
     if (canPanVideo() && e.button === 0) {
       state.isPanningVideo = true;
       state.panStartX = e.clientX;
@@ -4095,7 +4163,8 @@ async function initApp() {
       keepVersionContext = false,
       targetVersion = null,
       preserveContinuousSession = false,
-      playWhenMediaReady = false
+      playWhenMediaReady = false,
+      preparedVideoPath = null
     } = options;
     const loadToken = ++latestVideoLoadToken;
     const isStaleVideoLoad = () => loadToken !== latestVideoLoadToken;
@@ -4113,8 +4182,12 @@ async function initApp() {
       const fileIsAudio = isAudioFile(fileInfo.name);
 
       // ====== 코덱 확인 및 트랜스코딩 (비디오만) ======
-      let actualVideoPath = filePath;
-      const ffmpegAvailable = !fileIsAudio && await window.electronAPI.ffmpegIsAvailable();
+      const hasPreparedVideoPath = typeof preparedVideoPath === 'string' && preparedVideoPath.length > 0;
+      let actualVideoPath = hasPreparedVideoPath ? preparedVideoPath : filePath;
+      if (hasPreparedVideoPath) {
+        log.debug('준비된 연속 재생 미디어 경로 사용', { filePath, preparedVideoPath });
+      }
+      const ffmpegAvailable = !hasPreparedVideoPath && !fileIsAudio && await window.electronAPI.ffmpegIsAvailable();
 
       if (ffmpegAvailable) {
         const codecInfo = await window.electronAPI.ffmpegProbeCodec(filePath);
@@ -4474,7 +4547,9 @@ async function initApp() {
       renderHighlights();
 
       // 댓글 범위 렌더링
-      await refreshCommentRangesForCurrentMode();
+      await refreshCommentRangesForCurrentMode({
+        skipContinuousTimelineRefresh: preserveContinuousSession
+      });
       if (isStaleVideoLoad()) return false;
 
       // ====== 최근 파일 목록에 추가 ======
@@ -4898,6 +4973,8 @@ async function initApp() {
       <textarea class="comment-marker-input" placeholder="댓글 입력..." rows="1"></textarea>
       <div class="comment-marker-input-hint">Enter 확인 · Shift+Enter 줄바꿈 · Esc 취소</div>
     `;
+    inputWrapper.addEventListener('pointerdown', (e) => e.stopPropagation());
+    inputWrapper.addEventListener('mousedown', (e) => e.stopPropagation());
 
     markerEl.appendChild(inputWrapper);
     markerContainer.appendChild(markerEl);
@@ -10075,17 +10152,31 @@ async function initApp() {
     }
     return container;
   })();
+  let lastRemoteCursorCollaborators = [];
 
-  function renderRemoteCursors(collaborators) {
+  function clearRemoteCursors() {
+    if (!remoteCursorsContainer) return;
+    remoteCursorsContainer.querySelectorAll('.remote-cursor').forEach(el => el.remove());
+  }
+
+  function renderRemoteCursors(collaborators = []) {
     if (!remoteCursorsContainer) return;
 
+    const safeCollaborators = Array.isArray(collaborators) ? collaborators : [];
+    lastRemoteCursorCollaborators = safeCollaborators;
+
+    if (!userSettings.getShowRemoteCursors()) {
+      clearRemoteCursors();
+      return;
+    }
+
     // 기존 커서 중 더 이상 없는 것 제거
-    const activeIds = new Set(collaborators.map(c => `cursor-${c.connectionId}`));
+    const activeIds = new Set(safeCollaborators.filter(c => c.cursor).map(c => `cursor-${c.connectionId}`));
     remoteCursorsContainer.querySelectorAll('.remote-cursor').forEach(el => {
       if (!activeIds.has(el.id)) el.remove();
     });
 
-    for (const collab of collaborators) {
+    for (const collab of safeCollaborators) {
       if (!collab.cursor) continue;
 
       const cursorId = `cursor-${collab.connectionId}`;
@@ -10114,6 +10205,15 @@ async function initApp() {
       }
     }
   }
+
+  userSettings.addEventListener('showRemoteCursorsChanged', (event) => {
+    updateRemoteCursorToggleButton();
+    if (event.detail?.show) {
+      renderRemoteCursors(lastRemoteCursorCollaborators);
+    } else {
+      clearRemoteCursors();
+    }
+  });
 
   // 로컬 커서 → Presence 전송 (videoWrapper 위에서만)
   elements.videoWrapper?.addEventListener('mousemove', (e) => {
@@ -10651,6 +10751,7 @@ async function initApp() {
     continuousPlaybackState.waiting = false;
     continuousPlaybackState.skippedBatch = [];
     continuousPlaybackState.preparePromises.clear();
+    continuousPlaybackState.preparedMediaPaths.clear();
   }
 
   function isContinuousSessionActive(sessionId) {
@@ -10831,10 +10932,12 @@ async function initApp() {
 
       try {
         if (!shouldContinuePreparing()) return { ready: false, stale: true };
+        continuousPlaybackState.preparedMediaPaths.delete(item.id);
         markPlaylistItemStatus(item, CONTINUOUS_STATUS.PREPARING, '준비 중');
         const ffmpegAvailable = await window.electronAPI.ffmpegIsAvailable();
         if (!shouldContinuePreparing()) return { ready: false, stale: true };
         if (!ffmpegAvailable) {
+          continuousPlaybackState.preparedMediaPaths.set(item.id, item.videoPath);
           markPlaylistItemStatus(item, CONTINUOUS_STATUS.READY, '준비 완료');
           return { ready: true };
         }
@@ -10842,6 +10945,7 @@ async function initApp() {
         const codecInfo = await window.electronAPI.ffmpegProbeCodec(item.videoPath);
         if (!shouldContinuePreparing()) return { ready: false, stale: true };
         if (!codecInfo.success || codecInfo.isSupported) {
+          continuousPlaybackState.preparedMediaPaths.set(item.id, item.videoPath);
           markPlaylistItemStatus(item, CONTINUOUS_STATUS.READY, '준비 완료');
           return { ready: true };
         }
@@ -10849,6 +10953,7 @@ async function initApp() {
         const cacheResult = await window.electronAPI.ffmpegCheckCache(item.videoPath);
         if (!shouldContinuePreparing()) return { ready: false, stale: true };
         if (cacheResult.valid) {
+          continuousPlaybackState.preparedMediaPaths.set(item.id, cacheResult.convertedPath);
           markPlaylistItemStatus(item, CONTINUOUS_STATUS.READY, '준비 완료');
           return { ready: true, cached: true };
         }
@@ -10856,6 +10961,7 @@ async function initApp() {
         const result = await window.electronAPI.ffmpegPreTranscode(item.videoPath);
         if (!shouldContinuePreparing()) return { ready: false, stale: true };
         if (result.success) {
+          continuousPlaybackState.preparedMediaPaths.set(item.id, result.outputPath);
           markPlaylistItemStatus(item, CONTINUOUS_STATUS.READY, '준비 완료');
           return { ready: true };
         }
@@ -10930,7 +11036,11 @@ async function initApp() {
 
   async function loadContinuousPlaylistItem(item, sessionId) {
     if (!isContinuousSessionActive(sessionId)) return false;
-    const loaded = await loadVideoFromPlaylist(item, { preserveContinuousSession: true });
+    const preparedVideoPath = continuousPlaybackState.preparedMediaPaths.get(item.id);
+    const loaded = await loadVideoFromPlaylist(item, {
+      preserveContinuousSession: true,
+      preparedVideoPath
+    });
     if (!isContinuousSessionActive(sessionId)) return false;
     if (loaded === false) {
       markPlaylistItemStatus(item, CONTINUOUS_STATUS.ERROR, '건너뜀');

--- a/renderer/scripts/modules/user-settings.js
+++ b/renderer/scripts/modules/user-settings.js
@@ -186,6 +186,8 @@ export class UserSettings extends EventTarget {
       secondSkipAmount: 1,  // Ctrl+화살표로 이동할 초 수
       // 협업 플렉서스 패널 표시 여부
       showPlexusPanel: true,
+      // 다른 사람 협업 커서 표시 여부
+      showRemoteCursors: true,
       // 타임라인 프레임 격자 표시 여부
       showFrameGrid: true,
       // 100% 이하 줌에서 영상을 중앙에 고정할지 여부
@@ -567,6 +569,17 @@ export class UserSettings extends EventTarget {
     // 향후 외부에서 설정 변경을 감지해야 할 경우를 위한 hook
     this._emit('showFrameGridChanged', { show: this.settings.showFrameGrid });
     log.info('프레임 격자 설정 변경됨', { show });
+  }
+
+  getShowRemoteCursors() {
+    return this.settings.showRemoteCursors !== false;
+  }
+
+  setShowRemoteCursors(show) {
+    this.settings.showRemoteCursors = !!show;
+    this._save();
+    this._emit('showRemoteCursorsChanged', { show: this.settings.showRemoteCursors });
+    log.info('협업 커서 표시 설정 변경됨', { show: this.settings.showRemoteCursors });
   }
 
   getVideoCenterLocked() {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -1404,6 +1404,11 @@ body.app-fullscreen .video-comment-overlay-controls {
   border-radius: 50%;
 }
 
+.size-preview.eraser-preview::after {
+  background: transparent;
+  border: 2px solid var(--text-muted);
+}
+
 .eraser-mode-toggle {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -10106,6 +10111,13 @@ body.audio-mode .frame-indicator {
   letter-spacing: 0.5px;
 }
 
+.collab-plexus-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.collab-plexus-action-btn,
 .collab-plexus-sync-btn {
   display: flex;
   align-items: center;
@@ -10121,12 +10133,25 @@ body.audio-mode .frame-indicator {
   transition: all 0.15s;
 }
 
+.collab-plexus-action-btn:hover,
 .collab-plexus-sync-btn:hover {
   background: var(--accent-primary);
   color: var(--bg-primary);
   border-color: var(--accent-primary);
 }
 
+.collab-remote-cursor-btn.is-muted {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-tertiary);
+}
+
+.collab-remote-cursor-btn.is-muted:hover {
+  background: var(--accent-primary);
+  color: var(--bg-primary);
+  border-color: var(--accent-primary);
+}
+
+.collab-plexus-action-btn svg,
 .collab-plexus-sync-btn svg {
   flex-shrink: 0;
 }

--- a/renderer/styles/recent-files.css
+++ b/renderer/styles/recent-files.css
@@ -5,13 +5,17 @@
  * 기존 version-dropdown 토큰과 시각적으로 일관되게 유지.
  * ============================================================ */
 
-/* ---------- 드롭존 가로 배치 컨테이너 ---------- */
+/* ---------- 드롭존 액션 컨테이너 ---------- */
 
 .drop-zone-actions {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 16px;
-  margin-top: 12px;
+  justify-content: center;
+  gap: 10px;
+  width: min(calc(100vw - 48px), 860px);
+  max-width: 100%;
+  margin-top: 16px;
 }
 
 /* ---------- 드롭존 내부 인라인 최근 파일 ---------- */
@@ -19,12 +23,14 @@
 #recentFilesSection.recent-inline {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 8px;
   overflow-x: auto;
   overflow-y: hidden;
-  flex: 1;
+  flex: none;
+  width: min(100%, 760px);
   min-width: 0;
-  padding: 4px 0;
+  padding: 4px 2px 6px;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.12) transparent;
 }
@@ -52,6 +58,7 @@
   flex-direction: row;
   gap: 8px;
   flex-shrink: 0;
+  width: max-content;
 }
 
 /* 인라인 모드: 텍스트 칩 스타일 카드 */
@@ -85,6 +92,7 @@
 
 #recentFilesSection.recent-inline .recent-card-name {
   font-size: 12px;
+  max-width: 160px;
 }
 
 #recentFilesSection.recent-inline .recent-card-meta,

--- a/scripts/tests/collaboration-cursors-source.test.js
+++ b/scripts/tests/collaboration-cursors-source.test.js
@@ -1,0 +1,32 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
+const userSettingsSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/user-settings.js'), 'utf8'));
+const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
+
+test('remote cursor visibility is a local user setting', () => {
+  assert.match(userSettingsSource, /showRemoteCursors:\s*true/);
+  assert.match(userSettingsSource, /getShowRemoteCursors\(\) \{[\s\S]+return this\.settings\.showRemoteCursors !== false;/);
+  assert.match(userSettingsSource, /setShowRemoteCursors\(show\) \{[\s\S]+this\.settings\.showRemoteCursors = !!show;[\s\S]+this\._save\(\);[\s\S]+this\._emit\('showRemoteCursorsChanged'/);
+});
+
+test('collaboration popup exposes an action for other collaborators cursors', () => {
+  assert.match(indexSource, /id="collabPlexusPanel"[\s\S]+id="btnToggleRemoteCursors"/);
+  assert.match(indexSource, /id="remoteCursorsToggleLabel">커서 숨기기<\/span>/);
+  assert.doesNotMatch(indexSource, /id="toggleRemoteCursors"/);
+  assert.match(appSource, /const btnToggleRemoteCursors = document\.getElementById\('btnToggleRemoteCursors'\);/);
+  assert.match(appSource, /const remoteCursorsToggleLabel = document\.getElementById\('remoteCursorsToggleLabel'\);/);
+  assert.match(appSource, /function updateRemoteCursorToggleButton\(\) \{[\s\S]+remoteCursorsToggleLabel\.textContent = showRemoteCursors \? '커서 숨기기' : '커서 보이기';/);
+  assert.match(appSource, /userSettings\.setShowRemoteCursors\(!userSettings\.getShowRemoteCursors\(\)\);/);
+});
+
+test('remote cursor renderer clears cursors when the setting is off', () => {
+  assert.match(appSource, /function clearRemoteCursors\(\) \{[\s\S]+querySelectorAll\('\.remote-cursor'\)\.forEach\(el => el\.remove\(\)\);/);
+  assert.match(appSource, /if \(!userSettings\.getShowRemoteCursors\(\)\) \{[\s\S]+clearRemoteCursors\(\);[\s\S]+return;/);
+  assert.match(appSource, /userSettings\.addEventListener\('showRemoteCursorsChanged'/);
+});

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -1,0 +1,44 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
+const htmlSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
+
+test('comment editable fields recover focus when a parent pointer handler blocks default focus', () => {
+  assert.match(appSource, /function getCommentEditableTarget\(target\) \{[\s\S]+target\.closest\('\.comment-input, \.comment-marker-input, \.comment-reply-input, \.comment-edit-textarea, \.comment-reply-edit-textarea, \.thread-editor\[contenteditable="true"\]'\)/);
+  assert.match(appSource, /function installCommentEditableFocusRecovery\(\) \{[\s\S]+document\.addEventListener\('pointerdown', handleEditablePointerDown, true\);[\s\S]+editable\.focus\(\{ preventScroll: true \}\);/);
+  assert.match(appSource, /document\.addEventListener\('mousedown', handleEditablePointerDown, true\);/);
+  assert.match(appSource, /installCommentEditableFocusRecovery\(\);/);
+});
+
+test('right sidebar comment input is covered by the same focus recovery path', () => {
+  assert.match(htmlSource, /<textarea class="comment-input" id="commentInput"/);
+  assert.match(appSource, /commentInput: document\.getElementById\('commentInput'\)/);
+  assert.match(appSource, /target\.closest\('\.comment-input,/);
+});
+
+test('video panning does not steal mouse down from comment editors', () => {
+  const panHandlerMatch = appSource.match(/elements\.videoWrapper\?\.addEventListener\('mousedown', \(e\) => \{([\s\S]*?)\n  \}\);/);
+  assert.ok(panHandlerMatch, 'video wrapper panning mousedown handler should exist');
+  const panHandlerSource = panHandlerMatch[1];
+
+  assert.match(panHandlerSource, /if \(getCommentEditableTarget\(e\.target\)\) return;/);
+  assert.ok(
+    panHandlerSource.indexOf('if (getCommentEditableTarget(e.target)) return;') <
+      panHandlerSource.indexOf('if (canPanVideo() && e.button === 0)'),
+    'comment editor guard should run before panning preventDefault'
+  );
+});
+
+test('pending marker input stops pointer events from bubbling into video panning', () => {
+  const pendingMarkerMatch = appSource.match(/function renderPendingMarker\(marker\) \{([\s\S]*?)\n  \}\n\n  \/\*\*\n   \* Pending 마커 UI 제거/);
+  assert.ok(pendingMarkerMatch, 'pending marker renderer should exist');
+  const pendingMarkerSource = pendingMarkerMatch[1];
+
+  assert.match(pendingMarkerSource, /inputWrapper\.addEventListener\('pointerdown', \(e\) => e\.stopPropagation\(\)\);/);
+  assert.match(pendingMarkerSource, /inputWrapper\.addEventListener\('mousedown', \(e\) => e\.stopPropagation\(\)\);/);
+});

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -25,6 +25,18 @@ test('drawing tools expose a persisted eraser mode segmented control', () => {
   assert.match(appSource, /drawingManager\.setEraserMode\(mode\)/);
 });
 
+test('eraser tool hides color-only controls and uses a neutral size preview', () => {
+  assert.match(indexSource, /id="colorSection"/);
+  assert.match(appSource, /const colorSection = document\.getElementById\('colorSection'\);/);
+  assert.match(appSource, /const strokeSection = document\.getElementById\('strokeSection'\);/);
+  assert.match(appSource, /colorSection\.style\.display = 'none';/);
+  assert.match(appSource, /colorSection\.style\.display = 'block';/);
+  assert.match(appSource, /strokeSection\.style\.display = 'none';/);
+  assert.match(appSource, /strokeSection\.style\.display = 'block';/);
+  assert.match(appSource, /sizePreview\.classList\.toggle\('eraser-preview', currentToolType === 'eraser'\);/);
+  assert.match(mainCss, /\.size-preview\.eraser-preview::after/);
+});
+
 test('drawing canvas resolves Ctrl pen and brush strokes as eraser at stroke start', () => {
   assert.match(drawingCanvasSource, /setEraserMode\(mode\)/);
   assert.match(drawingCanvasSource, /_resolveEffectiveTool\(e\)/);

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -192,7 +192,7 @@ test('continuous playback starts next-item preparation before playback watchdog 
 });
 
 test('continuous video loads preserve aggregate timeline comment ranges', () => {
-  const helperMatch = appSource.match(/async function refreshCommentRangesForCurrentMode\(\) \{([\s\S]*?)\n  \}/);
+  const helperMatch = appSource.match(/async function refreshCommentRangesForCurrentMode\([^)]*\) \{([\s\S]*?)\n  \}/);
   assert.ok(helperMatch, 'current-mode comment range refresher should exist');
 
   const helperSource = helperMatch[1];
@@ -203,13 +203,27 @@ test('continuous video loads preserve aggregate timeline comment ranges', () => 
 
   const loadVideoCommentRefreshMatch = appSource.match(/renderHighlights\(\);\s*\n\s*\/\/ 댓글 범위 렌더링([\s\S]*?)\/\/ ====== 최근 파일 목록에 추가/);
   assert.ok(loadVideoCommentRefreshMatch, 'loadVideo should refresh comment ranges before recent files');
-  assert.match(loadVideoCommentRefreshMatch[1], /await refreshCommentRangesForCurrentMode\(\);/);
+  assert.match(loadVideoCommentRefreshMatch[1], /await refreshCommentRangesForCurrentMode\(/);
   assert.doesNotMatch(loadVideoCommentRefreshMatch[1], /\n\s*renderCommentRanges\(\);/);
+});
+
+test('continuous cut loads reuse the existing aggregate timeline instead of rebuilding it', () => {
+  const helperMatch = appSource.match(/async function refreshCommentRangesForCurrentMode\(options = \{\}\) \{([\s\S]*?)\n  \}/);
+  assert.ok(helperMatch, 'current-mode comment range refresher should accept options');
+
+  const helperSource = helperMatch[1];
+  assert.match(helperSource, /skipContinuousTimelineRefresh = false/);
+  assert.match(helperSource, /if \(skipContinuousTimelineRefresh && timeline\.playlistDuration > 0\) \{[\s\S]+renderPlaylistContinuousCommentList\(commentFilterState\.status\);[\s\S]+return;/);
+  assert.match(helperSource, /await updatePlaylistContinuousTimeline\(\);/);
+
+  const loadVideoCommentRefreshMatch = appSource.match(/renderHighlights\(\);\s*\n\s*\/\/ 댓글 범위 렌더링([\s\S]*?)\/\/ ====== 최근 파일 목록에 추가/);
+  assert.ok(loadVideoCommentRefreshMatch, 'loadVideo should refresh comment ranges before recent files');
+  assert.match(loadVideoCommentRefreshMatch[1], /await refreshCommentRangesForCurrentMode\(\{\s*skipContinuousTimelineRefresh: preserveContinuousSession\s*\}\);/);
 });
 
 test('continuous state is initialized before startup file-open comment refresh paths', () => {
   const stateIndex = appSource.indexOf('const playlistUIState = {');
-  const helperIndex = appSource.indexOf('async function refreshCommentRangesForCurrentMode()');
+  const helperIndex = appSource.indexOf('async function refreshCommentRangesForCurrentMode');
   const loadVideoIndex = appSource.indexOf('async function loadVideo(filePath, options = {})');
   const rendererReadyIndex = appSource.indexOf('window.electronAPI.notifyRendererReady?.();');
 
@@ -309,11 +323,33 @@ test('continuous playback only checks the current item before first play', () =>
 
 test('continuous playback skips item when playlist load fails', () => {
   assert.match(appSource, /async function loadContinuousPlaylistItem\(item, sessionId\)/);
-  assert.match(appSource, /const loaded = await loadVideoFromPlaylist\(item, \{ preserveContinuousSession: true \}\);/);
+  assert.match(appSource, /const loaded = await loadVideoFromPlaylist\(item, \{[\s\S]+preserveContinuousSession: true,[\s\S]+preparedVideoPath[\s\S]+\}\);/);
   assert.match(appSource, /markPlaylistItemStatus\(item, CONTINUOUS_STATUS\.ERROR, '건너뜀'\);/);
   assert.match(appSource, /continuousPlaybackState\.skippedBatch\.push\(item\);/);
   assert.match(appSource, /const loaded = await loadContinuousPlaylistItem\(currentItem, sessionId\);[\s\S]+if \(!loaded\) \{[\s\S]+await playNextContinuousItem\(sessionId\);/);
   assert.match(appSource, /const loaded = await loadContinuousPlaylistItem\(nextItem, sessionId\);[\s\S]+if \(!loaded\) \{[\s\S]+await playNextContinuousItem\(sessionId\);/);
+});
+
+test('continuous playback reuses prepared media paths at cut boundaries', () => {
+  assert.match(appSource, /preparedMediaPaths:\s*new Map\(\)/);
+  assert.match(appSource, /continuousPlaybackState\.preparedMediaPaths\.clear\(\);/);
+  assert.match(appSource, /continuousPlaybackState\.preparedMediaPaths\.set\(item\.id, item\.videoPath\);/);
+  assert.match(appSource, /continuousPlaybackState\.preparedMediaPaths\.set\(item\.id, cacheResult\.convertedPath\);/);
+  assert.match(appSource, /continuousPlaybackState\.preparedMediaPaths\.set\(item\.id, result\.outputPath\);/);
+
+  const loadVideoMatch = appSource.match(/async function loadVideo\(filePath, options = \{\}\) \{([\s\S]*?)\n  \}/);
+  assert.ok(loadVideoMatch, 'loadVideo should exist');
+  const loadVideoSource = loadVideoMatch[1];
+  assert.match(loadVideoSource, /preparedVideoPath = null/);
+  assert.match(loadVideoSource, /const hasPreparedVideoPath = typeof preparedVideoPath === 'string' && preparedVideoPath\.length > 0;/);
+  assert.match(loadVideoSource, /let actualVideoPath = hasPreparedVideoPath \? preparedVideoPath : filePath;/);
+  assert.match(loadVideoSource, /!hasPreparedVideoPath && !fileIsAudio && await window\.electronAPI\.ffmpegIsAvailable\(\)/);
+
+  const continuousLoaderMatch = appSource.match(/async function loadContinuousPlaylistItem\(item, sessionId\) \{([\s\S]*?)\n  \}/);
+  assert.ok(continuousLoaderMatch, 'continuous playlist loader should exist');
+  const continuousLoaderSource = continuousLoaderMatch[1];
+  assert.match(continuousLoaderSource, /const preparedVideoPath = continuousPlaybackState\.preparedMediaPaths\.get\(item\.id\);/);
+  assert.match(continuousLoaderSource, /preparedVideoPath/);
 });
 
 test('playlist loading returns the real loadVideo result', () => {

--- a/scripts/tests/recent-files-source.test.js
+++ b/scripts/tests/recent-files-source.test.js
@@ -1,0 +1,16 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
+const recentCss = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/recent-files.css'), 'utf8'));
+
+test('empty screen stacks recent files below the main open button', () => {
+  assert.match(indexSource, /<button class="btn btn-primary btn-large" id="btnOpenFile">[\s\S]*?<section id="recentFilesSection"/);
+  assert.match(recentCss, /\.drop-zone-actions\s*\{[^}]*flex-direction:\s*column;/);
+  assert.match(recentCss, /#recentFilesSection\.recent-inline\s*\{[\s\S]*?width:\s*min\(100%,\s*760px\);/);
+  assert.match(recentCss, /#recentFilesSection\.recent-inline \.recent-cards\s*\{[^}]*flex-direction:\s*row;/);
+});


### PR DESCRIPTION
## 📋 업데이트 요약

- 📝 오른쪽 댓글 입력창과 영상 위 댓글 입력창이 가끔 클릭되지 않던 문제를 줄였습니다.
- 👥 협업 중 사람이 많을 때 다른 사람 커서를 숨길 수 있게 했습니다.
- 🧰 지우개를 선택했을 때 색상처럼 헷갈리는 표시가 나오지 않게 정리했습니다.
- 🏠 첫 화면에서 최근 파일이 파일 열기 버튼 아래에 한 줄로 보이도록 배치를 다듬었습니다.
- ▶️ 타임라인 이어붙이기 자동 재생에서 다음 영상으로 넘어갈 때 불필요한 준비 작업을 줄였습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - `getCommentEditableTarget`, `installCommentEditableFocusRecovery`로 댓글 textarea/contenteditable 계열의 포커스 복구 경로를 공통화했습니다.
  - `videoWrapper` 패닝 시작 전에 댓글 입력창 대상은 제외해 `preventDefault()`가 입력 포커스를 막지 않게 했습니다.
  - `renderPendingMarker()`의 인라인 입력 wrapper에서 `pointerdown`/`mousedown` 전파를 막아 영상 패닝 핸들러와 충돌하지 않게 했습니다.
  - `continuousPlaybackState.preparedMediaPaths`를 추가하고 `loadVideo()`에 `preparedVideoPath` 옵션을 전달해 연속 재생 컷 경계에서 이미 준비한 미디어 경로를 재사용합니다.
  - `refreshCommentRangesForCurrentMode({ skipContinuousTimelineRefresh })`로 연속 재생 내부 컷 로드 시 기존 통합 타임라인/댓글 범위를 재사용합니다.
  - `renderRemoteCursors()`에서 `userSettings.getShowRemoteCursors()`를 반영해 커서 표시를 끄면 원격 커서를 즉시 제거합니다.
- `renderer/scripts/modules/user-settings.js`
  - `showRemoteCursors` 로컬 설정과 변경 이벤트를 추가했습니다.
- `renderer/index.html`, `renderer/styles/main.css`
  - 협업 플렉서스 패널 footer에 커서 숨김/표시 버튼을 추가했습니다.
  - 지우개 선택 시 색상/획 관련 컨트롤이 숨겨지도록 기존 도구 UI에 맞춰 조정했습니다.
- `renderer/styles/recent-files.css`
  - 빈 화면의 `drop-zone-actions`를 세로 흐름으로 바꾸고 최근 파일을 버튼 아래 한 줄 목록으로 배치했습니다.
- `package.json`, `package-lock.json`, `README.md`
  - 버전을 `1.3.1-beta`로 갱신하고 관련 테스트 스크립트를 추가했습니다.
- `scripts/tests/*`
  - 최근 파일 배치, 지우개 표시, 협업 커서, 댓글 입력 포커스, 이어붙이기 재생 최적화 회귀 테스트를 추가/보강했습니다.

## 🚧 개발 난항

- 댓글 입력 먹통 문제는 처음에 영상 위 입력창과 패닝 충돌로 좁혀졌지만, 사용자 확인 후 오른쪽 댓글 입력창까지 같은 보호 경로에 넣었습니다.
- 한때 Electron 창 포커스 복구와 단축키/토스트 위치 이동까지 넓게 방어하려 했지만, 실제 필요 범위를 벗어난 보강이라 제거하고 댓글 입력 자체의 공통 포커스 복구만 남겼습니다.
- 이어붙이기 재생 지연은 완전한 무딜레이 전환보다, 현재 구조에서 반복 준비 작업과 통합 타임라인 재계산을 줄이는 1단계 개선으로 정리했습니다.

## ✅ 테스트 가이드

실사용자용:
- 첫 화면에서 `파일 열기` 버튼 아래에 최근 파일들이 한 줄로 보이는지 확인합니다.
- 그리기 도구에서 지우개를 선택했을 때 색상 선택이 보이지 않는지 확인합니다.
- 협업 중 상단 `n명 작업중` 패널에서 `커서 숨기기`를 누르면 다른 사람 커서가 사라지는지 확인합니다.
- 오른쪽 댓글 입력창과 영상 위 댓글 입력창을 여러 번 클릭해 커서가 바로 뜨는지 확인합니다.
- 타임라인 이어붙이기 자동 재생에서 다음 영상으로 넘어갈 때 이전보다 멈칫거림이 줄었는지 확인합니다.

개발자용:
- `npm run test:recent`
- `npm run test:drawing`
- `npm run test:collaboration`
- `npm run test:comment-input`
- `npm run test:audio-waveform`
- `npm run test:video-pan`
- `npm run test:playlist`
- `npx eslint renderer\scripts\app.js renderer\scripts\modules\user-settings.js scripts\tests\comment-input-focus-source.test.js scripts\tests\recent-files-source.test.js scripts\tests\collaboration-cursors-source.test.js scripts\tests\drawing-runtime-source.test.js scripts\tests\playlist-continuous-runtime.test.js --rule "linebreak-style: off"`
- `npm run build`
