### PR TITLE
[v1.4.0-beta] 댓글 길이 편집 UI와 재생목록 댓글 표시 개선

### DIFF
--- a/docs/mockups/2026-06-07-comment-range-long-video.html
+++ b/docs/mockups/2026-06-07-comment-range-long-video.html
@@ -1,0 +1,503 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BAEFRAME 긴 영상 댓글 구간 목업</title>
+  <style>
+    :root {
+      --bg: #101214;
+      --panel: #181b1f;
+      --panel-2: #20242a;
+      --line: #333942;
+      --text: #edf1f5;
+      --muted: #9ba5b1;
+      --accent: #ffd000;
+      --blue: #4a9eff;
+      --green: #4ade80;
+      --orange: #f59e0b;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "Pretendard Variable", "Segoe UI", sans-serif;
+    }
+
+    .app {
+      display: grid;
+      grid-template-rows: 52px 1fr;
+      min-height: 100vh;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+      padding: 0 18px;
+      border-bottom: 1px solid var(--line);
+      background: #15181c;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: 0;
+    }
+
+    .controls {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    button,
+    label.toggle {
+      height: 30px;
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 0 10px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: var(--panel-2);
+      color: var(--muted);
+      font: inherit;
+      font-size: 12px;
+      cursor: pointer;
+    }
+
+    button.active,
+    label.toggle.active {
+      border-color: var(--accent);
+      color: var(--accent);
+      background: rgba(255, 208, 0, 0.11);
+    }
+
+    label.toggle input {
+      accent-color: var(--accent);
+    }
+
+    main {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 300px;
+      min-height: 0;
+    }
+
+    .workspace {
+      display: grid;
+      grid-template-rows: 1fr 184px;
+      min-width: 0;
+    }
+
+    .viewer {
+      display: grid;
+      place-items: center;
+      min-height: 260px;
+      background:
+        linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+        #0d0f12;
+      background-size: 48px 48px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .viewer-frame {
+      width: min(760px, 82%);
+      aspect-ratio: 16 / 9;
+      border: 1px solid #39414c;
+      background: linear-gradient(135deg, #161b22, #2a313a);
+      display: grid;
+      place-items: center;
+      color: #cfd6df;
+      font-size: 13px;
+    }
+
+    .timeline {
+      display: grid;
+      grid-template-columns: 112px minmax(0, 1fr);
+      grid-template-rows: 36px 36px 44px 44px;
+      background: var(--panel);
+      border-top: 1px solid #242a31;
+    }
+
+    .timeline-title,
+    .track-label {
+      display: flex;
+      align-items: center;
+      padding: 0 14px;
+      border-right: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    .ruler,
+    .track {
+      position: relative;
+      border-bottom: 1px solid var(--line);
+      overflow: visible;
+    }
+
+    .ruler {
+      background: #15181c;
+    }
+
+    .tick {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .tick span {
+      position: absolute;
+      top: 10px;
+      left: 6px;
+      color: var(--muted);
+      font-size: 11px;
+      white-space: nowrap;
+    }
+
+    .video-strip {
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 8px;
+      height: 20px;
+      border-radius: 4px;
+      background: linear-gradient(90deg, #29313b, #364150);
+      border: 1px solid #465160;
+    }
+
+    .comment-track {
+      height: 44px;
+      cursor: default;
+    }
+
+    .comment-range-item,
+    .comment-cluster-badge {
+      position: absolute;
+      top: 12px;
+      height: 20px;
+      border-radius: 4px;
+      border-left: 3px solid var(--blue);
+      border-right: 3px solid var(--blue);
+      background: rgba(74, 158, 255, 0.28);
+      overflow: hidden;
+      min-width: 2px;
+    }
+
+    .comment-range-item.resolved {
+      border-color: var(--green);
+      background: rgba(74, 222, 128, 0.23);
+    }
+
+    .comment-cluster-badge {
+      display: grid;
+      place-items: center;
+      min-width: 24px;
+      border: 0;
+      background: linear-gradient(135deg, #f59e0b, #d97706);
+      color: white;
+      font-size: 12px;
+      font-weight: 800;
+    }
+
+    .comment-range-item.ctrl-resize-candidate,
+    .comment-cluster-badge.ctrl-resize-candidate {
+      overflow: visible;
+      z-index: 20;
+      cursor: ew-resize;
+    }
+
+    .comment-range-item.ctrl-resize-candidate::before,
+    .comment-cluster-badge.ctrl-resize-candidate::before {
+      content: '';
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: max(72px, calc(100% + 16px));
+      height: calc(100% + 14px);
+      transform: translate(-50%, -50%);
+      border: 1px solid rgba(255, 208, 0, 0.82);
+      border-radius: 8px;
+      background: rgba(255, 208, 0, 0.16);
+      box-shadow: 0 0 18px rgba(255, 208, 0, 0.34);
+      z-index: -1;
+    }
+
+    .comment-range-item.ctrl-resize-candidate::after,
+    .comment-cluster-badge.ctrl-resize-candidate::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      width: 8px;
+      height: calc(100% + 12px);
+      transform: translateY(-50%);
+      border-radius: 999px;
+      background: var(--accent);
+      box-shadow: 0 0 10px rgba(255, 208, 0, 0.72);
+    }
+
+    .comment-range-item.ctrl-resize-left::after,
+    .comment-cluster-badge.ctrl-resize-left::after {
+      left: -8px;
+    }
+
+    .comment-range-item.ctrl-resize-right::after,
+    .comment-cluster-badge.ctrl-resize-right::after {
+      right: -8px;
+    }
+
+    aside {
+      border-left: 1px solid var(--line);
+      background: #15181c;
+      min-width: 0;
+      display: grid;
+      grid-template-rows: 42px 1fr;
+    }
+
+    .side-title {
+      display: flex;
+      align-items: center;
+      padding: 0 14px;
+      border-bottom: 1px solid var(--line);
+      font-size: 13px;
+      font-weight: 700;
+    }
+
+    .comment-list {
+      padding: 10px;
+      display: grid;
+      gap: 8px;
+      align-content: start;
+    }
+
+    .comment-row {
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      padding: 10px;
+      background: var(--panel);
+    }
+
+    .comment-row strong {
+      display: block;
+      font-size: 12px;
+      margin-bottom: 5px;
+    }
+
+    .comment-row span {
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    .readout {
+      color: var(--accent);
+      min-width: 190px;
+      font-size: 12px;
+      text-align: right;
+    }
+
+    @media (max-width: 900px) {
+      main {
+        grid-template-columns: 1fr;
+      }
+
+      aside {
+        display: none;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <header>
+      <h1>BAEFRAME 긴 영상 댓글 구간 목업</h1>
+      <div class="controls">
+        <button class="duration-btn active" data-duration="300">5분 영상</button>
+        <button class="duration-btn" data-duration="600">10분 영상</button>
+        <label class="toggle" id="ctrlToggleLabel">
+          <input id="ctrlToggle" type="checkbox">
+          Ctrl 리사이즈 모드
+        </label>
+        <div class="readout" id="readout">긴 영상 댓글 구간</div>
+      </div>
+    </header>
+    <main>
+      <section class="workspace">
+        <div class="viewer">
+          <div class="viewer-frame">더미 영상 프레임</div>
+        </div>
+        <div class="timeline">
+          <div class="timeline-title">타임라인</div>
+          <div class="ruler" id="ruler"></div>
+          <div class="track-label">영상</div>
+          <div class="track"><div class="video-strip"></div></div>
+          <div class="track-label">댓글</div>
+          <div class="track comment-track" id="commentTrack"></div>
+          <div class="track-label">선택</div>
+          <div class="track" id="selectionTrack"></div>
+        </div>
+      </section>
+      <aside>
+        <div class="side-title">댓글 탭</div>
+        <div class="comment-list" id="commentList"></div>
+      </aside>
+    </main>
+  </div>
+
+  <script>
+    const data = {
+      300: [
+        { start: 12, end: 18, text: '초반 컷 타이밍 확인' },
+        { start: 83, end: 86, text: '3초짜리 짧은 댓글' },
+        { start: 142, end: 145, text: '배경 깜빡임' },
+        { start: 205, end: 216, text: '길게 잡힌 연출 코멘트' },
+        { start: 251, end: 253, text: '2초 댓글', resolved: true }
+      ],
+      600: [
+        { start: 24, end: 30, text: '10분 영상 초반 수정' },
+        { start: 188, end: 191, text: '작은 바 테스트' },
+        { start: 304, end: 307, text: '겹침 A' },
+        { start: 305, end: 310, text: '겹침 B', cluster: true },
+        { start: 486, end: 492, text: '후반부 짧은 댓글' },
+        { start: 574, end: 576, text: '마지막 2초', resolved: true }
+      ]
+    };
+
+    let duration = 300;
+    const track = document.getElementById('commentTrack');
+    const ruler = document.getElementById('ruler');
+    const list = document.getElementById('commentList');
+    const readout = document.getElementById('readout');
+    const ctrlToggle = document.getElementById('ctrlToggle');
+    const ctrlToggleLabel = document.getElementById('ctrlToggleLabel');
+
+    function formatTime(value) {
+      const m = Math.floor(value / 60);
+      const s = String(Math.floor(value % 60)).padStart(2, '0');
+      return `${m}:${s}`;
+    }
+
+    function renderRuler() {
+      ruler.innerHTML = '';
+      const step = duration === 600 ? 120 : 60;
+      for (let t = 0; t <= duration; t += step) {
+        const tick = document.createElement('div');
+        tick.className = 'tick';
+        tick.style.left = `${(t / duration) * 100}%`;
+        const label = document.createElement('span');
+        label.textContent = formatTime(t);
+        tick.appendChild(label);
+        ruler.appendChild(tick);
+      }
+    }
+
+    function renderComments() {
+      track.innerHTML = '';
+      list.innerHTML = '';
+      data[duration].forEach((item, index) => {
+        const el = document.createElement('div');
+        el.className = item.cluster ? 'comment-cluster-badge' : 'comment-range-item';
+        if (item.resolved) el.classList.add('resolved');
+        el.dataset.index = String(index);
+        el.style.left = `${(item.start / duration) * 100}%`;
+        el.style.width = `${Math.max(((item.end - item.start) / duration) * 100, 0.24)}%`;
+        el.textContent = item.cluster ? '+2' : '';
+        track.appendChild(el);
+
+        const row = document.createElement('div');
+        row.className = 'comment-row';
+        row.innerHTML = `<strong>${item.text}</strong><span>${formatTime(item.start)} - ${formatTime(item.end)}</span>`;
+        list.appendChild(row);
+      });
+    }
+
+    function clearCandidate() {
+      document.querySelectorAll('.ctrl-resize-candidate').forEach(el => {
+        el.classList.remove('ctrl-resize-candidate', 'ctrl-resize-left', 'ctrl-resize-right');
+      });
+    }
+
+    function findCandidate(event) {
+      const items = [...track.querySelectorAll('.comment-range-item, .comment-cluster-badge')];
+      let best = null;
+      for (const el of items) {
+        const rect = el.getBoundingClientRect();
+        const extra = Math.max(0, (44 - rect.width) / 2);
+        const hit = {
+          left: rect.left - extra,
+          right: rect.right + extra,
+          top: rect.top - 10,
+          bottom: rect.bottom + 10
+        };
+        const inside = event.clientX >= hit.left && event.clientX <= hit.right &&
+          event.clientY >= hit.top && event.clientY <= hit.bottom;
+        if (!inside) continue;
+        const score = Math.abs(event.clientY - (rect.top + rect.height / 2)) +
+          Math.max(rect.left - event.clientX, event.clientX - rect.right, 0);
+        if (!best || score < best.score) {
+          best = {
+            el,
+            edge: event.clientX <= rect.left + rect.width / 2 ? 'left' : 'right',
+            score
+          };
+        }
+      }
+      return best;
+    }
+
+    function updateCandidate(event) {
+      if (!ctrlToggle.checked && !event.ctrlKey) {
+        clearCandidate();
+        readout.textContent = '긴 영상 댓글 구간';
+        return;
+      }
+      clearCandidate();
+      const target = findCandidate(event);
+      if (!target) {
+        readout.textContent = '후보 없음';
+        return;
+      }
+      target.el.classList.add('ctrl-resize-candidate', `ctrl-resize-${target.edge}`);
+      const item = data[duration][Number(target.el.dataset.index)];
+      readout.textContent = `${target.edge === 'left' ? '시작점' : '끝점'} 조절: ${formatTime(item.start)} - ${formatTime(item.end)}`;
+    }
+
+    document.querySelectorAll('.duration-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        duration = Number(btn.dataset.duration);
+        document.querySelectorAll('.duration-btn').forEach(b => b.classList.toggle('active', b === btn));
+        renderRuler();
+        renderComments();
+        readout.textContent = duration === 600 ? '10분 긴 영상' : '5분 긴 영상';
+      });
+    });
+
+    ctrlToggle.addEventListener('change', () => {
+      ctrlToggleLabel.classList.toggle('active', ctrlToggle.checked);
+      if (!ctrlToggle.checked) clearCandidate();
+    });
+
+    track.addEventListener('mousemove', updateCandidate);
+    track.addEventListener('mouseleave', () => {
+      clearCandidate();
+      readout.textContent = '긴 영상 댓글 구간';
+    });
+
+    renderRuler();
+    renderComments();
+  </script>
+</body>
+</html>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -858,6 +858,11 @@
                 <line x1="15" y1="3" x2="15" y2="21"/>
               </svg>
             </button>
+            <label class="comment-timeline-toggle" title="댓글 지속시간 구간 표시/숨김">
+              <input type="checkbox" id="toggleCommentTimelineRanges" checked>
+              <span class="comment-timeline-toggle-box" aria-hidden="true"></span>
+              <span class="comment-timeline-toggle-label">댓글 구간</span>
+            </label>
             <div class="zoom-buttons">
               <button class="zoom-btn" id="btnTimelineZoomOut" title="축소">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/></svg>

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -23,6 +23,7 @@ import { getVersionManager } from './modules/version-manager.js';
 import { getVersionDropdown } from './modules/version-dropdown.js';
 import { getSplitViewManager } from './modules/split-view-manager.js';
 import { getPlaylistManager } from './modules/playlist-manager.js';
+import { resizeClusterMembersByEdge } from './modules/comment-cluster.js';
 import { getCutlistManager } from './modules/cutlist-manager.js';
 import { findCurrentCut, mapGlobalTimeToCut } from './modules/cutlist-core.js';
 import {
@@ -112,6 +113,7 @@ async function initApp() {
     timelineSection: document.getElementById('timelineSection'),
     zoomSlider: document.getElementById('zoomSlider'),
     zoomDisplay: document.getElementById('zoomDisplay'),
+    toggleCommentTimelineRanges: document.getElementById('toggleCommentTimelineRanges'),
     playheadLine: document.getElementById('playheadLine'),
     playheadHandle: document.getElementById('playheadHandle'),
     videoTrackClip: document.getElementById('videoTrackClip'),
@@ -3330,6 +3332,10 @@ async function initApp() {
   let commentDragState = null;
   let commentJustDragged = false; // 드래그 직후 click 차단용 1-tick 플래그
   let commentInteractionsBound = false; // 위임 리스너 1회 바인딩 가드
+  let ctrlCommentResizeKeyDown = false;
+  let ctrlCommentResizeCandidate = null;
+  const CTRL_COMMENT_RESIZE_MIN_HIT_WIDTH = 72;
+  const CTRL_COMMENT_RESIZE_VERTICAL_PAD = 10;
 
   // 클러스터 호버 툴팁 상태
   let clusterTooltipEl = null;
@@ -3524,6 +3530,258 @@ async function initApp() {
     renderCommentRanges();
   }
 
+  function getEditableClusterMembers(clusterBadge) {
+    const key = clusterBadge?.dataset.clusterKey;
+    if (!key) return [];
+    return key.split('|')
+      .map(markerId => commentManager.getMarker(markerId))
+      .filter(Boolean);
+  }
+
+  function getResizeEdgeFromRectHalf(rect, clientX) {
+    return clientX <= rect.left + rect.width / 2 ? 'left' : 'right';
+  }
+
+  function getResizeEdgeFromElementHalf(element, e) {
+    return getResizeEdgeFromRectHalf(element.getBoundingClientRect(), e.clientX);
+  }
+
+  function getCtrlCommentResizeHitRect(rect) {
+    const extraX = Math.max(0, (CTRL_COMMENT_RESIZE_MIN_HIT_WIDTH - rect.width) / 2);
+    return {
+      left: rect.left - extraX,
+      right: rect.right + extraX,
+      top: rect.top - CTRL_COMMENT_RESIZE_VERTICAL_PAD,
+      bottom: rect.bottom + CTRL_COMMENT_RESIZE_VERTICAL_PAD
+    };
+  }
+
+  function isPointInClientRect(rect, clientX, clientY) {
+    return clientX >= rect.left &&
+      clientX <= rect.right &&
+      clientY >= rect.top &&
+      clientY <= rect.bottom;
+  }
+
+  function findCtrlCommentResizeTarget(e) {
+    if (!commentTrack) return null;
+    const candidates = Array.from(
+      commentTrack.querySelectorAll('.comment-range-item, .comment-cluster-badge')
+    );
+    let best = null;
+
+    for (const element of candidates) {
+      const rect = element.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) continue;
+
+      const hitRect = getCtrlCommentResizeHitRect(rect);
+      if (!isPointInClientRect(hitRect, e.clientX, e.clientY)) continue;
+
+      const centerY = rect.top + rect.height / 2;
+      const overflowX = Math.max(rect.left - e.clientX, e.clientX - rect.right, 0);
+      const score = Math.abs(e.clientY - centerY) * 2 + overflowX;
+      if (!best || score < best.score) {
+        best = {
+          element,
+          edge: getResizeEdgeFromRectHalf(rect, e.clientX),
+          score
+        };
+      }
+    }
+
+    return best;
+  }
+
+  function clearCtrlCommentResizeCandidate() {
+    if (ctrlCommentResizeCandidate?.element) {
+      ctrlCommentResizeCandidate.element.classList.remove(
+        'ctrl-resize-candidate',
+        'ctrl-resize-left',
+        'ctrl-resize-right'
+      );
+    }
+    ctrlCommentResizeCandidate = null;
+    commentTrack?.classList.remove('ctrl-resize-active');
+  }
+
+  function setCtrlCommentResizeCandidate(target) {
+    if (
+      ctrlCommentResizeCandidate?.element === target?.element &&
+      ctrlCommentResizeCandidate?.edge === target?.edge
+    ) {
+      return;
+    }
+
+    clearCtrlCommentResizeCandidate();
+    if (!target?.element) return;
+
+    target.element.classList.add('ctrl-resize-candidate', `ctrl-resize-${target.edge}`);
+    ctrlCommentResizeCandidate = target;
+    commentTrack?.classList.add('ctrl-resize-active');
+  }
+
+  function updateCtrlCommentResizeCandidate(e) {
+    if (commentDragState || (!e.ctrlKey && !ctrlCommentResizeKeyDown)) {
+      clearCtrlCommentResizeCandidate();
+      return;
+    }
+
+    const target = findCtrlCommentResizeTarget(e);
+    setCtrlCommentResizeCandidate(target);
+  }
+
+  function getClusterResizeEdgeFromEvent(clusterBadge, e) {
+    const clusterHandle = e.target.closest('.comment-cluster-handle');
+    if (clusterHandle?.dataset.handle) {
+      return clusterHandle.dataset.handle;
+    }
+
+    return getResizeEdgeFromElementHalf(clusterBadge, e);
+  }
+
+  function beginCommentRangeResize(item, marker, handle, e) {
+    const markerId = item.dataset.markerId;
+    const layerId = item.dataset.layerId;
+    e.preventDefault();
+    e.stopPropagation();
+    clearCtrlCommentResizeCandidate();
+    commentDragState = {
+      layerId,
+      markerId,
+      handle,
+      startX: e.clientX,
+      startFrame: marker.startFrame,
+      endFrame: marker.endFrame,
+      duration: marker.endFrame - marker.startFrame,
+      originalStartFrame: marker.startFrame,
+      originalEndFrame: marker.endFrame
+    };
+    item.classList.add('dragging');
+    document.body.style.cursor = 'ew-resize';
+  }
+
+  function beginCommentRangeMove(item, marker, e) {
+    const markerId = item.dataset.markerId;
+    const layerId = item.dataset.layerId;
+    e.preventDefault();
+    commentDragState = {
+      layerId,
+      markerId,
+      handle: 'move',
+      startX: e.clientX,
+      startFrame: marker.startFrame,
+      endFrame: marker.endFrame,
+      duration: marker.endFrame - marker.startFrame,
+      originalStartFrame: marker.startFrame,
+      originalEndFrame: marker.endFrame
+    };
+    item.classList.add('dragging');
+    document.body.style.cursor = 'grabbing';
+  }
+
+  function beginCommentClusterResize(clusterBadge, edge, e) {
+    const members = getEditableClusterMembers(clusterBadge);
+    if (members.length === 0) return false;
+
+    if (!members.every(marker => commentManager.canEdit(marker))) {
+      showToast('본인 코멘트만 수정할 수 있습니다.', 'warning');
+      return false;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+    hideClusterTooltip();
+    cancelClusterTooltip();
+    clearCtrlCommentResizeCandidate();
+
+    commentDragState = {
+      type: 'cluster',
+      clusterKey: clusterBadge.dataset.clusterKey,
+      handle: edge,
+      startX: e.clientX,
+      members: members.map(marker => ({
+        layerId: marker.layerId,
+        markerId: marker.id,
+        startFrame: marker.startFrame,
+        endFrame: marker.endFrame
+      })),
+      originalMembers: members.map(marker => ({
+        layerId: marker.layerId,
+        markerId: marker.id,
+        startFrame: marker.startFrame,
+        endFrame: marker.endFrame
+      }))
+    };
+
+    clusterBadge.classList.add('dragging');
+    document.body.style.cursor = 'ew-resize';
+    return true;
+  }
+
+  function applyCommentClusterResize(e) {
+    const { handle, startX, members } = commentDragState;
+    const trackRect = commentTrack.getBoundingClientRect();
+    const totalFrames = timeline.totalFrames || 1;
+    const deltaX = e.clientX - startX;
+    const deltaFrames = Math.round((deltaX / trackRect.width) * totalFrames);
+    const { updates } = resizeClusterMembersByEdge(members, {
+      edge: handle,
+      deltaFrames,
+      totalFrames
+    });
+
+    for (const update of updates) {
+      commentManager.updateMarker(update.markerId, {
+        startFrame: update.startFrame,
+        endFrame: update.endFrame
+      });
+    }
+    renderCommentRanges();
+  }
+
+  function finishCommentClusterResize(dragState) {
+    const nextMembers = dragState.originalMembers.map(original => {
+      const marker = commentManager.getMarker(original.markerId);
+      return {
+        ...original,
+        startFrame: marker?.startFrame ?? original.startFrame,
+        endFrame: marker?.endFrame ?? original.endFrame
+      };
+    });
+
+    const changed = nextMembers.some((next, index) =>
+      next.startFrame !== dragState.originalMembers[index].startFrame ||
+      next.endFrame !== dragState.originalMembers[index].endFrame
+    );
+
+    if (!changed) return;
+
+    pushUndo({
+      type: 'comment-cluster-range',
+      data: { clusterKey: dragState.clusterKey },
+      undo: () => {
+        for (const original of dragState.originalMembers) {
+          commentManager.updateMarker(original.markerId, {
+            startFrame: original.startFrame,
+            endFrame: original.endFrame
+          });
+        }
+        renderCommentRanges();
+        reviewDataManager.save();
+      },
+      redo: () => {
+        for (const next of nextMembers) {
+          commentManager.updateMarker(next.markerId, {
+            startFrame: next.startFrame,
+            endFrame: next.endFrame
+          });
+        }
+        renderCommentRanges();
+        reviewDataManager.save();
+      }
+    });
+  }
+
   // 댓글 범위 상호작용 설정 — commentTrack 1곳에 이벤트 위임 (1회만 바인딩)
   // 위임으로 전환한 이유: PR #112 이후 클러스터 펼침 시 .comment-range-item이 재생성되는데
   // 요소별 바인딩 방식은 재렌더 후 이벤트가 비어 편집 regression이 발생했다.
@@ -3591,15 +3849,40 @@ async function initApp() {
         return;
       }
 
-      // 2) 클러스터 배지 → 펼치기 토글
+      // 2) 클러스터 배지 → Ctrl/핸들은 그룹 리사이즈, 일반 클릭은 펼치기 토글
+      const clusterHandle = e.target.closest('.comment-cluster-handle');
       const clusterBadge = e.target.closest('.comment-cluster-badge');
       if (clusterBadge) {
         e.preventDefault();
         e.stopPropagation();
+        if (e.ctrlKey || clusterHandle) {
+          const edge = getClusterResizeEdgeFromEvent(clusterBadge, e);
+          beginCommentClusterResize(clusterBadge, edge, e);
+          return;
+        }
         const key = clusterBadge.dataset.clusterKey;
         timeline.expandedClusterId = (timeline.expandedClusterId === key) ? null : key;
         timeline.renderCommentRanges(timeline._lastComments || []);
         return;
+      }
+
+      if (e.ctrlKey) {
+        const ctrlTarget = findCtrlCommentResizeTarget(e);
+        if (ctrlTarget) {
+          if (ctrlTarget.element.classList.contains('comment-cluster-badge')) {
+            beginCommentClusterResize(ctrlTarget.element, ctrlTarget.edge, e);
+            return;
+          }
+
+          const marker = commentManager.getMarker(ctrlTarget.element.dataset.markerId);
+          if (!marker) return;
+          if (!commentManager.canEdit(marker)) {
+            showToast('본인 코멘트만 수정할 수 있습니다.', 'warning');
+            return;
+          }
+          beginCommentRangeResize(ctrlTarget.element, marker, ctrlTarget.edge, e);
+          return;
+        }
       }
 
       // 3) 핸들 mousedown → 리사이즈 시작
@@ -3608,28 +3891,13 @@ async function initApp() {
         const item = handle.closest('.comment-range-item');
         if (!item) return;
         const markerId = item.dataset.markerId;
-        const layerId = item.dataset.layerId;
         const marker = commentManager.getMarker(markerId);
         if (!marker) return;
         if (!commentManager.canEdit(marker)) {
           showToast('본인 코멘트만 수정할 수 있습니다.', 'warning');
           return;
         }
-        e.preventDefault();
-        e.stopPropagation();
-        commentDragState = {
-          layerId,
-          markerId,
-          handle: handle.dataset.handle, // 'left' or 'right'
-          startX: e.clientX,
-          startFrame: marker.startFrame,
-          endFrame: marker.endFrame,
-          duration: marker.endFrame - marker.startFrame,
-          originalStartFrame: marker.startFrame,
-          originalEndFrame: marker.endFrame
-        };
-        item.classList.add('dragging');
-        document.body.style.cursor = 'ew-resize';
+        beginCommentRangeResize(item, marker, handle.dataset.handle, e);
         return;
       }
 
@@ -3637,7 +3905,6 @@ async function initApp() {
       const item = e.target.closest('.comment-range-item');
       if (item) {
         const markerId = item.dataset.markerId;
-        const layerId = item.dataset.layerId;
         const marker = commentManager.getMarker(markerId);
         if (!marker) return;
         if (!commentManager.canEdit(marker)) {
@@ -3645,19 +3912,13 @@ async function initApp() {
           return;
         }
         e.preventDefault();
-        commentDragState = {
-          layerId,
-          markerId,
-          handle: 'move',
-          startX: e.clientX,
-          startFrame: marker.startFrame,
-          endFrame: marker.endFrame,
-          duration: marker.endFrame - marker.startFrame,
-          originalStartFrame: marker.startFrame,
-          originalEndFrame: marker.endFrame
-        };
-        item.classList.add('dragging');
-        document.body.style.cursor = 'grabbing';
+
+        if (e.ctrlKey) {
+          beginCommentRangeResize(item, marker, getResizeEdgeFromElementHalf(item, e), e);
+          return;
+        }
+
+        beginCommentRangeMove(item, marker, e);
       }
     });
 
@@ -3680,6 +3941,9 @@ async function initApp() {
       cancelClusterTooltip();
       hideClusterTooltip();
     });
+
+    commentTrack.addEventListener('mousemove', updateCtrlCommentResizeCandidate);
+    commentTrack.addEventListener('mouseleave', clearCtrlCommentResizeCandidate);
   }
 
   function cancelClusterTooltip() {
@@ -3761,9 +4025,30 @@ async function initApp() {
     tooltip.style.left = `${left}px`;
   }
 
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Control') return;
+    ctrlCommentResizeKeyDown = true;
+  });
+
+  document.addEventListener('keyup', (e) => {
+    if (e.key !== 'Control') return;
+    ctrlCommentResizeKeyDown = false;
+    clearCtrlCommentResizeCandidate();
+  });
+
+  window.addEventListener('blur', () => {
+    ctrlCommentResizeKeyDown = false;
+    clearCtrlCommentResizeCandidate();
+  });
+
   // 댓글 드래그 처리 (mousemove)
   document.addEventListener('mousemove', (e) => {
     if (!commentDragState) return;
+
+    if (commentDragState.type === 'cluster') {
+      applyCommentClusterResize(e);
+      return;
+    }
 
     const { layerId, markerId, handle, startX, startFrame, endFrame, duration } = commentDragState;
     const trackRect = commentTrack.getBoundingClientRect();
@@ -3833,6 +4118,21 @@ async function initApp() {
   // 댓글 드래그 종료
   document.addEventListener('mouseup', () => {
     if (commentDragState) {
+      if (commentDragState.type === 'cluster') {
+        const draggingCluster = commentTrack.querySelector(
+          `.comment-cluster-badge[data-cluster-key="${commentDragState.clusterKey}"]`
+        );
+        draggingCluster?.classList.remove('dragging');
+        finishCommentClusterResize(commentDragState);
+        commentDragState = null;
+        document.body.style.cursor = '';
+        clearCtrlCommentResizeCandidate();
+        commentJustDragged = true;
+        setTimeout(() => { commentJustDragged = false; }, 50);
+        reviewDataManager.save();
+        return;
+      }
+
       const { layerId, markerId, originalStartFrame, originalEndFrame } = commentDragState;
 
       const item = commentTrack.querySelector(
@@ -3875,6 +4175,7 @@ async function initApp() {
 
       commentDragState = null;
       document.body.style.cursor = '';
+      clearCtrlCommentResizeCandidate();
 
       // 드래그 직후 click 이벤트 차단 (클릭으로 오인한 접힘/선택 방지)
       commentJustDragged = true;
@@ -3900,6 +4201,7 @@ async function initApp() {
 
   commentManager.addEventListener('loaded', () => {
     void refreshCommentRangesForCurrentMode();
+    updateCommentList();
   });
 
   // ====== 비디오 줌/패닝 ======
@@ -8361,6 +8663,22 @@ async function initApp() {
     });
   }
 
+  function _syncCommentTimelineRangesToggleUI(show) {
+    if (elements.toggleCommentTimelineRanges) {
+      elements.toggleCommentTimelineRanges.checked = show;
+    }
+  }
+
+  const initCommentTimelineRangesVisible = userSettings.getShowCommentTimelineRanges();
+  timeline.setCommentRangesVisible(initCommentTimelineRangesVisible);
+  _syncCommentTimelineRangesToggleUI(initCommentTimelineRangesVisible);
+
+  elements.toggleCommentTimelineRanges?.addEventListener('change', (e) => {
+    const show = e.target.checked;
+    userSettings.setShowCommentTimelineRanges(show);
+    timeline.setCommentRangesVisible(show);
+  });
+
   // ====== 사용자 설정 모달 ======
   const userSettingsModal = document.getElementById('userSettingsModal');
   const userNameInput = document.getElementById('userNameInput');
@@ -11707,9 +12025,10 @@ async function initApp() {
 
     for (const segment of segments) {
       const item = items[segment.index];
-      if (!item?.bframePath) continue;
+      const bframePath = await playlistManager.ensureItemBframePath(item);
+      if (!bframePath) continue;
       try {
-        const bframeData = await window.electronAPI.loadReview(item.bframePath);
+        const bframeData = await window.electronAPI.loadReview(bframePath);
         if (playlistUIState.mode !== 'continuous' || playlistTimelineUpdateToken !== updateToken) return;
         if (!bframeData) continue;
         aggregateRanges.push(...extractPlaylistCommentRanges({
@@ -13420,7 +13739,7 @@ async function initApp() {
     const items = playlistManager.getItems();
     const progressById = new Map(await Promise.all(items.map(async item => [
       item.id,
-      await playlistManager.getItemProgress(item.bframePath)
+      await playlistManager.getItemProgress(item)
     ])));
 
     for (let i = 0; i < items.length; i++) {
@@ -13520,8 +13839,8 @@ async function initApp() {
     if (currentIndex < 0 || currentIndex >= items.length) return;
 
     const item = items[currentIndex];
-    // bframePath가 전달되면 사용, 아니면 아이템의 bframePath 사용
-    const pathToUse = bframePath || item.bframePath;
+    // bframePath가 전달되면 사용, 아니면 아이템에서 영상 옆 .bframe까지 복구
+    const pathToUse = bframePath || item;
     const progress = await playlistManager.getItemProgress(pathToUse);
 
     // 현재 아이템의 DOM 요소 찾기

--- a/renderer/scripts/modules/comment-cluster.js
+++ b/renderer/scripts/modules/comment-cluster.js
@@ -64,6 +64,55 @@ export function assignLanes(cluster) {
 }
 
 /**
+ * 렌더 단위 레인 할당 — 접힌 클러스터 배지와 단일 댓글이 서로 덮이지 않도록 배치.
+ *
+ * laneSpan은 펼친 클러스터처럼 세로로 여러 줄을 차지하는 렌더 단위가 예약할 줄 수다.
+ * @param {Array<{startFrame: number, endFrame: number, laneSpan?: number}>} items
+ * @returns {{lanes: Array<number>, maxLane: number}}
+ */
+export function assignRenderLanes(items) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return { lanes: [], maxLane: 0 };
+  }
+
+  const sorted = [...items].sort((a, b) =>
+    a.startFrame - b.startFrame || a.endFrame - b.endFrame
+  );
+  const laneEnds = [];
+
+  for (const item of sorted) {
+    const startFrame = Number.isFinite(item.startFrame) ? item.startFrame : 0;
+    const endFrame = Number.isFinite(item.endFrame)
+      ? Math.max(startFrame, item.endFrame)
+      : startFrame;
+    const laneSpan = Math.max(
+      1,
+      Math.floor(Number.isFinite(item.laneSpan) ? item.laneSpan : 1)
+    );
+
+    let assigned = 0;
+    while (true) {
+      let fits = true;
+      for (let i = 0; i < laneSpan; i++) {
+        if ((laneEnds[assigned + i] ?? -Infinity) > startFrame) {
+          fits = false;
+          break;
+        }
+      }
+      if (fits) break;
+      assigned++;
+    }
+
+    for (let i = 0; i < laneSpan; i++) {
+      laneEnds[assigned + i] = endFrame;
+    }
+    item._lane = assigned;
+  }
+
+  return { lanes: laneEnds, maxLane: laneEnds.length };
+}
+
+/**
  * 클러스터 고유 식별자 — 클러스터 내 모든 markerId를 정렬해 조합.
  * 정렬 순서가 바뀌거나 단일 댓글 위치가 이동해도 클러스터 구성원이 같은 한 안정된 키 반환.
  * @param {Array} cluster
@@ -72,6 +121,68 @@ export function assignLanes(cluster) {
 export function clusterKey(cluster) {
   if (!cluster || cluster.length === 0) return null;
   return cluster.map(c => c.markerId).sort().join('|');
+}
+
+function getFiniteFrame(value, fallback = 0) {
+  const frame = Number(value);
+  return Number.isFinite(frame) ? frame : fallback;
+}
+
+function clampDelta(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * 접힌 댓글 클러스터의 한쪽 끝을 조절할 때 모든 멤버에 적용할 frame 업데이트 계산.
+ *
+ * 각 댓글의 길이는 최소 1프레임을 유지하며, 가능한 범위 안에서 모든 댓글에 같은 delta를 적용한다.
+ *
+ * @param {Array<{markerId: string, startFrame: number, endFrame: number}>} cluster
+ * @param {{edge: 'left'|'right', deltaFrames: number, totalFrames?: number}} opts
+ * @returns {{appliedDeltaFrames: number, updates: Array}}
+ */
+export function resizeClusterMembersByEdge(cluster, opts = {}) {
+  if (!Array.isArray(cluster) || cluster.length === 0) {
+    return { appliedDeltaFrames: 0, updates: [] };
+  }
+
+  const edge = opts.edge === 'right' ? 'right' : 'left';
+  const deltaFrames = Math.round(getFiniteFrame(opts.deltaFrames, 0));
+  const totalFrames = getFiniteFrame(opts.totalFrames, 0);
+  const normalized = cluster.map(item => {
+    const startFrame = getFiniteFrame(item.startFrame, 0);
+    const endFrame = Math.max(startFrame + 1, getFiniteFrame(item.endFrame, startFrame + 1));
+    return { ...item, startFrame, endFrame };
+  });
+
+  let appliedDeltaFrames;
+  if (edge === 'left') {
+    const minStart = Math.min(...normalized.map(item => item.startFrame));
+    const maxShrink = Math.min(...normalized.map(item => item.endFrame - item.startFrame - 1));
+    appliedDeltaFrames = clampDelta(deltaFrames, -minStart, maxShrink);
+  } else {
+    const maxEnd = Math.max(...normalized.map(item => item.endFrame));
+    const maxShrink = Math.min(...normalized.map(item => item.endFrame - item.startFrame - 1));
+    const maxGrow = totalFrames > 0 ? Math.max(0, totalFrames - maxEnd) : Number.POSITIVE_INFINITY;
+    appliedDeltaFrames = clampDelta(deltaFrames, -maxShrink, maxGrow);
+  }
+
+  const updates = normalized.map(item => {
+    if (edge === 'left') {
+      return {
+        ...item,
+        startFrame: item.startFrame + appliedDeltaFrames,
+        endFrame: item.endFrame
+      };
+    }
+    return {
+      ...item,
+      startFrame: item.startFrame,
+      endFrame: item.endFrame + appliedDeltaFrames
+    };
+  });
+
+  return { appliedDeltaFrames, updates };
 }
 
 /**

--- a/renderer/scripts/modules/playlist-manager.js
+++ b/renderer/scripts/modules/playlist-manager.js
@@ -211,13 +211,20 @@ export class PlaylistManager {
       this.currentIndex = this.currentPlaylist.items.length > 0 ? 0 : -1;
       this.isModified = false;
 
+      const repairedBframeCount = await this._repairMissingBframePaths();
+
       // 썸네일 경로 검증 및 재생성
       await this._validateThumbnails();
+
+      if (repairedBframeCount > 0) {
+        await this.save(filePath);
+      }
 
       await this.onPlaylistLoaded?.(this.currentPlaylist);
       log.info('재생목록 로드 완료', {
         name: data.name,
-        itemCount: data.items.length
+        itemCount: data.items.length,
+        repairedBframeCount
       });
 
       return this.currentPlaylist;
@@ -551,7 +558,11 @@ export class PlaylistManager {
   /**
    * 개별 아이템의 피드백 완료율 계산
    */
-  async getItemProgress(bframePath) {
+  async getItemProgress(itemOrBframePath) {
+    const bframePath = typeof itemOrBframePath === 'object' && itemOrBframePath !== null
+      ? await this.ensureItemBframePath(itemOrBframePath)
+      : itemOrBframePath;
+
     if (!bframePath) {
       return { total: 0, resolved: 0, percent: 0, hasData: false };
     }
@@ -599,7 +610,7 @@ export class PlaylistManager {
     let resolvedMarkers = 0;
 
     for (const item of this.currentPlaylist.items) {
-      const progress = await this.getItemProgress(item.bframePath);
+      const progress = await this.getItemProgress(item);
       totalMarkers += progress.total;
       resolvedMarkers += progress.resolved;
     }
@@ -704,6 +715,59 @@ export class PlaylistManager {
     } catch {
       return '';
     }
+  }
+
+  async ensureItemBframePath(item, options = {}) {
+    if (!item?.videoPath) return '';
+
+    const savedPath = String(item.bframePath || '').trim();
+    if (savedPath) {
+      try {
+        if (await window.electronAPI.fileExists(savedPath)) {
+          return savedPath;
+        }
+      } catch {
+        return savedPath;
+      }
+    }
+
+    const inferredPath = await this._findBframePath(item.videoPath);
+    if (!inferredPath) {
+      return savedPath;
+    }
+
+    if (item.bframePath !== inferredPath) {
+      item.bframePath = inferredPath;
+      if (options.markModified !== false) {
+        this.isModified = true;
+      }
+      if (options.notify === true) {
+        this.onPlaylistModified?.();
+      }
+    }
+
+    return item.bframePath || '';
+  }
+
+  async _repairMissingBframePaths() {
+    if (!this.currentPlaylist?.items) return 0;
+
+    let repairedCount = 0;
+    for (const item of this.currentPlaylist.items) {
+      const previousPath = item.bframePath || '';
+      const nextPath = await this.ensureItemBframePath(item, {
+        markModified: false,
+        notify: false
+      });
+      if (nextPath && nextPath !== previousPath) {
+        repairedCount++;
+      }
+    }
+
+    if (repairedCount > 0) {
+      this.isModified = true;
+    }
+    return repairedCount;
   }
 
   /**

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -6,7 +6,7 @@
 import { createLogger } from '../logger.js';
 import { MARKER_COLORS } from './comment-manager.js';
 import { resolveFrameGridTier } from './frame-grid-tiers.js';
-import { findRangeClusters, assignLanes, clusterKey, splitClustersByPixelGap } from './comment-cluster.js';
+import { findRangeClusters, assignLanes, assignRenderLanes, clusterKey, splitClustersByPixelGap } from './comment-cluster.js';
 import { getTimelineFocalContentX, calculateAnchoredScrollLeft } from './timeline-zoom-core.js';
 import { formatPlaylistCommentLabel, formatPlaylistCommentTitle } from './playlist-comment-index.js';
 
@@ -48,6 +48,9 @@ export class Timeline extends EventTarget {
     // 클러스터 펼침/접힘 상태
     this.expandedClusterId = null;  // 현재 펼친 클러스터의 키 (markerId)
     this._lastComments = null;      // 펼치기/접기 재렌더용 캐시
+    this.commentRangesVisible = true;
+    this._lastPlaylistCommentRanges = null;
+    this._lastPlaylistCommentDuration = 0;
     this.playlistSegments = [];
     this.playlistDuration = 0;
     this.cutlistSegments = [];
@@ -1979,6 +1982,31 @@ export class Timeline extends EventTarget {
     // setupCommentRangeInteractions()에서 드래그 가드와 함께 위임 처리한다.
   }
 
+  setCommentRangesVisible(visible) {
+    this.commentRangesVisible = visible !== false;
+    if (!this.commentTrack) return;
+
+    if (!this.commentRangesVisible) {
+      this.commentTrack.style.display = 'none';
+      if (this.commentLayerHeader) {
+        this.commentLayerHeader.style.display = 'none';
+      }
+      return;
+    }
+
+    if (Array.isArray(this._lastPlaylistCommentRanges)) {
+      this.renderPlaylistCommentRanges(
+        this._lastPlaylistCommentRanges,
+        this._lastPlaylistCommentDuration
+      );
+      return;
+    }
+
+    if (Array.isArray(this._lastComments)) {
+      this.renderCommentRanges(this._lastComments);
+    }
+  }
+
   setPlaylistTimeline(segments, totalDuration) {
     this.playlistSegments = segments || [];
     this.playlistDuration = totalDuration || 0;
@@ -2121,12 +2149,22 @@ export class Timeline extends EventTarget {
 
   renderPlaylistCommentRanges(ranges, totalDuration) {
     if (!this.commentTrack) return;
+    this._lastPlaylistCommentRanges = ranges || [];
+    this._lastPlaylistCommentDuration = totalDuration || this.playlistDuration || this.duration || 0;
     this.commentTrack.querySelectorAll(
       '.playlist-comment-range, .comment-range-item, .comment-cluster-badge, .comment-cluster-close-badge'
     ).forEach(el => el.remove());
     this._lastComments = null;
     this.expandedClusterId = null;
-    const duration = totalDuration || this.playlistDuration || this.duration;
+    if (!this.commentRangesVisible) {
+      this.commentTrack.style.display = 'none';
+      if (this.commentLayerHeader) {
+        this.commentLayerHeader.style.display = 'none';
+      }
+      return;
+    }
+
+    const duration = this._lastPlaylistCommentDuration;
     if (!duration) {
       this.commentTrack.style.display = 'none';
       if (this.commentLayerHeader) {
@@ -2179,9 +2217,19 @@ export class Timeline extends EventTarget {
 
     // 데이터 캐시 (펼침/접힘 재렌더용)
     this._lastComments = comments;
+    this._lastPlaylistCommentRanges = null;
+    this._lastPlaylistCommentDuration = 0;
 
     // 기존 댓글 제거
     this.commentTrack.innerHTML = '';
+
+    if (!this.commentRangesVisible) {
+      this.commentTrack.style.display = 'none';
+      if (this.commentLayerHeader) {
+        this.commentLayerHeader.style.display = 'none';
+      }
+      return;
+    }
 
     // 댓글이 없으면 트랙 및 레이어 헤더 숨김 (기존 로직 유지)
     if (!comments || comments.length === 0) {
@@ -2221,17 +2269,28 @@ export class Timeline extends EventTarget {
       }
     }
 
-    // 3) 최대 레인 수 계산 — 펼친 클러스터가 있으면 그 클러스터의 레인 수
-    //    assignLanes 호출 결과(_lane)를 여기서 메모이제이션하여 step 5에서 재호출하지 않음
-    let maxLanes = 1;
+    // 3) 렌더 단위 레인 계산 — 접힌 클러스터 배지와 단일 댓글이 서로 덮이지 않게 배치
     const expandedClusters = new Set();
-    clusters.forEach(cluster => {
+    const renderItems = clusters.map(cluster => {
+      const startFrame = Math.min(...cluster.map(c => c.startFrame));
+      const endFrame = Math.max(...cluster.map(c => c.endFrame));
+      const item = {
+        cluster,
+        startFrame,
+        endFrame,
+        laneSpan: 1
+      };
+
       if (clusterKey(cluster) === this.expandedClusterId && cluster.length > 1) {
         const { maxLane } = assignLanes(cluster); // _lane이 여기서 1회 설정됨
-        maxLanes = Math.max(maxLanes, maxLane);
+        item.laneSpan = maxLane;
         expandedClusters.add(cluster);
       }
+
+      return item;
     });
+    const { maxLane: maxRenderLane } = assignRenderLanes(renderItems);
+    const maxLanes = Math.max(1, maxRenderLane);
 
     // 4) 트랙 높이 동적 설정 (애니메이션)
     const baseHeight = 24;
@@ -2243,24 +2302,28 @@ export class Timeline extends EventTarget {
     this.commentTrack.style.height = `${targetHeight}px`;
 
     // 5) 각 클러스터 렌더
-    clusters.forEach(cluster => {
+    renderItems.forEach(item => {
+      const { cluster } = item;
+      const laneTop = 2 + item._lane * laneHeight;
       if (cluster.length === 1) {
         // 단일 댓글 (또는 split 후 단일 멤버로 쪼개진 조각)
         const el = this._createCommentRangeElement(cluster[0]);
-        el.style.top = '2px';
+        el.style.top = `${laneTop}px`;
         this.commentTrack.appendChild(el);
       } else if (expandedClusters.has(cluster)) {
         // 펼친 클러스터 — step 3에서 assignLanes가 이미 실행되어 _lane이 설정된 상태
         cluster.forEach(c => {
           const el = this._createCommentRangeElement(c);
-          el.style.top = `${2 + c._lane * laneHeight}px`;
+          el.style.top = `${laneTop + c._lane * laneHeight}px`;
           this.commentTrack.appendChild(el);
         });
         const closeBadge = this._createClusterCloseBadge(cluster);
+        closeBadge.style.top = `${laneTop - 22}px`;
         this.commentTrack.appendChild(closeBadge);
       } else {
         // 접힌 클러스터 — 배지
         const badge = this._createClusterBadgeElement(cluster);
+        badge.style.top = `${laneTop}px`;
         this.commentTrack.appendChild(badge);
       }
     });
@@ -2346,11 +2409,21 @@ export class Timeline extends EventTarget {
     el.style.width = `${Math.max(widthPercent, 3)}%`;
     el.style.top = '2px';
 
+    const leftHandle = document.createElement('span');
+    leftHandle.className = 'comment-cluster-handle comment-cluster-handle-left';
+    leftHandle.dataset.handle = 'left';
+    el.appendChild(leftHandle);
+
     // "+N" 숫자 강조 레이블만 표시 (세로 스트라이프/라벨 제거)
     const label = document.createElement('span');
     label.className = 'comment-cluster-badge-label';
     label.textContent = `+${cluster.length}`;
     el.appendChild(label);
+
+    const rightHandle = document.createElement('span');
+    rightHandle.className = 'comment-cluster-handle comment-cluster-handle-right';
+    rightHandle.dataset.handle = 'right';
+    el.appendChild(rightHandle);
 
     return el;
   }

--- a/renderer/scripts/modules/user-settings.js
+++ b/renderer/scripts/modules/user-settings.js
@@ -190,6 +190,8 @@ export class UserSettings extends EventTarget {
       showRemoteCursors: true,
       // 타임라인 프레임 격자 표시 여부
       showFrameGrid: true,
+      // 타임라인 댓글 지속시간 구간 표시 여부
+      showCommentTimelineRanges: true,
       // 100% 이하 줌에서 영상을 중앙에 고정할지 여부
       videoCenterLocked: true,
       // 이 PC에서 마지막으로 사용한 지우개 방식
@@ -569,6 +571,21 @@ export class UserSettings extends EventTarget {
     // 향후 외부에서 설정 변경을 감지해야 할 경우를 위한 hook
     this._emit('showFrameGridChanged', { show: this.settings.showFrameGrid });
     log.info('프레임 격자 설정 변경됨', { show });
+  }
+
+  getShowCommentTimelineRanges() {
+    return this.settings.showCommentTimelineRanges !== false;
+  }
+
+  setShowCommentTimelineRanges(show) {
+    this.settings.showCommentTimelineRanges = !!show;
+    this._save();
+    this._emit('showCommentTimelineRangesChanged', {
+      show: this.settings.showCommentTimelineRanges
+    });
+    log.info('댓글 구간 타임라인 표시 설정 변경됨', {
+      show: this.settings.showCommentTimelineRanges
+    });
   }
 
   getShowRemoteCursors() {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -2098,6 +2098,66 @@ body.app-fullscreen .video-comment-overlay-controls {
   gap: 16px;
 }
 
+.comment-timeline-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 8px;
+  border: 1px solid var(--border-default, #333);
+  border-radius: 4px;
+  color: var(--text-secondary, #aaa);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.comment-timeline-toggle:hover {
+  background: var(--bg-elevated, #222);
+  border-color: var(--accent-primary, #ffd000);
+  color: var(--text-primary, #fff);
+}
+
+.comment-timeline-toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.comment-timeline-toggle-box {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
+  background: var(--bg-primary);
+  flex: 0 0 auto;
+}
+
+.comment-timeline-toggle input:checked + .comment-timeline-toggle-box {
+  background: var(--accent-primary, #ffd000);
+  border-color: var(--accent-primary, #ffd000);
+}
+
+.comment-timeline-toggle input:checked + .comment-timeline-toggle-box::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 4px;
+  height: 8px;
+  border: solid var(--bg-primary, #111);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.comment-timeline-toggle-label {
+  white-space: nowrap;
+}
+
 .zoom-control {
   display: flex;
   align-items: center;
@@ -3091,6 +3151,67 @@ body.app-fullscreen .video-comment-overlay-controls {
   opacity: 0.7;
 }
 
+.comment-range-item.ctrl-resize-candidate,
+.comment-cluster-badge.ctrl-resize-candidate {
+  overflow: visible;
+  z-index: 60;
+  cursor: ew-resize;
+  isolation: isolate;
+}
+
+.comment-range-item.ctrl-resize-candidate::before,
+.comment-cluster-badge.ctrl-resize-candidate::before {
+  --ctrl-resize-hit-width: 72px;
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: max(var(--ctrl-resize-hit-width), calc(100% + 16px));
+  height: calc(100% + 14px);
+  transform: translate(-50%, -50%);
+  border: 1px solid rgba(255, 208, 0, 0.8);
+  border-radius: 8px;
+  background:
+    linear-gradient(90deg, rgba(255, 208, 0, 0.22), rgba(255, 208, 0, 0.08));
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.35),
+    0 0 18px rgba(255, 208, 0, 0.35);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.comment-range-item.ctrl-resize-candidate::after,
+.comment-cluster-badge.ctrl-resize-candidate::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 8px;
+  height: calc(100% + 12px);
+  transform: translateY(-50%);
+  border-radius: 999px;
+  background: #ffd000;
+  box-shadow: 0 0 10px rgba(255, 208, 0, 0.75);
+  pointer-events: none;
+  z-index: 3;
+}
+
+.comment-range-item.ctrl-resize-candidate .comment-handle,
+.comment-range-item.ctrl-resize-candidate .comment-range-text,
+.comment-cluster-badge.ctrl-resize-candidate .comment-cluster-badge-label {
+  position: relative;
+  z-index: 2;
+}
+
+.comment-range-item.ctrl-resize-left::after,
+.comment-cluster-badge.ctrl-resize-left::after {
+  left: -8px;
+}
+
+.comment-range-item.ctrl-resize-right::after,
+.comment-cluster-badge.ctrl-resize-right::after {
+  right: -8px;
+}
+
 /* 댓글 핸들 (드래그용) */
 .comment-handle {
   position: absolute;
@@ -3160,7 +3281,7 @@ body.app-fullscreen .video-comment-overlay-controls {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 8px;
+  padding: 0 10px;
   color: #fff;
   overflow: hidden;
   white-space: nowrap;
@@ -3185,6 +3306,38 @@ body.app-fullscreen .video-comment-overlay-controls {
   font-variant-numeric: tabular-nums;
   user-select: none;
   pointer-events: none;
+  min-width: 22px;
+  text-align: center;
+}
+
+.comment-cluster-handle {
+  position: absolute;
+  top: 0;
+  width: 14px;
+  height: 100%;
+  cursor: ew-resize;
+  z-index: 2;
+}
+
+.comment-cluster-handle-left {
+  left: 0;
+}
+
+.comment-cluster-handle-right {
+  right: 0;
+}
+
+.comment-cluster-handle:hover {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.comment-cluster-badge.dragging {
+  cursor: ew-resize;
+  filter: brightness(1.18);
+  box-shadow:
+    0 0 0 2px rgba(255, 207, 112, 0.5),
+    0 4px 12px rgba(245, 158, 11, 0.6),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.2);
 }
 
 /* 접기 배지 (펼친 상태) — position은 JS에서 left만 설정, right/width는 content-driven */

--- a/scripts/tests/comment-cluster.test.js
+++ b/scripts/tests/comment-cluster.test.js
@@ -4,6 +4,17 @@
  */
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
+const userSettingsSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/user-settings.js'), 'utf8'));
+const timelineSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/timeline.js'), 'utf8'));
+const mainCss = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
+const longVideoMockupPath = path.join(rootDir, 'docs/mockups/2026-06-07-comment-range-long-video.html');
 
 let mod;
 test('모듈 로드', async () => {
@@ -109,6 +120,34 @@ test('재사용 가능한 레인: A(0-10), B(5-15), C(12-20) → A,C는 레인 0
   assert.equal(cs[2]._lane, 0);
 });
 
+test('렌더 단위 레인: 접힌 클러스터와 단일 댓글이 시간상 겹치면 다른 줄에 배치한다', () => {
+  const items = [
+    { id: 'cluster', startFrame: 24, endFrame: 120 },
+    { id: 'single', startFrame: 70, endFrame: 110 }
+  ];
+
+  const { maxLane } = mod.assignRenderLanes(items);
+
+  assert.equal(maxLane, 2);
+  assert.equal(items[0]._lane, 0);
+  assert.equal(items[1]._lane, 1);
+});
+
+test('렌더 단위 레인: 펼친 클러스터는 내부 레인 수만큼 세로 공간을 예약한다', () => {
+  const items = [
+    { id: 'expanded', startFrame: 0, endFrame: 100, laneSpan: 2 },
+    { id: 'overlap', startFrame: 20, endFrame: 40 },
+    { id: 'after', startFrame: 100, endFrame: 120 }
+  ];
+
+  const { maxLane } = mod.assignRenderLanes(items);
+
+  assert.equal(maxLane, 3);
+  assert.equal(items[0]._lane, 0);
+  assert.equal(items[1]._lane, 2);
+  assert.equal(items[2]._lane, 0);
+});
+
 // --- clusterKey ---
 
 test('clusterKey: 빈 클러스터 → null', () => {
@@ -129,6 +168,127 @@ test('clusterKey: 멤버 순서가 달라도 동일한 키 반환 (안정성)', 
   const k2 = mod.clusterKey([c('beta', 5, 15), c('alpha', 0, 10)]);
   assert.equal(k1, k2);
   assert.equal(k1, 'alpha|beta');
+});
+
+test('resizeClusterMembersByEdge: 왼쪽 끝 조절은 모든 멤버 startFrame을 같은 delta로 변경한다', () => {
+  const cluster = [
+    c('a', 10, 40),
+    c('b', 20, 50),
+    c('c', 25, 60)
+  ];
+
+  const result = mod.resizeClusterMembersByEdge(cluster, {
+    edge: 'left',
+    deltaFrames: 5,
+    totalFrames: 100
+  });
+
+  assert.equal(result.appliedDeltaFrames, 5);
+  assert.deepEqual(result.updates.map(item => [item.markerId, item.startFrame, item.endFrame]), [
+    ['a', 15, 40],
+    ['b', 25, 50],
+    ['c', 30, 60]
+  ]);
+});
+
+test('resizeClusterMembersByEdge: 오른쪽 끝 조절은 모든 멤버 endFrame을 같은 delta로 변경한다', () => {
+  const cluster = [
+    c('a', 10, 40),
+    c('b', 20, 50),
+    c('c', 25, 60)
+  ];
+
+  const result = mod.resizeClusterMembersByEdge(cluster, {
+    edge: 'right',
+    deltaFrames: -8,
+    totalFrames: 100
+  });
+
+  assert.equal(result.appliedDeltaFrames, -8);
+  assert.deepEqual(result.updates.map(item => [item.markerId, item.startFrame, item.endFrame]), [
+    ['a', 10, 32],
+    ['b', 20, 42],
+    ['c', 25, 52]
+  ]);
+});
+
+test('resizeClusterMembersByEdge: 너무 많이 줄이면 모든 댓글이 최소 1프레임을 유지하도록 delta를 제한한다', () => {
+  const cluster = [
+    c('a', 10, 14),
+    c('b', 20, 50)
+  ];
+
+  const result = mod.resizeClusterMembersByEdge(cluster, {
+    edge: 'right',
+    deltaFrames: -10,
+    totalFrames: 100
+  });
+
+  assert.equal(result.appliedDeltaFrames, -3);
+  assert.deepEqual(result.updates.map(item => [item.markerId, item.startFrame, item.endFrame]), [
+    ['a', 10, 11],
+    ['b', 20, 47]
+  ]);
+});
+
+test('접힌 댓글 클러스터 바는 손잡이와 Ctrl 드래그로 그룹 범위를 조절한다', () => {
+  assert.match(timelineSource, /comment-cluster-handle comment-cluster-handle-left/);
+  assert.match(timelineSource, /comment-cluster-handle comment-cluster-handle-right/);
+  assert.match(mainCss, /\.comment-cluster-handle/);
+  assert.match(appSource, /function beginCommentClusterResize\(clusterBadge, edge, e\)/);
+  assert.match(appSource, /e\.ctrlKey \|\| clusterHandle/);
+  assert.match(appSource, /resizeClusterMembersByEdge/);
+});
+
+test('일반 댓글 바도 Ctrl 드래그 시 클릭한 절반 기준으로 길이를 조절한다', () => {
+  assert.match(appSource, /function getResizeEdgeFromElementHalf\(element, e\)/);
+  assert.match(appSource, /function beginCommentRangeResize\(item, marker, handle, e\)/);
+  assert.match(appSource, /if \(e\.ctrlKey\) \{/);
+  assert.match(appSource, /beginCommentRangeResize\(item, marker, getResizeEdgeFromElementHalf\(item, e\), e\)/);
+  assert.match(appSource, /document\.body\.style\.cursor = 'ew-resize'/);
+});
+
+test('Ctrl 드래그는 짧은 댓글 바 근처의 넓은 영역에서도 리사이즈 대상을 찾는다', () => {
+  assert.match(appSource, /const CTRL_COMMENT_RESIZE_MIN_HIT_WIDTH = 72/);
+  assert.match(appSource, /function findCtrlCommentResizeTarget\(e\)/);
+  assert.match(appSource, /commentTrack\.querySelectorAll\([\s\S]*'\.comment-range-item, \.comment-cluster-badge'[\s\S]*\)/);
+  assert.match(appSource, /if \(e\.ctrlKey\) \{[\s\S]*findCtrlCommentResizeTarget\(e\)/);
+});
+
+test('Ctrl 키를 누르고 댓글 트랙에 마우스를 올리면 넓어진 리사이즈 후보 영역을 시각적으로 표시한다', () => {
+  assert.match(appSource, /let ctrlCommentResizeKeyDown = false/);
+  assert.match(appSource, /let ctrlCommentResizeCandidate = null/);
+  assert.match(appSource, /function updateCtrlCommentResizeCandidate\(e\)/);
+  assert.match(appSource, /ctrl-resize-candidate/);
+  assert.match(appSource, /ctrl-resize-left/);
+  assert.match(appSource, /ctrl-resize-right/);
+  assert.match(appSource, /commentTrack\.addEventListener\('mousemove', updateCtrlCommentResizeCandidate\)/);
+  assert.match(appSource, /document\.addEventListener\('keydown'[\s\S]*ctrlCommentResizeKeyDown = true/);
+  assert.match(mainCss, /\.comment-range-item\.ctrl-resize-candidate::before/);
+  assert.match(mainCss, /\.comment-cluster-badge\.ctrl-resize-candidate::before/);
+  assert.match(mainCss, /width: 72px/);
+});
+
+test('긴 영상 댓글 범위 목업은 5분/10분 타임라인과 Ctrl 리사이즈 시각화를 포함한다', () => {
+  assert.equal(fs.existsSync(longVideoMockupPath), true);
+  const mockupSource = normalizeNewlines(fs.readFileSync(longVideoMockupPath, 'utf8'));
+  assert.match(mockupSource, /data-duration="300"/);
+  assert.match(mockupSource, /data-duration="600"/);
+  assert.match(mockupSource, /Ctrl 리사이즈 모드/);
+  assert.match(mockupSource, /ctrl-resize-candidate/);
+  assert.match(mockupSource, /긴 영상/);
+});
+
+test('댓글 지속시간 타임라인 표시는 체크 토글로 켜고 끈다', () => {
+  assert.match(indexSource, /id="toggleCommentTimelineRanges"/);
+  assert.match(indexSource, /댓글 구간/);
+  assert.match(mainCss, /\.comment-timeline-toggle/);
+  assert.match(userSettingsSource, /showCommentTimelineRanges: true/);
+  assert.match(userSettingsSource, /getShowCommentTimelineRanges\(\)/);
+  assert.match(userSettingsSource, /setShowCommentTimelineRanges\(show\)/);
+  assert.match(timelineSource, /setCommentRangesVisible\(visible\)/);
+  assert.match(appSource, /toggleCommentTimelineRanges/);
+  assert.match(appSource, /timeline\.setCommentRangesVisible\(show\)/);
 });
 
 // --- splitClustersByPixelGap ---

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -42,3 +42,12 @@ test('pending marker input stops pointer events from bubbling into video panning
   assert.match(pendingMarkerSource, /inputWrapper\.addEventListener\('pointerdown', \(e\) => e\.stopPropagation\(\)\);/);
   assert.match(pendingMarkerSource, /inputWrapper\.addEventListener\('mousedown', \(e\) => e\.stopPropagation\(\)\);/);
 });
+
+test('loading review comments refreshes the right sidebar comment list', () => {
+  const loadedHandlerMatch = appSource.match(/commentManager\.addEventListener\('loaded', \(\) => \{([\s\S]*?)\n  \}\);/);
+  assert.ok(loadedHandlerMatch, 'commentManager loaded handler should exist');
+  const loadedHandlerSource = loadedHandlerMatch[1];
+
+  assert.match(loadedHandlerSource, /void refreshCommentRangesForCurrentMode\(\);/);
+  assert.match(loadedHandlerSource, /updateCommentList\(\);/);
+});

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -47,7 +47,18 @@ test('continuous timeline updates ignore stale async completions', () => {
   assert.match(timelineUpdateSource, /const updateToken = \+\+playlistTimelineUpdateToken;/);
   assert.match(timelineUpdateSource, /playlistTimelineUpdateToken !== updateToken/);
   assert.match(timelineUpdateSource, /const metadata = await collectPlaylistMetadata\(items\);[\s\S]+playlistTimelineUpdateToken !== updateToken/);
-  assert.match(timelineUpdateSource, /const bframeData = await window\.electronAPI\.loadReview\(item\.bframePath\);[\s\S]+playlistTimelineUpdateToken !== updateToken/);
+  assert.match(timelineUpdateSource, /const bframePath = await playlistManager\.ensureItemBframePath\(item\);[\s\S]+const bframeData = await window\.electronAPI\.loadReview\(bframePath\);[\s\S]+playlistTimelineUpdateToken !== updateToken/);
+});
+
+test('continuous aggregate comments recover missing bframePath from the media path', () => {
+  const timelineUpdateMatch = appSource.match(/async function updatePlaylistContinuousTimeline\(\) \{([\s\S]*?)\n  \}\n\n  async function quickCheckPlaylistForContinuous/);
+  assert.ok(timelineUpdateMatch, 'updatePlaylistContinuousTimeline should exist');
+
+  const timelineUpdateSource = timelineUpdateMatch[1];
+  assert.match(timelineUpdateSource, /const bframePath = await playlistManager\.ensureItemBframePath\(item\);/);
+  assert.match(timelineUpdateSource, /if \(!bframePath\) continue;/);
+  assert.match(timelineUpdateSource, /window\.electronAPI\.loadReview\(bframePath\)/);
+  assert.doesNotMatch(timelineUpdateSource, /if \(!item\?\.bframePath\) continue;/);
 });
 
 test('aggregate comment clicks stop when playlist item load fails', () => {

--- a/scripts/tests/playlist-ordering.test.js
+++ b/scripts/tests/playlist-ordering.test.js
@@ -198,3 +198,51 @@ test('PlaylistManager.addItems는 같은 호출 안의 중복 경로를 제외�
   assert.equal(addedItems.length, 1);
   assert.deepEqual(manager.getItems().map(item => item.fileName), ['shot1.mp4']);
 });
+
+test('PlaylistManager.open은 비어 있는 bframePath를 영상 옆 .bframe으로 복구해 저장한다', async () => {
+  const savedPlaylists = [];
+  global.window = {
+    appState: { userName: 'tester', sessionId: 'session-1' },
+    electronAPI: {
+      readPlaylist: async () => ({
+        playlistVersion: '1.0',
+        id: 'playlist-old',
+        name: '오래된 재생목록',
+        items: [
+          {
+            id: 'item-1',
+            videoPath: 'C:\\video\\shot1.mp4',
+            bframePath: '',
+            fileName: 'shot1.mp4',
+            thumbnailPath: 'data:image/png;base64,stub',
+            order: 0,
+            addedAt: '2026-06-06T00:00:00.000Z'
+          }
+        ],
+        settings: {
+          floatingMode: false,
+          continuous: {
+            loop: false,
+            sortMode: 'fileName',
+            manualOrder: false
+          }
+        }
+      }),
+      fileExists: async filePath => filePath === 'C:\\video\\shot1.bframe',
+      writePlaylist: async (targetPath, playlist) => {
+        savedPlaylists.push({ targetPath, playlist: JSON.parse(JSON.stringify(playlist)) });
+      }
+    }
+  };
+
+  const { PlaylistManager } = await import('../../renderer/scripts/modules/playlist-manager.js');
+  const manager = new PlaylistManager();
+
+  await manager.open('C:\\video\\old.bplaylist');
+
+  assert.equal(manager.getItems()[0].bframePath, 'C:\\video\\shot1.bframe');
+  assert.equal(savedPlaylists.length, 1);
+  assert.equal(savedPlaylists[0].targetPath, 'C:\\video\\old.bplaylist');
+  assert.equal(savedPlaylists[0].playlist.items[0].bframePath, 'C:\\video\\shot1.bframe');
+  assert.equal(manager.isModified, false);
+});


### PR DESCRIPTION
## 📋 업데이트 요약

🖱️ 댓글 길이 조절이 쉬워졌어요. 긴 영상에서 댓글 구간이 아주 작게 보여도 `Ctrl`을 누른 채 타임라인에 마우스를 올리면 잡을 수 있는 후보 영역이 크게 표시됩니다.

💬 겹친 댓글 숫자칸도 다루기 좋아졌어요. 여러 댓글이 겹쳐 `+3`처럼 접힌 상태여도 `Ctrl` 드래그로 전체 댓글 구간 길이를 조절할 수 있습니다.

👁️ 타임라인의 댓글 구간 표시는 체크박스로 켜고 끌 수 있게 했습니다. 화면이 복잡할 때는 숨기고, 길이 조절이 필요할 때만 다시 켤 수 있습니다.

📂 재생목록 파일을 연결했을 때 댓글이 오른쪽 댓글 탭과 타임라인에 제대로 나타나도록 보강했습니다.

🧪 5분/10분짜리 긴 영상 상황을 확인할 수 있는 미리보기 목업도 추가했습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - 일반 댓글 바와 접힌 댓글 클러스터 배지에 `Ctrl` 기반 resize target 탐색을 추가했습니다.
  - `CTRL_COMMENT_RESIZE_MIN_HIT_WIDTH = 72` 기준으로 짧은 댓글 바 주변 hit 영역을 확장했습니다.
  - `ctrl-resize-candidate`, `ctrl-resize-left/right`, `ctrl-resize-active` 클래스를 붙여 현재 조절 후보를 시각적으로 표시합니다.
  - 댓글 구간 표시 토글 상태를 읽어 타임라인 댓글 range 렌더링을 켜고 끄도록 연결했습니다.
  - bplaylist/continuous playlist 댓글이 오른쪽 패널과 aggregate timeline에 유지되도록 갱신 경로를 보강했습니다.

- `renderer/styles/main.css`
  - Ctrl 후보 영역에 72px 기준의 시각적 확장 영역, 노란 outline, 좌우 handle 표시를 추가했습니다.
  - 아주 작은 댓글 바도 hover 후보가 보이도록 pseudo element 기반 표시를 사용했습니다.

- `renderer/scripts/modules/comment-cluster.js`, `renderer/scripts/modules/timeline.js`
  - 겹친 댓글 클러스터의 길이 조절과 렌더링 안정성을 보강했습니다.

- `renderer/scripts/modules/playlist-manager.js`
  - 저장된 `.bplaylist` 항목에서 비어 있는 `bframePath`를 영상 옆 `.bframe`으로 복구하는 흐름을 강화했습니다.

- `renderer/scripts/modules/user-settings.js`, `renderer/index.html`
  - 댓글 구간 표시 토글 설정을 사용자 설정으로 저장/복원할 수 있게 추가했습니다.

- `docs/mockups/2026-06-07-comment-range-long-video.html`
  - 5분/10분 타임라인과 Ctrl 리사이즈 후보 표시를 확인할 수 있는 인터랙티브 목업을 추가했습니다.

## 🚧 개발 난항

- 처음에는 실제 앱이 아닌 목업에서 먼저 확인했지만, 사용자가 실제 앱 기준 확인을 원해서 Electron 앱을 원격 디버깅 포트로 띄워 검증했습니다.
- 기존 5초 더미 영상으로는 긴 영상의 댓글 바 축소 문제가 재현되지 않아, Python `av`를 이용해 실제 duration이 600초로 잡히는 10분짜리 저용량 더미 영상을 만들어 검증했습니다.
- 최초 hit 영역 기준 44px는 10분 영상에서 실제 댓글 바가 5px 수준으로 줄어드는 경우 체감이 약했습니다. 실제 앱 확인 후 72px로 키웠습니다.
- 기존 실행 중인 Electron preview 프로세스가 오래된 JS/CSS를 물고 있어 후보 표시가 안 보이는 문제가 있었고, 새 코드가 반영된 프로세스로 다시 띄워 확인했습니다.

## ✅ 테스트 가이드

실사용자용:

1. 긴 영상 또는 5~10분짜리 더미 영상을 엽니다.
2. 댓글을 몇 개 작성하거나 기존 댓글이 있는 `.bframe`을 엽니다.
3. 타임라인의 `댓글 구간` 체크를 켭니다.
4. `Ctrl`을 누른 채 댓글 바나 `+숫자` 배지 주변에 마우스를 올립니다.
5. 노란 후보 영역이 보이면 좌우로 드래그해 댓글 길이가 바뀌는지 확인합니다.
6. `댓글 구간` 체크를 끄면 타임라인 댓글 구간 표시가 사라지는지 확인합니다.
7. `.bplaylist` 파일을 재생목록으로 열고, 각 영상의 댓글이 오른쪽 댓글 탭과 타임라인에 표시되는지 확인합니다.

개발자용:

- `npm run test:cluster`
- `npm run test:playlist`
- `npm run test:comment-input`
- `npm run build`
- `git diff --check`

추가 확인:

- 실제 Electron 앱에서 10분짜리 더미 영상 `comment-range-long-10min-real.mp4`를 열어 `Ctrl` hover 시 `.ctrl-resize-candidate`가 붙는 것을 CDP로 확인했습니다.
