### PR TITLE
스페이스바 재생 포커스 충돌 수정

### DIFF
--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -53,6 +53,10 @@ import { getSlackNotifier } from './modules/slack-notifier.js';
 import { getRecentFilesManager } from './modules/recent-files-manager.js';
 import * as recentFilesView from './modules/recent-files-view.js';
 import { computeToastStackLayout, computeToastTimerPlan } from './modules/toast-stack-core.js';
+import {
+  shouldHandlePlayPauseShortcutFromTarget,
+  shouldIgnoreGlobalShortcutTarget
+} from './modules/keyboard-shortcut-targets.js';
 
 const log = createLogger('App');
 
@@ -8058,11 +8062,8 @@ async function initApp() {
    * 키보드 단축키 처리
    */
   async function handleKeydown(e) {
-    // 입력 필드에서는 단축키 무시
-    if (e.target.tagName === 'TEXTAREA' || e.target.tagName === 'INPUT') return;
-
-    // contenteditable 요소에서는 단축키 무시 (스레드 에디터 등)
-    if (e.target.isContentEditable) return;
+    const isPlayPauseShortcut = userSettings.matchShortcut('playPause', e);
+    if (isPlayPauseShortcut && !shouldHandlePlayPauseShortcutFromTarget(e.target)) return;
 
     // pending 마커 입력 중이면 단축키 무시 (textarea 포커스 전에도 적용)
     if (commentManager.pendingMarker) return;
@@ -8078,11 +8079,14 @@ async function initApp() {
     // ====== 공통 단축키 (사용자 설정 기반) ======
 
     // 재생/일시정지
-    if (userSettings.matchShortcut('playPause', e)) {
+    if (isPlayPauseShortcut) {
       e.preventDefault();
       handleUserPlayPauseToggle();
       return;
     }
+
+    // 폼 컨트롤에서는 Space 재생을 제외한 전역 단축키를 무시한다.
+    if (shouldIgnoreGlobalShortcutTarget(e.target)) return;
 
     // 댓글 모드
     if (userSettings.matchShortcut('commentMode', e)) {

--- a/renderer/scripts/modules/keyboard-shortcut-targets.js
+++ b/renderer/scripts/modules/keyboard-shortcut-targets.js
@@ -1,0 +1,65 @@
+const TEXT_ENTRY_INPUT_TYPES = new Set([
+  'text',
+  'search',
+  'url',
+  'tel',
+  'email',
+  'password',
+  'number',
+  'date',
+  'datetime-local',
+  'month',
+  'time',
+  'week'
+]);
+
+function getTagName(target) {
+  return String(target?.tagName || '').toUpperCase();
+}
+
+function getInputType(target) {
+  return String(target?.type || 'text').toLowerCase();
+}
+
+function isContentEditableTarget(target) {
+  if (!target || typeof target !== 'object') return false;
+  if (target.isContentEditable) return true;
+
+  if (typeof target.closest === 'function') {
+    try {
+      if (target.closest('[contenteditable="true"], [contenteditable="plaintext-only"]')) {
+        return true;
+      }
+    } catch {
+      // Non-Element test doubles can expose a partial closest() shape.
+    }
+  }
+
+  let node = target.parentElement;
+  while (node) {
+    if (node.isContentEditable) return true;
+    node = node.parentElement;
+  }
+  return false;
+}
+
+export function isTextEntryShortcutTarget(target) {
+  if (isContentEditableTarget(target)) return true;
+
+  const tagName = getTagName(target);
+  if (tagName === 'TEXTAREA') return true;
+  if (tagName !== 'INPUT') return false;
+
+  return TEXT_ENTRY_INPUT_TYPES.has(getInputType(target));
+}
+
+export function shouldHandlePlayPauseShortcutFromTarget(target) {
+  return !isTextEntryShortcutTarget(target);
+}
+
+export function shouldIgnoreGlobalShortcutTarget(target) {
+  if (isTextEntryShortcutTarget(target)) return true;
+
+  const tagName = getTagName(target);
+  return tagName === 'INPUT' || tagName === 'SELECT';
+}

--- a/scripts/tests/keyboard-shortcut-targets.test.js
+++ b/scripts/tests/keyboard-shortcut-targets.test.js
@@ -1,0 +1,32 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+test('play/pause shortcut can be handled from focused controls but not text editors', async () => {
+  const {
+    shouldHandlePlayPauseShortcutFromTarget
+  } = await import('../../renderer/scripts/modules/keyboard-shortcut-targets.js');
+
+  assert.equal(shouldHandlePlayPauseShortcutFromTarget({ tagName: 'INPUT', type: 'checkbox' }), true);
+  assert.equal(shouldHandlePlayPauseShortcutFromTarget({ tagName: 'INPUT', type: 'range' }), true);
+  assert.equal(shouldHandlePlayPauseShortcutFromTarget({ tagName: 'BUTTON' }), true);
+
+  assert.equal(shouldHandlePlayPauseShortcutFromTarget({ tagName: 'TEXTAREA' }), false);
+  assert.equal(shouldHandlePlayPauseShortcutFromTarget({ tagName: 'INPUT', type: 'text' }), false);
+  assert.equal(shouldHandlePlayPauseShortcutFromTarget({ tagName: 'INPUT', type: 'search' }), false);
+  assert.equal(shouldHandlePlayPauseShortcutFromTarget({ tagName: 'DIV', isContentEditable: true }), false);
+});
+
+test('non-playback shortcuts stay ignored for form controls', async () => {
+  const {
+    shouldIgnoreGlobalShortcutTarget
+  } = await import('../../renderer/scripts/modules/keyboard-shortcut-targets.js');
+
+  assert.equal(shouldIgnoreGlobalShortcutTarget({ tagName: 'INPUT', type: 'checkbox' }), true);
+  assert.equal(shouldIgnoreGlobalShortcutTarget({ tagName: 'INPUT', type: 'range' }), true);
+  assert.equal(shouldIgnoreGlobalShortcutTarget({ tagName: 'SELECT' }), true);
+  assert.equal(shouldIgnoreGlobalShortcutTarget({ tagName: 'TEXTAREA' }), true);
+  assert.equal(shouldIgnoreGlobalShortcutTarget({ tagName: 'INPUT', type: 'text' }), true);
+
+  assert.equal(shouldIgnoreGlobalShortcutTarget({ tagName: 'BUTTON' }), false);
+  assert.equal(shouldIgnoreGlobalShortcutTarget({ tagName: 'DIV' }), false);
+});

--- a/scripts/tests/playlist-autoplay-source.test.js
+++ b/scripts/tests/playlist-autoplay-source.test.js
@@ -53,7 +53,8 @@ test('starting playback warms the next autoplay item for button and spacebar pla
 
   assert.match(appSource, /elements\.btnPlay\.addEventListener\('click', handleUserPlayPauseToggle\);/);
 
-  const shortcutHandler = appSource.match(/if \(userSettings\.matchShortcut\('playPause', e\)\) \{([\s\S]*?)\n      return;/);
+  assert.match(appSource, /const isPlayPauseShortcut = userSettings\.matchShortcut\('playPause', e\);/);
+  const shortcutHandler = appSource.match(/if \(isPlayPauseShortcut\) \{([\s\S]*?)\n      return;/);
   assert.ok(shortcutHandler, 'play/pause shortcut handler should exist');
   assert.match(shortcutHandler[1], /handleUserPlayPauseToggle\(\);/);
 });


### PR DESCRIPTION
## 변경 내용
- 체크박스/버튼/슬라이더에 포커스가 남아도 Space 재생 단축키가 우선 처리되도록 단축키 타깃 분류를 추가했습니다.
- 텍스트 입력칸, textarea, contenteditable에서는 Space 입력이 그대로 유지되도록 분리했습니다.
- 기존 playlist autoplay source 테스트를 새 단축키 처리 구조에 맞춰 갱신했습니다.

## 검증
- `node --test scripts/tests/keyboard-shortcut-targets.test.js`
- `npm run test:comment-input`
- `npm run test:playlist`
- `npx eslint renderer/scripts/modules/keyboard-shortcut-targets.js scripts/tests/keyboard-shortcut-targets.test.js`
- `git diff --check`
- `npm run build`

## 참고
- `git diff --check`는 실패 없이 Windows 줄바꿈 변환 경고만 출력했습니다.