### PR TITLE
[v1.4.0-beta] 플레이바 조작성 개선 및 미들버튼 스크럽 추가

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -713,17 +713,14 @@
         </div>
       </div>
 
-      <!-- Resizer (Horizontal) -->
-      <div class="resizer resizer-h" id="viewerResizer"></div>
-
       <!-- Playback Controls -->
       <div class="controls-bar">
         <!-- 전체화면 시크바 -->
         <div class="fullscreen-seekbar" id="fullscreenSeekbar">
           <div class="seekbar-track">
             <div class="seekbar-progress" id="seekbarProgress"></div>
-            <div class="seekbar-handle" id="seekbarHandle"></div>
           </div>
+          <div class="seekbar-handle" id="seekbarHandle"></div>
         </div>
         <div class="playback-controls">
           <button class="control-btn" id="btnFirst" title="처음으로 (Home)">
@@ -837,6 +834,9 @@
           <input type="range" class="main-volume-slider" id="mainVolumeSlider" min="0" max="100" value="100" title="볼륨">
         </div>
       </div>
+
+      <!-- Timeline Height Resizer -->
+      <div class="resizer resizer-h" id="viewerResizer" title="타임라인 높이 조절"></div>
 
       <!-- Timeline -->
       <div class="timeline-section" id="timelineSection">

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -722,6 +722,7 @@
           </div>
           <div class="seekbar-handle" id="seekbarHandle"></div>
         </div>
+        <div class="playback-controls-scroll">
         <div class="playback-controls">
           <button class="control-btn" id="btnFirst" title="처음으로 (Home)">
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><polygon points="19 20 9 12 19 4 19 20"/><line x1="5" y1="19" x2="5" y2="5"/></svg>
@@ -832,6 +833,7 @@
             </svg>
           </button>
           <input type="range" class="main-volume-slider" id="mainVolumeSlider" min="0" max="100" value="100" title="볼륨">
