### PR TITLE
[v1.4.1-beta] 재생목록 답글 작성 및 mpv 직접 재생 개선

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1632,7 +1632,8 @@ function setupIpcHandlers() {
     try {
       const result = await metadataMpv.load(filePath, {
         pause: true,
-        forceWindow: false
+        forceWindow: false,
+        headless: true
       });
       const metadata = {
         success: true,

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -12,7 +12,7 @@ const { getMainWindow, minimizeWindow, toggleMaximize, closeWindow, isMaximized,
 const { RecentFilesStore } = require('./recent-files-store');
 const recentThumbCapture = require('./recent-thumb-capture');
 const { validateCutlistFilePath } = require('./cutlist-paths');
-const { mpvManager } = require('./mpv-manager');
+const { MPVManager, mpvManager } = require('./mpv-manager');
 const { mpvEmbedHost } = require('./mpv-embed-host');
 const { mpvOverlayHost } = require('./mpv-overlay-host');
 const Store = require('electron-store');
@@ -1623,6 +1623,35 @@ function setupIpcHandlers() {
     } catch (error) {
       trace.error(error);
       return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('mpv:probe-metadata', async (event, filePath) => {
+    const trace = log.trace('mpv:probe-metadata');
+    const metadataMpv = new MPVManager();
+    try {
+      const result = await metadataMpv.load(filePath, {
+        pause: true,
+        forceWindow: false
+      });
+      const metadata = {
+        success: true,
+        duration: Number(result.duration) || 0,
+        fps: Number(result.fps) || 24,
+        width: Number(result.width) || 0,
+        height: Number(result.height) || 0
+      };
+      trace.end({ success: true, filePath, duration: metadata.duration, fps: metadata.fps });
+      return metadata;
+    } catch (error) {
+      trace.error(error);
+      return { success: false, error: error.message };
+    } finally {
+      try {
+        await metadataMpv.stop({ commandTimeoutMs: 1000 });
+      } catch (stopError) {
+        log.debug('mpv 메타데이터 조회용 프로세스 정리 실패', { error: stopError.message });
+      }
     }
   });
 

--- a/main/mpv-manager.js
+++ b/main/mpv-manager.js
@@ -35,6 +35,15 @@ function createMpvIpcPath({
   return path.posix.join(String(tempDir).replace(/\\/g, '/'), `baeframe-mpv-${pid}-${safeUnique}.sock`);
 }
 
+function createMpvIpcUniqueId({
+  now = Date.now,
+  random = Math.random
+} = {}) {
+  const timePart = Number(now()).toString(36);
+  const randomPart = Math.floor(Number(random()) * Number.MAX_SAFE_INTEGER).toString(36);
+  return `${timePart}-${randomPart}`;
+}
+
 function normalizeMpvWid(wid) {
   if (wid === undefined || wid === null || wid === '') return null;
   const value = String(wid).trim();
@@ -102,6 +111,7 @@ class MPVManager {
     this.execFile = options.execFile || execFile;
     this.logger = options.logger || log;
     this.now = options.now || (() => Date.now());
+    this.random = options.random || Math.random;
     this.tempDir = options.tempDir || os.tmpdir();
 
     this.appRoot = options.appRoot || path.join(__dirname, '..');
@@ -356,7 +366,7 @@ class MPVManager {
     this.ipcPath = createMpvIpcPath({
       platform: this.platform,
       pid: this.processPid,
-      unique: this.now().toString(36),
+      unique: createMpvIpcUniqueId({ now: this.now, random: this.random }),
       tempDir: this.tempDir
     });
 
@@ -600,6 +610,7 @@ const mpvManager = new MPVManager();
 module.exports = {
   MPVManager,
   createMpvIpcPath,
+  createMpvIpcUniqueId,
   createMpvLaunchArgs,
   isMpvPilotEnabled,
   mpvManager

--- a/main/mpv-manager.js
+++ b/main/mpv-manager.js
@@ -110,6 +110,7 @@ class MPVManager {
     this.process = null;
     this.requestId = 0;
     this.embeddedWid = null;
+    this.forceWindow = true;
     this.loadQueue = Promise.resolve();
   }
 
@@ -157,7 +158,7 @@ class MPVManager {
       throw new Error(`mpv load file not found: ${filePath}`);
     }
 
-    await this.start({ wid: options.wid });
+    await this.start({ wid: options.wid, forceWindow: options.forceWindow });
     await this.sendCommand(['loadfile', filePath, 'replace']);
     await this.waitForPlaybackReady(filePath);
     if (options.videoTransform) {
@@ -329,7 +330,12 @@ class MPVManager {
 
     const hasWidOption = Object.prototype.hasOwnProperty.call(options, 'wid');
     const requestedWid = hasWidOption ? normalizeMpvWid(options.wid) : this.embeddedWid;
-    if (this.process && !this.process.killed && this.embeddedWid !== requestedWid) {
+    const requestedForceWindow = options.forceWindow !== false;
+    if (
+      this.process &&
+      !this.process.killed &&
+      (this.embeddedWid !== requestedWid || this.forceWindow !== requestedForceWindow)
+    ) {
       await this.stop();
     }
 
@@ -344,9 +350,10 @@ class MPVManager {
       tempDir: this.tempDir
     });
 
-    const args = createMpvLaunchArgs({ ipcPath: this.ipcPath, forceWindow: true, wid: requestedWid });
+    const args = createMpvLaunchArgs({ ipcPath: this.ipcPath, forceWindow: requestedForceWindow, wid: requestedWid });
     this.logger.info('starting mpv pilot process', { mpvPath: this.mpvPath, args });
     this.embeddedWid = requestedWid;
+    this.forceWindow = requestedForceWindow;
 
     const processRef = this.spawn(this.mpvPath, args, {
       stdio: 'ignore',
@@ -391,6 +398,7 @@ class MPVManager {
 
     this.process = null;
     this.embeddedWid = null;
+    this.forceWindow = true;
     return { success: true, stopped: true };
   }
 

--- a/main/mpv-manager.js
+++ b/main/mpv-manager.js
@@ -57,7 +57,7 @@ function clampNumber(value, min, max, fallback) {
   return Math.max(min, Math.min(max, number));
 }
 
-function createMpvLaunchArgs({ ipcPath, forceWindow = true, wid = null } = {}) {
+function createMpvLaunchArgs({ ipcPath, forceWindow = true, wid = null, headless = false } = {}) {
   if (!ipcPath) {
     throw new Error('mpv IPC path is required');
   }
@@ -74,6 +74,10 @@ function createMpvLaunchArgs({ ipcPath, forceWindow = true, wid = null } = {}) {
     '--hwdec=auto',
     `--input-ipc-server=${ipcPath}`
   ];
+
+  if (headless) {
+    args.push('--vo=null', '--ao=null');
+  }
 
   if (normalizedWid) {
     args.push(
@@ -111,6 +115,7 @@ class MPVManager {
     this.requestId = 0;
     this.embeddedWid = null;
     this.forceWindow = true;
+    this.headless = false;
     this.loadQueue = Promise.resolve();
   }
 
@@ -158,7 +163,7 @@ class MPVManager {
       throw new Error(`mpv load file not found: ${filePath}`);
     }
 
-    await this.start({ wid: options.wid, forceWindow: options.forceWindow });
+    await this.start({ wid: options.wid, forceWindow: options.forceWindow, headless: options.headless });
     await this.sendCommand(['loadfile', filePath, 'replace']);
     await this.waitForPlaybackReady(filePath);
     if (options.videoTransform) {
@@ -331,10 +336,15 @@ class MPVManager {
     const hasWidOption = Object.prototype.hasOwnProperty.call(options, 'wid');
     const requestedWid = hasWidOption ? normalizeMpvWid(options.wid) : this.embeddedWid;
     const requestedForceWindow = options.forceWindow !== false;
+    const requestedHeadless = options.headless === true;
     if (
       this.process &&
       !this.process.killed &&
-      (this.embeddedWid !== requestedWid || this.forceWindow !== requestedForceWindow)
+      (
+        this.embeddedWid !== requestedWid ||
+        this.forceWindow !== requestedForceWindow ||
+        this.headless !== requestedHeadless
+      )
     ) {
       await this.stop();
     }
@@ -350,10 +360,16 @@ class MPVManager {
       tempDir: this.tempDir
     });
 
-    const args = createMpvLaunchArgs({ ipcPath: this.ipcPath, forceWindow: requestedForceWindow, wid: requestedWid });
+    const args = createMpvLaunchArgs({
+      ipcPath: this.ipcPath,
+      forceWindow: requestedForceWindow,
+      wid: requestedWid,
+      headless: requestedHeadless
+    });
     this.logger.info('starting mpv pilot process', { mpvPath: this.mpvPath, args });
     this.embeddedWid = requestedWid;
     this.forceWindow = requestedForceWindow;
+    this.headless = requestedHeadless;
 
     const processRef = this.spawn(this.mpvPath, args, {
       stdio: 'ignore',
@@ -399,6 +415,7 @@ class MPVManager {
     this.process = null;
     this.embeddedWid = null;
     this.forceWindow = true;
+    this.headless = false;
     return { success: true, stopped: true };
   }
 

--- a/preload/preload.js
+++ b/preload/preload.js
@@ -115,6 +115,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   mpvIsEnabled: () => ipcRenderer.invoke('mpv:is-enabled'),
   mpvIsAvailable: () => ipcRenderer.invoke('mpv:is-available'),
   mpvLoad: (filePath, options) => ipcRenderer.invoke('mpv:load', filePath, options),
+  mpvProbeMetadata: (filePath) => ipcRenderer.invoke('mpv:probe-metadata', filePath),
   mpvPlay: () => ipcRenderer.invoke('mpv:play'),
   mpvPause: () => ipcRenderer.invoke('mpv:pause'),
   mpvSeek: (time) => ipcRenderer.invoke('mpv:seek', time),

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6068,7 +6068,8 @@ async function initApp() {
             showToast('mpv 재생에 실패해 기존 방식으로 다시 시도합니다.', 'warning');
             const fallbackOptions = {
               ...options,
-              allowMpvPilot: false
+              allowMpvPilot: false,
+              preparedVideoPath: preparedVideoPathIsOriginal ? null : preparedVideoPath
             };
             return loadVideo(filePath, fallbackOptions);
           }
@@ -13397,7 +13398,7 @@ async function initApp() {
         });
         if (!shouldContinuePreparing()) return { ready: false, stale: true };
         if (useMpvPilot) {
-          continuousPlaybackState.preparedMediaPaths.set(item.id, item.videoPath);
+          continuousPlaybackState.preparedMediaPaths.delete(item.id);
           markPlaylistItemStatus(item, CONTINUOUS_STATUS.READY, 'mpv 원본 준비');
           return { ready: true, mpv: true };
         }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -7683,13 +7683,14 @@ async function initApp() {
     const opened = await openPlaylistAggregateComment(key);
     if (!opened) return false;
 
-    const reply = commentManager.addReplyToMarker(range.markerId, text, commentManager.getAuthor());
+    const activeRange = playlistAggregateCommentRanges.find(item => getPlaylistAggregateCommentKey(item) === key) || range;
+    const reply = commentManager.addReplyToMarker(activeRange.markerId, text, commentManager.getAuthor());
     if (!reply) {
       showToast('원본 댓글을 찾을 수 없습니다.', 'warning');
       return false;
     }
 
-    range.replies = [...(range.replies || []), reply];
+    activeRange.replies = [...(activeRange.replies || []), reply];
     textarea.value = '';
     resizeReplyEditorToContent(textarea);
     renderPlaylistContinuousCommentList(commentFilterState.status);
@@ -13222,6 +13223,28 @@ async function initApp() {
           hasPreparedVideoPath: false
         })
         : false;
+
+      if (!hasDuration && item.videoPath && useMpvPilotForMetadata) {
+        try {
+          const mpvProbe = await window.electronAPI.mpvProbeMetadata(item.videoPath);
+          if (mpvProbe?.success) {
+            const probeDuration = Number(mpvProbe.duration);
+            const probeFps = Number(mpvProbe.fps);
+            if (Number.isFinite(probeDuration) && probeDuration > 0) {
+              duration = probeDuration;
+              fps = Number.isFinite(probeFps) && probeFps > 0
+                ? probeFps
+                : (Number.isFinite(fps) && fps > 0 ? fps : 24);
+              item.duration = duration;
+              item.fps = fps;
+            }
+          } else {
+            log.warn('mpv 타임라인 메타데이터 수집 실패', { fileName: item.fileName, error: mpvProbe?.error || 'probe failed' });
+          }
+        } catch (error) {
+          log.warn('mpv 타임라인 메타데이터 수집 실패', { fileName: item.fileName, error: error.message });
+        }
+      }
 
       if (!hasDuration && item.videoPath && !useMpvPilotForMetadata) {
         try {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -255,7 +255,26 @@ async function initApp() {
 
   function getCommentEditableTarget(target) {
     if (!(target instanceof Element)) return null;
-    return target.closest('.comment-input, .comment-marker-input, .comment-reply-input, .comment-edit-textarea, .comment-reply-edit-textarea, .thread-editor[contenteditable="true"]');
+    const standardEditable = target.closest('.comment-input, .comment-marker-input, .comment-reply-input, .comment-edit-textarea, .comment-reply-edit-textarea, .thread-editor[contenteditable="true"]');
+    return standardEditable || target.closest('.playlist-comment-reply-input');
+  }
+
+  function resizeReplyEditorToContent(editor) {
+    if (!editor) return;
+
+    if (editor instanceof HTMLTextAreaElement) {
+      const maxHeight = Number(editor.dataset.maxAutoHeight) || 150;
+      editor.style.height = 'auto';
+      const nextHeight = Math.min(Math.max(editor.scrollHeight, 34), maxHeight);
+      editor.style.height = `${nextHeight}px`;
+      editor.style.overflowY = editor.scrollHeight > maxHeight ? 'auto' : 'hidden';
+      return;
+    }
+
+    if (editor.isContentEditable) {
+      const maxHeight = Number(editor.dataset.maxAutoHeight) || 220;
+      editor.style.overflowY = editor.scrollHeight > maxHeight ? 'auto' : 'hidden';
+    }
   }
 
   function installCommentEditableFocusRecovery() {
@@ -5709,28 +5728,12 @@ async function initApp() {
       throw new Error(loadResult?.error || 'mpv 파일럿 로드 실패');
     }
 
-    let metadata = {
+    const metadata = {
       duration: Number(loadResult.duration) || 0,
       fps: Number(loadResult.fps) || 24,
       width: Number(loadResult.width) || 0,
       height: Number(loadResult.height) || 0
     };
-
-    try {
-      if (await window.electronAPI.ffmpegIsAvailable()) {
-        const probe = await window.electronAPI.ffmpegProbeCodec(filePath);
-        if (probe?.success) {
-          metadata = {
-            duration: Number(probe.duration) || metadata.duration,
-            fps: Number(probe.frameRate) || metadata.fps,
-            width: Number(probe.width) || metadata.width,
-            height: Number(probe.height) || metadata.height
-          };
-        }
-      }
-    } catch (error) {
-      log.debug('mpv 파일럿 메타데이터 보강 실패', { error: error.message });
-    }
 
     if (isStaleVideoLoad()) {
       await cleanupPendingMpvPilot();
@@ -5783,33 +5786,9 @@ async function initApp() {
   async function resolveMpvThumbnailVideoPath(filePath, {
     isStaleVideoLoad = () => false
   } = {}) {
-    if (!window.electronAPI?.ffmpegIsAvailable) return filePath;
-
-    try {
-      const ffmpegAvailable = await window.electronAPI.ffmpegIsAvailable();
-      if (isStaleVideoLoad()) return filePath;
-      if (!ffmpegAvailable) return filePath;
-
-      const codecInfo = await window.electronAPI.ffmpegProbeCodec(filePath);
-      if (isStaleVideoLoad()) return filePath;
-      if (!codecInfo?.success || codecInfo.isSupported) return filePath;
-
-      const cacheResult = await window.electronAPI.ffmpegCheckCache(filePath);
-      if (isStaleVideoLoad()) return filePath;
-      if (cacheResult?.valid && cacheResult.convertedPath) {
-        log.info('mpv 파일럿 썸네일용 캐시 파일 사용', { path: cacheResult.convertedPath });
-        return cacheResult.convertedPath;
-      }
-
-      log.info('mpv 파일럿 썸네일 생성 건너뜀: 원본 직접 재생을 위해 변환을 기다리지 않음', {
-        codec: codecInfo.codecName || 'unknown'
-      });
-      return null;
-    } catch (error) {
-      log.debug('mpv 파일럿 썸네일 경로 준비 실패', { error: error.message });
-    }
-
-    return filePath;
+    if (isStaleVideoLoad()) return null;
+    log.debug('mpv 파일럿 썸네일 생성 건너뜀: FFmpeg 없이 원본을 직접 재생합니다.', { filePath });
+    return null;
   }
 
   async function loadVideo(filePath, options = {}) {
@@ -7535,6 +7514,8 @@ async function initApp() {
 
     mentionManager.attach(editor);
     editor.focus();
+    resizeReplyEditorToContent(editor);
+    editor.addEventListener('input', () => resizeReplyEditorToContent(editor));
 
     const cleanup = () => {
       mentionManager.detach(editor);
@@ -7657,11 +7638,11 @@ async function initApp() {
 
   async function openPlaylistAggregateComment(key) {
     const range = playlistAggregateCommentRanges.find(item => getPlaylistAggregateCommentKey(item) === key);
-    if (!range) return;
+    if (!range) return false;
 
     const playlistManager = getPlaylistManager();
     const item = playlistManager.getItems().find(candidate => candidate.id === range.itemId);
-    if (!item) return;
+    if (!item) return false;
 
     suppressPlaylistSelectionLoad = true;
     try {
@@ -7686,6 +7667,35 @@ async function initApp() {
     updatePlaylistPosition();
     updateTimecodeDisplay();
     highlightPlaylistAggregateComment(key);
+    return true;
+  }
+
+  async function submitPlaylistAggregateReply(key, textarea) {
+    const text = textarea?.value?.trim() || '';
+    if (!text) return false;
+
+    const range = playlistAggregateCommentRanges.find(item => getPlaylistAggregateCommentKey(item) === key);
+    if (!range) {
+      showToast('답글을 달 댓글을 찾을 수 없습니다.', 'warning');
+      return false;
+    }
+
+    const opened = await openPlaylistAggregateComment(key);
+    if (!opened) return false;
+
+    const reply = commentManager.addReplyToMarker(range.markerId, text, commentManager.getAuthor());
+    if (!reply) {
+      showToast('원본 댓글을 찾을 수 없습니다.', 'warning');
+      return false;
+    }
+
+    range.replies = [...(range.replies || []), reply];
+    textarea.value = '';
+    resizeReplyEditorToContent(textarea);
+    renderPlaylistContinuousCommentList(commentFilterState.status);
+    highlightPlaylistAggregateComment(key);
+    showToast('답글이 추가되었습니다.', 'success');
+    return true;
   }
 
   function renderPlaylistContinuousCommentList(filter = getActiveCommentFilter()) {
@@ -7731,6 +7741,10 @@ async function initApp() {
       return;
     }
 
+    container.querySelectorAll('.playlist-comment-reply-input').forEach(el => {
+      mentionManager.detach(el);
+    });
+
     container.innerHTML = ranges.map(range => {
       const key = getPlaylistAggregateCommentKey(range);
       const title = escapeHtmlAttribute(formatPlaylistCommentPanelLine(range));
@@ -7756,17 +7770,67 @@ async function initApp() {
         <div class="comment-actions playlist-comment-readonly-actions">
           <span class="comment-author-inline ${getAuthorColorClass(author)}" style="color: ${authorColor.color}; font-weight: bold;">${highlightCommentSearchMatches(author, normalizedSearch)}</span>
           ${range.createdAt ? `<span class="comment-time-inline">${formatRelativeTime(range.createdAt)}</span>` : ''}
+          <button type="button" class="comment-action-btn playlist-comment-reply-toggle" title="답글">답글</button>
           ${replyCount > 0 ? `<span class="playlist-comment-reply-count">답글 ${replyCount}개</span>` : ''}
           <span class="playlist-comment-source">${highlightCommentSearchMatches(range.fileName, normalizedSearch)}</span>
+        </div>
+        <div class="playlist-comment-reply-form" hidden>
+          <textarea class="playlist-comment-reply-input" placeholder="답글 입력..." rows="1" data-max-auto-height="140"></textarea>
+          <button type="button" class="playlist-comment-reply-submit">전송</button>
         </div>
       </div>
     `;
     }).join('');
 
     container.querySelectorAll('.playlist-aggregate-comment').forEach(item => {
+      const replyToggle = item.querySelector('.playlist-comment-reply-toggle');
+      const replyForm = item.querySelector('.playlist-comment-reply-form');
+      const replyInput = item.querySelector('.playlist-comment-reply-input');
+
       item.addEventListener('click', async (e) => {
         if (e.target.closest('.gdrive-link-btn')) return;
+        if (e.target.closest('.playlist-comment-reply-form, .playlist-comment-reply-toggle')) return;
         await openPlaylistAggregateComment(item.dataset.aggregateCommentKey);
+      });
+
+      if (replyInput) {
+        mentionManager.attach(replyInput);
+        resizeReplyEditorToContent(replyInput);
+      }
+
+      replyToggle?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (!replyForm || !replyInput) return;
+        replyForm.hidden = !replyForm.hidden;
+        if (!replyForm.hidden) {
+          replyInput.focus();
+          resizeReplyEditorToContent(replyInput);
+        }
+      });
+
+      replyInput?.addEventListener('input', () => resizeReplyEditorToContent(replyInput));
+
+      replyInput?.addEventListener('paste', (e) => {
+        handleDrivePathPaste(e);
+      });
+
+      item.querySelector('.playlist-comment-reply-submit')?.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const submitBtn = e.currentTarget;
+        submitBtn.disabled = true;
+        try {
+          await submitPlaylistAggregateReply(item.dataset.aggregateCommentKey, replyInput);
+        } finally {
+          if (document.contains(submitBtn)) submitBtn.disabled = false;
+        }
+      });
+
+      replyInput?.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey && !mentionManager.isVisible) {
+          e.preventDefault();
+          e.stopPropagation();
+          item.querySelector('.playlist-comment-reply-submit')?.click();
+        }
       });
     });
 
@@ -8388,6 +8452,8 @@ async function initApp() {
 
       // 인라인 답글 textarea에 멘션 자동완성 부착
       if (replyInput) mentionManager.attach(replyInput);
+      resizeReplyEditorToContent(replyInput);
+      replyInput?.addEventListener('input', () => resizeReplyEditorToContent(replyInput));
 
       // 답글 이미지 버튼 클릭
       replyImageBtn?.addEventListener('click', async (e) => {
@@ -8433,6 +8499,7 @@ async function initApp() {
         }
         repliesContainer.classList.add('expanded');
         replyInput?.focus();
+        resizeReplyEditorToContent(replyInput);
       });
 
       // 답글 제출 (이미지 포함)
@@ -8460,6 +8527,7 @@ async function initApp() {
         commentManager._emit('markersChanged');
 
         replyInput.value = '';
+        resizeReplyEditorToContent(replyInput);
         clearReplyImage();
         showToast('답글이 추가되었습니다.', 'success');
       });
@@ -10884,6 +10952,7 @@ async function initApp() {
     // 에디터 초기화
     threadEditor.innerHTML = '';
     updateSubmitButtonState();
+    resizeReplyEditorToContent(threadEditor);
 
     // 멘션 자동완성 부착
     mentionManager.attach(threadEditor);
@@ -10901,6 +10970,7 @@ async function initApp() {
     threadOverlay.classList.remove('open');
     currentThreadMarkerId = null;
     threadEditor.innerHTML = '';
+    resizeReplyEditorToContent(threadEditor);
     clearThreadImage();
     restoreFocus();
   }
@@ -11156,6 +11226,7 @@ async function initApp() {
 
     // 에디터 및 이미지 초기화
     threadEditor.innerHTML = '';
+    resizeReplyEditorToContent(threadEditor);
     clearThreadImage();
     updateSubmitButtonState();
     showToast('답글이 추가되었습니다.', 'success');
@@ -11210,6 +11281,7 @@ async function initApp() {
   // 에디터 내용 변경 감지
   threadEditor?.addEventListener('input', () => {
     updateSubmitButtonState();
+    resizeReplyEditorToContent(threadEditor);
 
     // "- " 입력 시 자동 불릿 리스트
     const text = threadEditor.innerText;
@@ -12698,12 +12770,9 @@ async function initApp() {
       playlistManager.isActive()
     );
 
-    const ffmpegAvailable = await window.electronAPI.ffmpegIsAvailable();
-    if (!isCurrentBackgroundWork()) return;
-    if (!ffmpegAvailable) return;
-
     const items = playlistManager.getItems();
     const currentIndex = playlistManager.currentIndex;
+    let ffmpegAvailable = null;
 
     // 현재 아이템 다음부터 순서대로 확인 (우선순위: 바로 다음 아이템)
     for (let offset = 1; offset < items.length; offset++) {
@@ -12711,6 +12780,22 @@ async function initApp() {
       const item = items[targetIndex];
 
       try {
+        const useMpvPilot = await shouldUseMpvPilot(item.videoPath, {
+          fileIsAudio: isAudioFile(item.fileName || item.videoPath),
+          hasPreparedVideoPath: false
+        });
+        if (!isCurrentBackgroundWork()) return;
+        if (useMpvPilot) {
+          log.debug('mpv 파일럿 사전 변환 건너뜀', { fileName: item.fileName, index: targetIndex });
+          continue;
+        }
+
+        if (ffmpegAvailable === null) {
+          ffmpegAvailable = await window.electronAPI.ffmpegIsAvailable();
+          if (!isCurrentBackgroundWork()) return;
+        }
+        if (!ffmpegAvailable) return;
+
         // 코덱 확인
         const codecInfo = await window.electronAPI.ffmpegProbeCodec(item.videoPath);
         if (!isCurrentBackgroundWork()) return;
@@ -13131,7 +13216,14 @@ async function initApp() {
       let fps = Number(item.fps);
       const hasDuration = Number.isFinite(duration) && duration > 0;
 
-      if (!hasDuration && item.videoPath) {
+      const useMpvPilotForMetadata = !hasDuration && item.videoPath
+        ? await shouldUseMpvPilot(item.videoPath, {
+          fileIsAudio: isAudioFile(item.fileName || item.videoPath),
+          hasPreparedVideoPath: false
+        })
+        : false;
+
+      if (!hasDuration && item.videoPath && !useMpvPilotForMetadata) {
         try {
           const probe = await window.electronAPI.ffmpegProbeCodec(item.videoPath);
           if (probe?.success) {
@@ -13276,6 +13368,17 @@ async function initApp() {
         if (!shouldContinuePreparing()) return { ready: false, stale: true };
         continuousPlaybackState.preparedMediaPaths.delete(item.id);
         markPlaylistItemStatus(item, CONTINUOUS_STATUS.PREPARING, '준비 중');
+        const useMpvPilot = await shouldUseMpvPilot(item.videoPath, {
+          fileIsAudio: isAudioFile(item.fileName || item.videoPath),
+          hasPreparedVideoPath: false
+        });
+        if (!shouldContinuePreparing()) return { ready: false, stale: true };
+        if (useMpvPilot) {
+          continuousPlaybackState.preparedMediaPaths.set(item.id, item.videoPath);
+          markPlaylistItemStatus(item, CONTINUOUS_STATUS.READY, 'mpv 원본 준비');
+          return { ready: true, mpv: true };
+        }
+
         const ffmpegAvailable = await window.electronAPI.ffmpegIsAvailable();
         if (!shouldContinuePreparing()) return { ready: false, stale: true };
         if (!ffmpegAvailable) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -13224,6 +13224,7 @@ async function initApp() {
           hasPreparedVideoPath: false
         })
         : false;
+      let metadataResolvedByMpv = false;
 
       if (!hasDuration && item.videoPath && useMpvPilotForMetadata) {
         try {
@@ -13238,6 +13239,7 @@ async function initApp() {
                 : (Number.isFinite(fps) && fps > 0 ? fps : 24);
               item.duration = duration;
               item.fps = fps;
+              metadataResolvedByMpv = true;
             }
           } else {
             log.warn('mpv 타임라인 메타데이터 수집 실패', { fileName: item.fileName, error: mpvProbe?.error || 'probe failed' });
@@ -13247,7 +13249,7 @@ async function initApp() {
         }
       }
 
-      if (!hasDuration && item.videoPath && !useMpvPilotForMetadata) {
+      if (!hasDuration && item.videoPath && (!useMpvPilotForMetadata || !metadataResolvedByMpv)) {
         try {
           const probe = await window.electronAPI.ffmpegProbeCodec(item.videoPath);
           if (probe?.success) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -7728,6 +7728,10 @@ async function initApp() {
 
     updateFeedbackProgress(authorFilteredRanges.length, resolvedCount);
 
+    container.querySelectorAll('.playlist-comment-reply-input').forEach(el => {
+      mentionManager.detach(el);
+    });
+
     if (ranges.length === 0) {
       const emptyTitle = normalizedSearch ? '검색 결과가 없습니다' : '재생목록 댓글이 없습니다';
       const emptyHint = normalizedSearch
@@ -7743,10 +7747,6 @@ async function initApp() {
       `;
       return;
     }
-
-    container.querySelectorAll('.playlist-comment-reply-input').forEach(el => {
-      mentionManager.detach(el);
-    });
 
     container.innerHTML = ranges.map(range => {
       const key = getPlaylistAggregateCommentKey(range);

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -272,8 +272,9 @@ async function initApp() {
     }
 
     if (editor.isContentEditable) {
-      const maxHeight = Number(editor.dataset.maxAutoHeight) || 220;
-      editor.style.overflowY = editor.scrollHeight > maxHeight ? 'auto' : 'hidden';
+      const computedMaxHeight = Number.parseFloat(getComputedStyle(editor).maxHeight);
+      const maxHeight = Number(editor.dataset.maxAutoHeight) || (Number.isFinite(computedMaxHeight) ? computedMaxHeight : 220);
+      editor.style.overflowY = editor.scrollHeight > maxHeight ? 'auto' : '';
     }
   }
 

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -4484,6 +4484,69 @@ body.app-fullscreen .video-comment-overlay-controls {
   gap: 8px;
 }
 
+.playlist-comment-reply-toggle {
+  padding: 2px 6px;
+  min-height: 22px;
+  font-size: 11px;
+}
+
+.playlist-comment-reply-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.playlist-comment-reply-form[hidden] {
+  display: none;
+}
+
+.playlist-comment-reply-input {
+  flex: 1;
+  min-height: 34px;
+  max-height: 140px;
+  padding: 8px 10px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.35;
+  outline: none;
+  resize: none;
+  overflow-y: hidden;
+}
+
+.playlist-comment-reply-input:focus {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+.playlist-comment-reply-submit {
+  flex-shrink: 0;
+  padding: 8px 12px;
+  background: var(--accent-primary);
+  color: #000;
+  border: none;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.playlist-comment-reply-submit:hover {
+  background: var(--accent-secondary);
+}
+
+.playlist-comment-reply-submit:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
 .comment-item.glow {
   animation: commentGlow 2.5s ease-out;
 }
@@ -6805,6 +6868,9 @@ body.resizing .comment-panel {
   font-size: 12px;
   outline: none;
   resize: none;
+  min-height: 34px;
+  max-height: 150px;
+  overflow-y: hidden;
 }
 
 .comment-reply-input:focus {

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -51,3 +51,15 @@ test('loading review comments refreshes the right sidebar comment list', () => {
   assert.match(loadedHandlerSource, /void refreshCommentRangesForCurrentMode\(\);/);
   assert.match(loadedHandlerSource, /updateCommentList\(\);/);
 });
+
+test('right sidebar reply editors grow with long replies', () => {
+  assert.match(appSource, /function resizeReplyEditorToContent\(editor\) \{/);
+  assert.match(appSource, /replyInput\?\.addEventListener\('input', \(\) => resizeReplyEditorToContent\(replyInput\)\);/);
+  assert.match(appSource, /threadEditor\?\.addEventListener\('input', \(\) => \{[\s\S]+resizeReplyEditorToContent\(threadEditor\);/);
+});
+
+test('playlist aggregate comments can submit inline replies from the sidebar list', () => {
+  assert.match(appSource, /async function submitPlaylistAggregateReply\(key, textarea\) \{/);
+  assert.match(appSource, /<textarea class="playlist-comment-reply-input"[\s\S]+placeholder="답글 입력\.\.\."/);
+  assert.match(appSource, /item\.querySelector\('\.playlist-comment-reply-submit'\)\?\.addEventListener\('click'/);
+});

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -56,6 +56,8 @@ test('right sidebar reply editors grow with long replies', () => {
   assert.match(appSource, /function resizeReplyEditorToContent\(editor\) \{/);
   assert.match(appSource, /replyInput\?\.addEventListener\('input', \(\) => resizeReplyEditorToContent\(replyInput\)\);/);
   assert.match(appSource, /threadEditor\?\.addEventListener\('input', \(\) => \{[\s\S]+resizeReplyEditorToContent\(threadEditor\);/);
+  assert.match(appSource, /const computedMaxHeight = Number\.parseFloat\(getComputedStyle\(editor\)\.maxHeight\);/);
+  assert.match(appSource, /editor\.style\.overflowY = editor\.scrollHeight > maxHeight \? 'auto' : '';/);
 });
 
 test('playlist aggregate comments can submit inline replies from the sidebar list', () => {

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -62,4 +62,7 @@ test('playlist aggregate comments can submit inline replies from the sidebar lis
   assert.match(appSource, /async function submitPlaylistAggregateReply\(key, textarea\) \{/);
   assert.match(appSource, /<textarea class="playlist-comment-reply-input"[\s\S]+placeholder="답글 입력\.\.\."/);
   assert.match(appSource, /item\.querySelector\('\.playlist-comment-reply-submit'\)\?\.addEventListener\('click'/);
+  assert.match(appSource, /const activeRange = playlistAggregateCommentRanges\.find\(item => getPlaylistAggregateCommentKey\(item\) === key\) \|\| range;/);
+  assert.match(appSource, /commentManager\.addReplyToMarker\(activeRange\.markerId, text, commentManager\.getAuthor\(\)\)/);
+  assert.match(appSource, /activeRange\.replies = \[\.\.\.\(activeRange\.replies \|\| \[\]\), reply\];/);
 });

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -68,3 +68,17 @@ test('playlist aggregate comments can submit inline replies from the sidebar lis
   assert.match(appSource, /commentManager\.addReplyToMarker\(activeRange\.markerId, text, commentManager\.getAuthor\(\)\)/);
   assert.match(appSource, /activeRange\.replies = \[\.\.\.\(activeRange\.replies \|\| \[\]\), reply\];/);
 });
+
+test('playlist aggregate comment rerenders detach reply editors before empty state', () => {
+  const renderStart = appSource.indexOf('  function renderPlaylistContinuousCommentList');
+  assert.ok(renderStart >= 0, 'playlist aggregate comment renderer should exist');
+  const renderEnd = appSource.indexOf('  function getCutlistAggregateCommentKey', renderStart);
+  assert.ok(renderEnd > renderStart, 'playlist aggregate comment renderer should have a bounded body');
+  const renderSource = appSource.slice(renderStart, renderEnd);
+
+  const detachIndex = renderSource.indexOf("container.querySelectorAll('.playlist-comment-reply-input').forEach");
+  const emptyIndex = renderSource.indexOf('if (ranges.length === 0)');
+  assert.ok(detachIndex >= 0, 'reply editors should be detached during playlist comment rerender');
+  assert.ok(emptyIndex >= 0, 'playlist comment renderer should handle empty results');
+  assert.ok(detachIndex < emptyIndex, 'reply editors should be detached before empty-state innerHTML replacement');
+});

--- a/scripts/tests/mpv-manager.test.js
+++ b/scripts/tests/mpv-manager.test.js
@@ -137,6 +137,53 @@ test('launch args can attach mpv to an embedded window id', () => {
   assert.ok(args.includes('--cursor-autohide=always'));
 });
 
+test('load can start hidden no-window mpv for metadata probes', async () => {
+  const bundledPath = path.normalize('C:\\repo\\mpv\\win32\\mpv.exe');
+  const videoPath = path.normalize('C:\\video\\shot.mov');
+  const spawned = [];
+  const commands = [];
+  const manager = createManager({
+    existing: [bundledPath, videoPath]
+  });
+  manager.spawn = (_cmd, args) => {
+    const processRef = {
+      killed: false,
+      on() {},
+      kill() {
+        this.killed = true;
+      }
+    };
+    spawned.push({ args, processRef });
+    return processRef;
+  };
+  manager._waitForIpcReady = async () => true;
+  manager.sendCommand = async (command) => {
+    commands.push(command);
+    return { error: 'success' };
+  };
+  manager.waitForPlaybackReady = async () => ({
+    success: true,
+    duration: 12.5,
+    fps: 24,
+    width: 1920,
+    height: 1080
+  });
+  manager.getStatus = async () => ({
+    success: true,
+    duration: 12.5,
+    fps: 24,
+    width: 1920,
+    height: 1080
+  });
+
+  const result = await manager.load(videoPath, { pause: true, forceWindow: false });
+
+  assert.equal(result.duration, 12.5);
+  assert.ok(spawned[0].args.includes('--force-window=no'));
+  assert.ok(commands.some(command => command[0] === 'loadfile' && command[1] === videoPath));
+  assert.equal(manager.forceWindow, false);
+});
+
 test('start restarts mpv when the embedded window id changes', async () => {
   const bundledPath = path.normalize('C:\\repo\\mpv\\win32\\mpv.exe');
   const spawned = [];

--- a/scripts/tests/mpv-manager.test.js
+++ b/scripts/tests/mpv-manager.test.js
@@ -137,6 +137,18 @@ test('launch args can attach mpv to an embedded window id', () => {
   assert.ok(args.includes('--cursor-autohide=always'));
 });
 
+test('launch args can use null audio and video outputs for headless metadata probes', () => {
+  const args = createMpvLaunchArgs({
+    ipcPath: '\\\\.\\pipe\\baeframe-mpv-headless',
+    forceWindow: false,
+    headless: true
+  });
+
+  assert.ok(args.includes('--force-window=no'));
+  assert.ok(args.includes('--vo=null'));
+  assert.ok(args.includes('--ao=null'));
+});
+
 test('load can start hidden no-window mpv for metadata probes', async () => {
   const bundledPath = path.normalize('C:\\repo\\mpv\\win32\\mpv.exe');
   const videoPath = path.normalize('C:\\video\\shot.mov');
@@ -176,12 +188,15 @@ test('load can start hidden no-window mpv for metadata probes', async () => {
     height: 1080
   });
 
-  const result = await manager.load(videoPath, { pause: true, forceWindow: false });
+  const result = await manager.load(videoPath, { pause: true, forceWindow: false, headless: true });
 
   assert.equal(result.duration, 12.5);
   assert.ok(spawned[0].args.includes('--force-window=no'));
+  assert.ok(spawned[0].args.includes('--vo=null'));
+  assert.ok(spawned[0].args.includes('--ao=null'));
   assert.ok(commands.some(command => command[0] === 'loadfile' && command[1] === videoPath));
   assert.equal(manager.forceWindow, false);
+  assert.equal(manager.headless, true);
 });
 
 test('start restarts mpv when the embedded window id changes', async () => {

--- a/scripts/tests/mpv-manager.test.js
+++ b/scripts/tests/mpv-manager.test.js
@@ -6,6 +6,7 @@ const {
   MPVManager,
   createMpvLaunchArgs,
   createMpvIpcPath,
+  createMpvIpcUniqueId,
   isMpvPilotEnabled
 } = require('../../main/mpv-manager');
 
@@ -109,6 +110,15 @@ test('detects mpv availability even when pilot env is not enabled', async () => 
 test('creates stable platform-specific IPC paths', () => {
   assert.match(createMpvIpcPath({ platform: 'win32', pid: 77, unique: 'abc' }), /^\\\\\.\\pipe\\baeframe-mpv-77-abc$/);
   assert.match(createMpvIpcPath({ platform: 'linux', pid: 77, unique: 'abc', tempDir: '/tmp' }), /^\/tmp\/baeframe-mpv-77-abc\.sock$/);
+});
+
+test('creates unique IPC suffixes for same-millisecond mpv starts', () => {
+  const first = createMpvIpcUniqueId({ now: () => 12345, random: () => 0.1 });
+  const second = createMpvIpcUniqueId({ now: () => 12345, random: () => 0.2 });
+
+  assert.notEqual(first, second);
+  assert.match(first, /^9ix-[a-z0-9]+$/);
+  assert.match(second, /^9ix-[a-z0-9]+$/);
 });
 
 test('launch args enable JSON IPC without user config', () => {

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -137,7 +137,7 @@ test('mpv pilot falls back to the normal playback path when mpv load fails', () 
 
   assert.match(loadVideoSource, /allowMpvPilot = true/);
   assert.match(loadVideoSource, /const useMpvPilot = allowMpvPilot && await shouldUseMpvPilot\(filePath, \{ fileIsAudio, hasPreparedVideoPath: hasConvertedPreparedVideoPath \}\);/);
-  assert.match(loadVideoSource, /catch \(mpvError\) \{[\s\S]+mpv 파일럿 로드 실패, 기존 재생 방식으로 재시도[\s\S]+allowMpvPilot: false[\s\S]+return loadVideo\(filePath, fallbackOptions\);[\s\S]+\}/);
+  assert.match(loadVideoSource, /catch \(mpvError\) \{[\s\S]+mpv 파일럿 로드 실패, 기존 재생 방식으로 재시도[\s\S]+allowMpvPilot: false,[\s\S]+preparedVideoPath: preparedVideoPathIsOriginal \? null : preparedVideoPath[\s\S]+return loadVideo\(filePath, fallbackOptions\);[\s\S]+\}/);
 });
 
 test('mpv pilot can be enabled from app playback settings without an env var', () => {

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -75,7 +75,7 @@ test('main process registers mpv IPC handlers through the manager and embed host
     assert.match(ipcSource, new RegExp(`ipcMain\\.handle\\('${channel}'`));
   }
   assert.match(ipcSource, /ipcMain\.handle\('mpv:probe-metadata'[\s\S]+const metadataMpv = new MPVManager\(\);/);
-  assert.match(ipcSource, /metadataMpv\.load\(filePath, \{[\s\S]+forceWindow: false[\s\S]+\}\)/);
+  assert.match(ipcSource, /metadataMpv\.load\(filePath, \{[\s\S]+forceWindow: false,[\s\S]+headless: true[\s\S]+\}\)/);
   assert.match(ipcSource, /mpvEmbedHost\.ensure\(bounds\)/);
   assert.match(ipcSource, /mpvEmbedHost\.updateBounds\(bounds\)/);
   assert.match(ipcSource, /mpvEmbedHost\.setVisible\(nextVisible\)/);
@@ -160,7 +160,7 @@ test('mpv pilot can be enabled from app playback settings without an env var', (
 test('mpv pilot embeds into the BAEFRAME viewer before loading media', () => {
   assert.match(mpvManagerSource, /this\.loadQueue = Promise\.resolve\(\);/);
   assert.match(mpvManagerSource, /async load\(filePath, options = \{\}\) \{[\s\S]+const queuedLoad = this\.loadQueue\.then\(runLoad, runLoad\);[\s\S]+this\.loadQueue = queuedLoad\.catch\(\(\) => \{\}\);[\s\S]+return queuedLoad;/);
-  assert.match(mpvManagerSource, /async _load\(filePath, options = \{\}\) \{[\s\S]+await this\.start\(\{ wid: options\.wid, forceWindow: options\.forceWindow \}\);/);
+  assert.match(mpvManagerSource, /async _load\(filePath, options = \{\}\) \{[\s\S]+await this\.start\(\{ wid: options\.wid, forceWindow: options\.forceWindow, headless: options\.headless \}\);/);
   assert.match(mpvManagerSource, /`--wid=\$\{normalizedWid\}`/);
 
   assert.match(appSource, /function getMpvEmbedBounds\(\) \{[\s\S]+syncMpvFullscreenViewportInset\(\);[\s\S]+elements\.videoWrapper\?\.getBoundingClientRect\(\)[\s\S]+height: rect\.height/);

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -27,6 +27,7 @@ test('preload exposes a narrow mpv API surface', () => {
   assert.match(preloadSource, /mpvIsEnabled: \(\) => ipcRenderer\.invoke\('mpv:is-enabled'\)/);
   assert.match(preloadSource, /mpvIsAvailable: \(\) => ipcRenderer\.invoke\('mpv:is-available'\)/);
   assert.match(preloadSource, /mpvLoad: \(filePath, options\) => ipcRenderer\.invoke\('mpv:load', filePath, options\)/);
+  assert.match(preloadSource, /mpvProbeMetadata: \(filePath\) => ipcRenderer\.invoke\('mpv:probe-metadata', filePath\)/);
   assert.match(preloadSource, /mpvPlay: \(\) => ipcRenderer\.invoke\('mpv:play'\)/);
   assert.match(preloadSource, /mpvPause: \(\) => ipcRenderer\.invoke\('mpv:pause'\)/);
   assert.match(preloadSource, /mpvSeek: \(time\) => ipcRenderer\.invoke\('mpv:seek', time\)/);
@@ -46,13 +47,14 @@ test('preload exposes a narrow mpv API surface', () => {
 });
 
 test('main process registers mpv IPC handlers through the manager and embed host', () => {
-  assert.match(ipcSource, /const \{ mpvManager \} = require\('\.\/mpv-manager'\);/);
+  assert.match(ipcSource, /const \{ MPVManager, mpvManager \} = require\('\.\/mpv-manager'\);/);
   assert.match(ipcSource, /const \{ mpvEmbedHost \} = require\('\.\/mpv-embed-host'\);/);
   assert.match(ipcSource, /const \{ mpvOverlayHost \} = require\('\.\/mpv-overlay-host'\);/);
   for (const channel of [
     'mpv:is-enabled',
     'mpv:is-available',
     'mpv:load',
+    'mpv:probe-metadata',
     'mpv:play',
     'mpv:pause',
     'mpv:seek',
@@ -72,6 +74,8 @@ test('main process registers mpv IPC handlers through the manager and embed host
   ]) {
     assert.match(ipcSource, new RegExp(`ipcMain\\.handle\\('${channel}'`));
   }
+  assert.match(ipcSource, /ipcMain\.handle\('mpv:probe-metadata'[\s\S]+const metadataMpv = new MPVManager\(\);/);
+  assert.match(ipcSource, /metadataMpv\.load\(filePath, \{[\s\S]+forceWindow: false[\s\S]+\}\)/);
   assert.match(ipcSource, /mpvEmbedHost\.ensure\(bounds\)/);
   assert.match(ipcSource, /mpvEmbedHost\.updateBounds\(bounds\)/);
   assert.match(ipcSource, /mpvEmbedHost\.setVisible\(nextVisible\)/);
@@ -156,7 +160,7 @@ test('mpv pilot can be enabled from app playback settings without an env var', (
 test('mpv pilot embeds into the BAEFRAME viewer before loading media', () => {
   assert.match(mpvManagerSource, /this\.loadQueue = Promise\.resolve\(\);/);
   assert.match(mpvManagerSource, /async load\(filePath, options = \{\}\) \{[\s\S]+const queuedLoad = this\.loadQueue\.then\(runLoad, runLoad\);[\s\S]+this\.loadQueue = queuedLoad\.catch\(\(\) => \{\}\);[\s\S]+return queuedLoad;/);
-  assert.match(mpvManagerSource, /async _load\(filePath, options = \{\}\) \{[\s\S]+await this\.start\(\{ wid: options\.wid \}\);/);
+  assert.match(mpvManagerSource, /async _load\(filePath, options = \{\}\) \{[\s\S]+await this\.start\(\{ wid: options\.wid, forceWindow: options\.forceWindow \}\);/);
   assert.match(mpvManagerSource, /`--wid=\$\{normalizedWid\}`/);
 
   assert.match(appSource, /function getMpvEmbedBounds\(\) \{[\s\S]+syncMpvFullscreenViewportInset\(\);[\s\S]+elements\.videoWrapper\?\.getBoundingClientRect\(\)[\s\S]+height: rect\.height/);

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -107,7 +107,7 @@ test('loadVideo checks mpv pilot before FFmpeg transcode and falls back by defau
   assert.match(loadVideoSource, /await videoPlayer\.load\(actualVideoPath\);/);
 });
 
-test('mpv pilot keeps a Chromium-decodable path for thumbnails', () => {
+test('mpv pilot skips thumbnail generation without FFmpeg probing', () => {
   const loadVideoMatch = appSource.match(/async function loadVideo\(filePath, options = \{\}\) \{([\s\S]*?)\n  \}\n\n  \/\//);
   assert.ok(loadVideoMatch, 'loadVideo should exist');
   const loadVideoSource = loadVideoMatch[1];
@@ -116,7 +116,7 @@ test('mpv pilot keeps a Chromium-decodable path for thumbnails', () => {
   assert.ok(resolveMpvThumbnailMatch, 'resolveMpvThumbnailVideoPath should exist');
   const resolveMpvThumbnailSource = resolveMpvThumbnailMatch[0];
 
-  assert.match(resolveMpvThumbnailSource, /ffmpegProbeCodec\(filePath\)[\s\S]+ffmpegCheckCache\(filePath\)/);
+  assert.doesNotMatch(resolveMpvThumbnailSource, /window\.electronAPI\.ffmpeg/);
   assert.match(resolveMpvThumbnailSource, /return null;/);
   assert.doesNotMatch(resolveMpvThumbnailSource, /showTranscodeOverlay\(filePath/);
   assert.match(loadVideoSource, /let thumbnailVideoPath = actualVideoPath;/);
@@ -259,6 +259,8 @@ test('mpv pilot cleans up pending embed host when load is stale or fails before 
   assert.match(loadMpvSource, /if \(isStaleVideoLoad\(\)\) \{[\s\S]+await cleanupPendingMpvPilot\(\);[\s\S]+return false;[\s\S]+\}/);
   assert.match(loadMpvSource, /catch \(error\) \{[\s\S]+await cleanupPendingMpvPilot\(\);[\s\S]+throw error;[\s\S]+\}/);
   assert.match(loadMpvSource, /if \(!loadResult\?\.success\) \{[\s\S]+await cleanupPendingMpvPilot\(\);[\s\S]+throw new Error/);
+  assert.doesNotMatch(loadMpvSource, /ffmpegIsAvailable|ffmpegProbeCodec/);
+  assert.match(loadMpvSource, /duration: Number\(loadResult\.duration\) \|\| 0/);
   assert.match(loadMpvSource, /document\.body\.classList\.add\('mpv-pilot-mode'\);[\s\S]+mpvPilotHostPreparing = false;[\s\S]+syncMpvHostVisibilityWithDom\(\);/);
 });
 

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -25,11 +25,14 @@ test('continuous metadata skips FFmpeg probes for mpv pilot originals', () => {
   const metadataSource = metadataMatch[1];
   assert.match(metadataSource, /state\.currentFile === item\.videoPath && videoPlayer\.duration/);
   assert.match(metadataSource, /const useMpvPilotForMetadata = !hasDuration && item\.videoPath[\s\S]+await shouldUseMpvPilot\(item\.videoPath/);
+  assert.match(metadataSource, /if \(!hasDuration && item\.videoPath && useMpvPilotForMetadata\) \{[\s\S]+const mpvProbe = await window\.electronAPI\.mpvProbeMetadata\(item\.videoPath\);/);
   assert.match(metadataSource, /if \(!hasDuration && item\.videoPath && !useMpvPilotForMetadata\) \{/);
   assert.ok(
     metadataSource.indexOf('const useMpvPilotForMetadata') <
+      metadataSource.indexOf('window.electronAPI.mpvProbeMetadata(item.videoPath)') &&
+      metadataSource.indexOf('window.electronAPI.mpvProbeMetadata(item.videoPath)') <
       metadataSource.indexOf('ffmpegProbeCodec(item.videoPath)'),
-    'mpv eligibility should be checked before playlist metadata probing'
+    'mpv eligibility and mpv metadata probing should run before FFmpeg probing'
   );
   assert.match(metadataSource, /ffmpegProbeCodec\(item\.videoPath\)/);
   assert.match(metadataSource, /probe\.duration/);

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -18,15 +18,17 @@ test('continuous runtime imports the shared helper module', () => {
   assert.match(appSource, /CONTINUOUS_STATUS[\s\S]+findNextPlayableIndex[\s\S]+createSkippedToastMessage[\s\S]+from '\.\/modules\/playlist-continuous-core\.js'/);
 });
 
-test('continuous metadata skips FFmpeg probes for mpv pilot originals', () => {
+test('continuous metadata uses mpv before FFmpeg fallback for mpv pilot originals', () => {
   const metadataMatch = appSource.match(/async function collectPlaylistMetadata\(items\) \{([\s\S]*?)\n  \}\n\n  async function updatePlaylistContinuousTimeline/);
   assert.ok(metadataMatch, 'collectPlaylistMetadata should exist');
 
   const metadataSource = metadataMatch[1];
   assert.match(metadataSource, /state\.currentFile === item\.videoPath && videoPlayer\.duration/);
   assert.match(metadataSource, /const useMpvPilotForMetadata = !hasDuration && item\.videoPath[\s\S]+await shouldUseMpvPilot\(item\.videoPath/);
+  assert.match(metadataSource, /let metadataResolvedByMpv = false;/);
   assert.match(metadataSource, /if \(!hasDuration && item\.videoPath && useMpvPilotForMetadata\) \{[\s\S]+const mpvProbe = await window\.electronAPI\.mpvProbeMetadata\(item\.videoPath\);/);
-  assert.match(metadataSource, /if \(!hasDuration && item\.videoPath && !useMpvPilotForMetadata\) \{/);
+  assert.match(metadataSource, /metadataResolvedByMpv = true;/);
+  assert.match(metadataSource, /if \(!hasDuration && item\.videoPath && \(!useMpvPilotForMetadata \|\| !metadataResolvedByMpv\)\) \{/);
   assert.ok(
     metadataSource.indexOf('const useMpvPilotForMetadata') <
       metadataSource.indexOf('window.electronAPI.mpvProbeMetadata(item.videoPath)') &&

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -18,12 +18,19 @@ test('continuous runtime imports the shared helper module', () => {
   assert.match(appSource, /CONTINUOUS_STATUS[\s\S]+findNextPlayableIndex[\s\S]+createSkippedToastMessage[\s\S]+from '\.\/modules\/playlist-continuous-core\.js'/);
 });
 
-test('continuous metadata probes unloaded playlist items without saved duration', () => {
+test('continuous metadata skips FFmpeg probes for mpv pilot originals', () => {
   const metadataMatch = appSource.match(/async function collectPlaylistMetadata\(items\) \{([\s\S]*?)\n  \}\n\n  async function updatePlaylistContinuousTimeline/);
   assert.ok(metadataMatch, 'collectPlaylistMetadata should exist');
 
   const metadataSource = metadataMatch[1];
   assert.match(metadataSource, /state\.currentFile === item\.videoPath && videoPlayer\.duration/);
+  assert.match(metadataSource, /const useMpvPilotForMetadata = !hasDuration && item\.videoPath[\s\S]+await shouldUseMpvPilot\(item\.videoPath/);
+  assert.match(metadataSource, /if \(!hasDuration && item\.videoPath && !useMpvPilotForMetadata\) \{/);
+  assert.ok(
+    metadataSource.indexOf('const useMpvPilotForMetadata') <
+      metadataSource.indexOf('ffmpegProbeCodec(item.videoPath)'),
+    'mpv eligibility should be checked before playlist metadata probing'
+  );
   assert.match(metadataSource, /ffmpegProbeCodec\(item\.videoPath\)/);
   assert.match(metadataSource, /probe\.duration/);
   assert.match(metadataSource, /probe\.frameRate/);
@@ -1003,6 +1010,45 @@ test('playlist background pre-transcode ignores stale playlist generations', () 
   assert.match(preTranscodeSource, /const isCurrentBackgroundWork = \(\) => \(/);
   assert.match(preTranscodeSource, /if \(!isCurrentBackgroundWork\(\)\) return;/);
   assert.match(preTranscodeSource, /ffmpegPreTranscode\(item\.videoPath\)[\s\S]+if \(!isCurrentBackgroundWork\(\)\) return;/);
+});
+
+test('mpv pilot playlist preparation skips background transcode work', () => {
+  const prepareMatch = appSource.match(/async function preparePlaylistItemInBackground\(item, sessionId = continuousPlaybackState\.sessionId\) \{([\s\S]*?)\n  \}\n\n  function prepareNextPlaylistItem/);
+  assert.ok(prepareMatch, 'preparePlaylistItemInBackground should exist');
+
+  const prepareSource = prepareMatch[1];
+  assert.match(prepareSource, /const useMpvPilot = await shouldUseMpvPilot\(item\.videoPath, \{[\s\S]+fileIsAudio: isAudioFile\(item\.fileName \|\| item\.videoPath\),[\s\S]+hasPreparedVideoPath: false[\s\S]+\}\);/);
+  assert.ok(
+    prepareSource.indexOf('const useMpvPilot = await shouldUseMpvPilot') <
+      prepareSource.indexOf('const ffmpegAvailable = await window.electronAPI.ffmpegIsAvailable();'),
+    'mpv pilot eligibility should be checked before FFmpeg probing'
+  );
+  assert.match(prepareSource, /if \(useMpvPilot\) \{[\s\S]+continuousPlaybackState\.preparedMediaPaths\.set\(item\.id, item\.videoPath\);[\s\S]+markPlaylistItemStatus\(item, CONTINUOUS_STATUS\.READY, 'mpv 원본 준비'\);[\s\S]+return \{ ready: true, mpv: true \};[\s\S]+\}/);
+  assert.ok(
+    prepareSource.indexOf('if (useMpvPilot)') <
+      prepareSource.indexOf('window.electronAPI.ffmpegPreTranscode(item.videoPath)'),
+    'mpv-ready playlist items must return before background transcode starts'
+  );
+});
+
+test('mpv pilot playlist pre-transcode scan skips ffmpeg background conversion', () => {
+  const preTranscodeMatch = appSource.match(/async function preTranscodePlaylistItems\(\) \{([\s\S]*?)\n  \}\n\n  function toLocalMediaUrl/);
+  assert.ok(preTranscodeMatch, 'preTranscodePlaylistItems should exist');
+
+  const preTranscodeSource = preTranscodeMatch[1];
+  assert.match(preTranscodeSource, /let ffmpegAvailable = null;/);
+  assert.match(preTranscodeSource, /const useMpvPilot = await shouldUseMpvPilot\(item\.videoPath, \{[\s\S]+fileIsAudio: isAudioFile\(item\.fileName \|\| item\.videoPath\),[\s\S]+hasPreparedVideoPath: false[\s\S]+\}\);/);
+  assert.ok(
+    preTranscodeSource.indexOf('const useMpvPilot = await shouldUseMpvPilot') <
+      preTranscodeSource.indexOf('ffmpegProbeCodec(item.videoPath)'),
+    'mpv eligibility should be checked before codec probing in the pre-transcode scan'
+  );
+  assert.match(preTranscodeSource, /if \(useMpvPilot\) \{[\s\S]+log\.debug\('mpv 파일럿 사전 변환 건너뜀'[\s\S]+continue;[\s\S]+\}/);
+  assert.ok(
+    preTranscodeSource.indexOf('if (useMpvPilot)') <
+      preTranscodeSource.indexOf('window.electronAPI.ffmpegPreTranscode(item.videoPath)'),
+    'mpv-ready items must skip ffmpegPreTranscode'
+  );
 });
 
 test('ffmpeg detection checks the main checkout when running from a git worktree', () => {

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -1026,7 +1026,10 @@ test('mpv pilot playlist preparation skips background transcode work', () => {
       prepareSource.indexOf('const ffmpegAvailable = await window.electronAPI.ffmpegIsAvailable();'),
     'mpv pilot eligibility should be checked before FFmpeg probing'
   );
-  assert.match(prepareSource, /if \(useMpvPilot\) \{[\s\S]+continuousPlaybackState\.preparedMediaPaths\.set\(item\.id, item\.videoPath\);[\s\S]+markPlaylistItemStatus\(item, CONTINUOUS_STATUS\.READY, 'mpv 원본 준비'\);[\s\S]+return \{ ready: true, mpv: true \};[\s\S]+\}/);
+  assert.match(prepareSource, /if \(useMpvPilot\) \{[\s\S]+continuousPlaybackState\.preparedMediaPaths\.delete\(item\.id\);[\s\S]+markPlaylistItemStatus\(item, CONTINUOUS_STATUS\.READY, 'mpv 원본 준비'\);[\s\S]+return \{ ready: true, mpv: true \};[\s\S]+\}/);
+  const mpvReadyBlock = prepareSource.match(/if \(useMpvPilot\) \{([\s\S]*?)\n        \}/);
+  assert.ok(mpvReadyBlock, 'mpv ready block should exist');
+  assert.doesNotMatch(mpvReadyBlock[1], /preparedMediaPaths\.set/);
   assert.ok(
     prepareSource.indexOf('if (useMpvPilot)') <
       prepareSource.indexOf('window.electronAPI.ffmpegPreTranscode(item.videoPath)'),


### PR DESCRIPTION
## 📋 업데이트 요약

💬 재생목록 댓글 목록에서 댓글을 눌러 이동한 뒤 따로 찾지 않아도, 그 자리에서 바로 답글을 달 수 있게 했습니다.

✍️ 사이드 댓글바에서 답글이 길어질 때 입력칸이 내용 길이에 맞춰 자연스럽게 커집니다. 긴 문장을 적을 때 입력칸이 너무 답답하게 느껴지는 문제를 줄였습니다.

⚡ mpv 직접 재생 파일럿을 켠 경우, 재생목록의 다음 영상을 미리 준비할 때도 영상 변환 작업을 돌리지 않게 했습니다. 이제 mpv로 볼 수 있는 영상은 원본을 바로 쓰도록 정리했습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - `submitPlaylistAggregateReply()`를 추가해 재생목록 통합 댓글 카드에서 바로 `commentManager.addReplyToMarker()`로 답글을 저장하도록 연결했습니다.
  - `renderPlaylistContinuousCommentList()`에 답글 토글, 입력창, 전송 버튼, Enter 전송, 멘션 연결, Drive 경로 붙여넣기 처리를 추가했습니다.
  - `resizeReplyEditorToContent()`를 추가하고 사이드 댓글 답글 입력창, 스레드 입력창, 재생목록 답글 입력창에 연결했습니다.
  - `loadVideoWithMpvPilot()`에서 mpv 로드 후 FFmpeg 메타데이터 보강을 제거해 mpv 직접 재생 경로가 FFmpeg 확인을 호출하지 않게 했습니다.
  - `resolveMpvThumbnailVideoPath()`는 mpv 파일럿 사용 시 썸네일용 FFmpeg 확인 없이 썸네일 생성을 건너뛰도록 정리했습니다.
  - `preTranscodePlaylistItems()`와 `preparePlaylistItemInBackground()`에서 mpv 파일럿 가능 여부를 FFmpeg 확인보다 먼저 검사하고, 가능한 경우 원본 경로를 준비 완료로 처리한 뒤 FFmpeg 변환으로 내려가지 않게 했습니다.
  - `collectPlaylistMetadata()`에서도 mpv로 원본 재생 가능한 항목은 FFmpeg probe를 건너뛰게 했습니다.

- `renderer/styles/main.css`
  - 재생목록 답글 입력 폼 스타일을 추가했습니다.
  - 기존 사이드 댓글 답글 textarea에 `min-height`, `max-height`, `overflow-y`를 지정해 자동 확장과 최대 높이 이후 스크롤 동작을 맞췄습니다.

- `scripts/tests/*`
  - 댓글 입력 자동 확장과 재생목록 인라인 답글 소스 테스트를 추가했습니다.
  - mpv 직접 재생 경로가 FFmpeg probe를 호출하지 않는지, 재생목록 백그라운드 준비가 FFmpeg 변환으로 내려가지 않는지 회귀 테스트를 추가했습니다.

## 🚧 개발 난항

- 기존 재생 경로는 실제 mpv 재생 자체는 변환 없이 진행했지만, 재생목록의 백그라운드 준비와 타임라인 메타데이터 수집 경로가 별도로 FFmpeg를 호출할 수 있었습니다. 그래서 `loadVideo()` 한 곳만 보는 방식으로는 문제가 완전히 잡히지 않았고, 재생목록 준비 함수까지 함께 정리했습니다.
- mpv 경로에서 썸네일을 유지하려면 Chromium이 읽을 수 있는 영상인지 판단해야 하는데, 그 판단 자체가 FFmpeg 확인에 기대고 있었습니다. 이번 변경에서는 “mpv는 변환 없이 빠르게 재생한다”는 목적을 우선해 mpv 파일럿 사용 시 썸네일 생성을 건너뛰도록 선택했습니다.
- 재생목록 댓글은 클릭하면 해당 원본 댓글로 이동하는 구조라, 답글 전송 전에 원본 댓글을 먼저 열고 같은 저장 경로를 타도록 처리했습니다.

## ✅ 테스트 가이드

실사용자용

1. 재생목록을 열고 댓글 목록에서 댓글 카드의 `답글`을 눌러 답글을 작성합니다.
2. Enter로 전송되는지, Shift+Enter로 줄바꿈이 되는지 확인합니다.
3. 사이드 댓글바에서 긴 답글을 작성해 입력칸이 내용에 맞춰 커지는지 확인합니다.
4. 앱 설정 > 재생에서 `mpv 직접 재생 파일럿`을 켜고 재생목록을 재생합니다.
5. mpv로 재생되는 항목이 변환 대기 없이 바로 준비되는지 확인합니다.

개발자용

- `npm run test:mpv`
- `npm run test:playlist`
- `npm run test:comment-input`
- `npm run build`