### PR TITLE
프로젝트 파일 아이콘 등록 보강

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -14,6 +14,8 @@ files:
   - package.json
 
 extraResources:
+  - from: BFRAME_ico.ico
+    to: project-file.ico
   - from: mpv/
     to: mpv/
     filter:
@@ -40,6 +42,7 @@ protocols:
       - baeframe
 
 win:
+  icon: BFRAME_ico.ico
   target:
     - target: dir
       arch: x64

--- a/integration/installer/install-integration.ps1
+++ b/integration/installer/install-integration.ps1
@@ -116,6 +116,27 @@ function Resolve-BaeframePath {
   throw 'Unable to locate app executable. Re-run with -AppPath "C:\path\to\BFRAME_alpha_v2.exe".'
 }
 
+function Resolve-ProjectFileIconValue {
+  param([string]$ResolvedAppPath)
+
+  $appDir = Split-Path -Parent $ResolvedAppPath
+  $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+  $candidates = @(
+    (Join-Path $appDir 'resources\project-file.ico'),
+    (Join-Path $appDir 'project-file.ico'),
+    (Join-Path $repoRoot 'BFRAME_ico.ico')
+  )
+
+  foreach ($pathCandidate in $candidates) {
+    if ($pathCandidate -and (Test-Path $pathCandidate)) {
+      $resolvedIconPath = (Resolve-Path $pathCandidate).Path
+      return "$resolvedIconPath,0"
+    }
+  }
+
+  return "$ResolvedAppPath,0"
+}
+
 function Test-Windows11 {
   $build = [int][Environment]::OSVersion.Version.Build
   return $build -ge 22000
@@ -316,6 +337,7 @@ function Register-ProjectFileAssociations {
   param([string]$ResolvedAppPath)
 
   $escapedCommand = "`"$ResolvedAppPath`" `"%1`""
+  $projectFileIconValue = Resolve-ProjectFileIconValue -ResolvedAppPath $ResolvedAppPath
 
   foreach ($association in $ProjectFileAssociations) {
     $extension = [string]$association.extension
@@ -335,7 +357,7 @@ function Register-ProjectFileAssociations {
       Set-ItemProperty -Path $progIdKey -Name '(default)' -Value $label -Force
 
       New-Item -Path $defaultIconKey -Force | Out-Null
-      Set-ItemProperty -Path $defaultIconKey -Name '(default)' -Value ("$ResolvedAppPath,0") -Force
+      Set-ItemProperty -Path $defaultIconKey -Name '(default)' -Value $projectFileIconValue -Force
 
       New-Item -Path $openKey -Force | Out-Null
       New-ItemProperty -Path $openKey -Name 'MUIVerb' -PropertyType String -Value 'Open with BAEFRAME' -Force | Out-Null
@@ -347,6 +369,7 @@ function Register-ProjectFileAssociations {
         extension = $extension
         progId = $progId
         command = $escapedCommand
+        icon = $projectFileIconValue
       }
     }
   }

--- a/main/project-file-associations.js
+++ b/main/project-file-associations.js
@@ -1,4 +1,6 @@
 const { execFile } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 const PROJECT_FILE_ASSOCIATIONS = [
   {
@@ -13,14 +15,27 @@ const PROJECT_FILE_ASSOCIATIONS = [
   }
 ];
 
-function buildProjectFileAssociationOperations(appPath) {
+function resolveProjectFileIconPath({
+  resourcesPath = process.resourcesPath,
+  existsSync = fs.existsSync
+} = {}) {
+  if (!resourcesPath) {
+    return null;
+  }
+
+  const iconPath = path.join(resourcesPath, 'project-file.ico');
+  return existsSync(iconPath) ? iconPath : null;
+}
+
+function buildProjectFileAssociationOperations(appPath, projectFileIconPath = null) {
   if (!appPath) {
     throw new Error('appPath is required');
   }
 
   return PROJECT_FILE_ASSOCIATIONS.flatMap(({ extension, progId, label }) => {
     const commandValue = `"${appPath}" "%1"`;
-    const iconValue = `"${appPath}",0`;
+    const iconSourcePath = projectFileIconPath || appPath;
+    const iconValue = `"${iconSourcePath}",0`;
 
     return [
       {
@@ -72,6 +87,7 @@ function logResult(logger, level, message, meta) {
 
 async function registerProjectFileAssociations({
   appPath = process.execPath,
+  projectFileIconPath = resolveProjectFileIconPath(),
   platform = process.platform,
   isDefaultApp = process.defaultApp,
   runner = runRegistryCommand,
@@ -87,7 +103,7 @@ async function registerProjectFileAssociations({
 
   let operations;
   try {
-    operations = buildProjectFileAssociationOperations(appPath);
+    operations = buildProjectFileAssociationOperations(appPath, projectFileIconPath);
   } catch (error) {
     logResult(logger, 'warn', '프로젝트 파일 연결 준비 실패', { error: error.message });
     return { ok: false, skipped: false, error };
@@ -100,6 +116,7 @@ async function registerProjectFileAssociations({
 
     logResult(logger, 'info', '프로젝트 파일 연결 자동 등록 완료', {
       appPath,
+      projectFileIconPath: projectFileIconPath || appPath,
       extensions: PROJECT_FILE_ASSOCIATIONS.map(spec => spec.extension)
     });
     return { ok: true, skipped: false, operations: operations.length };
@@ -115,6 +132,7 @@ async function registerProjectFileAssociations({
 
 module.exports = {
   PROJECT_FILE_ASSOCIATIONS,
+  resolveProjectFileIconPath,
   buildProjectFileAssociationOperations,
   registerProjectFileAssociations
 };

--- a/scripts/tests/bplaylist-file-association-source.test.js
+++ b/scripts/tests/bplaylist-file-association-source.test.js
@@ -17,6 +17,8 @@ test('electron builder registers saved playlist files as BAEFRAME project files'
   assert.match(builderConfig, /fileAssociations:[\s\S]+ext: bplaylist/);
   assert.match(builderConfig, /ext: bplaylist[\s\S]+name: BAEFRAME Playlist/);
   assert.match(builderConfig, /ext: bplaylist[\s\S]+description: BAEFRAME Playlist File/);
+  assert.match(builderConfig, /extraResources:[\s\S]+from: BFRAME_ico\.ico[\s\S]+to: project-file\.ico/);
+  assert.match(builderConfig, /win:[\s\S]+icon: BFRAME_ico\.ico/);
 });
 
 test('team integration installer registers bplaylist double-click file association', () => {

--- a/scripts/tests/project-file-associations.test.js
+++ b/scripts/tests/project-file-associations.test.js
@@ -34,6 +34,22 @@ test('registry operations force bplaylist and bframe to open with the current ex
   assert.ok(operations.every(operation => operation.args.includes('/f')));
 });
 
+test('registry operations use packaged project file icon when available', () => {
+  const operations = projectFileAssociations.buildProjectFileAssociationOperations(
+    'C:\\BAEFRAME\\BFRAME_alpha_v2.exe',
+    'C:\\BAEFRAME\\resources\\project-file.ico'
+  );
+  const iconValues = operations
+    .filter(operation => operation.args.some(arg => arg.includes('DefaultIcon')))
+    .map(operation => operation.args.join(' '));
+
+  assert.equal(iconValues.length, 2);
+  assert.match(iconValues[0], /BAEFRAME\.Review\\DefaultIcon/);
+  assert.match(iconValues[0], /"C:\\BAEFRAME\\resources\\project-file\.ico",0/);
+  assert.match(iconValues[1], /BAEFRAME\.Playlist\\DefaultIcon/);
+  assert.match(iconValues[1], /"C:\\BAEFRAME\\resources\\project-file\.ico",0/);
+});
+
 test('auto registration runs only for packaged Windows apps and does not block startup on failure', async () => {
   const calls = [];
   const success = await projectFileAssociations.registerProjectFileAssociations({


### PR DESCRIPTION
## 요약
- .bplaylist/.bframe 파일 연결이 배포된 project-file.ico를 직접 아이콘으로 쓰도록 변경
- Windows 빌드에 project-file.ico를 extraResource로 포함하고 앱 아이콘을 명시
- 자동 등록 및 수동 통합 설치 스크립트의 DefaultIcon 경로를 보강

## 검증
- npm run test:playlist
- npm run test:cutlist
- git diff --check
- npm run build
- dist\\win-unpacked\\resources\\project-file.ico 포함 확인