+        </div>
         </div>
       </div>
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5717,7 +5717,7 @@ async function initApp() {
   function updateFullscreenMiddleScrub(e) {
     if (!state.isFullscreenScrubbing) return;
 
-    if (e.buttons !== 0 && (e.buttons & 4) === 0) {
+    if (e.buttons === 0 || (e.buttons & 4) === 0) {
       finishFullscreenMiddleScrub();
       return;
     }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -304,6 +304,10 @@ async function initApp() {
     panStartY: 0,
     panInitialX: 0,
     panInitialY: 0,
+    isFullscreenScrubbing: false,
+    fullscreenScrubStartX: 0,
+    fullscreenScrubStartTime: 0,
+    fullscreenScrubDuration: 0,
     // 오디오 모드
     isAudioMode: false
   };
@@ -4359,6 +4363,12 @@ async function initApp() {
   // 비디오 패닝
   elements.videoWrapper?.addEventListener('mousedown', (e) => {
     if (getCommentEditableTarget(e.target)) return;
+
+    if (canStartFullscreenMiddleScrub(e)) {
+      startFullscreenMiddleScrub(e);
+      return;
+    }
+
     if (canPanVideo() && e.button === 0) {
       state.isPanningVideo = true;
       state.panStartX = e.clientX;
@@ -4370,7 +4380,18 @@ async function initApp() {
     }
   });
 
+  elements.videoWrapper?.addEventListener('auxclick', (e) => {
+    if (e.button === 1) {
+      e.preventDefault();
+    }
+  });
+
   document.addEventListener('mousemove', (e) => {
+    if (state.isFullscreenScrubbing) {
+      updateFullscreenMiddleScrub(e);
+      return;
+    }
+
     if (state.isPanningVideo) {
       const scale = state.videoZoom / 100;
       const dx = (e.clientX - state.panStartX) / scale;
@@ -4382,6 +4403,10 @@ async function initApp() {
   });
 
   document.addEventListener('mouseup', () => {
+    if (state.isFullscreenScrubbing) {
+      finishFullscreenMiddleScrub();
+    }
+
     if (state.isPanningVideo) {
       state.isPanningVideo = false;
       elements.videoWrapper?.classList.remove('panning');
@@ -5560,6 +5585,7 @@ async function initApp() {
    */
   let fullscreenMouseHandler = null;
   let fullscreenTimecodeOverlay = null;
+  let fullscreenScrubOverlay = null;
 
   async function toggleFullscreen() {
     // Electron 시스템 전체화면 API 호출
@@ -5605,6 +5631,8 @@ async function initApp() {
       };
       document.addEventListener('mousemove', fullscreenMouseHandler);
     } else {
+      finishFullscreenMiddleScrub();
+
       // 전체화면 해제 시 이벤트 리스너 제거
       if (fullscreenMouseHandler) {
         document.removeEventListener('mousemove', fullscreenMouseHandler);
@@ -5662,8 +5690,95 @@ async function initApp() {
     seekbarHandle.style.left = `${percent}%`;
   }
 
-  // 전체화면 시크바 이벤트 설정
   const fullscreenSeekbar = document.getElementById('fullscreenSeekbar');
+
+  function setFullscreenSeekbarScrubbing(scrubbing) {
+    fullscreenSeekbar?.classList.toggle('is-scrubbing', scrubbing);
+  }
+
+  function canStartFullscreenMiddleScrub(e) {
+    return e.button === 1 &&
+      !state.isDrawMode &&
+      videoPlayer.isLoaded &&
+      videoPlayer.duration > 0;
+  }
+
+  function startFullscreenMiddleScrub(e) {
+    state.isFullscreenScrubbing = true;
+    state.fullscreenScrubStartX = e.clientX;
+    state.fullscreenScrubStartTime = videoPlayer.currentTime || 0;
+    state.fullscreenScrubDuration = videoPlayer.duration || 0;
+    elements.videoWrapper?.classList.add('fullscreen-scrubbing');
+    setFullscreenSeekbarScrubbing(true);
+    showFullscreenScrubOverlay(state.fullscreenScrubStartTime);
+    e.preventDefault();
+  }
+
+  function updateFullscreenMiddleScrub(e) {
+    if (!state.isFullscreenScrubbing) return;
+
+    if (e.buttons !== 0 && (e.buttons & 4) === 0) {
+      finishFullscreenMiddleScrub();
+      return;
+    }
+
+    const dx = e.clientX - state.fullscreenScrubStartX;
+    const timeDelta = (dx / Math.max(1, window.innerWidth)) * state.fullscreenScrubDuration;
+    const targetTime = Math.max(
+      0,
+      Math.min(state.fullscreenScrubDuration, state.fullscreenScrubStartTime + timeDelta)
+    );
+
+    videoPlayer.seek(targetTime);
+    updateFullscreenTimecode();
+    updateFullscreenSeekbar();
+    showFullscreenScrubOverlay(targetTime);
+    e.preventDefault();
+  }
+
+  function finishFullscreenMiddleScrub() {
+    if (!state.isFullscreenScrubbing) return;
+
+    state.isFullscreenScrubbing = false;
+    elements.videoWrapper?.classList.remove('fullscreen-scrubbing');
+    setFullscreenSeekbarScrubbing(false);
+    hideFullscreenScrubOverlay();
+  }
+
+  function ensureFullscreenScrubOverlay() {
+    if (fullscreenScrubOverlay) return fullscreenScrubOverlay;
+
+    fullscreenScrubOverlay = document.createElement('div');
+    fullscreenScrubOverlay.className = 'fullscreen-scrub-overlay';
+    fullscreenScrubOverlay.innerHTML = `
+      <div class="fullscreen-scrub-track">
+        <div class="fullscreen-scrub-progress"></div>
+      </div>
+      <div class="fullscreen-scrub-time">00:00:00:00 / 00:00:00:00</div>
+    `;
+    document.body.appendChild(fullscreenScrubOverlay);
+    return fullscreenScrubOverlay;
+  }
+
+  function showFullscreenScrubOverlay(time) {
+    if (!state.isFullscreen) return;
+
+    const overlay = ensureFullscreenScrubOverlay();
+    const duration = state.fullscreenScrubDuration || videoPlayer.duration || 0;
+    const fps = videoPlayer.fps || 24;
+    const percent = duration > 0 ? Math.max(0, Math.min(100, (time / duration) * 100)) : 0;
+
+    overlay.querySelector('.fullscreen-scrub-progress').style.width = `${percent}%`;
+    overlay.querySelector('.fullscreen-scrub-time').textContent =
+      `${formatTimecode(time, fps)} / ${formatTimecode(duration, fps)}`;
+    overlay.classList.add('visible');
+  }
+
+  function hideFullscreenScrubOverlay() {
+    fullscreenScrubOverlay?.classList.remove('visible');
+  }
+
+  // 전체화면 시크바 이벤트 설정
   if (fullscreenSeekbar) {
     let isSeeking = false;
 
@@ -5677,8 +5792,12 @@ async function initApp() {
     };
 
     fullscreenSeekbar.addEventListener('mousedown', (e) => {
+      if (e.button !== 0) return;
+
       isSeeking = true;
+      setFullscreenSeekbarScrubbing(true);
       seekToPosition(e);
+      e.preventDefault();
     });
 
     document.addEventListener('mousemove', (e) => {
@@ -5689,9 +5808,14 @@ async function initApp() {
 
     document.addEventListener('mouseup', () => {
       isSeeking = false;
+      setFullscreenSeekbarScrubbing(false);
     });
 
-    fullscreenSeekbar.addEventListener('click', seekToPosition);
+    fullscreenSeekbar.addEventListener('click', (e) => {
+      if (e.button === 0) {
+        seekToPosition(e);
+      }
+    });
   }
 
   /**

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -1705,7 +1705,7 @@ body.app-fullscreen .video-comment-overlay-controls {
   align-items: center;
   padding: 0 16px;
   gap: 16px;
-  overflow-x: auto;
+  overflow: visible;
   flex-shrink: 0;
   position: relative;
 }
@@ -8050,6 +8050,7 @@ body.app-fullscreen .controls-bar {
   z-index: 1000;
   background: linear-gradient(transparent, rgba(0, 0, 0, 0.9)) !important;
   opacity: 0;
+  overflow: visible;
   transform: translateY(100%);
   transition: all 0.3s ease;
 }
@@ -8064,30 +8065,38 @@ body.app-fullscreen.show-controls .controls-bar {
 .fullscreen-seekbar {
   display: block;
   position: absolute;
-  top: -8px;
+  top: -28px;
   left: 0;
   right: 0;
-  height: 16px;
-  padding: 6px 0;
+  height: 44px;
+  padding: 0;
   cursor: pointer;
   z-index: 5;
 }
 
 body.app-fullscreen .fullscreen-seekbar {
-  top: -8px;
+  top: -28px;
 }
 
 .seekbar-track {
-  position: relative;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 28px;
+  transform: translateY(-50%);
   width: 100%;
   height: 4px;
   background: rgba(255, 255, 255, 0.2);
   border-radius: 2px;
-  transition: height 0.1s ease;
+  transition: height 0.14s ease, box-shadow 0.14s ease, background 0.14s ease;
+  z-index: 1;
 }
 
-.fullscreen-seekbar:hover .seekbar-track {
-  height: 6px;
+.fullscreen-seekbar:hover .seekbar-track,
+.fullscreen-seekbar.is-scrubbing .seekbar-track {
+  height: 12px;
+  background: rgba(255, 255, 255, 0.26);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.08), 0 4px 14px rgba(0, 0, 0, 0.45);
 }
 
 .seekbar-progress {
@@ -8096,24 +8105,32 @@ body.app-fullscreen .fullscreen-seekbar {
   top: 0;
   height: 100%;
   background: var(--accent-primary);
-  border-radius: 2px;
+  border-radius: inherit;
   width: 0%;
 }
 
 .seekbar-handle {
   position: absolute;
-  top: 50%;
+  top: 28px;
   transform: translate(-50%, -50%);
   width: 12px;
   height: 12px;
+  box-sizing: border-box;
   background: var(--accent-primary);
+  border: 2px solid rgba(0, 0, 0, 0.45);
   border-radius: 50%;
+  box-shadow: 0 0 0 0 rgba(255, 208, 0, 0);
   opacity: 0;
-  transition: opacity 0.1s ease;
+  transition: opacity 0.12s ease, width 0.14s ease, height 0.14s ease, box-shadow 0.14s ease;
   left: 0%;
+  z-index: 2;
 }
 
-.fullscreen-seekbar:hover .seekbar-handle {
+.fullscreen-seekbar:hover .seekbar-handle,
+.fullscreen-seekbar.is-scrubbing .seekbar-handle {
+  width: 22px;
+  height: 22px;
+  box-shadow: 0 0 0 4px rgba(255, 208, 0, 0.16), 0 4px 14px rgba(0, 0, 0, 0.5);
   opacity: 1;
 }
 
@@ -8190,6 +8207,58 @@ body.app-fullscreen .fullscreen-timecode-overlay {
 
 .fullscreen-timecode-overlay .total-time {
   color: var(--text-secondary);
+}
+
+.fullscreen-scrub-overlay {
+  position: fixed;
+  left: 50%;
+  bottom: 96px;
+  width: min(520px, calc(100vw - 48px));
+  padding: 12px 14px;
+  transform: translate(-50%, 8px);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 1100;
+  background: rgba(8, 8, 8, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.fullscreen-scrub-overlay.visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.fullscreen-scrub-track {
+  width: 100%;
+  height: 6px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+}
+
+.fullscreen-scrub-progress {
+  width: 0%;
+  height: 100%;
+  background: var(--accent-primary);
+  border-radius: inherit;
+}
+
+.fullscreen-scrub-time {
+  margin-top: 8px;
+  color: rgba(255, 255, 255, 0.88);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+body:not(.app-fullscreen) .fullscreen-scrub-overlay {
+  display: none;
 }
 
 /* 전체화면에서 댓글 모드 표시 */

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -1710,10 +1710,38 @@ body.app-fullscreen .video-comment-overlay-controls {
   position: relative;
 }
 
+.playback-controls-scroll {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+}
+
+.playback-controls-scroll::-webkit-scrollbar {
+  height: 6px;
+}
+
+.playback-controls-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.playback-controls-scroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+}
+
 .playback-controls {
   display: flex;
   align-items: center;
   gap: 4px;
+  flex-shrink: 0;
 }
 
 .control-btn {

--- a/scripts/tests/video-pan-controls.test.js
+++ b/scripts/tests/video-pan-controls.test.js
@@ -14,6 +14,25 @@ const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'render
 const mainCss = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
 const userSettingsSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/user-settings.js'), 'utf8'));
 
+function cssBlock(selector) {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`(^|\\n)${escapedSelector}\\s*\\{`).exec(mainCss);
+  const start = match ? match.index + match[1].length : -1;
+  assert.notEqual(start, -1, `${selector} CSS block should exist`);
+  const open = mainCss.indexOf('{', start);
+  const close = mainCss.indexOf('\n}', open);
+  assert.notEqual(close, -1, `${selector} CSS block should close`);
+  return mainCss.slice(open + 1, close);
+}
+
+function jsFunction(name) {
+  const start = appSource.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name} function should exist`);
+  const close = appSource.indexOf('\n  }', start);
+  assert.notEqual(close, -1, `${name} function should close`);
+  return appSource.slice(start, close + 4);
+}
+
 test('video center lock is exposed as a persisted zoom-control toggle', () => {
   assert.match(indexSource, /id="btnVideoCenterLock"/);
   assert.match(indexSource, /aria-label="화면 중앙 고정"/);
@@ -34,4 +53,62 @@ test('center lock keeps 100 percent and smaller zoom levels centered', () => {
   assert.match(appSource, /function shouldCenterVideo\(\) \{[\s\S]*state\.videoCenterLocked && state\.videoZoom <= 100[\s\S]*\}/);
   assert.match(appSource, /if \(shouldCenterVideo\(\)\) \{[\s\S]*state\.videoPanX = 0;[\s\S]*state\.videoPanY = 0;[\s\S]*\}/);
   assert.match(appSource, /setVideoCenterLocked\(!state\.videoCenterLocked\)/);
+});
+
+test('video bottom seekbar stays slim until hover or active scrubbing', () => {
+  assert.match(mainCss, /\.seekbar-track\s*\{[\s\S]*height:\s*4px;/);
+  assert.match(mainCss, /\.fullscreen-seekbar:hover \.seekbar-track,\s*\.fullscreen-seekbar\.is-scrubbing \.seekbar-track\s*\{[\s\S]*height:\s*12px;/);
+  assert.match(mainCss, /\.fullscreen-seekbar:hover \.seekbar-handle,\s*\.fullscreen-seekbar\.is-scrubbing \.seekbar-handle\s*\{[\s\S]*opacity:\s*1;/);
+  assert.match(appSource, /function setFullscreenSeekbarScrubbing\(scrubbing\) \{[\s\S]*fullscreenSeekbar\?\.classList\.toggle\('is-scrubbing', scrubbing\);[\s\S]*\}/);
+});
+
+test('video bottom seekbar handle grows as a centered circular grip', () => {
+  assert.match(mainCss, /\.seekbar-handle\s*\{[\s\S]*top:\s*28px;[\s\S]*transform:\s*translate\(-50%, -50%\);[\s\S]*width:\s*12px;[\s\S]*height:\s*12px;[\s\S]*z-index:\s*2;/);
+  assert.match(mainCss, /\.fullscreen-seekbar:hover \.seekbar-handle,\s*\.fullscreen-seekbar\.is-scrubbing \.seekbar-handle\s*\{[\s\S]*width:\s*22px;[\s\S]*height:\s*22px;[\s\S]*box-shadow:/);
+});
+
+test('video bottom seekbar handle is layered above the track so the circle rises over the bar', () => {
+  assert.match(indexSource, /<div class="fullscreen-seekbar" id="fullscreenSeekbar">\s*<div class="seekbar-track">\s*<div class="seekbar-progress" id="seekbarProgress"><\/div>\s*<\/div>\s*<div class="seekbar-handle" id="seekbarHandle"><\/div>\s*<\/div>/);
+  assert.match(mainCss, /\.fullscreen-seekbar\s*\{[\s\S]*top:\s*-28px;[\s\S]*height:\s*44px;[\s\S]*padding:\s*0;/);
+  assert.match(mainCss, /\.seekbar-track\s*\{[\s\S]*position:\s*absolute;[\s\S]*top:\s*28px;[\s\S]*transform:\s*translateY\(-50%\);[\s\S]*z-index:\s*1;/);
+});
+
+test('playback controls allow the enlarged seekbar handle above the bar in normal and fullscreen modes', () => {
+  const normalControls = cssBlock('.controls-bar');
+  const fullscreenControls = cssBlock('body.app-fullscreen .controls-bar');
+
+  assert.match(normalControls, /overflow:\s*visible;/);
+  assert.doesNotMatch(normalControls, /overflow-x:\s*auto;/);
+  assert.match(fullscreenControls, /overflow:\s*visible;/);
+});
+
+test('middle-button drag scrubs video in normal and fullscreen modes', () => {
+  const canStartMiddleScrub = jsFunction('canStartFullscreenMiddleScrub');
+
+  assert.match(appSource, /isFullscreenScrubbing:\s*false/);
+  assert.match(canStartMiddleScrub, /e\.button === 1/);
+  assert.match(canStartMiddleScrub, /!state\.isDrawMode/);
+  assert.match(canStartMiddleScrub, /videoPlayer\.isLoaded/);
+  assert.match(canStartMiddleScrub, /videoPlayer\.duration > 0/);
+  assert.doesNotMatch(canStartMiddleScrub, /state\.isFullscreen/);
+  assert.match(appSource, /function startFullscreenMiddleScrub\(e\) \{[\s\S]*state\.fullscreenScrubStartX = e\.clientX;[\s\S]*state\.fullscreenScrubStartTime = videoPlayer\.currentTime \|\| 0;[\s\S]*showFullscreenScrubOverlay/);
+  assert.match(appSource, /function updateFullscreenMiddleScrub\(e\) \{[\s\S]*const timeDelta = \(dx \/ Math\.max\(1, window\.innerWidth\)\) \* state\.fullscreenScrubDuration;[\s\S]*videoPlayer\.seek\(targetTime\);[\s\S]*\}/);
+  assert.match(appSource, /elements\.videoWrapper\?\.addEventListener\('auxclick', \(e\) => \{[\s\S]*if \(e\.button === 1\) \{[\s\S]*e\.preventDefault\(\);/);
+  assert.match(mainCss, /\.fullscreen-scrub-overlay\s*\{/);
+  assert.match(mainCss, /\.fullscreen-scrub-overlay\.visible\s*\{/);
+});
+
+test('timeline height resizer sits below playback controls, not on the seekbar edge', () => {
+  const controlsIndex = indexSource.indexOf('<!-- Playback Controls -->');
+  const resizerIndex = indexSource.indexOf('id="viewerResizer"');
+  const timelineIndex = indexSource.indexOf('<!-- Timeline -->');
+
+  assert.notEqual(controlsIndex, -1, 'playback controls markup should exist');
+  assert.notEqual(resizerIndex, -1, 'timeline height resizer should exist');
+  assert.notEqual(timelineIndex, -1, 'timeline markup should exist');
+  assert.ok(
+    controlsIndex < resizerIndex && resizerIndex < timelineIndex,
+    'timeline height resizer should be between playback controls and timeline'
+  );
+  assert.match(indexSource, /id="viewerResizer"[^>]*title="타임라인 높이 조절"/);
 });

--- a/scripts/tests/video-pan-controls.test.js
+++ b/scripts/tests/video-pan-controls.test.js
@@ -76,10 +76,15 @@ test('video bottom seekbar handle is layered above the track so the circle rises
 test('playback controls allow the enlarged seekbar handle above the bar in normal and fullscreen modes', () => {
   const normalControls = cssBlock('.controls-bar');
   const fullscreenControls = cssBlock('body.app-fullscreen .controls-bar');
+  const scrollControls = cssBlock('.playback-controls-scroll');
 
   assert.match(normalControls, /overflow:\s*visible;/);
   assert.doesNotMatch(normalControls, /overflow-x:\s*auto;/);
   assert.match(fullscreenControls, /overflow:\s*visible;/);
+  assert.match(indexSource, /<div class="fullscreen-seekbar" id="fullscreenSeekbar">[\s\S]*?<\/div>\s*<div class="playback-controls-scroll">[\s\S]*?<div class="playback-controls">/);
+  assert.match(scrollControls, /overflow-x:\s*auto;/);
+  assert.match(scrollControls, /overflow-y:\s*hidden;/);
+  assert.match(scrollControls, /min-width:\s*0;/);
 });
 
 test('middle-button drag scrubs video in normal and fullscreen modes', () => {

--- a/scripts/tests/video-pan-controls.test.js
+++ b/scripts/tests/video-pan-controls.test.js
@@ -98,6 +98,7 @@ test('middle-button drag scrubs video in normal and fullscreen modes', () => {
   assert.doesNotMatch(canStartMiddleScrub, /state\.isFullscreen/);
   assert.match(appSource, /function startFullscreenMiddleScrub\(e\) \{[\s\S]*state\.fullscreenScrubStartX = e\.clientX;[\s\S]*state\.fullscreenScrubStartTime = videoPlayer\.currentTime \|\| 0;[\s\S]*showFullscreenScrubOverlay/);
   assert.match(appSource, /function updateFullscreenMiddleScrub\(e\) \{[\s\S]*const timeDelta = \(dx \/ Math\.max\(1, window\.innerWidth\)\) \* state\.fullscreenScrubDuration;[\s\S]*videoPlayer\.seek\(targetTime\);[\s\S]*\}/);
+  assert.match(appSource, /if \(e\.buttons === 0 \|\| \(e\.buttons & 4\) === 0\) \{[\s\S]*finishFullscreenMiddleScrub\(\);[\s\S]*return;/);
   assert.match(appSource, /elements\.videoWrapper\?\.addEventListener\('auxclick', \(e\) => \{[\s\S]*if \(e\.button === 1\) \{[\s\S]*e\.preventDefault\(\);/);
   assert.match(mainCss, /\.fullscreen-scrub-overlay\s*\{/);
   assert.match(mainCss, /\.fullscreen-scrub-overlay\.visible\s*\{/);


### PR DESCRIPTION
## 📋 업데이트 요약

🎬 영상 하단 재생 바에 마우스를 올리면 바와 손잡이가 더 커져서 원하는 위치를 잡기 쉬워졌습니다.

🖱️ 영상 화면 위에서 마우스 가운데 버튼을 누른 채 좌우로 드래그하면 재생 위치를 바로 이동할 수 있습니다. 이제 일반 화면과 전체화면 둘 다에서 동작합니다.

📏 타임라인 높이 조절 영역을 재생 바와 분리해서, 하단 바에 마우스를 올렸을 때 화면이 튀거나 덜컥거리는 현상을 줄였습니다.

## 🔧 상세 기술 설명

- `renderer/index.html`
  - `seekbarHandle`을 `seekbar-track` 내부에서 분리해 트랙 위 별도 레이어로 배치했습니다.
  - `viewerResizer`를 재생 컨트롤 아래, 타임라인 위로 이동해 플레이바 hover 영역과 리사이저 hit area가 충돌하지 않게 정리했습니다.

- `renderer/styles/main.css`
  - `.fullscreen-seekbar`, `.seekbar-track`, `.seekbar-handle`의 위치/레이어를 재정렬했습니다.
  - 트랙과 원형 손잡이의 중심을 같은 `top: 28px` 기준으로 맞춰 hover 시 손잡이가 위아래 균형 있게 커지도록 했습니다.
  - 일반 화면/전체화면의 `.controls-bar`에 `overflow: visible`을 적용해 커진 손잡이가 잘리지 않게 했습니다.
  - 전체화면 미들버튼 스크럽용 오버레이 스타일을 추가했습니다.

- `renderer/scripts/app.js`
  - `canStartFullscreenMiddleScrub`, `startFullscreenMiddleScrub`, `updateFullscreenMiddleScrub`, `finishFullscreenMiddleScrub` 흐름을 추가했습니다.
  - `mousedown`에서 마우스 가운데 버튼을 감지해 영상 재생 위치를 좌우 드래그로 이동하도록 연결했습니다.
  - 기존 전체화면 제한 조건을 제거해 일반 화면에서도 같은 입력 방식이 동작하도록 했습니다.
  - `auxclick` 기본 동작을 막아 브라우저식 가운데 클릭 동작이 영상 조작을 방해하지 않게 했습니다.

- `scripts/tests/video-pan-controls.test.js`
  - 플레이바 hover 두께, 원형 손잡이 중심 정렬, 손잡이 잘림 방지, 미들버튼 스크럽의 일반/전체화면 동작, 리사이저 위치를 회귀 테스트로 고정했습니다.

## 🚧 개발 난항

- 플레이헤드 손잡이를 키우는 과정에서 처음에는 원이 아래쪽으로만 커져 보이거나 위쪽이 잘리는 문제가 있었습니다. 원인을 트랙 내부 기준 배치와 컨트롤 바 overflow로 보고, 손잡이를 트랙 밖 독립 레이어로 분리한 뒤 중심선을 같은 값으로 맞췄습니다.
- 재생 바 hover 영역과 타임라인 높이 조절 영역이 겹치면서 하단 패널이 덜컥거리는 문제가 있었습니다. 리사이저를 재생 바와 타임라인 사이의 명확한 구역으로 옮겨 입력 충돌을 줄였습니다.
- “일반 화면에서도 가능” 요구가 플레이바 hover가 아니라 미들버튼 드래그 스크럽에 대한 의미였기 때문에, 최종적으로 전체화면 조건을 제거하고 두 화면 모드 모두에서 동작하도록 정리했습니다.

## ✅ 테스트 가이드

실사용자용:
- 영상 하단 재생 바에 마우스를 올렸을 때 바가 두꺼워지고 원형 손잡이가 가운데 기준으로 커지는지 확인합니다.
- 일반 화면에서 영상 영역 위에 마우스 가운데 버튼을 누른 채 좌우로 드래그해 재생 위치가 이동하는지 확인합니다.
- 전체화면에서도 같은 방식으로 재생 위치가 이동하는지 확인합니다.
- 하단 재생 바에 마우스를 올려도 타임라인 높이 조절이 덜컥거리며 튀지 않는지 확인합니다.

개발자용:
- `npm run test:video-pan`
- `npm run test:comment-input`
- `npm run test:cluster`
- `git diff --check`
- `npm run build`