### PR TITLE
폼 컨트롤 재생 단축키 충돌 보완

### DIFF
--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -8063,7 +8063,7 @@ async function initApp() {
    */
   async function handleKeydown(e) {
     const isPlayPauseShortcut = userSettings.matchShortcut('playPause', e);
-    if (isPlayPauseShortcut && !shouldHandlePlayPauseShortcutFromTarget(e.target)) return;
+    if (isPlayPauseShortcut && !shouldHandlePlayPauseShortcutFromTarget(e.target, e)) return;
 
     // pending 마커 입력 중이면 단축키 무시 (textarea 포커스 전에도 적용)
     if (commentManager.pendingMarker) return;

--- a/renderer/scripts/modules/keyboard-shortcut-targets.js
+++ b/renderer/scripts/modules/keyboard-shortcut-targets.js
@@ -53,8 +53,15 @@ export function isTextEntryShortcutTarget(target) {
   return TEXT_ENTRY_INPUT_TYPES.has(getInputType(target));
 }
 
-export function shouldHandlePlayPauseShortcutFromTarget(target) {
-  return !isTextEntryShortcutTarget(target);
+export function shouldHandlePlayPauseShortcutFromTarget(target, event = null) {
+  if (isTextEntryShortcutTarget(target)) return false;
+
+  const tagName = getTagName(target);
+  if (tagName === 'INPUT' && event?.code && event.code !== 'Space') {
+    return false;
+  }
+
+  return true;
 }
 
 export function shouldIgnoreGlobalShortcutTarget(target) {

--- a/scripts/tests/keyboard-shortcut-targets.test.js
+++ b/scripts/tests/keyboard-shortcut-targets.test.js
@@ -1,5 +1,11 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
 
 test('play/pause shortcut can be handled from focused controls but not text editors', async () => {
   const {
@@ -14,6 +20,26 @@ test('play/pause shortcut can be handled from focused controls but not text edit
   assert.equal(shouldHandlePlayPauseShortcutFromTarget({ tagName: 'INPUT', type: 'text' }), false);
   assert.equal(shouldHandlePlayPauseShortcutFromTarget({ tagName: 'INPUT', type: 'search' }), false);
   assert.equal(shouldHandlePlayPauseShortcutFromTarget({ tagName: 'DIV', isContentEditable: true }), false);
+});
+
+test('form controls only allow play/pause override for the Space shortcut', async () => {
+  const {
+    shouldHandlePlayPauseShortcutFromTarget
+  } = await import('../../renderer/scripts/modules/keyboard-shortcut-targets.js');
+
+  assert.equal(
+    shouldHandlePlayPauseShortcutFromTarget({ tagName: 'INPUT', type: 'range' }, { code: 'Space' }),
+    true
+  );
+  assert.equal(
+    shouldHandlePlayPauseShortcutFromTarget({ tagName: 'INPUT', type: 'range' }, { code: 'ArrowLeft' }),
+    false
+  );
+  assert.equal(
+    shouldHandlePlayPauseShortcutFromTarget({ tagName: 'INPUT', type: 'checkbox' }, { code: 'KeyK' }),
+    false
+  );
+  assert.match(appSource, /shouldHandlePlayPauseShortcutFromTarget\(e\.target, e\)/);
 });
 
 test('non-playback shortcuts stay ignored for form controls', async () => {


### PR DESCRIPTION
## 요약
- #122 코덱스 리뷰 P2 보완: 폼 컨트롤 포커스 상태에서 play/pause 커스텀 단축키가 컨트롤 조작키를 가로채지 않도록 제한
- `Space`는 기존 의도대로 재생/일시정지로 처리하되, range/checkbox 등 input에서 `ArrowLeft`, `KeyK` 같은 다른 키는 컨트롤 기본 동작을 유지
- 회귀 테스트로 Space 허용과 비-Space 차단을 고정

## 검증
- `node --test scripts/tests/keyboard-shortcut-targets.test.js`
- `npx eslint renderer/scripts/modules/keyboard-shortcut-targets.js scripts/tests/keyboard-shortcut-targets.test.js`
- `git diff --check` (line-ending warning only)
- `npm run test:comment-input`
- `npm run test:playlist`
- `npm run test:cluster`
- `npm run build`