### PR TITLE
[v1.4.0-beta] 재생목록 이어붙이기 안정성 개선

### DIFF
--- a/preload/preload.js
+++ b/preload/preload.js
@@ -106,7 +106,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   ffmpegGetSupportedCodecs: () => ipcRenderer.invoke('ffmpeg:get-supported-codecs'),
   ffmpegPreTranscode: (filePath) => ipcRenderer.invoke('ffmpeg:pre-transcode', filePath),
   onPreTranscodeProgress: (callback) => {
-    ipcRenderer.on('ffmpeg:pre-transcode-progress', (event, data) => callback(data));
+    const listener = (event, data) => callback(data);
+    ipcRenderer.on('ffmpeg:pre-transcode-progress', listener);
+    return () => ipcRenderer.removeListener('ffmpeg:pre-transcode-progress', listener);
   },
 
   // ====== 파일 관련 (유틸리티) ======
@@ -159,7 +161,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('app:request-save-before-quit', () => callback());
   },
   onTranscodeProgress: (callback) => {
-    ipcRenderer.on('ffmpeg:transcode-progress', (event, data) => callback(data));
+    const listener = (event, data) => callback(data);
+    ipcRenderer.on('ffmpeg:transcode-progress', listener);
+    return () => ipcRenderer.removeListener('ffmpeg:transcode-progress', listener);
   },
   onFileChanged: (callback) => {
     ipcRenderer.on('file:changed', (event, data) => callback(data));

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -406,7 +406,6 @@ async function initApp() {
     playlistTimelineUpdateToken += 1;
     playlistAggregateCommentRanges = [];
     timeline.clearPlaylistTimeline();
-    timeline.clearCommentMarkers();
   }
 
   function getDialogFileName(filePath) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -37,7 +37,8 @@ import {
 import {
   extractPlaylistCommentRanges,
   formatPlaylistCommentPanelLine,
-  formatPlaylistTimecode
+  formatPlaylistTimecode,
+  getPlaylistAggregateCommentKey
 } from './modules/playlist-comment-index.js';
 import {
   buildCutlistCommentContext,
@@ -340,6 +341,7 @@ async function initApp() {
 
   let suppressPlaylistSelectionLoad = false;
   let playlistAutoPlayAfterSelection = false;
+  let playlistSelectionLoadToken = 0;
   const playlistMediaPreload = {
     element: null,
     itemId: null,
@@ -400,6 +402,13 @@ async function initApp() {
     return normalizeComparableFilePath(a) === normalizeComparableFilePath(b);
   }
 
+  function resetPlaylistContinuousTimelineState() {
+    playlistTimelineUpdateToken += 1;
+    playlistAggregateCommentRanges = [];
+    timeline.clearPlaylistTimeline();
+    timeline.clearCommentMarkers();
+  }
+
   function getDialogFileName(filePath) {
     const normalized = String(filePath || '').replace(/\\/g, '/');
     return normalized.split('/').filter(Boolean).pop() || '선택한 info 파일';
@@ -429,10 +438,15 @@ async function initApp() {
   async function openPlaylistFile(filePath) {
     const normalizedPath = normalizePlaylistOpenPath(filePath);
     const playlistManager = getPlaylistManager();
+    playlistSelectionLoadToken += 1;
     await playlistManager.open(normalizedPath);
+    resetPlaylistContinuousTimelineState();
     showPlaylistSidebar();
     if (playlistManager.getItemCount() > 0) {
       playlistManager.selectItem(0);
+    }
+    if (playlistUIState.mode === 'continuous') {
+      updatePlaylistContinuousTimeline();
     }
     return true;
   }
@@ -1968,11 +1982,30 @@ async function initApp() {
   });
 
   // ====== 작성자 필터 드롭다운 ======
+  function getAuthorFilterSourceItems() {
+    if (playlistUIState.mode === 'continuous') {
+      return playlistAggregateCommentRanges;
+    }
+    if (cutlistUIState.active) {
+      return cutlistAggregateCommentRanges;
+    }
+    return commentManager.getAllMarkers();
+  }
+
+  function getAuthorFilterAuthorIds() {
+    const uniqueAuthors = new Set();
+    getAuthorFilterSourceItems().forEach(m => {
+      if (m.deleted) return;
+      uniqueAuthors.add(m.authorId || m.author || 'unknown');
+    });
+    return uniqueAuthors;
+  }
+
   function updateAuthorFilterMenu() {
     const menu = document.getElementById('authorFilterMenu');
     if (!menu) return;
 
-    const allMarkers = commentManager.getAllMarkers();
+    const allMarkers = getAuthorFilterSourceItems();
     const authors = new Map();
 
     allMarkers.forEach(m => {
@@ -2127,10 +2160,7 @@ async function initApp() {
     else {
       if (commentFilterState.authors === null) {
         // 전체 선택 → 이 작성자만 해제
-        const allMarkers = commentManager.getAllMarkers();
-        const uniqueAuthors = new Set(
-          allMarkers.filter(m => !m.deleted).map(m => m.authorId || m.author || 'unknown')
-        );
+        const uniqueAuthors = getAuthorFilterAuthorIds();
         commentFilterState.authors = [...uniqueAuthors].filter(id => id !== authorId);
       } else {
         const idx = commentFilterState.authors.indexOf(authorId);
@@ -2140,10 +2170,7 @@ async function initApp() {
           commentFilterState.authors.push(authorId);
         }
         // 모든 작성자가 선택되면 null(전체)로 리셋
-        const allMarkers = commentManager.getAllMarkers();
-        const uniqueAuthors = new Set(
-          allMarkers.filter(m => !m.deleted).map(m => m.authorId || m.author || 'unknown')
-        );
+        const uniqueAuthors = getAuthorFilterAuthorIds();
         if (commentFilterState.authors.length >= uniqueAuthors.size) {
           commentFilterState.authors = null;
         }
@@ -4574,10 +4601,31 @@ async function initApp() {
   // ====== 트랜스코딩 상태 관리 ======
   let isTranscoding = false;
   let transcodeResolve = null;
+  let activeTranscodeOverlayToken = 0;
+  let activeTranscodeOverlayCleanup = null;
   let latestVideoLoadToken = 0;
 
   function isStaleVideoLoadToken(loadToken) {
     return loadToken !== latestVideoLoadToken;
+  }
+
+  function supersedeActiveTranscodeOverlay(reason = 'stale') {
+    activeTranscodeOverlayToken += 1;
+
+    if (typeof activeTranscodeOverlayCleanup === 'function') {
+      activeTranscodeOverlayCleanup(true);
+      activeTranscodeOverlayCleanup = null;
+    }
+
+    const overlay = document.getElementById('transcodeOverlay');
+    overlay?.classList.remove('active');
+    isTranscoding = false;
+
+    if (transcodeResolve) {
+      const resolve = transcodeResolve;
+      transcodeResolve = null;
+      resolve({ success: false, stale: true, error: reason });
+    }
   }
 
   function isCurrentReviewPath(bframePath) {
@@ -4676,6 +4724,10 @@ async function initApp() {
    * @returns {Promise<{success: boolean, outputPath?: string, error?: string}>}
    */
   async function showTranscodeOverlay(filePath, codecName) {
+    supersedeActiveTranscodeOverlay('새 변환 시작');
+    const overlayToken = ++activeTranscodeOverlayToken;
+    const isActiveTranscodeOverlay = () => overlayToken === activeTranscodeOverlayToken;
+
     const overlay = document.getElementById('transcodeOverlay');
     const subtitle = document.getElementById('transcodeSubtitle');
     const progressFill = document.getElementById('transcodeProgressFill');
@@ -4693,63 +4745,84 @@ async function initApp() {
 
     // 진행률 이벤트 리스너
     const progressHandler = (data) => {
+      if (!isActiveTranscodeOverlay()) return;
       if (data.filePath === filePath) {
         progressFill.style.width = `${data.progress}%`;
         percentText.textContent = `${data.progress}%`;
         statusText.textContent = data.progress < 100 ? '변환 중...' : '완료 처리 중...';
       }
     };
-    window.electronAPI.onTranscodeProgress(progressHandler);
-    window.electronAPI.onPreTranscodeProgress(progressHandler);
+    const unsubscribeTranscodeProgress = window.electronAPI.onTranscodeProgress(progressHandler);
+    const unsubscribePreTranscodeProgress = window.electronAPI.onPreTranscodeProgress(progressHandler);
 
-    const cleanupTranscodeProgressListeners = () => {
-      window.electronAPI.removeAllListeners('ffmpeg:transcode-progress');
-      window.electronAPI.removeAllListeners('ffmpeg:pre-transcode-progress');
-    };
-
-    // 취소 버튼 핸들러
-    const handleCancel = async () => {
-      log.info('사용자가 트랜스코딩 취소 요청');
-      await window.electronAPI.ffmpegCancel();
-      isTranscoding = false;
-      overlay.classList.remove('active');
-      cleanupTranscodeProgressListeners();
-      if (transcodeResolve) {
-        transcodeResolve({ success: false, error: '사용자 취소' });
-        transcodeResolve = null;
+    const cleanupTranscodeProgressListeners = (force = false) => {
+      if (!force && !isActiveTranscodeOverlay()) return;
+      unsubscribeTranscodeProgress?.();
+      unsubscribePreTranscodeProgress?.();
+      if (activeTranscodeOverlayCleanup === cleanupTranscodeProgressListeners) {
+        activeTranscodeOverlayCleanup = null;
       }
     };
-    cancelBtn.addEventListener('click', handleCancel, { once: true });
 
     return new Promise(async (resolve) => {
       transcodeResolve = resolve;
 
+      const finish = (result) => {
+        if (transcodeResolve === resolve) {
+          transcodeResolve = null;
+        }
+        resolve(result);
+      };
+
+      const cleanupOverlay = (force = false) => {
+        if (!force && !isActiveTranscodeOverlay()) return;
+        isTranscoding = false;
+        overlay.classList.remove('active');
+        cleanupTranscodeProgressListeners(force);
+        cancelBtn.removeEventListener('click', handleCancel);
+        if (activeTranscodeOverlayCleanup === cleanupOverlay) {
+          activeTranscodeOverlayCleanup = null;
+        }
+      };
+
+      const handleCancel = async () => {
+        if (!isActiveTranscodeOverlay()) return;
+        activeTranscodeOverlayToken += 1;
+        log.info('사용자가 트랜스코딩 취소 요청');
+        await window.electronAPI.ffmpegCancel();
+        cleanupOverlay(true);
+        finish({ success: false, error: '사용자 취소' });
+      };
+
+      activeTranscodeOverlayCleanup = cleanupOverlay;
+      cancelBtn.addEventListener('click', handleCancel, { once: true });
+
       try {
         const result = await window.electronAPI.ffmpegTranscode(filePath);
 
-        isTranscoding = false;
-        overlay.classList.remove('active');
-        cleanupTranscodeProgressListeners();
-        cancelBtn.removeEventListener('click', handleCancel);
+        if (!isActiveTranscodeOverlay()) {
+          return;
+        }
+
+        cleanupOverlay();
 
         if (result.success) {
           log.info('트랜스코딩 완료', { outputPath: result.outputPath, fromCache: result.fromCache });
-          resolve({ success: true, outputPath: result.outputPath });
+          finish({ success: true, outputPath: result.outputPath });
         } else {
           log.error('트랜스코딩 실패', { error: result.error });
-          resolve({ success: false, error: result.error });
+          finish({ success: false, error: result.error });
         }
       } catch (error) {
-        isTranscoding = false;
-        overlay.classList.remove('active');
-        cleanupTranscodeProgressListeners();
-        cancelBtn.removeEventListener('click', handleCancel);
+        if (!isActiveTranscodeOverlay()) {
+          return;
+        }
+
+        cleanupOverlay();
 
         log.error('트랜스코딩 예외', { error: error.message });
-        resolve({ success: false, error: error.message });
+        finish({ success: false, error: error.message });
       }
-
-      transcodeResolve = null;
     });
   }
 
@@ -4944,6 +5017,7 @@ async function initApp() {
     } = options;
     const loadToken = ++latestVideoLoadToken;
     const isStaleVideoLoad = () => loadToken !== latestVideoLoadToken;
+    supersedeActiveTranscodeOverlay('새 영상 선택');
     if (!preserveContinuousSession && continuousPlaybackState.active) {
       stopContinuousPlayback();
     }
@@ -4982,6 +5056,7 @@ async function initApp() {
             // 트랜스코딩 필요 - UI 표시
             const transcoded = await showTranscodeOverlay(filePath, codecInfo.codecName);
             if (isStaleVideoLoad()) return false;
+            if (transcoded.stale) return false;
             if (transcoded.success) {
               actualVideoPath = transcoded.outputPath;
             } else {
@@ -6640,10 +6715,6 @@ async function initApp() {
     });
   }
 
-  function getPlaylistAggregateCommentKey(range) {
-    return `${range.itemId || ''}:${range.layerId || ''}:${range.markerId || ''}`;
-  }
-
   function playlistRangeMatchesCommentSearch(range, normalizedQuery) {
     if (!normalizedQuery) return true;
     if (markerMatchesCommentSearch(range, normalizedQuery)) return true;
@@ -6717,7 +6788,8 @@ async function initApp() {
     const isAlreadyLoaded = state.currentFile === item.videoPath;
     if (!isAlreadyLoaded) {
       const loaded = await loadVideoFromPlaylist(item, {
-        preserveContinuousSession: continuousPlaybackState.active
+        preserveContinuousSession: continuousPlaybackState.active,
+        shouldContinue: () => playlistUIState.mode === 'continuous'
       });
       if (!loaded) return;
     }
@@ -12039,7 +12111,8 @@ async function initApp() {
     const isAlreadyLoaded = state.currentFile === item.videoPath;
     if (!isAlreadyLoaded) {
       const loaded = await loadVideoFromPlaylist(item, {
-        preserveContinuousSession: continuousPlaybackState.active
+        preserveContinuousSession: continuousPlaybackState.active,
+        shouldContinue: () => playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0
       });
       if (!loaded) return false;
     }
@@ -12057,8 +12130,10 @@ async function initApp() {
     continuousPlaybackState.active = false;
     continuousPlaybackState.waiting = false;
     continuousPlaybackState.skippedBatch = [];
+    continuousPlaybackState.loadingItemId = null;
     continuousPlaybackState.preparePromises.clear();
     continuousPlaybackState.preparedMediaPaths.clear();
+    clearPlaylistMediaPreload();
   }
 
   function isContinuousSessionActive(sessionId) {
@@ -12139,6 +12214,7 @@ async function initApp() {
   async function updatePlaylistContinuousTimeline() {
     if (playlistUIState.mode !== 'continuous') return;
     timeline.clearCommentMarkers();
+    timeline.renderPlaylistCommentRanges([], 0);
     const updateToken = ++playlistTimelineUpdateToken;
     const playlistManager = getPlaylistManager();
     const items = playlistManager.getItems();
@@ -12355,7 +12431,8 @@ async function initApp() {
         holdPreviousFrameUntilReady: true,
         playWhenMediaReady: true,
         deferCollaborationStart: true,
-        preparedVideoPath
+        preparedVideoPath,
+        shouldContinue: () => isContinuousSessionActive(sessionId)
       });
       if (!isContinuousSessionActive(sessionId)) return false;
       if (loaded === false) {
@@ -12619,8 +12696,7 @@ async function initApp() {
 
     if (nextMode === 'review') {
       stopContinuousPlayback({ keepCurrentVideo: true });
-      playlistAggregateCommentRanges = [];
-      timeline.setPlaylistTimeline([], 0);
+      resetPlaylistContinuousTimelineState();
       renderCommentRanges();
       updateTimelineMarkers();
       updateCommentList();
@@ -12640,8 +12716,6 @@ async function initApp() {
     }
 
     setPlaylistMode('review');
-    playlistAggregateCommentRanges = [];
-    timeline.setPlaylistTimeline([], 0);
   }
 
   async function refreshPlaylistModifiedTimes() {
@@ -13450,6 +13524,11 @@ async function initApp() {
 
     playlistManager.onItemSelected = async (item, index) => {
       log.info('재생목록 아이템 선택', { index, fileName: item.fileName });
+      const selectionLoadToken = ++playlistSelectionLoadToken;
+      const shouldContinuePlaylistSelectionLoad = () => (
+        selectionLoadToken === playlistSelectionLoadToken &&
+        playlistManager.getCurrentItem()?.id === item.id
+      );
       const shouldAutoPlaySelectedItem = playlistAutoPlayAfterSelection && userSettings.getPlaylistAutoPlay();
       playlistAutoPlayAfterSelection = false;
       if (suppressPlaylistSelectionLoad) {
@@ -13459,8 +13538,10 @@ async function initApp() {
       }
 
       const loaded = await loadVideoFromPlaylist(item, {
-        playWhenMediaReady: shouldAutoPlaySelectedItem
+        playWhenMediaReady: shouldAutoPlaySelectedItem,
+        shouldContinue: shouldContinuePlaylistSelectionLoad
       });
+      if (!shouldContinuePlaylistSelectionLoad()) return;
       updatePlaylistCurrentItem();
       updatePlaylistPosition();
       updatePlaylistContinuousTimeline();
@@ -13475,7 +13556,9 @@ async function initApp() {
     };
 
     playlistManager.onPlaylistClosed = () => {
+      playlistSelectionLoadToken += 1;
       clearPlaylistMediaPreload();
+      resetPlaylistContinuousTimelineState();
       hidePlaylistSidebar();
     };
 
@@ -13707,8 +13790,13 @@ async function initApp() {
 
   // 재생목록에서 영상 로드
   async function loadVideoFromPlaylist(item, options = {}) {
+    const { shouldContinue = null, ...loadOptions } = options;
+    const canContinuePlaylistLoad = () => typeof shouldContinue !== 'function' || shouldContinue();
+    if (!canContinuePlaylistLoad()) return false;
+
     // 파일 존재 확인
     const exists = await window.electronAPI.fileExists(item.videoPath);
+    if (!canContinuePlaylistLoad()) return false;
     if (!exists) {
       showToast(`파일을 찾을 수 없습니다: ${item.fileName}`, 'error');
       markPlaylistItemAsMissing(item.id);
@@ -13718,10 +13806,13 @@ async function initApp() {
     // 현재 영상 저장
     if (reviewDataManager.isModified) {
       await reviewDataManager.save();
+      if (!canContinuePlaylistLoad()) return false;
     }
 
     // 새 영상 로드
-    const loaded = await loadVideo(item.videoPath, options);
+    if (!canContinuePlaylistLoad()) return false;
+    const loaded = await loadVideo(item.videoPath, loadOptions);
+    if (!canContinuePlaylistLoad()) return false;
     return loaded === true;
   }
 

--- a/renderer/scripts/modules/playlist-comment-index.js
+++ b/renderer/scripts/modules/playlist-comment-index.js
@@ -50,6 +50,10 @@ export function formatPlaylistCommentTitle(range = {}) {
   return `${getPlaylistCutLabel(range)} 컷 ${localTimecode} / 전체 ${globalTimecode} - ${range.text || '댓글'}`;
 }
 
+export function getPlaylistAggregateCommentKey(range = {}) {
+  return `${range.itemId || ''}:${range.layerId || ''}:${range.markerId || ''}`;
+}
+
 export function extractPlaylistCommentRanges(options) {
   const bframeData = options.bframeData || {};
   const segment = options.segment;
@@ -81,10 +85,19 @@ export function extractPlaylistCommentRanges(options) {
         : (Number.isFinite(markerFps) && markerFps > 0 ? markerFps : fallbackFps);
       const startFrame = Number(marker.startFrame) || 0;
       const endFrame = Number(marker.endFrame) || startFrame;
-      const startTime = startFrame / fps;
-      const endTime = Math.max(startTime, endFrame / fps);
+      const rawStartTime = startFrame / fps;
+      const rawEndTime = Math.max(rawStartTime, endFrame / fps);
+      const segmentDuration = Number(segment.duration);
+      const maxLocalTime = Number.isFinite(segmentDuration) && segmentDuration > 0
+        ? segmentDuration
+        : Infinity;
+      if (rawStartTime > maxLocalTime) continue;
+      const startTime = Math.max(0, Math.min(rawStartTime, maxLocalTime));
+      const endTime = Math.max(startTime, Math.min(rawEndTime, maxLocalTime));
       const globalStartTime = segment.startTime + startTime;
       const globalEndTime = segment.startTime + endTime;
+      const localStartFrame = Math.round(startTime * fps);
+      const localEndFrame = Math.round(endTime * fps);
       ranges.push({
         itemId: segment.itemId,
         itemIndex: segment.index,
@@ -108,10 +121,10 @@ export function extractPlaylistCommentRanges(options) {
         localEndTime: endTime,
         globalStartTime,
         globalEndTime,
-        localStartFrame: startFrame,
-        localEndFrame: endFrame,
-        startFrame,
-        endFrame,
+        localStartFrame,
+        localEndFrame,
+        startFrame: localStartFrame,
+        endFrame: localEndFrame,
         startTimecode: formatPlaylistTimecode(startTime, fps),
         localStartTimecode: formatPlaylistTimecode(startTime, fps),
         globalStartTimecode: formatPlaylistTimecode(globalStartTime, fps)

--- a/renderer/scripts/modules/split-view-manager.js
+++ b/renderer/scripts/modules/split-view-manager.js
@@ -1190,7 +1190,7 @@ export class SplitViewManager {
                 if (progressFill) progressFill.style.width = `${data.progress}%`;
               }
             };
-            window.electronAPI.onTranscodeProgress(progressHandler);
+            const unsubscribeTranscodeProgress = window.electronAPI.onTranscodeProgress(progressHandler);
 
             try {
               const transcodeResult = await window.electronAPI.ffmpegTranscode(versionInfo.path);
@@ -1203,7 +1203,7 @@ export class SplitViewManager {
               }
             } finally {
               // 리스너 정리
-              window.electronAPI.removeAllListeners?.('ffmpeg:transcode-progress');
+              unsubscribeTranscodeProgress?.();
             }
           }
         }

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -8,7 +8,11 @@ import { MARKER_COLORS } from './comment-manager.js';
 import { resolveFrameGridTier } from './frame-grid-tiers.js';
 import { findRangeClusters, assignLanes, assignRenderLanes, clusterKey, splitClustersByPixelGap } from './comment-cluster.js';
 import { getTimelineFocalContentX, calculateAnchoredScrollLeft } from './timeline-zoom-core.js';
-import { formatPlaylistCommentLabel, formatPlaylistCommentTitle } from './playlist-comment-index.js';
+import {
+  formatPlaylistCommentLabel,
+  formatPlaylistCommentTitle,
+  getPlaylistAggregateCommentKey
+} from './playlist-comment-index.js';
 
 const log = createLogger('Timeline');
 
@@ -2008,11 +2012,42 @@ export class Timeline extends EventTarget {
   }
 
   setPlaylistTimeline(segments, totalDuration) {
-    this.playlistSegments = segments || [];
+    this.playlistSegments = Array.isArray(segments) ? segments : [];
     this.playlistDuration = totalDuration || 0;
     this._updateRuler();
     this._updatePlayheadPosition();
+    if (!this.playlistSegments.length || !this.playlistDuration) {
+      this.clearPlaylistCommentRanges();
+    }
     this._renderPlaylistSegments();
+  }
+
+  clearPlaylistCommentRanges() {
+    this._lastPlaylistCommentRanges = null;
+    this._lastPlaylistCommentDuration = 0;
+    this.expandedClusterId = null;
+
+    if (!this.commentTrack) return;
+    this.commentTrack.querySelectorAll('.playlist-comment-range').forEach(el => el.remove());
+
+    const hasCommentContent = this.commentTrack.querySelector(
+      '.comment-range-item, .comment-cluster-badge, .comment-cluster-close-badge'
+    );
+    if (!hasCommentContent) {
+      this.commentTrack.style.display = 'none';
+      if (this.commentLayerHeader) {
+        this.commentLayerHeader.style.display = 'none';
+      }
+    }
+  }
+
+  clearPlaylistTimeline() {
+    this.playlistSegments = [];
+    this.playlistDuration = 0;
+    this._updateRuler();
+    this._updatePlayheadPosition();
+    this._clearPlaylistSegmentElements();
+    this.clearPlaylistCommentRanges();
   }
 
   setCutlistTimeline(segments, totalDuration) {
@@ -2035,7 +2070,7 @@ export class Timeline extends EventTarget {
 
   _renderPlaylistSegments() {
     if (!this.tracksContainer) return;
-    this.tracksContainer.querySelectorAll('.playlist-segment-boundary, .playlist-segment-block').forEach(el => el.remove());
+    this._clearPlaylistSegmentElements();
     const videoTrackRow = this.tracksContainer.querySelector('.video-track-row');
     const duration = this.playlistDuration || this.duration;
     const hasSegments = Boolean(duration && this.playlistSegments?.length);
@@ -2092,6 +2127,15 @@ export class Timeline extends EventTarget {
         this._emit('seek', { time, itemId: segment.itemId });
       });
       this.tracksContainer.appendChild(boundary);
+    }
+  }
+
+  _clearPlaylistSegmentElements() {
+    if (!this.tracksContainer) return;
+    this.tracksContainer.querySelectorAll('.playlist-segment-boundary, .playlist-segment-block').forEach(el => el.remove());
+    const videoTrackRow = this.tracksContainer.querySelector('.video-track-row');
+    if (videoTrackRow) {
+      videoTrackRow.classList.remove('has-playlist-segments');
     }
   }
 
@@ -2184,7 +2228,7 @@ export class Timeline extends EventTarget {
       el.style.setProperty('--comment-color', range.color);
       el.dataset.itemId = range.itemId;
       el.dataset.markerId = range.markerId;
-      el.dataset.aggregateCommentKey = `${range.itemId || ''}:${range.layerId || ''}:${range.markerId || ''}`;
+      el.dataset.aggregateCommentKey = getPlaylistAggregateCommentKey(range);
       el.dataset.localStartFrame = String(range.localStartFrame);
       el.title = formatPlaylistCommentTitle(range);
       const label = document.createElement('span');

--- a/scripts/tests/playlist-comment-index.test.js
+++ b/scripts/tests/playlist-comment-index.test.js
@@ -209,3 +209,49 @@ test('통합 댓글 위치는 저장된 리뷰 fps보다 현재 세그먼트 fps
   assert.equal(range.globalStartTime, 12);
   assert.equal(range.localStartTimecode, '00:00:02:00');
 });
+
+test('통합 댓글 구간은 세그먼트 길이를 넘지 않게 자른다', () => {
+  const bframeData = {
+    fps: 10,
+    comments: {
+      layers: [
+        {
+          id: 'layer-a',
+          visible: true,
+          markers: [
+            { id: 'm1', startFrame: 40, endFrame: 80, text: '끝 구간 확인' }
+          ]
+        }
+      ]
+    }
+  };
+  const segment = {
+    itemId: 'item-1',
+    index: 0,
+    fileName: 'short.mov',
+    startTime: 100,
+    duration: 5,
+    fps: 10
+  };
+
+  const [range] = mod.extractPlaylistCommentRanges({
+    bframeData,
+    segment,
+    visibleLayerIds: null,
+    allowedAuthorIds: null
+  });
+
+  assert.equal(range.localStartTime, 4);
+  assert.equal(range.localEndTime, 5);
+  assert.equal(range.globalStartTime, 104);
+  assert.equal(range.globalEndTime, 105);
+  assert.equal(range.endFrame, 50);
+});
+
+test('통합 댓글 키는 한 헬퍼에서 만든다', () => {
+  assert.equal(typeof mod.getPlaylistAggregateCommentKey, 'function');
+  assert.equal(
+    mod.getPlaylistAggregateCommentKey({ itemId: 'item-1', layerId: 'layer-a', markerId: 'm1' }),
+    'item-1:layer-a:m1'
+  );
+});

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -8,6 +8,8 @@ const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
 const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
 const timelineSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/timeline.js'), 'utf8'));
 const ffmpegManagerSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'main/ffmpeg-manager.js'), 'utf8'));
+const preloadSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'preload/preload.js'), 'utf8'));
+const splitViewSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/split-view-manager.js'), 'utf8'));
 const playlistCss = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/playlist-panel.css'), 'utf8'));
 const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
 
@@ -50,6 +52,42 @@ test('continuous timeline updates ignore stale async completions', () => {
   assert.match(timelineUpdateSource, /const bframePath = await playlistManager\.ensureItemBframePath\(item\);[\s\S]+const bframeData = await window\.electronAPI\.loadReview\(bframePath\);[\s\S]+playlistTimelineUpdateToken !== updateToken/);
 });
 
+test('opening or replacing playlists clears stale continuous timeline state', () => {
+  assert.match(appSource, /function resetPlaylistContinuousTimelineState\(\) \{/);
+
+  const resetMatch = appSource.match(/function resetPlaylistContinuousTimelineState\(\) \{([\s\S]*?)\n  \}/);
+  assert.ok(resetMatch, 'continuous timeline reset helper should exist');
+  const resetSource = resetMatch[1];
+  assert.match(resetSource, /playlistTimelineUpdateToken \+= 1;/);
+  assert.match(resetSource, /playlistAggregateCommentRanges = \[\];/);
+  assert.match(resetSource, /timeline\.clearPlaylistTimeline\(\);/);
+
+  const openMatch = appSource.match(/async function openPlaylistFile\(filePath\) \{([\s\S]*?)\n  \}/);
+  assert.ok(openMatch, 'openPlaylistFile should exist');
+  const openSource = openMatch[1];
+  assert.match(openSource, /playlistSelectionLoadToken \+= 1;[\s\S]+await playlistManager\.open\(normalizedPath\);/);
+  assert.ok(
+    openSource.indexOf('await playlistManager.open(normalizedPath);') <
+      openSource.indexOf('resetPlaylistContinuousTimelineState();'),
+    'existing continuous timeline should clear only after the replacement playlist opens successfully'
+  );
+  assert.match(openSource, /if \(playlistUIState\.mode === 'continuous'\) \{[\s\S]+updatePlaylistContinuousTimeline\(\);[\s\S]+\}/);
+});
+
+test('review mode exits through the shared continuous timeline reset helper', () => {
+  const modeStart = appSource.indexOf('function setPlaylistMode(mode)');
+  const modeEnd = appSource.indexOf('  async function refreshPlaylistModifiedTimes', modeStart);
+  assert.notEqual(modeStart, -1, 'setPlaylistMode should exist');
+  assert.notEqual(modeEnd, -1, 'setPlaylistMode boundary should exist');
+  const modeSource = appSource.slice(modeStart, modeEnd);
+  const reviewBranchIndex = modeSource.indexOf("nextMode === 'review'");
+  const resetIndex = modeSource.indexOf('resetPlaylistContinuousTimelineState();', reviewBranchIndex);
+  const renderIndex = modeSource.indexOf('renderCommentRanges();', reviewBranchIndex);
+
+  assert.notEqual(resetIndex, -1, 'review mode should clear continuous state through the shared helper');
+  assert.ok(resetIndex < renderIndex, 'continuous state should clear before normal comments render');
+});
+
 test('continuous aggregate comments recover missing bframePath from the media path', () => {
   const timelineUpdateMatch = appSource.match(/async function updatePlaylistContinuousTimeline\(\) \{([\s\S]*?)\n  \}\n\n  async function quickCheckPlaylistForContinuous/);
   assert.ok(timelineUpdateMatch, 'updatePlaylistContinuousTimeline should exist');
@@ -90,6 +128,65 @@ test('aggregate comment range rendering keeps the comment track header in sync',
   assert.match(renderSource, /this\.commentLayerHeader/);
   assert.match(renderSource, /this\.commentLayerHeader\.style\.display = 'none';/);
   assert.match(renderSource, /this\.commentLayerHeader\.style\.display = 'flex';/);
+});
+
+test('continuous timeline refresh clears stale comment bars before async metadata loads', () => {
+  const timelineUpdateMatch = appSource.match(/async function updatePlaylistContinuousTimeline\(\) \{([\s\S]*?)\n  \}\n\n  async function quickCheckPlaylistForContinuous/);
+  assert.ok(timelineUpdateMatch, 'updatePlaylistContinuousTimeline should exist');
+
+  const timelineUpdateSource = timelineUpdateMatch[1];
+  assert.match(timelineUpdateSource, /timeline\.clearCommentMarkers\(\);\s*\n\s*timeline\.renderPlaylistCommentRanges\(\[\], 0\);/);
+  assert.ok(
+    timelineUpdateSource.indexOf('timeline.renderPlaylistCommentRanges([], 0);') <
+      timelineUpdateSource.indexOf('const metadata = await collectPlaylistMetadata(items);'),
+    'stale single-video or previous playlist comment bars should clear before async metadata work'
+  );
+});
+
+test('playlist timeline clear removes joined comments and cached aggregate ranges', () => {
+  assert.match(timelineSource, /clearPlaylistCommentRanges\(\) \{/);
+  assert.match(timelineSource, /clearPlaylistTimeline\(\) \{/);
+
+  const clearCommentMatch = timelineSource.match(/clearPlaylistCommentRanges\(\) \{([\s\S]*?)\n  \}/);
+  assert.ok(clearCommentMatch, 'clearPlaylistCommentRanges should exist');
+  const clearCommentSource = clearCommentMatch[1];
+  assert.match(clearCommentSource, /this\._lastPlaylistCommentRanges = null;/);
+  assert.match(clearCommentSource, /this\._lastPlaylistCommentDuration = 0;/);
+  assert.match(clearCommentSource, /querySelectorAll\('\.playlist-comment-range'\)/);
+
+  const setTimelineMatch = timelineSource.match(/setPlaylistTimeline\(segments, totalDuration\) \{([\s\S]*?)\n  \}/);
+  assert.ok(setTimelineMatch, 'setPlaylistTimeline should exist');
+  assert.match(setTimelineMatch[1], /if \(!this\.playlistSegments\.length \|\| !this\.playlistDuration\) \{[\s\S]+this\.clearPlaylistCommentRanges\(\);/);
+});
+
+test('continuous author filter menu uses aggregate playlist comments', () => {
+  assert.match(appSource, /function getAuthorFilterSourceItems\(\) \{/);
+  assert.match(appSource, /function getAuthorFilterAuthorIds\(\) \{/);
+
+  const sourceMatch = appSource.match(/function getAuthorFilterSourceItems\(\) \{([\s\S]*?)\n  \}/);
+  assert.ok(sourceMatch, 'author filter source helper should exist');
+  assert.match(sourceMatch[1], /if \(playlistUIState\.mode === 'continuous'\) \{[\s\S]+return playlistAggregateCommentRanges;/);
+
+  const idsMatch = appSource.match(/function getAuthorFilterAuthorIds\(\) \{([\s\S]*?)\n  \}/);
+  assert.ok(idsMatch, 'author filter author id helper should exist');
+  assert.match(idsMatch[1], /getAuthorFilterSourceItems\(\)/);
+
+  const menuMatch = appSource.match(/function updateAuthorFilterMenu\(\) \{([\s\S]*?)\n  \}/);
+  assert.ok(menuMatch, 'updateAuthorFilterMenu should exist');
+  assert.match(menuMatch[1], /const allMarkers = getAuthorFilterSourceItems\(\);/);
+
+  const clickMatch = appSource.match(/document\.getElementById\('authorFilterMenu'\)\?\.addEventListener\('click', \(e\) => \{([\s\S]*?)\n  \}\);/);
+  assert.ok(clickMatch, 'author filter click handler should exist');
+  const clickSource = clickMatch[1];
+  assert.match(clickSource, /const uniqueAuthors = getAuthorFilterAuthorIds\(\);/);
+  assert.doesNotMatch(clickSource, /commentManager\.getAllMarkers\(\)/);
+});
+
+test('playlist aggregate comment keys are generated by the shared helper', () => {
+  assert.match(appSource, /getPlaylistAggregateCommentKey[\s\S]+from '\.\/modules\/playlist-comment-index\.js'/);
+  assert.match(timelineSource, /getPlaylistAggregateCommentKey[\s\S]+from '\.\/playlist-comment-index\.js'/);
+  assert.match(timelineSource, /el\.dataset\.aggregateCommentKey = getPlaylistAggregateCommentKey\(range\);/);
+  assert.doesNotMatch(appSource, /function getPlaylistAggregateCommentKey\(range\) \{[\s\S]*return `\$\{range\.itemId/);
 });
 
 test('continuous mode hides single-video vertical comment markers', () => {
@@ -283,6 +380,30 @@ test('manual video loads cancel active continuous playback and stale loads', () 
   assert.match(loadVideoSource, /if \(isStaleVideoLoad\(\)\) return false;/);
 });
 
+test('rapid playlist item selections cannot let older pre-load checks win', () => {
+  assert.match(appSource, /let playlistSelectionLoadToken = 0;/);
+
+  const selectedMatch = appSource.match(/playlistManager\.onItemSelected = async \(item, index\) => \{([\s\S]*?)\n    \};/);
+  assert.ok(selectedMatch, 'playlist item selected callback should exist');
+  const selectedSource = selectedMatch[1];
+  assert.match(selectedSource, /const selectionLoadToken = \+\+playlistSelectionLoadToken;/);
+  assert.match(selectedSource, /const shouldContinuePlaylistSelectionLoad = \(\) => \([\s\S]+selectionLoadToken === playlistSelectionLoadToken[\s\S]+playlistManager\.getCurrentItem\(\)\?\.id === item\.id[\s\S]+\);/);
+  assert.match(selectedSource, /loadVideoFromPlaylist\(item, \{[\s\S]+shouldContinue: shouldContinuePlaylistSelectionLoad[\s\S]+\}\);/);
+  assert.match(selectedSource, /if \(!shouldContinuePlaylistSelectionLoad\(\)\) return;/);
+
+  const playlistLoaderMatch = appSource.match(/async function loadVideoFromPlaylist\(item, options = \{\}\) \{([\s\S]*?)\n  \}/);
+  assert.ok(playlistLoaderMatch, 'playlist loader should exist');
+  const playlistLoaderSource = playlistLoaderMatch[1];
+  assert.match(playlistLoaderSource, /shouldContinue = null/);
+  assert.match(playlistLoaderSource, /const canContinuePlaylistLoad = \(\) => typeof shouldContinue !== 'function' \|\| shouldContinue\(\);/);
+  assert.match(playlistLoaderSource, /if \(!canContinuePlaylistLoad\(\)\) return false;/);
+  assert.ok(
+    playlistLoaderSource.indexOf('if (!canContinuePlaylistLoad()) return false;') <
+      playlistLoaderSource.indexOf('const loaded = await loadVideo(item.videoPath, loadOptions);'),
+    'stale playlist selections must stop before loadVideo can claim the latest load token'
+  );
+});
+
 test('continuous completion flushes skipped batch before stopping playback', () => {
   const completionBranchMatch = appSource.match(/if \(nextIndex < 0\) \{([\s\S]*?)\n    \}/);
   assert.ok(completionBranchMatch, 'completion branch should exist');
@@ -464,7 +585,8 @@ test('playlist loading returns the real loadVideo result', () => {
   assert.ok(loadVideoFromPlaylistMatch, 'playlist loader should exist');
 
   const playlistLoaderSource = loadVideoFromPlaylistMatch[1];
-  assert.match(playlistLoaderSource, /const loaded = await loadVideo\(item\.videoPath, options\);/);
+  assert.match(playlistLoaderSource, /const \{ shouldContinue = null, \.\.\.loadOptions \} = options;/);
+  assert.match(playlistLoaderSource, /const loaded = await loadVideo\(item\.videoPath, loadOptions\);/);
   assert.match(playlistLoaderSource, /return loaded === true;/);
   assert.doesNotMatch(playlistLoaderSource, /await loadVideo\(item\.videoPath\);\s*return true;/);
 
@@ -500,9 +622,39 @@ test('normal transcode overlay follows joined pre-transcode progress', () => {
   assert.ok(overlayMatch, 'showTranscodeOverlay should exist');
 
   const overlaySource = overlayMatch[1];
-  assert.match(overlaySource, /window\.electronAPI\.onTranscodeProgress\(progressHandler\);/);
-  assert.match(overlaySource, /window\.electronAPI\.onPreTranscodeProgress\(progressHandler\);/);
-  assert.match(overlaySource, /removeAllListeners\('ffmpeg:transcode-progress'\);[\s\S]+removeAllListeners\('ffmpeg:pre-transcode-progress'\);/);
+  assert.match(overlaySource, /const unsubscribeTranscodeProgress = window\.electronAPI\.onTranscodeProgress\(progressHandler\);/);
+  assert.match(overlaySource, /const unsubscribePreTranscodeProgress = window\.electronAPI\.onPreTranscodeProgress\(progressHandler\);/);
+  assert.match(overlaySource, /unsubscribeTranscodeProgress\?\.\(\);[\s\S]+unsubscribePreTranscodeProgress\?\.\(\);/);
+  assert.doesNotMatch(overlaySource, /removeAllListeners\('ffmpeg:transcode-progress'\)/);
+});
+
+test('transcode progress listeners unsubscribe individually instead of clearing shared channels', () => {
+  assert.match(preloadSource, /onTranscodeProgress: \(callback\) => \{[\s\S]+const listener = \(event, data\) => callback\(data\);[\s\S]+ipcRenderer\.on\('ffmpeg:transcode-progress', listener\);[\s\S]+return \(\) => ipcRenderer\.removeListener\('ffmpeg:transcode-progress', listener\);/);
+  assert.match(preloadSource, /onPreTranscodeProgress: \(callback\) => \{[\s\S]+const listener = \(event, data\) => callback\(data\);[\s\S]+ipcRenderer\.on\('ffmpeg:pre-transcode-progress', listener\);[\s\S]+return \(\) => ipcRenderer\.removeListener\('ffmpeg:pre-transcode-progress', listener\);/);
+
+  const splitMatch = splitViewSource.match(/const progressHandler = \(data\) => \{[\s\S]*?try \{[\s\S]*?\} finally \{([\s\S]*?)\n\s*\}/);
+  assert.ok(splitMatch, 'split view transcode progress cleanup should exist');
+  assert.match(splitViewSource, /const unsubscribeTranscodeProgress = window\.electronAPI\.onTranscodeProgress\(progressHandler\);/);
+  assert.match(splitMatch[1], /unsubscribeTranscodeProgress\?\.\(\);/);
+  assert.doesNotMatch(splitMatch[1], /removeAllListeners/);
+});
+
+test('normal transcode overlay is superseded when users switch videos quickly', () => {
+  assert.match(appSource, /let activeTranscodeOverlayToken = 0;/);
+  assert.match(appSource, /function supersedeActiveTranscodeOverlay\(/);
+
+  const overlayMatch = appSource.match(/async function showTranscodeOverlay\(filePath, codecName\) \{([\s\S]*?)\n  \}/);
+  assert.ok(overlayMatch, 'showTranscodeOverlay should exist');
+  const overlaySource = overlayMatch[1];
+  assert.match(overlaySource, /const overlayToken = \+\+activeTranscodeOverlayToken;/);
+  assert.match(overlaySource, /const isActiveTranscodeOverlay = \(\) => overlayToken === activeTranscodeOverlayToken;/);
+  assert.match(overlaySource, /const progressHandler = \(data\) => \{[\s\S]+if \(!isActiveTranscodeOverlay\(\)\) return;/);
+  assert.match(overlaySource, /if \(!isActiveTranscodeOverlay\(\)\) \{[\s\S]+return;[\s\S]+\}/);
+
+  const loadVideoMatch = appSource.match(/async function loadVideo\(filePath, options = \{\}\) \{([\s\S]*?)\n  \}/);
+  assert.ok(loadVideoMatch, 'loadVideo should exist');
+  assert.match(loadVideoMatch[1], /supersedeActiveTranscodeOverlay\('새 영상 선택'\);/);
+  assert.match(loadVideoMatch[1], /if \(transcoded\.stale\) return false;/);
 });
 
 test('playlist rows render and color continuous status text', () => {

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -61,6 +61,11 @@ test('opening or replacing playlists clears stale continuous timeline state', ()
   assert.match(resetSource, /playlistTimelineUpdateToken \+= 1;/);
   assert.match(resetSource, /playlistAggregateCommentRanges = \[\];/);
   assert.match(resetSource, /timeline\.clearPlaylistTimeline\(\);/);
+  assert.doesNotMatch(
+    resetSource,
+    /timeline\.clearCommentMarkers\(\);/,
+    'continuous reset must not erase normal review markers when opening an empty playlist'
+  );
 
   const openMatch = appSource.match(/async function openPlaylistFile\(filePath\) \{([\s\S]*?)\n  \}/);
   assert.ok(openMatch, 'openPlaylistFile should exist');


### PR DESCRIPTION
## 📋 업데이트 요약

🎞️ 재생목록을 타임라인으로 이어붙일 때 화면이 갱신되지 않거나 이전 표시가 남는 문제를 줄였습니다.

💬 이어붙이기 상태에서 댓글이 다른 영상 구간까지 번지거나, 해제 후에도 댓글 표시가 어긋나는 상황을 정리했습니다.

⚡ 인코딩이 필요한 영상을 빠르게 넘겨볼 때 오래된 변환 진행 표시가 현재 선택한 영상 화면을 덮어쓰지 않도록 개선했습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - `resetPlaylistContinuousTimelineState()`를 추가해 재생목록 이어붙이기 타임라인과 통합 댓글 상태를 한 곳에서 초기화하도록 정리했습니다.
  - `playlistSelectionLoadToken`과 `shouldContinue` 가드를 추가해 오래 걸린 이전 선택 로드가 최신 선택을 덮어쓰지 못하게 했습니다.
  - 작성자 필터 기준을 `getAuthorFilterSourceItems()` / `getAuthorFilterAuthorIds()`로 통일해 이어붙이기 모드에서는 전체 재생목록 통합 댓글 기준으로 동작하게 했습니다.
  - 트랜스코딩 오버레이에 토큰 기반 stale 방어를 추가했습니다.

- `renderer/scripts/modules/timeline.js`
  - `clearPlaylistTimeline()`, `clearPlaylistCommentRanges()`를 추가해 재생목록 세그먼트와 통합 댓글 DOM을 명확히 제거하도록 했습니다.

- `renderer/scripts/modules/playlist-comment-index.js`
  - 통합 댓글 구간을 영상 세그먼트 길이 안으로 제한했습니다.
  - `getPlaylistAggregateCommentKey()`를 공용 헬퍼로 분리했습니다.

- `preload/preload.js`, `renderer/scripts/modules/split-view-manager.js`
  - FFmpeg 진행률 리스너를 전역 삭제하지 않고 등록한 리스너만 해제하도록 변경했습니다.

## 🚧 개발 난항

- 이어붙이기 타임라인, 댓글 표시, 영상 로드, 트랜스코딩 UI가 모두 비동기로 얽혀 있어 단순 화면 갱신만으로는 문제가 재발할 수 있었습니다.
- 특히 새 재생목록 열기 실패 시 기존 화면을 먼저 지우는 순서 문제와, 작성자 필터의 표시 기준과 클릭 처리 기준이 다른 문제가 리뷰 중 추가로 발견되어 회귀 테스트를 보강했습니다.
- FFmpeg 진행률 이벤트는 여러 화면이 같은 채널을 공유하고 있어, 기존 `removeAllListeners` 방식이 다른 화면의 진행률 표시까지 끊을 수 있었습니다. 개별 unsubscribe 방식으로 바꿨습니다.

## ✅ 테스트 가이드

실사용자용:
- 재생목록을 연 뒤 타임라인 이어붙이기를 켜고 끄며 댓글 표시가 정상인지 확인합니다.
- 이어붙이기 상태에서 다른 재생목록을 열거나 드래그해 기존 타임라인 잔상이 남지 않는지 확인합니다.
- 인코딩이 필요한 영상을 여러 개 빠르게 선택해도 이전 변환 표시가 현재 영상에 남지 않는지 확인합니다.

개발자용:
- `npm run test:playlist`
- `npm run test:cluster`
- `npm run test:comment-input`
- `git diff --check`
- `npm run build`