### PR TITLE
[v1.4.0-beta] mpv 재생목록 안정화 및 비교 실행 옵션 추가

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -55,6 +55,10 @@ const {
   parseRoutedFileUrl,
   safeDecodeURIComponent
 } = require('./launch-routing');
+const {
+  resolveMultiInstanceUserDataPath,
+  shouldAllowMultipleInstances
+} = require('./instance-policy');
 debugLog('내부 모듈 로드 완료');
 
 const log = createLogger('Main');
@@ -228,11 +232,36 @@ if (process.defaultApp) {
 
 // 단일 인스턴스 잠금 (개발 모드에서는 다중 인스턴스 허용)
 const isDev = process.env.NODE_ENV === 'development';
+const allowMultipleInstances = shouldAllowMultipleInstances({
+  isDev,
+  argv: process.argv,
+  env: process.env
+});
+const multiInstanceUserDataPath = resolveMultiInstanceUserDataPath({
+  allowMultipleInstances,
+  isDev,
+  argv: process.argv,
+  env: process.env,
+  appDataDir: process.env.APPDATA,
+  pid: process.pid
+});
+if (multiInstanceUserDataPath) {
+  try {
+    fs.mkdirSync(multiInstanceUserDataPath, { recursive: true });
+    app.setPath('userData', multiInstanceUserDataPath);
+    log.info('다중 인스턴스 전용 사용자 데이터 폴더 사용', { userData: multiInstanceUserDataPath });
+    debugLog(`다중 인스턴스 전용 userData: ${multiInstanceUserDataPath}`);
+  } catch (error) {
+    log.warn('다중 인스턴스 사용자 데이터 폴더 설정 실패', { error: error.message, userData: multiInstanceUserDataPath });
+    debugLog(`다중 인스턴스 userData 설정 실패: ${error.message}`);
+  }
+}
 debugLog(`개발 모드: ${isDev}`);
+debugLog(`다중 인스턴스 허용: ${allowMultipleInstances}`);
 debugLog('단일 인스턴스 잠금 요청 중...');
 
-// 개발 모드에서는 잠금 건너뜀 (협업 테스트용)
-const gotTheLock = isDev ? true : app.requestSingleInstanceLock();
+// 개발/명시적 비교 모드에서는 잠금 건너뜀 (협업/재생 비교 테스트용)
+const gotTheLock = allowMultipleInstances ? true : app.requestSingleInstanceLock();
 debugLog(`잠금 결과: ${gotTheLock}`);
 
 if (!gotTheLock) {

--- a/main/instance-policy.js
+++ b/main/instance-policy.js
@@ -1,0 +1,80 @@
+const path = require('path');
+const os = require('os');
+
+function isTruthy(value) {
+  const normalized = String(value || '').trim().toLowerCase();
+  return ['1', 'true', 'yes', 'on'].includes(normalized);
+}
+
+function getSwitchValue(argv = [], switchName) {
+  const prefix = `${switchName}=`;
+  const exactIndex = argv.findIndex(arg => arg === switchName);
+  if (exactIndex >= 0 && exactIndex + 1 < argv.length) {
+    const next = argv[exactIndex + 1];
+    if (next && !String(next).startsWith('--')) return String(next);
+  }
+
+  const matched = argv.find(arg => String(arg).startsWith(prefix));
+  return matched ? String(matched).slice(prefix.length) : null;
+}
+
+function hasSwitch(argv = [], switchName) {
+  return argv.some(arg => arg === switchName || String(arg).startsWith(`${switchName}=`));
+}
+
+function sanitizeProfileName(value) {
+  return String(value || '')
+    .trim()
+    .replace(/[^a-zA-Z0-9가-힣_.-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[.-]+|[.-]+$/g, '')
+    .slice(0, 80) || 'default';
+}
+
+function shouldAllowMultipleInstances({ isDev = false, argv = process.argv, env = process.env } = {}) {
+  return Boolean(
+    isDev ||
+    hasSwitch(argv, '--multi-instance') ||
+    hasSwitch(argv, '--multi-instance-isolated') ||
+    hasSwitch(argv, '--multi-instance-profile') ||
+    hasSwitch(argv, '--multi-instance-user-data') ||
+    isTruthy(env.BAEFRAME_MULTI_INSTANCE) ||
+    Boolean(env.BAEFRAME_MULTI_INSTANCE_USER_DATA)
+  );
+}
+
+function resolveMultiInstanceUserDataPath({
+  allowMultipleInstances = false,
+  isDev = false,
+  argv = process.argv,
+  env = process.env,
+  appDataDir = env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
+  pid = process.pid
+} = {}) {
+  if (!allowMultipleInstances || isDev) return null;
+
+  const explicitDir = getSwitchValue(argv, '--multi-instance-user-data') ||
+    env.BAEFRAME_MULTI_INSTANCE_USER_DATA;
+  if (explicitDir) return path.resolve(String(explicitDir));
+
+  const profileName = getSwitchValue(argv, '--multi-instance-profile') ||
+    env.BAEFRAME_MULTI_INSTANCE_PROFILE;
+  const shouldIsolate = Boolean(
+    profileName ||
+    hasSwitch(argv, '--multi-instance-isolated') ||
+    isTruthy(env.BAEFRAME_MULTI_INSTANCE_ISOLATED)
+  );
+  if (!shouldIsolate) return null;
+
+  const safeProfileName = sanitizeProfileName(profileName || `pid-${pid}`);
+  return path.join(appDataDir, 'baeframe', 'multi-instance', safeProfileName);
+}
+
+module.exports = {
+  getSwitchValue,
+  hasSwitch,
+  isTruthy,
+  resolveMultiInstanceUserDataPath,
+  sanitizeProfileName,
+  shouldAllowMultipleInstances
+};

--- a/main/instance-policy.js
+++ b/main/instance-policy.js
@@ -39,7 +39,9 @@ function shouldAllowMultipleInstances({ isDev = false, argv = process.argv, env 
     hasSwitch(argv, '--multi-instance-profile') ||
     hasSwitch(argv, '--multi-instance-user-data') ||
     isTruthy(env.BAEFRAME_MULTI_INSTANCE) ||
-    Boolean(env.BAEFRAME_MULTI_INSTANCE_USER_DATA)
+    Boolean(env.BAEFRAME_MULTI_INSTANCE_USER_DATA) ||
+    Boolean(env.BAEFRAME_MULTI_INSTANCE_PROFILE) ||
+    isTruthy(env.BAEFRAME_MULTI_INSTANCE_ISOLATED)
   );
 }
 

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1644,6 +1644,18 @@ function setupIpcHandlers() {
     }
   });
 
+  ipcMain.handle('mpv:set-host-visible', async (event, visible) => {
+    try {
+      const nextVisible = visible !== false;
+      const embed = mpvEmbedHost.setVisible(nextVisible);
+      const overlay = mpvOverlayHost.setVisible(nextVisible);
+      return { success: embed.success !== false && overlay.success !== false, visible: nextVisible, embed, overlay };
+    } catch (error) {
+      log.debug('mpv 호스트 표시 상태 변경 실패', { error: error.message });
+      return { success: false, error: error.message };
+    }
+  });
+
   ipcMain.handle('mpv:destroy-embed', async () => {
     try {
       return mpvEmbedHost.destroy();

--- a/main/mpv-embed-host.js
+++ b/main/mpv-embed-host.js
@@ -125,6 +125,22 @@ class MPVEmbedHost {
     return { success: true, bounds: screenBounds };
   }
 
+  setVisible(visible) {
+    if (!this.window || this.window.isDestroyed?.()) {
+      return { success: true, visible: false, ready: false };
+    }
+
+    const nextVisible = visible !== false;
+    if (nextVisible) {
+      this._repositionToParent();
+      this._showHostWindow(this.parentWindow || this.getMainWindow());
+    } else {
+      this._hideHostWindow();
+    }
+
+    return { success: true, visible: nextVisible, ready: true };
+  }
+
   destroy() {
     const hostWindow = this.window;
     this.window = null;

--- a/main/mpv-embed-host.js
+++ b/main/mpv-embed-host.js
@@ -80,6 +80,7 @@ class MPVEmbedHost {
     this.parentShowHandler = null;
     this.parentClosedHandler = null;
     this.repositionPending = false;
+    this.requestedVisible = true;
   }
 
   async ensure(bounds) {
@@ -103,7 +104,11 @@ class MPVEmbedHost {
       }
     }
 
-    this._showHostWindow(mainWindow);
+    if (this.requestedVisible === false) {
+      this._hideHostWindow();
+    } else {
+      this._showHostWindow(mainWindow);
+    }
 
     const wid = nativeWindowHandleToMpvWid(hostWindow.getNativeWindowHandle(), this.platform);
     return { success: true, wid, bounds: screenBounds };
@@ -126,11 +131,13 @@ class MPVEmbedHost {
   }
 
   setVisible(visible) {
+    const nextVisible = visible !== false;
+    this.requestedVisible = nextVisible;
+
     if (!this.window || this.window.isDestroyed?.()) {
-      return { success: true, visible: false, ready: false };
+      return { success: true, visible: nextVisible, ready: false };
     }
 
-    const nextVisible = visible !== false;
     if (nextVisible) {
       this._repositionToParent();
       this._showHostWindow(this.parentWindow || this.getMainWindow());
@@ -146,6 +153,7 @@ class MPVEmbedHost {
     this.window = null;
     this.contentLoaded = false;
     this.lastBounds = null;
+    this.requestedVisible = true;
     this._unbindParentWindow();
 
     if (!hostWindow || hostWindow.isDestroyed?.()) {
@@ -206,7 +214,11 @@ class MPVEmbedHost {
     };
     this.parentShowHandler = () => {
       this._repositionToParent();
-      this._showHostWindow(parent);
+      if (this.requestedVisible === false) {
+        this._hideHostWindow();
+      } else {
+        this._showHostWindow(parent);
+      }
     };
     this.parentClosedHandler = () => {
       this.destroy();

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -348,6 +348,7 @@ class MPVOverlayHost {
     this.parentShowHandler = null;
     this.parentClosedHandler = null;
     this.repositionPending = false;
+    this.requestedVisible = true;
   }
 
   async ensure(bounds) {
@@ -371,7 +372,11 @@ class MPVOverlayHost {
       }
     }
 
-    this._showOverlayWindow(mainWindow);
+    if (this.requestedVisible === false) {
+      this._hideOverlayWindow();
+    } else {
+      this._showOverlayWindow(mainWindow);
+    }
     return { success: true, bounds: screenBounds };
   }
 
@@ -411,11 +416,13 @@ class MPVOverlayHost {
   }
 
   setVisible(visible) {
+    const nextVisible = visible !== false;
+    this.requestedVisible = nextVisible;
+
     if (!this.window || this.window.isDestroyed?.()) {
-      return { success: true, visible: false, ready: false };
+      return { success: true, visible: nextVisible, ready: false };
     }
 
-    const nextVisible = visible !== false;
     if (nextVisible) {
       this._repositionToParent();
       this._showOverlayWindow(this.parentWindow || this.getMainWindow());
@@ -431,6 +438,7 @@ class MPVOverlayHost {
     this.window = null;
     this.contentLoaded = false;
     this.lastBounds = null;
+    this.requestedVisible = true;
     this._unbindParentWindow();
 
     if (!hostWindow || hostWindow.isDestroyed?.()) {
@@ -491,7 +499,11 @@ class MPVOverlayHost {
     };
     this.parentShowHandler = () => {
       this._repositionToParent();
-      this._showOverlayWindow(parent);
+      if (this.requestedVisible === false) {
+        this._hideOverlayWindow();
+      } else {
+        this._showOverlayWindow(parent);
+      }
     };
     this.parentClosedHandler = () => {
       this.destroy();

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -75,11 +75,15 @@ const OVERLAY_HTML = `
       z-index: 3;
     }
     #markerMirror,
-    #tooltipMirror {
+    #tooltipMirror,
+    #htmlOverlay {
       position: absolute;
       inset: 0;
       z-index: 15;
       pointer-events: none;
+    }
+    #htmlOverlay {
+      z-index: 14;
     }
     #tooltipMirror {
       z-index: 16;
@@ -243,6 +247,7 @@ const OVERLAY_HTML = `
   <div id="overlayRoot">
     <img id="onionCanvasMirror" class="mirror-canvas" alt="">
     <img id="drawingCanvasMirror" class="mirror-canvas" alt="">
+    <div id="htmlOverlay"></div>
     <div id="markerMirror"></div>
     <div id="tooltipMirror"></div>
   </div>
@@ -272,10 +277,12 @@ const OVERLAY_HTML = `
 
     window.__applyMpvOverlayState = function applyMpvOverlayState(state) {
       const nextState = state || {};
+      const htmlOverlay = document.getElementById('htmlOverlay');
       const markerMirror = document.getElementById('markerMirror');
       const tooltipMirror = document.getElementById('tooltipMirror');
       applyImage('onionCanvasMirror', nextState.onionDataUrl, nextState.canvas);
       applyImage('drawingCanvasMirror', nextState.drawingDataUrl, nextState.canvas);
+      htmlOverlay.innerHTML = nextState.htmlOverlayHtml || '';
       markerMirror.innerHTML = nextState.markerHtml || '';
       tooltipMirror.innerHTML = nextState.tooltipHtml || '';
       applyOverlayTransform(markerMirror, nextState);
@@ -313,6 +320,7 @@ function normalizeOverlayState(state = {}) {
     onionDataUrl: normalizeImageDataUrl(state.onionDataUrl),
     markerHtml: typeof state.markerHtml === 'string' ? state.markerHtml : '',
     tooltipHtml: typeof state.tooltipHtml === 'string' ? state.tooltipHtml : '',
+    htmlOverlayHtml: typeof state.htmlOverlayHtml === 'string' ? state.htmlOverlayHtml : '',
     markerTransform: typeof state.markerTransform === 'string' ? state.markerTransform : '',
     markerTransformOrigin: typeof state.markerTransformOrigin === 'string'
       ? state.markerTransformOrigin

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -402,6 +402,22 @@ class MPVOverlayHost {
     }
   }
 
+  setVisible(visible) {
+    if (!this.window || this.window.isDestroyed?.()) {
+      return { success: true, visible: false, ready: false };
+    }
+
+    const nextVisible = visible !== false;
+    if (nextVisible) {
+      this._repositionToParent();
+      this._showOverlayWindow(this.parentWindow || this.getMainWindow());
+    } else {
+      this._hideOverlayWindow();
+    }
+
+    return { success: true, visible: nextVisible, ready: true };
+  }
+
   destroy() {
     const hostWindow = this.window;
     this.window = null;

--- a/preload/preload.js
+++ b/preload/preload.js
@@ -125,6 +125,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   mpvStop: () => ipcRenderer.invoke('mpv:stop'),
   mpvPrepareEmbed: (bounds) => ipcRenderer.invoke('mpv:prepare-embed', bounds),
   mpvUpdateEmbedBounds: (bounds) => ipcRenderer.invoke('mpv:update-embed-bounds', bounds),
+  mpvSetHostVisible: (visible) => ipcRenderer.invoke('mpv:set-host-visible', visible),
   mpvDestroyEmbed: () => ipcRenderer.invoke('mpv:destroy-embed'),
   mpvPrepareOverlay: (bounds) => ipcRenderer.invoke('mpv:prepare-overlay', bounds),
   mpvUpdateOverlayBounds: (bounds) => ipcRenderer.invoke('mpv:update-overlay-bounds', bounds),

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -3472,6 +3472,7 @@ async function initApp() {
 
       if (videoCommentRangeOverlay) {
         videoCommentRangeOverlay.classList.toggle('hidden', !overlayEnabled);
+        scheduleMpvOverlayStateSync();
       }
     });
   }
@@ -3484,6 +3485,7 @@ async function initApp() {
 
       if (videoCommentRangeOverlay) {
         videoCommentRangeOverlay.classList.toggle('position-top', overlayPositionTop);
+        scheduleMpvOverlayStateSync();
       }
     });
   }
@@ -3508,6 +3510,7 @@ async function initApp() {
     // 댓글이 없으면 숨김
     if (!ranges || ranges.length === 0) {
       videoCommentRangeOverlay.classList.remove('visible');
+      scheduleMpvOverlayStateSync();
       return;
     }
 
@@ -3565,6 +3568,7 @@ async function initApp() {
 
     // 초기 플레이헤드 위치 업데이트
     updateVideoCommentPlayhead();
+    scheduleMpvOverlayStateSync();
   }
 
   // 플레이헤드 위치 업데이트
@@ -3586,6 +3590,7 @@ async function initApp() {
         bar.classList.toggle('active', isActive);
       }
     });
+    scheduleMpvOverlayStateSync();
   }
 
   // HEX to RGBA 변환 헬퍼
@@ -4402,10 +4407,12 @@ async function initApp() {
 
     elements.zoomIndicatorOverlay.textContent = `${Math.round(zoom)}%`;
     elements.zoomIndicatorOverlay.classList.add('visible');
+    scheduleMpvOverlayStateSync();
 
     clearTimeout(window._zoomIndicatorTimeout);
     window._zoomIndicatorTimeout = setTimeout(() => {
       elements.zoomIndicatorOverlay.classList.remove('visible');
+      scheduleMpvOverlayStateSync();
     }, 800);
   }
 
@@ -5103,6 +5110,8 @@ async function initApp() {
   let mpvOverlayLastLiveDrawSyncAt = 0;
   let mpvHostVisibilitySyncPending = false;
   let mpvHostLastRequestedVisible = null;
+  let fullscreenTimecodeOverlay = null;
+  let fullscreenScrubOverlay = null;
 
   const MPV_BLOCKING_OVERLAY_SELECTOR = [
     '.modal-overlay.active',
@@ -5110,8 +5119,61 @@ async function initApp() {
     '.image-viewer-overlay.open',
     '.split-view-overlay.open',
     '.prompt-modal-overlay.open',
-    '.credits-overlay.open'
+    '.credits-overlay.active',
+    '.video-loading-overlay.active',
+    '.codec-error-overlay.active',
+    '.app-saving-overlay.active',
+    '.transcode-overlay.active'
   ].join(',');
+
+  const MPV_HTML_OVERLAY_STYLE_PROPERTIES = [
+    'align-items',
+    'backdrop-filter',
+    'background',
+    'background-color',
+    'border',
+    'border-color',
+    'border-radius',
+    'border-style',
+    'border-width',
+    'bottom',
+    'box-shadow',
+    'box-sizing',
+    'color',
+    'display',
+    'flex-direction',
+    'font',
+    'font-family',
+    'font-size',
+    'font-weight',
+    'gap',
+    'height',
+    'justify-content',
+    'left',
+    'letter-spacing',
+    'line-height',
+    'margin',
+    'max-height',
+    'max-width',
+    'min-height',
+    'min-width',
+    'opacity',
+    'overflow',
+    'padding',
+    'pointer-events',
+    'position',
+    'right',
+    'text-align',
+    'text-overflow',
+    'top',
+    'transform',
+    'transform-origin',
+    'visibility',
+    'white-space',
+    'width',
+    'z-index',
+    '-webkit-backdrop-filter'
+  ];
 
   function isElementVisiblyBlockingMpv(element) {
     if (!element) return false;
@@ -5330,6 +5392,62 @@ async function initApp() {
     return tooltipLayer.innerHTML;
   }
 
+  function copyComputedMpvOverlayStyles(source, target) {
+    const computedStyle = window.getComputedStyle(source);
+    MPV_HTML_OVERLAY_STYLE_PROPERTIES.forEach((property) => {
+      const value = computedStyle.getPropertyValue(property);
+      if (value) target.style.setProperty(property, value);
+    });
+  }
+
+  function cloneMpvHtmlOverlayElement(element, wrapperRect) {
+    if (!element || !isElementVisiblyBlockingMpv(element)) return null;
+
+    const rect = element.getBoundingClientRect();
+    const clone = element.cloneNode(true);
+    const sourceElements = [element, ...element.querySelectorAll('*')];
+    const targetElements = [clone, ...clone.querySelectorAll('*')];
+
+    sourceElements.forEach((sourceElement, index) => {
+      const targetElement = targetElements[index];
+      if (targetElement) copyComputedMpvOverlayStyles(sourceElement, targetElement);
+    });
+
+    clone.removeAttribute('id');
+    clone.querySelectorAll('[id]').forEach((child) => child.removeAttribute('id'));
+    clone.style.position = 'absolute';
+    clone.style.left = `${rect.left - wrapperRect.left}px`;
+    clone.style.top = `${rect.top - wrapperRect.top}px`;
+    clone.style.right = 'auto';
+    clone.style.bottom = 'auto';
+    clone.style.width = `${rect.width}px`;
+    clone.style.height = `${rect.height}px`;
+    clone.style.margin = '0';
+    clone.style.pointerEvents = 'none';
+    clone.style.transform = 'none';
+
+    return clone;
+  }
+
+  function serializeMpvOverlayHtml() {
+    const wrapperRect = elements.videoWrapper?.getBoundingClientRect();
+    if (!wrapperRect) return '';
+
+    const htmlOverlay = document.createElement('div');
+    [
+      elements.currentCutOverlay,
+      elements.zoomIndicatorOverlay,
+      videoCommentRangeOverlay,
+      fullscreenTimecodeOverlay,
+      fullscreenScrubOverlay
+    ].forEach((element) => {
+      const clone = cloneMpvHtmlOverlayElement(element, wrapperRect);
+      if (clone) htmlOverlay.appendChild(clone);
+    });
+
+    return htmlOverlay.innerHTML;
+  }
+
   function getMpvOverlayState() {
     const wrapperRect = elements.videoWrapper?.getBoundingClientRect();
     const canvasRect = elements.drawingCanvas?.getBoundingClientRect();
@@ -5340,6 +5458,7 @@ async function initApp() {
       onionDataUrl: getCanvasOverlayDataUrl(elements.onionSkinCanvas),
       markerHtml: serializeMpvOverlayMarkerHtml(),
       tooltipHtml: serializeMpvOverlayTooltipHtml(),
+      htmlOverlayHtml: serializeMpvOverlayHtml(),
       markerTransform: markerContainer?.style.transform || '',
       markerTransformOrigin: markerContainer?.style.transformOrigin || 'center center',
       videoTransform: getMpvVideoTransform(),
@@ -6360,8 +6479,6 @@ async function initApp() {
    * 전체화면 모드 토글 (시스템 전체화면)
    */
   let fullscreenMouseHandler = null;
-  let fullscreenTimecodeOverlay = null;
-  let fullscreenScrubOverlay = null;
 
   function setFullscreenControlsVisible(visible) {
     const wasVisible = document.body.classList.contains('show-controls');
@@ -6427,6 +6544,7 @@ async function initApp() {
       if (fullscreenTimecodeOverlay) {
         fullscreenTimecodeOverlay.remove();
         fullscreenTimecodeOverlay = null;
+        scheduleMpvOverlayStateSync();
       }
       setFullscreenControlsVisible(false);
     }
@@ -6456,6 +6574,7 @@ async function initApp() {
 
     fullscreenTimecodeOverlay.querySelector('.current-time').textContent = formatTimecode(currentTime);
     fullscreenTimecodeOverlay.querySelector('.total-time').textContent = formatTimecode(duration);
+    scheduleMpvOverlayStateSync();
   }
 
   /**
@@ -6557,10 +6676,12 @@ async function initApp() {
     overlay.querySelector('.fullscreen-scrub-time').textContent =
       `${formatTimecode(time, fps)} / ${formatTimecode(duration, fps)}`;
     overlay.classList.add('visible');
+    scheduleMpvOverlayStateSync();
   }
 
   function hideFullscreenScrubOverlay() {
     fullscreenScrubOverlay?.classList.remove('visible');
+    scheduleMpvOverlayStateSync();
   }
 
   // 전체화면 시크바 이벤트 설정
@@ -13862,11 +13983,13 @@ async function initApp() {
     if (!cut || !cutlistUIState.active) {
       elements.currentCutOverlay.hidden = true;
       elements.currentCutOverlay.textContent = '';
+      scheduleMpvOverlayStateSync();
       return;
     }
 
     elements.currentCutOverlay.hidden = false;
     elements.currentCutOverlay.textContent = `${cut.label} · BAEFRAME ${formatCutlistFrameRange(cut.startFrame, cut.endFrame)}`;
+    scheduleMpvOverlayStateSync();
   }
 
   function getCurrentCutlistSourceForFile(filePath) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -13407,10 +13407,12 @@ async function initApp() {
     if (videoPlayer.engine !== 'html5') {
       const currentTime = Math.max(0, Number(videoPlayer.currentTime) || 0);
       const duration = Math.max(0, Number(videoPlayer.duration) || 0);
+      const externalEofReached = videoPlayer.externalEofReached === true;
       return {
         currentTime,
         duration,
-        ended: duration > 0 && duration - currentTime <= 0.25 && !videoPlayer.isPlaying,
+        ended: externalEofReached || (duration > 0 && duration - currentTime <= 0.25 && !videoPlayer.isPlaying),
+        externalEofReached,
         paused: !videoPlayer.isPlaying,
         ready: videoPlayer.isLoaded === true
       };
@@ -13426,6 +13428,7 @@ async function initApp() {
   }
 
   function hasContinuousPlaybackReachedMediaEnd(snapshot = getContinuousPlaybackSnapshot()) {
+    if (snapshot.externalEofReached === true) return true;
     return snapshot.duration > 0 && snapshot.duration - snapshot.currentTime <= 0.25 && snapshot.ended === true;
   }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -13470,8 +13470,7 @@ async function initApp() {
 
     const snapshot = getContinuousPlaybackSnapshot();
     const startTime = snapshot.currentTime;
-    const duration = snapshot.duration;
-    if (duration > 0 && duration - startTime <= 0.25) return Promise.resolve(true);
+    if (hasContinuousPlaybackReachedMediaEnd(snapshot)) return Promise.resolve(true);
 
     return new Promise(resolve => {
       let settled = false;
@@ -13505,11 +13504,7 @@ async function initApp() {
           return;
         }
         const currentSnapshot = getContinuousPlaybackSnapshot();
-        if (hasAdvanced() || currentSnapshot.ended) {
-          finish(true);
-          return;
-        }
-        if (currentSnapshot.paused && !videoPlayer.isPlaying) {
+        if (hasAdvanced() || hasContinuousPlaybackReachedMediaEnd(currentSnapshot)) {
           finish(true);
           return;
         }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5809,9 +5809,11 @@ async function initApp() {
 
       // ====== 코덱 확인 및 트랜스코딩 (비디오만) ======
       const hasPreparedVideoPath = typeof preparedVideoPath === 'string' && preparedVideoPath.length > 0;
+      const preparedVideoPathIsOriginal = hasPreparedVideoPath && isSameFilePath(preparedVideoPath, filePath);
+      const hasConvertedPreparedVideoPath = hasPreparedVideoPath && !preparedVideoPathIsOriginal;
       let actualVideoPath = hasPreparedVideoPath ? preparedVideoPath : filePath;
       let thumbnailVideoPath = actualVideoPath;
-      const useMpvPilot = allowMpvPilot && await shouldUseMpvPilot(filePath, { fileIsAudio, hasPreparedVideoPath });
+      const useMpvPilot = allowMpvPilot && await shouldUseMpvPilot(filePath, { fileIsAudio, hasPreparedVideoPath: hasConvertedPreparedVideoPath });
       if (isStaleVideoLoad()) return false;
       if (hasPreparedVideoPath) {
         log.debug('준비된 연속 재생 미디어 경로 사용', { filePath, preparedVideoPath });
@@ -13367,7 +13369,34 @@ async function initApp() {
     return new Promise(resolve => setTimeout(resolve, ms));
   }
 
+  function getContinuousPlaybackSnapshot() {
+    const media = videoPlayer.videoElement;
+    if (videoPlayer.engine !== 'html5') {
+      const currentTime = Math.max(0, Number(videoPlayer.currentTime) || 0);
+      const duration = Math.max(0, Number(videoPlayer.duration) || 0);
+      return {
+        currentTime,
+        duration,
+        ended: duration > 0 && duration - currentTime <= 0.25 && !videoPlayer.isPlaying,
+        paused: !videoPlayer.isPlaying,
+        ready: videoPlayer.isLoaded === true
+      };
+    }
+
+    return {
+      currentTime: Math.max(0, Number(media?.currentTime ?? videoPlayer.currentTime) || 0),
+      duration: Math.max(0, Number(media?.duration ?? videoPlayer.duration) || 0),
+      ended: media?.ended === true,
+      paused: media?.paused === true,
+      ready: Number(media?.readyState || 0) >= 2
+    };
+  }
+
   function waitForContinuousMediaReady(timeoutMs = 1200) {
+    if (videoPlayer.engine !== 'html5') {
+      return Promise.resolve(videoPlayer.isLoaded === true);
+    }
+
     const media = videoPlayer.videoElement;
     if (!media) return Promise.resolve(false);
     if (media.readyState >= 2) return Promise.resolve(true);
@@ -13397,10 +13426,11 @@ async function initApp() {
     const timeoutMs = options.timeoutMs || 1100;
     const minDelta = options.minDelta || 0.03;
     const media = videoPlayer.videoElement;
-    if (!media) return Promise.resolve(false);
+    if (videoPlayer.engine === 'html5' && !media) return Promise.resolve(false);
 
-    const startTime = Number(media.currentTime || videoPlayer.currentTime) || 0;
-    const duration = Number(media.duration || videoPlayer.duration) || 0;
+    const snapshot = getContinuousPlaybackSnapshot();
+    const startTime = snapshot.currentTime;
+    const duration = snapshot.duration;
     if (duration > 0 && duration - startTime <= 0.25) return Promise.resolve(true);
 
     return new Promise(resolve => {
@@ -13410,15 +13440,17 @@ async function initApp() {
       const finish = (value) => {
         if (settled) return;
         settled = true;
-        media.removeEventListener('timeupdate', onProgress);
-        media.removeEventListener('ended', onEnded);
+        media?.removeEventListener('timeupdate', onProgress);
+        media?.removeEventListener('ended', onEnded);
+        videoPlayer.removeEventListener('timeupdate', onProgress);
+        videoPlayer.removeEventListener('ended', onEnded);
         clearInterval(interval);
         resolve(value);
       };
 
       const hasAdvanced = () => {
-        const currentTime = Number(media.currentTime || videoPlayer.currentTime) || 0;
-        return currentTime - startTime >= minDelta;
+        const currentSnapshot = getContinuousPlaybackSnapshot();
+        return currentSnapshot.currentTime - startTime >= minDelta;
       };
 
       const onProgress = () => {
@@ -13430,11 +13462,12 @@ async function initApp() {
           finish(false);
           return;
         }
-        if (hasAdvanced() || media.ended) {
+        const currentSnapshot = getContinuousPlaybackSnapshot();
+        if (hasAdvanced() || currentSnapshot.ended) {
           finish(true);
           return;
         }
-        if (media.paused && !videoPlayer.isPlaying) {
+        if (currentSnapshot.paused && !videoPlayer.isPlaying) {
           finish(true);
           return;
         }
@@ -13443,8 +13476,10 @@ async function initApp() {
         }
       }, 120);
 
-      media.addEventListener('timeupdate', onProgress);
-      media.addEventListener('ended', onEnded, { once: true });
+      media?.addEventListener('timeupdate', onProgress);
+      media?.addEventListener('ended', onEnded, { once: true });
+      videoPlayer.addEventListener('timeupdate', onProgress);
+      videoPlayer.addEventListener('ended', onEnded, { once: true });
     });
   }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -13429,8 +13429,9 @@ async function initApp() {
   }
 
   function hasContinuousPlaybackReachedMediaEnd(snapshot = getContinuousPlaybackSnapshot()) {
-    const nearMediaEnd = snapshot.duration > 0 && snapshot.duration - snapshot.currentTime <= 0.25;
-    if (snapshot.externalEofReached === true) return nearMediaEnd;
+    const hasKnownDuration = snapshot.duration > 0;
+    const nearMediaEnd = hasKnownDuration && snapshot.duration - snapshot.currentTime <= 0.25;
+    if (snapshot.externalEofReached === true) return !hasKnownDuration || nearMediaEnd;
     return nearMediaEnd && snapshot.ended === true;
   }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5195,6 +5195,17 @@ async function initApp() {
       .some(isElementVisiblyBlockingMpv);
   }
 
+  function didMpvHostVisibilityApply(result, shouldShowMpvHost) {
+    if (!result?.success) return false;
+    if (shouldShowMpvHost) return true;
+    return result.embed?.ready === true && result.overlay?.ready === true;
+  }
+
+  function forceMpvHostVisibilitySync() {
+    mpvHostLastRequestedVisible = null;
+    syncMpvHostVisibilityWithDom();
+  }
+
   function syncMpvHostVisibilityWithDom() {
     if (!mpvPilotHostPreparing && !document.body.classList.contains('mpv-pilot-mode')) return;
     if (!window.electronAPI?.mpvSetHostVisible) return;
@@ -5208,7 +5219,7 @@ async function initApp() {
 
       try {
         const result = await window.electronAPI.mpvSetHostVisible(shouldShowMpvHost);
-        if (result?.success && (result.embed?.ready || result.overlay?.ready || shouldShowMpvHost)) {
+        if (didMpvHostVisibilityApply(result, shouldShowMpvHost)) {
           mpvHostLastRequestedVisible = shouldShowMpvHost;
         }
       } catch (error) {
@@ -5297,7 +5308,7 @@ async function initApp() {
 
     const result = await window.electronAPI.mpvPrepareEmbed(bounds);
     if (result?.success && result.wid) {
-      syncMpvHostVisibilityWithDom();
+      forceMpvHostVisibilitySync();
       return result;
     }
 
@@ -5315,7 +5326,7 @@ async function initApp() {
 
     const result = await window.electronAPI.mpvPrepareOverlay(bounds);
     if (result?.success) {
-      syncMpvHostVisibilityWithDom();
+      forceMpvHostVisibilitySync();
       return result;
     }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1032,6 +1032,10 @@ async function initApp() {
 
     const playlistManager = getPlaylistManager();
     if (continuousPlaybackState.active) {
+      if (!hasContinuousPlaybackReachedMediaEnd()) {
+        log.warn('타임라인 이어붙이기: 영상 끝이 아닌 종료 신호를 무시합니다', getContinuousPlaybackSnapshot());
+        return;
+      }
       log.info('타임라인 이어붙이기: 다음 재생 가능 항목으로 이동');
       void playNextContinuousItem(continuousPlaybackState.sessionId);
       return;
@@ -13392,6 +13396,10 @@ async function initApp() {
     };
   }
 
+  function hasContinuousPlaybackReachedMediaEnd(snapshot = getContinuousPlaybackSnapshot()) {
+    return snapshot.duration > 0 && snapshot.duration - snapshot.currentTime <= 0.25 && snapshot.ended === true;
+  }
+
   function waitForContinuousMediaReady(timeoutMs = 1200) {
     if (videoPlayer.engine !== 'html5') {
       return Promise.resolve(videoPlayer.isLoaded === true);
@@ -13456,7 +13464,9 @@ async function initApp() {
       const onProgress = () => {
         if (hasAdvanced()) finish(true);
       };
-      const onEnded = () => finish(true);
+      const onEnded = () => {
+        if (hasContinuousPlaybackReachedMediaEnd()) finish(true);
+      };
       const interval = setInterval(() => {
         if (!isContinuousSessionActive(sessionId)) {
           finish(false);

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1066,6 +1066,7 @@ async function initApp() {
   videoPlayer.addEventListener('externalstopped', () => {
     elements.videoWrapper?.classList.remove('mpv-pilot-mode');
     document.body.classList.remove('mpv-pilot-mode');
+    mpvHostLastRequestedVisible = null;
   });
 
   // 코덱 미지원
@@ -5100,6 +5101,71 @@ async function initApp() {
   let mpvOverlayStateSyncPending = false;
   let mpvOverlayStateSyncTimer = null;
   let mpvOverlayLastLiveDrawSyncAt = 0;
+  let mpvHostVisibilitySyncPending = false;
+  let mpvHostLastRequestedVisible = null;
+
+  const MPV_BLOCKING_OVERLAY_SELECTOR = [
+    '.modal-overlay.active',
+    '.thread-overlay.open',
+    '.image-viewer-overlay.open',
+    '.split-view-overlay.open',
+    '.prompt-modal-overlay.open',
+    '.credits-overlay.open'
+  ].join(',');
+
+  function isElementVisiblyBlockingMpv(element) {
+    if (!element) return false;
+    const style = window.getComputedStyle(element);
+    if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity || 1) === 0) {
+      return false;
+    }
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
+  function hasBlockingOverlayForMpv() {
+    return Array.from(document.querySelectorAll(MPV_BLOCKING_OVERLAY_SELECTOR))
+      .some(isElementVisiblyBlockingMpv);
+  }
+
+  function syncMpvHostVisibilityWithDom() {
+    if (!document.body.classList.contains('mpv-pilot-mode')) return;
+    if (!window.electronAPI?.mpvSetHostVisible) return;
+    if (mpvHostVisibilitySyncPending) return;
+
+    mpvHostVisibilitySyncPending = true;
+    requestAnimationFrame(async () => {
+      mpvHostVisibilitySyncPending = false;
+      const shouldShowMpvHost = !hasBlockingOverlayForMpv();
+      if (mpvHostLastRequestedVisible === shouldShowMpvHost) return;
+
+      try {
+        const result = await window.electronAPI.mpvSetHostVisible(shouldShowMpvHost);
+        if (result?.success && (result.embed?.ready || result.overlay?.ready || shouldShowMpvHost)) {
+          mpvHostLastRequestedVisible = shouldShowMpvHost;
+        }
+      } catch (error) {
+        log.debug('mpv 호스트 표시 상태 동기화 실패', { error: error.message });
+      }
+    });
+  }
+
+  function installMpvBlockingOverlayObserver() {
+    const observer = new MutationObserver((mutations) => {
+      if (!document.body.classList.contains('mpv-pilot-mode')) return;
+      if (!mutations.some((mutation) => mutation.type === 'attributes' || mutation.type === 'childList')) return;
+      syncMpvHostVisibilityWithDom();
+    });
+    observer.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ['class', 'style', 'hidden']
+    });
+    syncMpvHostVisibilityWithDom();
+  }
+
+  installMpvBlockingOverlayObserver();
 
   function getMpvEmbedBounds() {
     syncMpvFullscreenViewportInset();
@@ -5164,6 +5230,7 @@ async function initApp() {
 
     const result = await window.electronAPI.mpvPrepareEmbed(bounds);
     if (result?.success && result.wid) {
+      syncMpvHostVisibilityWithDom();
       return result;
     }
 
@@ -5181,6 +5248,7 @@ async function initApp() {
 
     const result = await window.electronAPI.mpvPrepareOverlay(bounds);
     if (result?.success) {
+      syncMpvHostVisibilityWithDom();
       return result;
     }
 
@@ -5393,6 +5461,7 @@ async function initApp() {
     try {
       return await window.electronAPI.mpvStop();
     } finally {
+      mpvHostLastRequestedVisible = null;
       await window.electronAPI?.mpvDestroyOverlay?.();
       await window.electronAPI?.mpvDestroyEmbed?.();
     }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -13428,8 +13428,9 @@ async function initApp() {
   }
 
   function hasContinuousPlaybackReachedMediaEnd(snapshot = getContinuousPlaybackSnapshot()) {
-    if (snapshot.externalEofReached === true) return true;
-    return snapshot.duration > 0 && snapshot.duration - snapshot.currentTime <= 0.25 && snapshot.ended === true;
+    const nearMediaEnd = snapshot.duration > 0 && snapshot.duration - snapshot.currentTime <= 0.25;
+    if (snapshot.externalEofReached === true) return nearMediaEnd;
+    return nearMediaEnd && snapshot.ended === true;
   }
 
   function waitForContinuousMediaReady(timeoutMs = 1200) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5133,6 +5133,7 @@ async function initApp() {
     '.credits-overlay.active',
     '.codec-error-overlay.active',
     '.app-saving-overlay.active',
+    '#videoLoadingOverlay.active',
     '.transcode-overlay.active'
   ].join(',');
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -67,6 +67,7 @@ const SUPPORTED_MEDIA_EXTENSIONS = [...SUPPORTED_VIDEO_EXTENSIONS, ...SUPPORTED_
 const SUPPORTED_PLAYLIST_EXTENSION = 'bplaylist';
 const SUPPORTED_CUTLIST_EXTENSION = 'bcutlist';
 const MPV_OVERLAY_LIVE_DRAW_SYNC_INTERVAL_MS = 48;
+const MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS = 350;
 
 // 전역 에러 핸들러 설정
 setupGlobalErrorHandlers();
@@ -4417,6 +4418,11 @@ async function initApp() {
     window._zoomIndicatorTimeout = setTimeout(() => {
       elements.zoomIndicatorOverlay.classList.remove('visible');
       scheduleMpvOverlayStateSync();
+      setTimeout(() => {
+        if (!elements.zoomIndicatorOverlay?.classList.contains('visible')) {
+          scheduleMpvOverlayStateSync({ force: true });
+        }
+      }, MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS);
     }, 800);
   }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6718,6 +6718,11 @@ async function initApp() {
   function hideFullscreenScrubOverlay() {
     fullscreenScrubOverlay?.classList.remove('visible');
     scheduleMpvOverlayStateSync();
+    setTimeout(() => {
+      if (!fullscreenScrubOverlay?.classList.contains('visible')) {
+        scheduleMpvOverlayStateSync({ force: true });
+      }
+    }, MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS);
   }
 
   // 전체화면 시크바 이벤트 설정

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5114,6 +5114,7 @@ async function initApp() {
   let mpvOverlayLastLiveDrawSyncAt = 0;
   let mpvHostVisibilitySyncPending = false;
   let mpvHostLastRequestedVisible = null;
+  let mpvPilotHostPreparing = false;
   let fullscreenTimecodeOverlay = null;
   let fullscreenScrubOverlay = null;
 
@@ -5195,7 +5196,7 @@ async function initApp() {
   }
 
   function syncMpvHostVisibilityWithDom() {
-    if (!document.body.classList.contains('mpv-pilot-mode')) return;
+    if (!mpvPilotHostPreparing && !document.body.classList.contains('mpv-pilot-mode')) return;
     if (!window.electronAPI?.mpvSetHostVisible) return;
     if (mpvHostVisibilitySyncPending) return;
 
@@ -5218,7 +5219,7 @@ async function initApp() {
 
   function installMpvBlockingOverlayObserver() {
     const observer = new MutationObserver((mutations) => {
-      if (!document.body.classList.contains('mpv-pilot-mode')) return;
+      if (!mpvPilotHostPreparing && !document.body.classList.contains('mpv-pilot-mode')) return;
       if (!mutations.some((mutation) => mutation.type === 'attributes' || mutation.type === 'childList')) return;
       syncMpvHostVisibilityWithDom();
     });
@@ -5618,8 +5619,7 @@ async function initApp() {
     isStaleVideoLoad = () => false
   } = {}) {
     activeMpvPilotLoadToken = loadToken;
-    const embedHost = await prepareMpvEmbedHost();
-    await prepareMpvOverlayHost();
+    let embedHost = null;
     let mpvLoadStarted = false;
     const ownsMpvPilotLoad = () => activeMpvPilotLoadToken === loadToken;
     const clearMpvPilotLoadOwner = () => {
@@ -5643,9 +5643,20 @@ async function initApp() {
       } catch (error) {
         log.debug('mpv 파일럿 준비 정리 실패', { error: error.message });
       } finally {
+        mpvPilotHostPreparing = false;
         clearMpvPilotLoadOwner();
       }
     };
+
+    try {
+      mpvPilotHostPreparing = true;
+      embedHost = await prepareMpvEmbedHost();
+      await prepareMpvOverlayHost();
+    } catch (error) {
+      await cleanupPendingMpvPilot();
+      throw error;
+    }
+
     const stopCurrentMpvPilotEngine = async () => {
       try {
         return await stopMpvPilotEngine();
@@ -5732,6 +5743,8 @@ async function initApp() {
 
     elements.videoWrapper?.classList.add('mpv-pilot-mode');
     document.body.classList.add('mpv-pilot-mode');
+    mpvPilotHostPreparing = false;
+    syncMpvHostVisibilityWithDom();
     syncCanvasOverlay();
     syncMpvEmbedBounds();
     syncMpvVideoTransform();

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5125,7 +5125,6 @@ async function initApp() {
     '.split-view-overlay.open',
     '.prompt-modal-overlay.open',
     '.credits-overlay.active',
-    '.video-loading-overlay.active',
     '.codec-error-overlay.active',
     '.app-saving-overlay.active',
     '.transcode-overlay.active'

--- a/renderer/scripts/modules/video-player.js
+++ b/renderer/scripts/modules/video-player.js
@@ -875,8 +875,7 @@ export class VideoPlayer extends EventTarget {
       const nextFps = Number(status.fps);
       const nextWidth = Number(status.width);
       const nextHeight = Number(status.height);
-      const eofReached = status.eofReached === true;
-      this.externalEofReached = eofReached;
+      const rawEofReached = status.eofReached === true;
       let metadataChanged = false;
       if (Number.isFinite(nextDuration) && nextDuration > 0 && this.duration !== nextDuration) {
         this.duration = nextDuration;
@@ -898,6 +897,8 @@ export class VideoPlayer extends EventTarget {
         this.currentTime = Math.max(0, Math.min(nextTime, this.duration || nextTime));
       }
       this.totalFrames = Math.max(0, Math.floor((this.duration || 0) * this.fps));
+      const eofReached = rawEofReached && this.duration > 0 && this.duration - this.currentTime <= 0.25;
+      this.externalEofReached = eofReached;
       if (metadataChanged) {
         this._emit('loadedmetadata', {
           duration: this.duration,

--- a/renderer/scripts/modules/video-player.js
+++ b/renderer/scripts/modules/video-player.js
@@ -897,7 +897,8 @@ export class VideoPlayer extends EventTarget {
         this.currentTime = Math.max(0, Math.min(nextTime, this.duration || nextTime));
       }
       this.totalFrames = Math.max(0, Math.floor((this.duration || 0) * this.fps));
-      const eofReached = rawEofReached && this.duration > 0 && this.duration - this.currentTime <= 0.25;
+      const hasKnownDuration = this.duration > 0;
+      const eofReached = rawEofReached && (!hasKnownDuration || this.duration - this.currentTime <= 0.25);
       this.externalEofReached = eofReached;
       if (metadataChanged) {
         this._emit('loadedmetadata', {

--- a/renderer/scripts/modules/video-player.js
+++ b/renderer/scripts/modules/video-player.js
@@ -23,6 +23,7 @@ export class VideoPlayer extends EventTarget {
     this._externalStatusTimer = null;
     this._externalStatusPending = false;
     this._externalEndedEmitted = false;
+    this.externalEofReached = false;
 
     // 상태
     this.isLoaded = false;
@@ -218,6 +219,7 @@ export class VideoPlayer extends EventTarget {
     this.engine = 'html5';
     this.externalControls = null;
     this._externalEndedEmitted = false;
+    this.externalEofReached = false;
 
     if (wasExternalPlaying) {
       this.isPlaying = false;
@@ -232,6 +234,7 @@ export class VideoPlayer extends EventTarget {
     this.engine = config.engineName || 'external';
     this.externalControls = config.controls || null;
     this._externalEndedEmitted = false;
+    this.externalEofReached = false;
     this.filePath = config.filePath || null;
     this.duration = Math.max(0, Number(config.duration) || 0);
     this.fps = Math.max(1, Number(config.fps) || this.fps || 24);
@@ -419,6 +422,7 @@ export class VideoPlayer extends EventTarget {
     try {
       if (this.engine !== 'html5') {
         this._externalEndedEmitted = false;
+        this.externalEofReached = false;
         const result = await this.externalControls?.play?.();
         if (result?.success === false) {
           throw new Error(result.error || '외부 플레이어 재생 실패');
@@ -486,6 +490,7 @@ export class VideoPlayer extends EventTarget {
 
     time = Math.max(0, Math.min(time, this.duration));
     this._externalEndedEmitted = false;
+    this.externalEofReached = false;
 
     // 내부 상태 즉시 업데이트 (timeupdate 이벤트 전에)
     this.currentTime = time;
@@ -871,6 +876,7 @@ export class VideoPlayer extends EventTarget {
       const nextWidth = Number(status.width);
       const nextHeight = Number(status.height);
       const eofReached = status.eofReached === true;
+      this.externalEofReached = eofReached;
       let metadataChanged = false;
       if (Number.isFinite(nextDuration) && nextDuration > 0 && this.duration !== nextDuration) {
         this.duration = nextDuration;

--- a/scripts/tests/instance-policy.test.js
+++ b/scripts/tests/instance-policy.test.js
@@ -23,6 +23,8 @@ test('explicit multi-instance switches allow packaged comparison runs', () => {
   assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe', '--multi-instance-user-data=C:\\temp\\A'], env: {} }), true);
   assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe'], env: { BAEFRAME_MULTI_INSTANCE: '1' } }), true);
   assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe'], env: { BAEFRAME_MULTI_INSTANCE_USER_DATA: 'C:\\temp\\A' } }), true);
+  assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe'], env: { BAEFRAME_MULTI_INSTANCE_PROFILE: 'A' } }), true);
+  assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe'], env: { BAEFRAME_MULTI_INSTANCE_ISOLATED: '1' } }), true);
 });
 
 test('multi-instance profile uses an isolated user data folder only when requested', () => {

--- a/scripts/tests/instance-policy.test.js
+++ b/scripts/tests/instance-policy.test.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const test = require('node:test');
+const path = require('path');
+
+const {
+  getSwitchValue,
+  resolveMultiInstanceUserDataPath,
+  sanitizeProfileName,
+  shouldAllowMultipleInstances
+} = require('../../main/instance-policy');
+
+test('development mode allows multiple instances without a switch', () => {
+  assert.equal(shouldAllowMultipleInstances({ isDev: true, argv: [], env: {} }), true);
+});
+
+test('packaged mode stays single-instance by default', () => {
+  assert.equal(shouldAllowMultipleInstances({ isDev: false, argv: [], env: {} }), false);
+});
+
+test('explicit multi-instance switches allow packaged comparison runs', () => {
+  assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe', '--multi-instance'], env: {} }), true);
+  assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe', '--multi-instance-profile=A'], env: {} }), true);
+  assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe', '--multi-instance-user-data=C:\\temp\\A'], env: {} }), true);
+  assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe'], env: { BAEFRAME_MULTI_INSTANCE: '1' } }), true);
+  assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe'], env: { BAEFRAME_MULTI_INSTANCE_USER_DATA: 'C:\\temp\\A' } }), true);
+});
+
+test('multi-instance profile uses an isolated user data folder only when requested', () => {
+  const shared = resolveMultiInstanceUserDataPath({
+    allowMultipleInstances: true,
+    isDev: false,
+    argv: ['BFRAME_alpha_v2.exe', '--multi-instance'],
+    env: {},
+    appDataDir: 'C:\\Users\\tester\\AppData\\Roaming',
+    pid: 1234
+  });
+  assert.equal(shared, null);
+
+  const isolated = resolveMultiInstanceUserDataPath({
+    allowMultipleInstances: true,
+    isDev: false,
+    argv: ['BFRAME_alpha_v2.exe', '--multi-instance-profile=shot-A'],
+    env: {},
+    appDataDir: 'C:\\Users\\tester\\AppData\\Roaming',
+    pid: 1234
+  });
+  assert.equal(isolated, path.join('C:\\Users\\tester\\AppData\\Roaming', 'baeframe', 'multi-instance', 'shot-A'));
+});
+
+test('multi-instance profile names are sanitized for filesystem use', () => {
+  assert.equal(sanitizeProfileName(' shot A/B:compare '), 'shot-A-B-compare');
+  assert.equal(getSwitchValue(['app.exe', '--multi-instance-profile', 'A'], '--multi-instance-profile'), 'A');
+});

--- a/scripts/tests/mpv-embed-host.test.js
+++ b/scripts/tests/mpv-embed-host.test.js
@@ -336,6 +336,16 @@ test('hides the host while the parent is minimized and restores it with fresh bo
   assert.equal(host.window.visible, true);
   assert.deepEqual(host.window.bounds, { x: 150, y: 180, width: 640, height: 360 });
   assert.ok(host.window.events.some(([name]) => name === 'showInactive'));
+
+  const showCountBeforeHiddenRestore = host.window.events.filter(([name]) => name === 'showInactive').length;
+  host.setVisible(false);
+  for (const handler of listeners.get('restore') || []) {
+    handler();
+  }
+  await waitForAsyncReposition();
+
+  assert.equal(host.window.visible, false);
+  assert.equal(host.window.events.filter(([name]) => name === 'showInactive').length, showCountBeforeHiddenRestore);
 });
 
 test('destroys the host and unbinds parent listeners when the parent closes', async () => {

--- a/scripts/tests/mpv-embed-host.test.js
+++ b/scripts/tests/mpv-embed-host.test.js
@@ -145,6 +145,58 @@ test('updates and destroys an existing host window', async () => {
   assert.equal(host.window, null);
 });
 
+test('hides and restores an embedded host without destroying playback', async () => {
+  const events = [];
+  const fakeMainWindow = {
+    isDestroyed: () => false,
+    isMinimized: () => false,
+    getContentBounds: () => ({ x: 20, y: 30, width: 800, height: 600 })
+  };
+  class FakeBrowserWindow {
+    constructor() {
+      this.destroyed = false;
+    }
+    loadURL() {
+      return Promise.resolve();
+    }
+    setBounds(bounds) {
+      events.push(['setBounds', bounds]);
+    }
+    showInactive() {
+      events.push(['showInactive']);
+    }
+    hide() {
+      events.push(['hide']);
+    }
+    isDestroyed() {
+      return this.destroyed;
+    }
+    getNativeWindowHandle() {
+      return createHandleBuffer(99);
+    }
+    on() {}
+    destroy() {
+      this.destroyed = true;
+    }
+  }
+
+  const host = new MPVEmbedHost({
+    BrowserWindow: FakeBrowserWindow,
+    getMainWindow: () => fakeMainWindow,
+    platform: 'win32'
+  });
+
+  await host.ensure({ x: 1, y: 2, width: 300, height: 200 });
+  const hideResult = host.setVisible(false);
+  const showResult = host.setVisible(true);
+
+  assert.deepEqual(hideResult, { success: true, visible: false, ready: true });
+  assert.deepEqual(showResult, { success: true, visible: true, ready: true });
+  assert.ok(events.some(([name]) => name === 'hide'));
+  assert.ok(events.filter(([name]) => name === 'showInactive').length >= 2);
+  assert.equal(host.window.isDestroyed(), false);
+});
+
 test('repositions the host window when the parent window moves', async () => {
   const listeners = new Map();
   let contentBounds = { x: 100, y: 80, width: 1200, height: 800 };

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -255,6 +255,7 @@ test('repositions and hides overlay with the parent window', async () => {
       this.bounds = null;
       this.visible = false;
       this.destroyed = false;
+      this.showCount = 0;
     }
     loadURL() {
       return Promise.resolve();
@@ -265,6 +266,7 @@ test('repositions and hides overlay with the parent window', async () => {
     setIgnoreMouseEvents() {}
     showInactive() {
       this.visible = true;
+      this.showCount += 1;
     }
     moveTop() {}
     hide() {
@@ -300,4 +302,14 @@ test('repositions and hides overlay with the parent window', async () => {
 
   assert.equal(host.window.visible, true);
   assert.deepEqual(host.window.bounds, { x: 150, y: 180, width: 640, height: 360 });
+
+  const showCountBeforeHiddenRestore = host.window.showCount;
+  host.setVisible(false);
+  for (const handler of listeners.get('restore') || []) {
+    handler();
+  }
+  await waitForAsyncReposition();
+
+  assert.equal(host.window.visible, false);
+  assert.equal(host.window.showCount, showCountBeforeHiddenRestore);
 });

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -16,6 +16,7 @@ test('normalizes overlay state to bounded serializable fields', () => {
     onionDataUrl: 'file://not-allowed',
     markerHtml: '<div class="comment-marker"></div>',
     tooltipHtml: '<div class="comment-marker-tooltip visible"></div>',
+    htmlOverlayHtml: '<div class="current-cut-overlay">Cut 01</div>',
     canvas: { left: 10.4, top: 20.6, width: 640.2, height: 360.7 },
     markerTransform: 'scale(2) translate(1px, 2px)',
     markerTransformOrigin: 'center center'
@@ -26,6 +27,7 @@ test('normalizes overlay state to bounded serializable fields', () => {
   assert.equal(state.onionDataUrl, '');
   assert.equal(state.markerHtml, '<div class="comment-marker"></div>');
   assert.equal(state.tooltipHtml, '<div class="comment-marker-tooltip visible"></div>');
+  assert.equal(state.htmlOverlayHtml, '<div class="current-cut-overlay">Cut 01</div>');
   assert.equal(state.markerTransform, 'scale(2) translate(1px, 2px)');
   assert.equal(state.markerTransformOrigin, 'center center');
 });
@@ -108,6 +110,7 @@ test('creates a click-through overlay window above the viewer area', async () =>
   const overlayHtml = decodeURIComponent(events.find(([name]) => name === 'loadURL')?.[1] || '');
   assert.equal(overlayHtml.includes('__applyMpvOverlayState'), true);
   assert.equal(overlayHtml.includes('applyOverlayTransform'), true);
+  assert.equal(overlayHtml.includes('htmlOverlay'), true);
   assert.equal(overlayHtml.includes('tooltipMirror'), true);
   assert.equal(overlayHtml.includes("applyImage('drawingCanvasMirror', nextState.drawingDataUrl, nextState.canvas)"), true);
   assert.doesNotMatch(
@@ -116,6 +119,7 @@ test('creates a click-through overlay window above the viewer area', async () =>
   );
   assert.equal(overlayHtml.includes("element.style.transform = 'none';"), true);
   assert.equal(overlayHtml.includes('tooltipMirror.innerHTML = nextState.tooltipHtml'), true);
+  assert.equal(overlayHtml.includes('htmlOverlay.innerHTML = nextState.htmlOverlayHtml'), true);
   assert.equal(overlayHtml.includes("tooltipMirror.style.transform = 'none';"), true);
   assert.ok(events.some(([name]) => name === 'showInactive'));
   assert.ok(events.some(([name]) => name === 'moveTop'));
@@ -160,6 +164,7 @@ test('updates overlay state through the isolated overlay document', async () => 
   await host.ensure({ x: 0, y: 0, width: 300, height: 200 });
   const result = await host.updateState({
     markerHtml: '<div class="comment-marker pending"></div>',
+    htmlOverlayHtml: '<div class="current-cut-overlay">Cut 01</div>',
     drawingDataUrl: 'data:image/png;base64,draw',
     canvas: { left: 1, top: 2, width: 3, height: 4 }
   });
@@ -168,6 +173,7 @@ test('updates overlay state through the isolated overlay document', async () => 
   assert.equal(scripts.length, 1);
   assert.match(scripts[0], /window\.__applyMpvOverlayState/);
   assert.match(scripts[0], /comment-marker pending/);
+  assert.match(scripts[0], /current-cut-overlay/);
   assert.match(scripts[0], /data:image\/png;base64,draw/);
 });
 

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -171,6 +171,61 @@ test('updates overlay state through the isolated overlay document', async () => 
   assert.match(scripts[0], /data:image\/png;base64,draw/);
 });
 
+test('hides and restores the native overlay host with the mpv embed host', async () => {
+  const events = [];
+  const fakeMainWindow = {
+    isDestroyed: () => false,
+    isMinimized: () => false,
+    getContentBounds: () => ({ x: 20, y: 30, width: 1200, height: 800 })
+  };
+  class FakeBrowserWindow {
+    constructor() {
+      this.destroyed = false;
+      this.webContents = {
+        executeJavaScript: async () => {}
+      };
+    }
+    loadURL() {
+      return Promise.resolve();
+    }
+    setBounds(bounds) {
+      events.push(['setBounds', bounds]);
+    }
+    showInactive() {
+      events.push(['showInactive']);
+    }
+    hide() {
+      events.push(['hide']);
+    }
+    moveTop() {
+      events.push(['moveTop']);
+    }
+    setIgnoreMouseEvents() {}
+    isDestroyed() {
+      return this.destroyed;
+    }
+    on() {}
+    destroy() {
+      this.destroyed = true;
+    }
+  }
+
+  const host = new MPVOverlayHost({
+    BrowserWindow: FakeBrowserWindow,
+    getMainWindow: () => fakeMainWindow
+  });
+
+  await host.ensure({ x: 1, y: 2, width: 300, height: 200 });
+  const hideResult = host.setVisible(false);
+  const showResult = host.setVisible(true);
+
+  assert.deepEqual(hideResult, { success: true, visible: false, ready: true });
+  assert.deepEqual(showResult, { success: true, visible: true, ready: true });
+  assert.ok(events.some(([name]) => name === 'hide'));
+  assert.ok(events.filter(([name]) => name === 'showInactive').length >= 2);
+  assert.equal(host.window.isDestroyed(), false);
+});
+
 test('repositions and hides overlay with the parent window', async () => {
   const listeners = new Map();
   let contentBounds = { x: 100, y: 80, width: 1200, height: 800 };

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -167,7 +167,7 @@ test('mpv pilot embeds into the BAEFRAME viewer before loading media', () => {
   assert.match(appSource, /async function syncMpvEmbedBounds\(\) \{[\s\S]+window\.electronAPI\.mpvUpdateEmbedBounds\(bounds\)/);
   assert.match(appSource, /async function prepareMpvOverlayHost\(\) \{[\s\S]+window\.electronAPI\.mpvPrepareOverlay\(bounds\)/);
   assert.match(appSource, /async function syncMpvOverlayState\(\) \{[\s\S]+window\.electronAPI\.mpvUpdateOverlayState\(state\)/);
-  assert.match(appSource, /const embedHost = await prepareMpvEmbedHost\(\);/);
+  assert.match(appSource, /let embedHost = null;[\s\S]+embedHost = await prepareMpvEmbedHost\(\);/);
   assert.match(appSource, /await prepareMpvOverlayHost\(\);/);
   assert.match(appSource, /loadResult = await window\.electronAPI\.mpvLoad\(filePath, \{[\s\S]+pause: true,[\s\S]+wid: embedHost\?\.wid,[\s\S]+videoTransform: getMpvVideoTransform\(\)[\s\S]+\}\);/);
   assert.match(appSource, /stop: \(\) => stopCurrentMpvPilotEngine\(\)/);
@@ -192,8 +192,9 @@ test('mpv pilot hides native host while DOM blocking overlays are open', () => {
   });
   assert.doesNotMatch(appSource, /'\.credits-overlay\.open'/);
   assert.match(appSource, /function hasBlockingOverlayForMpv\(\) \{[\s\S]+document\.querySelectorAll\(MPV_BLOCKING_OVERLAY_SELECTOR\)[\s\S]+some\(isElementVisiblyBlockingMpv\);/);
-  assert.match(appSource, /function syncMpvHostVisibilityWithDom\(\) \{[\s\S]+document\.body\.classList\.contains\('mpv-pilot-mode'\)[\s\S]+const shouldShowMpvHost = !hasBlockingOverlayForMpv\(\);[\s\S]+window\.electronAPI\.mpvSetHostVisible\(shouldShowMpvHost\);/);
-  assert.match(appSource, /function installMpvBlockingOverlayObserver\(\) \{[\s\S]+new MutationObserver\(\(mutations\) => \{[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+\}\);[\s\S]+attributeFilter: \['class', 'style', 'hidden'\]/);
+  assert.match(appSource, /let mpvPilotHostPreparing = false;/);
+  assert.match(appSource, /function syncMpvHostVisibilityWithDom\(\) \{[\s\S]+if \(!mpvPilotHostPreparing && !document\.body\.classList\.contains\('mpv-pilot-mode'\)\) return;[\s\S]+const shouldShowMpvHost = !hasBlockingOverlayForMpv\(\);[\s\S]+window\.electronAPI\.mpvSetHostVisible\(shouldShowMpvHost\);/);
+  assert.match(appSource, /function installMpvBlockingOverlayObserver\(\) \{[\s\S]+new MutationObserver\(\(mutations\) => \{[\s\S]+if \(!mpvPilotHostPreparing && !document\.body\.classList\.contains\('mpv-pilot-mode'\)\) return;[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+\}\);[\s\S]+attributeFilter: \['class', 'style', 'hidden'\]/);
   assert.match(appSource, /installMpvBlockingOverlayObserver\(\);/);
   assert.match(appSource, /async function prepareMpvEmbedHost\(\) \{[\s\S]+if \(result\?\.success && result\.wid\) \{[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+return result;/);
   assert.match(appSource, /async function prepareMpvOverlayHost\(\) \{[\s\S]+if \(result\?\.success\) \{[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+return result;/);
@@ -241,18 +242,21 @@ test('mpv pilot cleans up pending embed host when load is stale or fails before 
   assert.match(appSource, /let activeMpvPilotLoadToken = null;/);
   assert.match(loadMpvSource, /loadToken = null,[\s\S]+isStaleVideoLoad = \(\) => false/);
   assert.match(loadMpvSource, /activeMpvPilotLoadToken = loadToken;/);
+  assert.match(loadMpvSource, /let embedHost = null;/);
   assert.match(loadMpvSource, /const ownsMpvPilotLoad = \(\) => activeMpvPilotLoadToken === loadToken;/);
   assert.match(loadMpvSource, /const clearMpvPilotLoadOwner = \(\) => \{[\s\S]+if \(ownsMpvPilotLoad\(\)\) \{[\s\S]+activeMpvPilotLoadToken = null;[\s\S]+\}/);
   assert.match(loadMpvSource, /const cleanupPendingMpvPilot = async \(\) => \{/);
   assert.match(loadMpvSource, /const cleanupPendingMpvPilot = async \(\) => \{[\s\S]+if \(isStaleVideoLoad\(\) && !ownsMpvPilotLoad\(\)\) \{[\s\S]+return;[\s\S]+\}[\s\S]+if \(mpvLoadStarted\)/);
   assert.match(loadMpvSource, /if \(mpvLoadStarted\) \{[\s\S]+await stopMpvPilotEngine\(\);[\s\S]+\}/);
   assert.match(loadMpvSource, /await window\.electronAPI\?\.mpvDestroyEmbed\?\.\(\);/);
-  assert.match(loadMpvSource, /finally \{[\s\S]+clearMpvPilotLoadOwner\(\);[\s\S]+\}/);
+  assert.match(loadMpvSource, /finally \{[\s\S]+mpvPilotHostPreparing = false;[\s\S]+clearMpvPilotLoadOwner\(\);[\s\S]+\}/);
+  assert.match(loadMpvSource, /try \{[\s\S]+mpvPilotHostPreparing = true;[\s\S]+embedHost = await prepareMpvEmbedHost\(\);[\s\S]+await prepareMpvOverlayHost\(\);[\s\S]+\} catch \(error\) \{[\s\S]+await cleanupPendingMpvPilot\(\);[\s\S]+throw error;[\s\S]+\}/);
   assert.match(loadMpvSource, /const stopCurrentMpvPilotEngine = async \(\) => \{[\s\S]+await stopMpvPilotEngine\(\);[\s\S]+clearMpvPilotLoadOwner\(\);[\s\S]+\};/);
   assert.match(loadMpvSource, /stop: \(\) => stopCurrentMpvPilotEngine\(\)/);
   assert.match(loadMpvSource, /if \(isStaleVideoLoad\(\)\) \{[\s\S]+await cleanupPendingMpvPilot\(\);[\s\S]+return false;[\s\S]+\}/);
   assert.match(loadMpvSource, /catch \(error\) \{[\s\S]+await cleanupPendingMpvPilot\(\);[\s\S]+throw error;[\s\S]+\}/);
   assert.match(loadMpvSource, /if \(!loadResult\?\.success\) \{[\s\S]+await cleanupPendingMpvPilot\(\);[\s\S]+throw new Error/);
+  assert.match(loadMpvSource, /document\.body\.classList\.add\('mpv-pilot-mode'\);[\s\S]+mpvPilotHostPreparing = false;[\s\S]+syncMpvHostVisibilityWithDom\(\);/);
 });
 
 test('mpv pilot mirrors DOM overlays into a click-through native overlay window', () => {

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -183,7 +183,6 @@ test('mpv pilot hides native host while DOM blocking overlays are open', () => {
   assert.match(appSource, /const MPV_BLOCKING_OVERLAY_SELECTOR = \[[\s\S]+'.modal-overlay.active'[\s\S]+'.thread-overlay.open'[\s\S]+'.image-viewer-overlay.open'[\s\S]+\]\.join\(','\);/);
   [
     '.credits-overlay.active',
-    '.video-loading-overlay.active',
     '.codec-error-overlay.active',
     '.app-saving-overlay.active',
     '.transcode-overlay.active'
@@ -191,6 +190,7 @@ test('mpv pilot hides native host while DOM blocking overlays are open', () => {
     assert.match(appSource, new RegExp(`'${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
   });
   assert.doesNotMatch(appSource, /'\.credits-overlay\.open'/);
+  assert.doesNotMatch(appSource, /'\.video-loading-overlay\.active'/);
   assert.match(appSource, /function hasBlockingOverlayForMpv\(\) \{[\s\S]+document\.querySelectorAll\(MPV_BLOCKING_OVERLAY_SELECTOR\)[\s\S]+some\(isElementVisiblyBlockingMpv\);/);
   assert.match(appSource, /let mpvPilotHostPreparing = false;/);
   assert.match(appSource, /function didMpvHostVisibilityApply\(result, shouldShowMpvHost\) \{[\s\S]+if \(!result\?\.success\) return false;[\s\S]+if \(shouldShowMpvHost\) return true;[\s\S]+return result\.embed\?\.ready === true && result\.overlay\?\.ready === true;/);

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -179,6 +179,16 @@ test('mpv pilot embeds into the BAEFRAME viewer before loading media', () => {
 
 test('mpv pilot hides native host while DOM blocking overlays are open', () => {
   assert.match(appSource, /const MPV_BLOCKING_OVERLAY_SELECTOR = \[[\s\S]+'.modal-overlay.active'[\s\S]+'.thread-overlay.open'[\s\S]+'.image-viewer-overlay.open'[\s\S]+\]\.join\(','\);/);
+  [
+    '.credits-overlay.active',
+    '.video-loading-overlay.active',
+    '.codec-error-overlay.active',
+    '.app-saving-overlay.active',
+    '.transcode-overlay.active'
+  ].forEach((selector) => {
+    assert.match(appSource, new RegExp(`'${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
+  });
+  assert.doesNotMatch(appSource, /'\.credits-overlay\.open'/);
   assert.match(appSource, /function hasBlockingOverlayForMpv\(\) \{[\s\S]+document\.querySelectorAll\(MPV_BLOCKING_OVERLAY_SELECTOR\)[\s\S]+some\(isElementVisiblyBlockingMpv\);/);
   assert.match(appSource, /function syncMpvHostVisibilityWithDom\(\) \{[\s\S]+document\.body\.classList\.contains\('mpv-pilot-mode'\)[\s\S]+const shouldShowMpvHost = !hasBlockingOverlayForMpv\(\);[\s\S]+window\.electronAPI\.mpvSetHostVisible\(shouldShowMpvHost\);/);
   assert.match(appSource, /function installMpvBlockingOverlayObserver\(\) \{[\s\S]+new MutationObserver\(\(mutations\) => \{[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+\}\);[\s\S]+attributeFilter: \['class', 'style', 'hidden'\]/);
@@ -249,7 +259,20 @@ test('mpv pilot mirrors DOM overlays into a click-through native overlay window'
   assert.match(appSource, /function serializeMpvOverlayMarkerHtml\(\) \{[\s\S]+if \(!isMpvMarkerOverlayVisible\(\)\) return '';/);
   assert.match(appSource, /function serializeMpvOverlayTooltipHtml\(\) \{[\s\S]+const tooltipLayer = document\.createElement\('div'\);[\s\S]+document\.querySelectorAll\('\.comment-marker-tooltip'\)\.forEach\(\(tooltip\) => \{[\s\S]+tooltipClone\.style\.position = 'absolute';[\s\S]+tooltipClone\.style\.transform = 'none';[\s\S]+tooltipLayer\.appendChild\(tooltipClone\);[\s\S]+\}\);/);
   assert.match(appSource, /function serializeMpvOverlayTooltipHtml\(\) \{[\s\S]+if \(!isMpvMarkerOverlayVisible\(\)\) return '';/);
-  assert.match(appSource, /function getMpvOverlayState\(\) \{[\s\S]+drawingDataUrl[\s\S]+onionDataUrl[\s\S]+markerHtml: serializeMpvOverlayMarkerHtml\(\)[\s\S]+tooltipHtml: serializeMpvOverlayTooltipHtml\(\)/);
+  assert.match(appSource, /function copyComputedMpvOverlayStyles\(source, target\) \{/);
+  const htmlOverlayMatch = appSource.match(/function serializeMpvOverlayHtml\(\) \{([\s\S]*?)\n  \}\n\n  function getMpvOverlayState/);
+  assert.ok(htmlOverlayMatch, 'serializeMpvOverlayHtml should exist');
+  const htmlOverlaySource = htmlOverlayMatch[1];
+  [
+    'elements.currentCutOverlay',
+    'elements.zoomIndicatorOverlay',
+    'videoCommentRangeOverlay',
+    'fullscreenTimecodeOverlay',
+    'fullscreenScrubOverlay'
+  ].forEach((source) => {
+    assert.match(htmlOverlaySource, new RegExp(source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+  assert.match(appSource, /function getMpvOverlayState\(\) \{[\s\S]+drawingDataUrl[\s\S]+onionDataUrl[\s\S]+markerHtml: serializeMpvOverlayMarkerHtml\(\)[\s\S]+tooltipHtml: serializeMpvOverlayTooltipHtml\(\)[\s\S]+htmlOverlayHtml: serializeMpvOverlayHtml\(\)/);
   assert.match(appSource, /function scheduleMpvOverlayStateSync\(options = \{\}\) \{[\s\S]+syncMpvOverlayState\(\);/);
   assert.match(appSource, /drawingManager\.addEventListener\('drawmove', \(\) => \{[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}\);/);
   assert.match(appSource, /drawingManager\.addEventListener\('frameRendered', \(e\) => \{[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}\);/);

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -193,11 +193,13 @@ test('mpv pilot hides native host while DOM blocking overlays are open', () => {
   assert.doesNotMatch(appSource, /'\.credits-overlay\.open'/);
   assert.match(appSource, /function hasBlockingOverlayForMpv\(\) \{[\s\S]+document\.querySelectorAll\(MPV_BLOCKING_OVERLAY_SELECTOR\)[\s\S]+some\(isElementVisiblyBlockingMpv\);/);
   assert.match(appSource, /let mpvPilotHostPreparing = false;/);
-  assert.match(appSource, /function syncMpvHostVisibilityWithDom\(\) \{[\s\S]+if \(!mpvPilotHostPreparing && !document\.body\.classList\.contains\('mpv-pilot-mode'\)\) return;[\s\S]+const shouldShowMpvHost = !hasBlockingOverlayForMpv\(\);[\s\S]+window\.electronAPI\.mpvSetHostVisible\(shouldShowMpvHost\);/);
+  assert.match(appSource, /function didMpvHostVisibilityApply\(result, shouldShowMpvHost\) \{[\s\S]+if \(!result\?\.success\) return false;[\s\S]+if \(shouldShowMpvHost\) return true;[\s\S]+return result\.embed\?\.ready === true && result\.overlay\?\.ready === true;/);
+  assert.match(appSource, /function forceMpvHostVisibilitySync\(\) \{[\s\S]+mpvHostLastRequestedVisible = null;[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+\}/);
+  assert.match(appSource, /function syncMpvHostVisibilityWithDom\(\) \{[\s\S]+if \(!mpvPilotHostPreparing && !document\.body\.classList\.contains\('mpv-pilot-mode'\)\) return;[\s\S]+const shouldShowMpvHost = !hasBlockingOverlayForMpv\(\);[\s\S]+window\.electronAPI\.mpvSetHostVisible\(shouldShowMpvHost\);[\s\S]+didMpvHostVisibilityApply\(result, shouldShowMpvHost\)/);
   assert.match(appSource, /function installMpvBlockingOverlayObserver\(\) \{[\s\S]+new MutationObserver\(\(mutations\) => \{[\s\S]+if \(!mpvPilotHostPreparing && !document\.body\.classList\.contains\('mpv-pilot-mode'\)\) return;[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+\}\);[\s\S]+attributeFilter: \['class', 'style', 'hidden'\]/);
   assert.match(appSource, /installMpvBlockingOverlayObserver\(\);/);
-  assert.match(appSource, /async function prepareMpvEmbedHost\(\) \{[\s\S]+if \(result\?\.success && result\.wid\) \{[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+return result;/);
-  assert.match(appSource, /async function prepareMpvOverlayHost\(\) \{[\s\S]+if \(result\?\.success\) \{[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+return result;/);
+  assert.match(appSource, /async function prepareMpvEmbedHost\(\) \{[\s\S]+if \(result\?\.success && result\.wid\) \{[\s\S]+forceMpvHostVisibilitySync\(\);[\s\S]+return result;/);
+  assert.match(appSource, /async function prepareMpvOverlayHost\(\) \{[\s\S]+if \(result\?\.success\) \{[\s\S]+forceMpvHostVisibilitySync\(\);[\s\S]+return result;/);
   assert.match(appSource, /videoPlayer\.addEventListener\('externalstopped', \(\) => \{[\s\S]+mpvHostLastRequestedVisible = null;/);
   assert.match(appSource, /async function stopMpvPilotEngine\(\) \{[\s\S]+finally \{[\s\S]+mpvHostLastRequestedVisible = null;/);
 });

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -325,11 +325,16 @@ test('mpv external playback preserves frame seek and loop behavior', () => {
 test('mpv external playback emits ended when keep-open reaches EOF', () => {
   assert.match(mpvManagerSource, /this\.getOptionalProperty\('eof-reached', false\)/);
   assert.match(videoPlayerSource, /this\._externalEndedEmitted = false;/);
+  assert.match(videoPlayerSource, /this\.externalEofReached = false;/);
   assert.match(videoPlayerSource, /const eofReached = status\.eofReached === true;/);
+  assert.match(videoPlayerSource, /this\.externalEofReached = eofReached;/);
   assert.match(videoPlayerSource, /const externalIsPlaying = status\.paused === false;[\s\S]+const nextIsPlaying = !eofReached && externalIsPlaying;[\s\S]+this\.isPlaying = externalIsPlaying;[\s\S]+this\.isPlaying = nextIsPlaying;/);
   assert.match(videoPlayerSource, /if \(eofReached && !this\._externalEndedEmitted\) \{[\s\S]+this\._externalEndedEmitted = true;[\s\S]+this\._emit\('ended'\);[\s\S]+\}/);
   assert.match(videoPlayerSource, /if \(!eofReached\) \{[\s\S]+this\._externalEndedEmitted = false;[\s\S]+\}/);
-  assert.match(videoPlayerSource, /seek\(time\) \{[\s\S]+this\._externalEndedEmitted = false;/);
+  assert.match(videoPlayerSource, /seek\(time\) \{[\s\S]+this\._externalEndedEmitted = false;[\s\S]+this\.externalEofReached = false;/);
+  assert.match(videoPlayerSource, /async play\(\) \{[\s\S]+if \(this\.engine !== 'html5'\) \{[\s\S]+this\._externalEndedEmitted = false;[\s\S]+this\.externalEofReached = false;/);
+  assert.match(videoPlayerSource, /useExternalEngine\(config = \{\}\) \{[\s\S]+this\._externalEndedEmitted = false;[\s\S]+this\.externalEofReached = false;/);
+  assert.match(videoPlayerSource, /useHtml5Engine\(\) \{[\s\S]+this\._externalEndedEmitted = false;[\s\S]+this\.externalEofReached = false;/);
 });
 
 test('mpv engine replacement resets playing state before html5 loads', () => {

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -37,6 +37,7 @@ test('preload exposes a narrow mpv API surface', () => {
   assert.match(preloadSource, /mpvStop: \(\) => ipcRenderer\.invoke\('mpv:stop'\)/);
   assert.match(preloadSource, /mpvPrepareEmbed: \(bounds\) => ipcRenderer\.invoke\('mpv:prepare-embed', bounds\)/);
   assert.match(preloadSource, /mpvUpdateEmbedBounds: \(bounds\) => ipcRenderer\.invoke\('mpv:update-embed-bounds', bounds\)/);
+  assert.match(preloadSource, /mpvSetHostVisible: \(visible\) => ipcRenderer\.invoke\('mpv:set-host-visible', visible\)/);
   assert.match(preloadSource, /mpvDestroyEmbed: \(\) => ipcRenderer\.invoke\('mpv:destroy-embed'\)/);
   assert.match(preloadSource, /mpvPrepareOverlay: \(bounds\) => ipcRenderer\.invoke\('mpv:prepare-overlay', bounds\)/);
   assert.match(preloadSource, /mpvUpdateOverlayBounds: \(bounds\) => ipcRenderer\.invoke\('mpv:update-overlay-bounds', bounds\)/);
@@ -62,6 +63,7 @@ test('main process registers mpv IPC handlers through the manager and embed host
     'mpv:stop',
     'mpv:prepare-embed',
     'mpv:update-embed-bounds',
+    'mpv:set-host-visible',
     'mpv:destroy-embed',
     'mpv:prepare-overlay',
     'mpv:update-overlay-bounds',
@@ -72,8 +74,10 @@ test('main process registers mpv IPC handlers through the manager and embed host
   }
   assert.match(ipcSource, /mpvEmbedHost\.ensure\(bounds\)/);
   assert.match(ipcSource, /mpvEmbedHost\.updateBounds\(bounds\)/);
+  assert.match(ipcSource, /mpvEmbedHost\.setVisible\(nextVisible\)/);
   assert.match(ipcSource, /mpvEmbedHost\.destroy\(\)/);
   assert.match(ipcSource, /mpvOverlayHost\.ensure\(bounds\)/);
+  assert.match(ipcSource, /mpvOverlayHost\.setVisible\(nextVisible\)/);
   assert.match(ipcSource, /mpvOverlayHost\.updateBounds\(bounds\)/);
   assert.match(ipcSource, /mpvOverlayHost\.updateState\(state\)/);
   assert.match(ipcSource, /mpvOverlayHost\.destroy\(\)/);
@@ -171,6 +175,18 @@ test('mpv pilot embeds into the BAEFRAME viewer before loading media', () => {
   assert.match(videoPlayerSource, /this\.videoHeight = 0;/);
   assert.match(videoPlayerSource, /this\.videoWidth = Math\.max\(0, Number\(config\.width\) \|\| 0\);/);
   assert.match(videoPlayerSource, /this\.videoHeight = Math\.max\(0, Number\(config\.height\) \|\| 0\);/);
+});
+
+test('mpv pilot hides native host while DOM blocking overlays are open', () => {
+  assert.match(appSource, /const MPV_BLOCKING_OVERLAY_SELECTOR = \[[\s\S]+'.modal-overlay.active'[\s\S]+'.thread-overlay.open'[\s\S]+'.image-viewer-overlay.open'[\s\S]+\]\.join\(','\);/);
+  assert.match(appSource, /function hasBlockingOverlayForMpv\(\) \{[\s\S]+document\.querySelectorAll\(MPV_BLOCKING_OVERLAY_SELECTOR\)[\s\S]+some\(isElementVisiblyBlockingMpv\);/);
+  assert.match(appSource, /function syncMpvHostVisibilityWithDom\(\) \{[\s\S]+document\.body\.classList\.contains\('mpv-pilot-mode'\)[\s\S]+const shouldShowMpvHost = !hasBlockingOverlayForMpv\(\);[\s\S]+window\.electronAPI\.mpvSetHostVisible\(shouldShowMpvHost\);/);
+  assert.match(appSource, /function installMpvBlockingOverlayObserver\(\) \{[\s\S]+new MutationObserver\(\(mutations\) => \{[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+\}\);[\s\S]+attributeFilter: \['class', 'style', 'hidden'\]/);
+  assert.match(appSource, /installMpvBlockingOverlayObserver\(\);/);
+  assert.match(appSource, /async function prepareMpvEmbedHost\(\) \{[\s\S]+if \(result\?\.success && result\.wid\) \{[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+return result;/);
+  assert.match(appSource, /async function prepareMpvOverlayHost\(\) \{[\s\S]+if \(result\?\.success\) \{[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+return result;/);
+  assert.match(appSource, /videoPlayer\.addEventListener\('externalstopped', \(\) => \{[\s\S]+mpvHostLastRequestedVisible = null;/);
+  assert.match(appSource, /async function stopMpvPilotEngine\(\) \{[\s\S]+finally \{[\s\S]+mpvHostLastRequestedVisible = null;/);
 });
 
 test('mpv pilot routes audio and viewport controls through mpv IPC', () => {

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -282,6 +282,8 @@ test('mpv pilot mirrors DOM overlays into a click-through native overlay window'
   });
   assert.match(appSource, /function getMpvOverlayState\(\) \{[\s\S]+drawingDataUrl[\s\S]+onionDataUrl[\s\S]+markerHtml: serializeMpvOverlayMarkerHtml\(\)[\s\S]+tooltipHtml: serializeMpvOverlayTooltipHtml\(\)[\s\S]+htmlOverlayHtml: serializeMpvOverlayHtml\(\)/);
   assert.match(appSource, /function scheduleMpvOverlayStateSync\(options = \{\}\) \{[\s\S]+syncMpvOverlayState\(\);/);
+  assert.match(appSource, /const MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS = 350;/);
+  assert.match(appSource, /function showZoomIndicator\(zoom\) \{[\s\S]+elements\.zoomIndicatorOverlay\.classList\.remove\('visible'\);[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+setTimeout\(\(\) => \{[\s\S]+if \(!elements\.zoomIndicatorOverlay\?\.classList\.contains\('visible'\)\) \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);[\s\S]+\}[\s\S]+\}, MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS\);/);
   assert.match(appSource, /drawingManager\.addEventListener\('drawmove', \(\) => \{[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}\);/);
   assert.match(appSource, /drawingManager\.addEventListener\('frameRendered', \(e\) => \{[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}\);/);
   assert.match(appSource, /function renderVideoMarkers\(\) \{[\s\S]+scheduleMpvOverlayStateSync\(\);/);

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -99,7 +99,9 @@ test('loadVideo checks mpv pilot before FFmpeg transcode and falls back by defau
   const loadVideoSource = loadVideoMatch[1];
 
   assert.match(appSource, /async function shouldUseMpvPilot\(filePath, \{ fileIsAudio, hasPreparedVideoPath \} = \{\}\) \{/);
-  assert.match(loadVideoSource, /const useMpvPilot = allowMpvPilot && await shouldUseMpvPilot\(filePath, \{ fileIsAudio, hasPreparedVideoPath \}\);/);
+  assert.match(loadVideoSource, /const preparedVideoPathIsOriginal = hasPreparedVideoPath && isSameFilePath\(preparedVideoPath, filePath\);/);
+  assert.match(loadVideoSource, /const hasConvertedPreparedVideoPath = hasPreparedVideoPath && !preparedVideoPathIsOriginal;/);
+  assert.match(loadVideoSource, /const useMpvPilot = allowMpvPilot && await shouldUseMpvPilot\(filePath, \{ fileIsAudio, hasPreparedVideoPath: hasConvertedPreparedVideoPath \}\);/);
   assert.match(loadVideoSource, /!useMpvPilot && !hasPreparedVideoPath && !fileIsAudio && await window\.electronAPI\.ffmpegIsAvailable\(\)/);
   assert.match(loadVideoSource, /await loadVideoWithMpvPilot\(filePath, \{[\s\S]+initialFrame,[\s\S]+loadToken,[\s\S]+isStaleVideoLoad[\s\S]+\}\);/);
   assert.match(loadVideoSource, /await videoPlayer\.load\(actualVideoPath\);/);
@@ -130,7 +132,7 @@ test('mpv pilot falls back to the normal playback path when mpv load fails', () 
   const loadVideoSource = loadVideoMatch[1];
 
   assert.match(loadVideoSource, /allowMpvPilot = true/);
-  assert.match(loadVideoSource, /const useMpvPilot = allowMpvPilot && await shouldUseMpvPilot\(filePath, \{ fileIsAudio, hasPreparedVideoPath \}\);/);
+  assert.match(loadVideoSource, /const useMpvPilot = allowMpvPilot && await shouldUseMpvPilot\(filePath, \{ fileIsAudio, hasPreparedVideoPath: hasConvertedPreparedVideoPath \}\);/);
   assert.match(loadVideoSource, /catch \(mpvError\) \{[\s\S]+mpv 파일럿 로드 실패, 기존 재생 방식으로 재시도[\s\S]+allowMpvPilot: false[\s\S]+return loadVideo\(filePath, fallbackOptions\);[\s\S]+\}/);
 });
 

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -316,7 +316,7 @@ test('mpv external playback preserves frame seek and loop behavior', () => {
   assert.match(appSource, /videoPlayer\.addEventListener\('externalstopped', \(\) => \{[\s\S]+elements\.videoWrapper\?\.classList\.remove\('mpv-pilot-mode'\);[\s\S]+document\.body\.classList\.remove\('mpv-pilot-mode'\);[\s\S]+\}\);/);
   assert.match(videoPlayerSource, /const nextWidth = Number\(status\.width\);[\s\S]+const nextHeight = Number\(status\.height\);[\s\S]+if \(Number\.isFinite\(nextWidth\) && nextWidth > 0 && this\.videoWidth !== nextWidth\) \{[\s\S]+this\.videoWidth = nextWidth;[\s\S]+\}[\s\S]+if \(Number\.isFinite\(nextHeight\) && nextHeight > 0 && this\.videoHeight !== nextHeight\) \{[\s\S]+this\.videoHeight = nextHeight;/);
   assert.match(videoPlayerSource, /let metadataChanged = false;[\s\S]+metadataChanged = true;[\s\S]+if \(metadataChanged\) \{[\s\S]+this\._emit\('loadedmetadata', \{[\s\S]+duration: this\.duration,[\s\S]+totalFrames: this\.totalFrames,[\s\S]+fps: this\.fps,[\s\S]+width: this\.videoWidth,[\s\S]+height: this\.videoHeight,[\s\S]+engine: this\.engine/);
-  assert.match(videoPlayerSource, /async _syncExternalStatus\(\) \{[\s\S]+const rawEofReached = status\.eofReached === true;[\s\S]+const eofReached = rawEofReached && this\.duration > 0 && this\.duration - this\.currentTime <= 0\.25;[\s\S]+const externalIsPlaying = status\.paused === false;[\s\S]+const nextIsPlaying = !eofReached && externalIsPlaying;[\s\S]+this\.isPlaying = externalIsPlaying;[\s\S]+if \(this\._handleLoopRestartIfNeeded\(\)\) \{[\s\S]+return;[\s\S]+\}[\s\S]+this\.isPlaying = nextIsPlaying;/);
+  assert.match(videoPlayerSource, /async _syncExternalStatus\(\) \{[\s\S]+const rawEofReached = status\.eofReached === true;[\s\S]+const hasKnownDuration = this\.duration > 0;[\s\S]+const eofReached = rawEofReached && \(!hasKnownDuration \|\| this\.duration - this\.currentTime <= 0\.25\);[\s\S]+const externalIsPlaying = status\.paused === false;[\s\S]+const nextIsPlaying = !eofReached && externalIsPlaying;[\s\S]+this\.isPlaying = externalIsPlaying;[\s\S]+if \(this\._handleLoopRestartIfNeeded\(\)\) \{[\s\S]+return;[\s\S]+\}[\s\S]+this\.isPlaying = nextIsPlaying;/);
 
   const seekToFrameMatch = videoPlayerSource.match(/seekToFrame\(frame\) \{([\s\S]*?)\n  \}/);
   assert.ok(seekToFrameMatch, 'seekToFrame should exist');
@@ -328,7 +328,8 @@ test('mpv external playback emits ended when keep-open reaches EOF', () => {
   assert.match(videoPlayerSource, /this\._externalEndedEmitted = false;/);
   assert.match(videoPlayerSource, /this\.externalEofReached = false;/);
   assert.match(videoPlayerSource, /const rawEofReached = status\.eofReached === true;/);
-  assert.match(videoPlayerSource, /const eofReached = rawEofReached && this\.duration > 0 && this\.duration - this\.currentTime <= 0\.25;/);
+  assert.match(videoPlayerSource, /const hasKnownDuration = this\.duration > 0;/);
+  assert.match(videoPlayerSource, /const eofReached = rawEofReached && \(!hasKnownDuration \|\| this\.duration - this\.currentTime <= 0\.25\);/);
   assert.match(videoPlayerSource, /this\.externalEofReached = eofReached;/);
   assert.doesNotMatch(videoPlayerSource, /this\.externalEofReached = rawEofReached;/);
   assert.match(videoPlayerSource, /const externalIsPlaying = status\.paused === false;[\s\S]+const nextIsPlaying = !eofReached && externalIsPlaying;[\s\S]+this\.isPlaying = externalIsPlaying;[\s\S]+this\.isPlaying = nextIsPlaying;/);

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -285,6 +285,7 @@ test('mpv pilot mirrors DOM overlays into a click-through native overlay window'
   assert.match(appSource, /function scheduleMpvOverlayStateSync\(options = \{\}\) \{[\s\S]+syncMpvOverlayState\(\);/);
   assert.match(appSource, /const MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS = 350;/);
   assert.match(appSource, /function showZoomIndicator\(zoom\) \{[\s\S]+elements\.zoomIndicatorOverlay\.classList\.remove\('visible'\);[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+setTimeout\(\(\) => \{[\s\S]+if \(!elements\.zoomIndicatorOverlay\?\.classList\.contains\('visible'\)\) \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);[\s\S]+\}[\s\S]+\}, MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS\);/);
+  assert.match(appSource, /function hideFullscreenScrubOverlay\(\) \{[\s\S]+fullscreenScrubOverlay\?\.classList\.remove\('visible'\);[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+setTimeout\(\(\) => \{[\s\S]+if \(!fullscreenScrubOverlay\?\.classList\.contains\('visible'\)\) \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);[\s\S]+\}[\s\S]+\}, MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS\);/);
   assert.match(appSource, /drawingManager\.addEventListener\('drawmove', \(\) => \{[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}\);/);
   assert.match(appSource, /drawingManager\.addEventListener\('frameRendered', \(e\) => \{[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}\);/);
   assert.match(appSource, /function renderVideoMarkers\(\) \{[\s\S]+scheduleMpvOverlayStateSync\(\);/);

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -316,7 +316,7 @@ test('mpv external playback preserves frame seek and loop behavior', () => {
   assert.match(appSource, /videoPlayer\.addEventListener\('externalstopped', \(\) => \{[\s\S]+elements\.videoWrapper\?\.classList\.remove\('mpv-pilot-mode'\);[\s\S]+document\.body\.classList\.remove\('mpv-pilot-mode'\);[\s\S]+\}\);/);
   assert.match(videoPlayerSource, /const nextWidth = Number\(status\.width\);[\s\S]+const nextHeight = Number\(status\.height\);[\s\S]+if \(Number\.isFinite\(nextWidth\) && nextWidth > 0 && this\.videoWidth !== nextWidth\) \{[\s\S]+this\.videoWidth = nextWidth;[\s\S]+\}[\s\S]+if \(Number\.isFinite\(nextHeight\) && nextHeight > 0 && this\.videoHeight !== nextHeight\) \{[\s\S]+this\.videoHeight = nextHeight;/);
   assert.match(videoPlayerSource, /let metadataChanged = false;[\s\S]+metadataChanged = true;[\s\S]+if \(metadataChanged\) \{[\s\S]+this\._emit\('loadedmetadata', \{[\s\S]+duration: this\.duration,[\s\S]+totalFrames: this\.totalFrames,[\s\S]+fps: this\.fps,[\s\S]+width: this\.videoWidth,[\s\S]+height: this\.videoHeight,[\s\S]+engine: this\.engine/);
-  assert.match(videoPlayerSource, /async _syncExternalStatus\(\) \{[\s\S]+const externalIsPlaying = status\.paused === false;[\s\S]+const nextIsPlaying = !eofReached && externalIsPlaying;[\s\S]+this\.isPlaying = externalIsPlaying;[\s\S]+if \(this\._handleLoopRestartIfNeeded\(\)\) \{[\s\S]+return;[\s\S]+\}[\s\S]+this\.isPlaying = nextIsPlaying;/);
+  assert.match(videoPlayerSource, /async _syncExternalStatus\(\) \{[\s\S]+const rawEofReached = status\.eofReached === true;[\s\S]+const eofReached = rawEofReached && this\.duration > 0 && this\.duration - this\.currentTime <= 0\.25;[\s\S]+const externalIsPlaying = status\.paused === false;[\s\S]+const nextIsPlaying = !eofReached && externalIsPlaying;[\s\S]+this\.isPlaying = externalIsPlaying;[\s\S]+if \(this\._handleLoopRestartIfNeeded\(\)\) \{[\s\S]+return;[\s\S]+\}[\s\S]+this\.isPlaying = nextIsPlaying;/);
 
   const seekToFrameMatch = videoPlayerSource.match(/seekToFrame\(frame\) \{([\s\S]*?)\n  \}/);
   assert.ok(seekToFrameMatch, 'seekToFrame should exist');
@@ -327,8 +327,10 @@ test('mpv external playback emits ended when keep-open reaches EOF', () => {
   assert.match(mpvManagerSource, /this\.getOptionalProperty\('eof-reached', false\)/);
   assert.match(videoPlayerSource, /this\._externalEndedEmitted = false;/);
   assert.match(videoPlayerSource, /this\.externalEofReached = false;/);
-  assert.match(videoPlayerSource, /const eofReached = status\.eofReached === true;/);
+  assert.match(videoPlayerSource, /const rawEofReached = status\.eofReached === true;/);
+  assert.match(videoPlayerSource, /const eofReached = rawEofReached && this\.duration > 0 && this\.duration - this\.currentTime <= 0\.25;/);
   assert.match(videoPlayerSource, /this\.externalEofReached = eofReached;/);
+  assert.doesNotMatch(videoPlayerSource, /this\.externalEofReached = rawEofReached;/);
   assert.match(videoPlayerSource, /const externalIsPlaying = status\.paused === false;[\s\S]+const nextIsPlaying = !eofReached && externalIsPlaying;[\s\S]+this\.isPlaying = externalIsPlaying;[\s\S]+this\.isPlaying = nextIsPlaying;/);
   assert.match(videoPlayerSource, /if \(eofReached && !this\._externalEndedEmitted\) \{[\s\S]+this\._externalEndedEmitted = true;[\s\S]+this\._emit\('ended'\);[\s\S]+\}/);
   assert.match(videoPlayerSource, /if \(!eofReached\) \{[\s\S]+this\._externalEndedEmitted = false;[\s\S]+\}/);

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -185,6 +185,7 @@ test('mpv pilot hides native host while DOM blocking overlays are open', () => {
     '.credits-overlay.active',
     '.codec-error-overlay.active',
     '.app-saving-overlay.active',
+    '#videoLoadingOverlay.active',
     '.transcode-overlay.active'
   ].forEach((selector) => {
     assert.match(appSource, new RegExp(`'${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -374,6 +374,23 @@ test('continuous playback verifies that native playback actually advances', () =
   assert.match(appSource, /const started = await playContinuousItemWithWatchdog\(nextItem, sessionId\);[\s\S]+if \(!started\) \{[\s\S]+await playNextContinuousItem\(sessionId\);/);
 });
 
+test('continuous playback watchdog uses VideoPlayer state for external engines', () => {
+  const readyMatch = appSource.match(/function waitForContinuousMediaReady\(timeoutMs = 1200\) \{([\s\S]*?)\n  \}\n\n  function waitForContinuousPlaybackAdvance/);
+  assert.ok(readyMatch, 'waitForContinuousMediaReady should exist');
+  assert.match(readyMatch[1], /if \(videoPlayer\.engine !== 'html5'\) \{[\s\S]+return Promise\.resolve\(videoPlayer\.isLoaded === true\);/);
+
+  const advanceMatch = appSource.match(/function waitForContinuousPlaybackAdvance\(sessionId, options = \{\}\) \{([\s\S]*?)\n  \}\n\n  async function playContinuousItemWithWatchdog/);
+  assert.ok(advanceMatch, 'waitForContinuousPlaybackAdvance should exist');
+  const advanceSource = advanceMatch[1];
+  assert.match(advanceSource, /const snapshot = getContinuousPlaybackSnapshot\(\);/);
+  assert.match(advanceSource, /const startTime = snapshot\.currentTime;/);
+  assert.match(advanceSource, /const duration = snapshot\.duration;/);
+  assert.match(advanceSource, /const currentSnapshot = getContinuousPlaybackSnapshot\(\);/);
+  assert.match(advanceSource, /return currentSnapshot\.currentTime - startTime >= minDelta;/);
+  assert.doesNotMatch(advanceSource, /media\.currentTime \|\| videoPlayer\.currentTime/);
+  assert.doesNotMatch(advanceSource, /media\.duration \|\| videoPlayer\.duration/);
+});
+
 test('continuous mode keeps timeline tools separate from autoplay control', () => {
   const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
   assert.match(indexSource, /id="playlistTabReview"[\s\S]*?>개별영상 모드<\/button>/);

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -384,9 +384,11 @@ test('continuous playback watchdog uses VideoPlayer state for external engines',
   const advanceSource = advanceMatch[1];
   assert.match(advanceSource, /const snapshot = getContinuousPlaybackSnapshot\(\);/);
   assert.match(advanceSource, /const startTime = snapshot\.currentTime;/);
-  assert.match(advanceSource, /const duration = snapshot\.duration;/);
+  assert.match(advanceSource, /if \(hasContinuousPlaybackReachedMediaEnd\(snapshot\)\) return Promise\.resolve\(true\);/);
   assert.match(advanceSource, /const currentSnapshot = getContinuousPlaybackSnapshot\(\);/);
   assert.match(advanceSource, /return currentSnapshot\.currentTime - startTime >= minDelta;/);
+  assert.match(advanceSource, /hasAdvanced\(\) \|\| hasContinuousPlaybackReachedMediaEnd\(currentSnapshot\)/);
+  assert.doesNotMatch(advanceSource, /currentSnapshot\.paused && !videoPlayer\.isPlaying[\s\S]+finish\(true\)/);
   assert.doesNotMatch(advanceSource, /media\.currentTime \|\| videoPlayer\.currentTime/);
   assert.doesNotMatch(advanceSource, /media\.duration \|\| videoPlayer\.duration/);
 });

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -398,8 +398,10 @@ test('continuous playback only advances on confirmed media end', () => {
   assert.match(appSource, /const externalEofReached = videoPlayer\.externalEofReached === true;/);
   assert.match(appSource, /ended: externalEofReached \|\| \(duration > 0 && duration - currentTime <= 0\.25 && !videoPlayer\.isPlaying\),/);
   assert.match(appSource, /externalEofReached,/);
-  assert.match(appSource, /if \(snapshot\.externalEofReached === true\) return true;/);
-  assert.match(appSource, /return snapshot\.duration > 0 && snapshot\.duration - snapshot\.currentTime <= 0\.25 && snapshot\.ended === true;/);
+  assert.match(appSource, /const nearMediaEnd = snapshot\.duration > 0 && snapshot\.duration - snapshot\.currentTime <= 0\.25;/);
+  assert.match(appSource, /if \(snapshot\.externalEofReached === true\) return nearMediaEnd;/);
+  assert.match(appSource, /return nearMediaEnd && snapshot\.ended === true;/);
+  assert.doesNotMatch(appSource, /if \(snapshot\.externalEofReached === true\) return true;/);
 
   const endedListenerMatch = appSource.match(/videoPlayer\.addEventListener\('ended', \(\) => \{([\s\S]*?)\n  \}\);/);
   assert.ok(endedListenerMatch, 'videoPlayer ended listener should exist');

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -391,6 +391,22 @@ test('continuous playback watchdog uses VideoPlayer state for external engines',
   assert.doesNotMatch(advanceSource, /media\.duration \|\| videoPlayer\.duration/);
 });
 
+test('continuous playback only advances on confirmed media end', () => {
+  assert.match(appSource, /function hasContinuousPlaybackReachedMediaEnd\(snapshot = getContinuousPlaybackSnapshot\(\)\) \{/);
+  assert.match(appSource, /return snapshot\.duration > 0 && snapshot\.duration - snapshot\.currentTime <= 0\.25 && snapshot\.ended === true;/);
+
+  const endedListenerMatch = appSource.match(/videoPlayer\.addEventListener\('ended', \(\) => \{([\s\S]*?)\n  \}\);/);
+  assert.ok(endedListenerMatch, 'videoPlayer ended listener should exist');
+  const endedListenerSource = endedListenerMatch[1];
+  assert.match(endedListenerSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+if \(!hasContinuousPlaybackReachedMediaEnd\(\)\) \{[\s\S]+return;[\s\S]+playNextContinuousItem\(continuousPlaybackState\.sessionId\);/);
+
+  const advanceMatch = appSource.match(/function waitForContinuousPlaybackAdvance\(sessionId, options = \{\}\) \{([\s\S]*?)\n  \}\n\n  async function playContinuousItemWithWatchdog/);
+  assert.ok(advanceMatch, 'waitForContinuousPlaybackAdvance should exist');
+  const advanceSource = advanceMatch[1];
+  assert.match(advanceSource, /const onEnded = \(\) => \{[\s\S]+if \(hasContinuousPlaybackReachedMediaEnd\(\)\) finish\(true\);[\s\S]+\};/);
+  assert.doesNotMatch(advanceSource, /const onEnded = \(\) => finish\(true\);/);
+});
+
 test('continuous mode keeps timeline tools separate from autoplay control', () => {
   const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
   assert.match(indexSource, /id="playlistTabReview"[\s\S]*?>개별영상 모드<\/button>/);
@@ -478,7 +494,7 @@ test('continuous selection does not auto-load before preparation finishes', () =
 });
 
 test('ended event routes active continuous playback before normal autoplay', () => {
-  assert.match(appSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+playNextContinuousItem\(continuousPlaybackState\.sessionId\);[\s\S]+return;[\s\S]+if \(playlistManager\.isActive\(\) && userSettings\.getPlaylistAutoPlay\(\)/);
+  assert.match(appSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+hasContinuousPlaybackReachedMediaEnd\(\)[\s\S]+playNextContinuousItem\(continuousPlaybackState\.sessionId\);[\s\S]+return;[\s\S]+if \(playlistManager\.isActive\(\) && userSettings\.getPlaylistAutoPlay\(\)/);
 });
 
 test('manual video loads cancel active continuous playback and stale loads', () => {

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -393,6 +393,10 @@ test('continuous playback watchdog uses VideoPlayer state for external engines',
 
 test('continuous playback only advances on confirmed media end', () => {
   assert.match(appSource, /function hasContinuousPlaybackReachedMediaEnd\(snapshot = getContinuousPlaybackSnapshot\(\)\) \{/);
+  assert.match(appSource, /const externalEofReached = videoPlayer\.externalEofReached === true;/);
+  assert.match(appSource, /ended: externalEofReached \|\| \(duration > 0 && duration - currentTime <= 0\.25 && !videoPlayer\.isPlaying\),/);
+  assert.match(appSource, /externalEofReached,/);
+  assert.match(appSource, /if \(snapshot\.externalEofReached === true\) return true;/);
   assert.match(appSource, /return snapshot\.duration > 0 && snapshot\.duration - snapshot\.currentTime <= 0\.25 && snapshot\.ended === true;/);
 
   const endedListenerMatch = appSource.match(/videoPlayer\.addEventListener\('ended', \(\) => \{([\s\S]*?)\n  \}\);/);

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -398,8 +398,9 @@ test('continuous playback only advances on confirmed media end', () => {
   assert.match(appSource, /const externalEofReached = videoPlayer\.externalEofReached === true;/);
   assert.match(appSource, /ended: externalEofReached \|\| \(duration > 0 && duration - currentTime <= 0\.25 && !videoPlayer\.isPlaying\),/);
   assert.match(appSource, /externalEofReached,/);
-  assert.match(appSource, /const nearMediaEnd = snapshot\.duration > 0 && snapshot\.duration - snapshot\.currentTime <= 0\.25;/);
-  assert.match(appSource, /if \(snapshot\.externalEofReached === true\) return nearMediaEnd;/);
+  assert.match(appSource, /const hasKnownDuration = snapshot\.duration > 0;/);
+  assert.match(appSource, /const nearMediaEnd = hasKnownDuration && snapshot\.duration - snapshot\.currentTime <= 0\.25;/);
+  assert.match(appSource, /if \(snapshot\.externalEofReached === true\) return !hasKnownDuration \|\| nearMediaEnd;/);
   assert.match(appSource, /return nearMediaEnd && snapshot\.ended === true;/);
   assert.doesNotMatch(appSource, /if \(snapshot\.externalEofReached === true\) return true;/);
 

--- a/scripts/tests/project-file-associations.test.js
+++ b/scripts/tests/project-file-associations.test.js
@@ -96,3 +96,13 @@ test('main process starts project file association repair during app startup', (
   assert.match(mainIndex, /app\.whenReady\(\)\.then/);
   assert.match(mainIndex, /appPath: process\.execPath/);
 });
+
+test('main process keeps single-instance default but allows explicit comparison instances', () => {
+  const mainIndex = read('main/index.js');
+
+  assert.match(mainIndex, /shouldAllowMultipleInstances/);
+  assert.match(mainIndex, /resolveMultiInstanceUserDataPath/);
+  assert.match(mainIndex, /const allowMultipleInstances = shouldAllowMultipleInstances\(/);
+  assert.match(mainIndex, /const gotTheLock = allowMultipleInstances \? true : app\.requestSingleInstanceLock\(\);/);
+  assert.match(mainIndex, /app\.setPath\('userData', multiInstanceUserDataPath\);/);
+});


### PR DESCRIPTION
## 📋 업데이트 요약

🎬 재생목록에서 타임라인으로 이어 볼 때, 영상이 실제로 끝나기 전에 다음 영상으로 넘어가던 문제를 줄였습니다.

🖼️ 설정창, 로딩창, 오류창처럼 화면을 덮는 창이 떠 있을 때 mpv 영상만 위에 남아 보이던 문제를 보정했습니다.

🧪 같은 영상을 비교하면서 볼 수 있도록, 필요할 때 배프레임을 여러 개 띄우는 실행 옵션을 추가했습니다. 기본 실행 방식은 기존처럼 하나만 열립니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - `hasContinuousPlaybackReachedMediaEnd()`로 mpv 종료 신호가 와도 현재 시간이 실제 끝 지점 근처인지 확인한 뒤 다음 항목으로 이동하도록 변경했습니다.
  - 타임라인 이어붙이기 상태 확인을 HTML video 기준에서 `VideoPlayer` 상태 기준으로 보강해 외부 mpv 엔진에서도 재생 위치 판단이 맞도록 수정했습니다.
  - mpv 위에 표시되어야 하는 HTML 오버레이를 복제해 `mpv-overlay-host`로 넘기는 경로를 추가했습니다.
  - DOM의 모달/오버레이 상태를 감지해 `mpv:set-host-visible`로 mpv 호스트 표시 상태를 동기화합니다.

- `main/mpv-embed-host.js`, `main/mpv-overlay-host.js`, `main/ipc-handlers.js`, `preload/preload.js`
  - mpv embed/overlay 창을 일시적으로 숨기거나 다시 보이게 하는 IPC 경로를 추가했습니다.
  - mpv overlay 창에 `htmlOverlayHtml`을 반영해 줌 표시, 컷 표시, 코멘트 범위 같은 기존 화면 요소가 mpv 모드에서도 보이도록 보강했습니다.

- `main/instance-policy.js`, `main/index.js`
  - 기본 앱 실행은 기존 단일 인스턴스를 유지합니다.
  - `--multi-instance`, `--multi-instance-profile`, `--multi-instance-isolated`, `--multi-instance-user-data` 옵션과 `BAEFRAME_MULTI_INSTANCE` 계열 환경변수로 명시적인 다중 실행을 허용합니다.
  - 프로필별 `userData` 경로를 분리해 비교 실행 중 설정/캐시 충돌 위험을 줄였습니다.

- 테스트 추가/보강
  - `scripts/tests/playlist-continuous-runtime.test.js`
  - `scripts/tests/mpv-runtime-source.test.js`
  - `scripts/tests/mpv-embed-host.test.js`
  - `scripts/tests/mpv-overlay-host.test.js`
  - `scripts/tests/instance-policy.test.js`
  - `scripts/tests/project-file-associations.test.js`

## 🚧 개발 난항

mpv 영상은 일반 화면 요소처럼 앱 내부에 완전히 섞이는 방식이 아니라 별도 창처럼 붙는 구조라, 설정창이나 로딩창이 떠도 영상만 위에 남는 문제가 생겼습니다. 그래서 앱 화면의 가림 상태를 감지해 mpv 창 자체의 표시 상태를 같이 조정하는 방식으로 처리했습니다.

재생목록 문제는 mpv 모드에서 실제 재생 상태와 숨겨진 HTML video 상태가 어긋날 수 있는 점이 원인이었습니다. 특히 `ended` 신호가 들어와도 실제 영상 시간이 끝에 도달하지 않은 경우가 있어, 종료 신호만 믿지 않고 현재 시간과 전체 길이를 함께 확인하도록 바꿨습니다.

다중 실행은 편하지만 기본값으로 켜면 기존 사용자 데이터와 충돌할 수 있어서, 명시적으로 옵션을 준 경우에만 허용하는 방식으로 제한했습니다.

## ✅ 테스트 가이드

실사용자용:

1. mpv 모드를 켠 상태로 재생목록을 엽니다.
2. 재생목록을 타임라인 보기/이어붙이기 방식으로 재생합니다.
3. 영상이 끝나기 전에 다음 영상으로 넘어가지 않는지 확인합니다.
4. 재생 중 설정창, 오류창, 로딩창 같은 화면을 띄웠을 때 mpv 영상이 창 위에 덩그러니 남지 않는지 확인합니다.
5. 비교 실행은 PowerShell에서 아래처럼 실행합니다.

```powershell
$exe = "G:\공유 드라이브\JBBJ 자료실\한솔이의 두근두근 실험실\BAEFRAME\테스트버전 빌드\BFRAME_alpha_v2.exe"
$env:BAEFRAME_MPV_PILOT = "1"
Start-Process $exe -ArgumentList "--multi-instance-profile=A"
Start-Process $exe -ArgumentList "--multi-instance-profile=B"
```

개발자용:

- `node --test scripts/tests/instance-policy.test.js`
- `npm run test:playlist`
- `npm run test:mpv`
- `npm run build`
- 빌드된 `dist\win-unpacked\BFRAME_alpha_v2.exe` 2개 인스턴스 실행 확인
- 공유 드라이브 배포 후 원본/배포본 파일 개수 및 `app.asar` 해시 비교