### PR TITLE
[v1.4.0-beta] 재생목록 이어보기와 mpv 파일 실행 안정화

### DIFF
--- a/main/instance-policy.js
+++ b/main/instance-policy.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const os = require('os');
-const { isLaunchArgument } = require('./launch-routing');
+const { classifyLaunchArgument } = require('./launch-routing');
 
 function isTruthy(value) {
   const normalized = String(value || '').trim().toLowerCase();
@@ -23,8 +23,11 @@ function hasSwitch(argv = [], switchName) {
   return argv.some(arg => arg === switchName || String(arg).startsWith(`${switchName}=`));
 }
 
-function hasFileLaunchArgument(argv = []) {
-  return argv.some(arg => isLaunchArgument(arg));
+function hasProjectLaunchArgument(argv = []) {
+  return argv.some((arg) => {
+    const launchType = classifyLaunchArgument(arg);
+    return launchType === 'project' || launchType === 'playlist';
+  });
 }
 
 function sanitizeProfileName(value) {
@@ -39,7 +42,7 @@ function sanitizeProfileName(value) {
 function shouldAllowMultipleInstances({ isDev = false, argv = process.argv, env = process.env } = {}) {
   return Boolean(
     isDev ||
-    hasFileLaunchArgument(argv) ||
+    hasProjectLaunchArgument(argv) ||
     hasSwitch(argv, '--multi-instance') ||
     hasSwitch(argv, '--multi-instance-isolated') ||
     hasSwitch(argv, '--multi-instance-profile') ||
@@ -80,7 +83,7 @@ function resolveMultiInstanceUserDataPath({
 
 module.exports = {
   getSwitchValue,
-  hasFileLaunchArgument,
+  hasProjectLaunchArgument,
   hasSwitch,
   isTruthy,
   resolveMultiInstanceUserDataPath,

--- a/main/instance-policy.js
+++ b/main/instance-policy.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const os = require('os');
+const { isLaunchArgument } = require('./launch-routing');
 
 function isTruthy(value) {
   const normalized = String(value || '').trim().toLowerCase();
@@ -22,6 +23,10 @@ function hasSwitch(argv = [], switchName) {
   return argv.some(arg => arg === switchName || String(arg).startsWith(`${switchName}=`));
 }
 
+function hasFileLaunchArgument(argv = []) {
+  return argv.some(arg => isLaunchArgument(arg));
+}
+
 function sanitizeProfileName(value) {
   return String(value || '')
     .trim()
@@ -34,6 +39,7 @@ function sanitizeProfileName(value) {
 function shouldAllowMultipleInstances({ isDev = false, argv = process.argv, env = process.env } = {}) {
   return Boolean(
     isDev ||
+    hasFileLaunchArgument(argv) ||
     hasSwitch(argv, '--multi-instance') ||
     hasSwitch(argv, '--multi-instance-isolated') ||
     hasSwitch(argv, '--multi-instance-profile') ||
@@ -74,6 +80,7 @@ function resolveMultiInstanceUserDataPath({
 
 module.exports = {
   getSwitchValue,
+  hasFileLaunchArgument,
   hasSwitch,
   isTruthy,
   resolveMultiInstanceUserDataPath,

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -76,6 +76,7 @@ const OVERLAY_HTML = `
     }
     #markerMirror,
     #tooltipMirror,
+    #toastMirror,
     #htmlOverlay {
       position: absolute;
       inset: 0;
@@ -88,8 +89,12 @@ const OVERLAY_HTML = `
     #tooltipMirror {
       z-index: 16;
     }
+    #toastMirror {
+      z-index: 50;
+    }
     #markerMirror *,
-    #tooltipMirror * {
+    #tooltipMirror *,
+    #toastMirror * {
       pointer-events: none !important;
     }
     .comment-marker {
@@ -250,6 +255,7 @@ const OVERLAY_HTML = `
     <div id="htmlOverlay"></div>
     <div id="markerMirror"></div>
     <div id="tooltipMirror"></div>
+    <div id="toastMirror"></div>
   </div>
   <script>
     function applyOverlayTransform(element, state) {
@@ -280,11 +286,13 @@ const OVERLAY_HTML = `
       const htmlOverlay = document.getElementById('htmlOverlay');
       const markerMirror = document.getElementById('markerMirror');
       const tooltipMirror = document.getElementById('tooltipMirror');
+      const toastMirror = document.getElementById('toastMirror');
       applyImage('onionCanvasMirror', nextState.onionDataUrl, nextState.canvas);
       applyImage('drawingCanvasMirror', nextState.drawingDataUrl, nextState.canvas);
       htmlOverlay.innerHTML = nextState.htmlOverlayHtml || '';
       markerMirror.innerHTML = nextState.markerHtml || '';
       tooltipMirror.innerHTML = nextState.tooltipHtml || '';
+      toastMirror.innerHTML = nextState.toastHtml || '';
       applyOverlayTransform(markerMirror, nextState);
       tooltipMirror.style.transform = 'none';
       tooltipMirror.style.transformOrigin = 'center center';
@@ -321,6 +329,7 @@ function normalizeOverlayState(state = {}) {
     markerHtml: typeof state.markerHtml === 'string' ? state.markerHtml : '',
     tooltipHtml: typeof state.tooltipHtml === 'string' ? state.tooltipHtml : '',
     htmlOverlayHtml: typeof state.htmlOverlayHtml === 'string' ? state.htmlOverlayHtml : '',
+    toastHtml: typeof state.toastHtml === 'string' ? state.toastHtml : '',
     markerTransform: typeof state.markerTransform === 'string' ? state.markerTransform : '',
     markerTransformOrigin: typeof state.markerTransformOrigin === 'string'
       ? state.markerTransformOrigin

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:playlist-ordering": "node --test scripts/tests/playlist-ordering.test.js",
     "test:playlist-continuous": "node --test scripts/tests/playlist-continuous-core.test.js",
     "test:playlist-comments": "node --test scripts/tests/playlist-comment-index.test.js",
-    "test:playlist": "node --test scripts/tests/playlist-ordering.test.js scripts/tests/playlist-continuous-core.test.js scripts/tests/playlist-continuous-runtime.test.js scripts/tests/playlist-comment-index.test.js scripts/tests/playlist-autoplay-source.test.js scripts/tests/bplaylist-file-association-source.test.js scripts/tests/project-file-associations.test.js",
+    "test:playlist": "node --test scripts/tests/playlist-ordering.test.js scripts/tests/playlist-continuous-core.test.js scripts/tests/playlist-continuous-runtime.test.js scripts/tests/playlist-comment-index.test.js scripts/tests/playlist-autoplay-source.test.js scripts/tests/bplaylist-file-association-source.test.js scripts/tests/project-file-associations.test.js scripts/tests/instance-policy.test.js",
     "test:cutlist": "node --test scripts/tests/cutlist-manager.test.js scripts/tests/cutlist-schema.test.js scripts/tests/moho-scene-info-parser.test.js scripts/tests/cutlist-core.test.js scripts/tests/cutlist-runtime-source.test.js scripts/tests/cutlist-comment-index.test.js",
     "test:drawing": "node --test scripts/tests/drawing-stroke-records.test.js scripts/tests/drawing-runtime-source.test.js scripts/tests/keyframe-multi-select-source.test.js",
     "test:video-pan": "node --test scripts/tests/video-pan-controls.test.js",

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -4730,7 +4730,12 @@ async function initApp() {
   let activeTranscodeOverlayToken = 0;
   let activeTranscodeOverlayCleanup = null;
   let latestVideoLoadToken = 0;
+  let activeVideoLoadPath = null;
   let activeMpvPilotLoadToken = null;
+
+  function hasActiveVideoLoadForDifferentFile(filePath) {
+    return typeof activeVideoLoadPath === 'string' && !isSameFilePath(activeVideoLoadPath, filePath);
+  }
 
   function invalidateActiveVideoLoad() {
     latestVideoLoadToken += 1;
@@ -5844,8 +5849,13 @@ async function initApp() {
       : () => true;
     const loadToken = ++latestVideoLoadToken;
     const isStaleVideoLoad = () => loadToken !== latestVideoLoadToken;
-    const canContinueVideoLoad = () => !isStaleVideoLoad() && shouldContinueVideoLoad();
+    let allowNavigationGuardAbort = true;
+    const canContinueVideoLoad = () => (
+      !isStaleVideoLoad() &&
+      (!allowNavigationGuardAbort || shouldContinueVideoLoad())
+    );
     if (!canContinueVideoLoad()) return false;
+    activeVideoLoadPath = filePath;
     supersedeActiveTranscodeOverlay('새 영상 선택');
     if (!preserveContinuousSession && continuousPlaybackState.active) {
       stopContinuousPlayback();
@@ -5922,6 +5932,8 @@ async function initApp() {
           log.warn('저장 실패했지만 사용자가 전환 진행 선택');
         }
       }
+
+      allowNavigationGuardAbort = false;
 
       // ====== 이전 파일 감시 및 협업 세션 정리 (누적 방지) ======
       if (reviewDataManager.currentBframePath) {
@@ -6294,6 +6306,10 @@ async function initApp() {
       reviewDataManager.resumeAutoSave();
       showToast('파일을 로드할 수 없습니다.', 'error');
       return false;
+    } finally {
+      if (loadToken === latestVideoLoadToken) {
+        activeVideoLoadPath = null;
+      }
     }
   }
 
@@ -7702,7 +7718,8 @@ async function initApp() {
     }
     if (!isCurrentNavigation()) return false;
 
-    const isAlreadyLoaded = isSameFilePath(state.currentFile, item.videoPath);
+    const isAlreadyLoaded = isSameFilePath(state.currentFile, item.videoPath) &&
+      !hasActiveVideoLoadForDifferentFile(item.videoPath);
     if (!isAlreadyLoaded) {
       const loaded = await loadVideoFromPlaylist(item, {
         preserveContinuousSession: true,
@@ -13222,7 +13239,8 @@ async function initApp() {
       if (!isCurrentNavigation()) return false;
     }
 
-    const isAlreadyLoaded = isSameFilePath(state.currentFile, item.videoPath);
+    const isAlreadyLoaded = isSameFilePath(state.currentFile, item.videoPath) &&
+      !hasActiveVideoLoadForDifferentFile(item.videoPath);
     const targetFrame = Math.max(0, Math.floor(mapped.localTime * (mapped.segment.fps || item.fps || videoPlayer.fps || 24)));
     if (!isAlreadyLoaded) {
       const loaded = await loadVideoFromPlaylist(item, {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5512,6 +5512,12 @@ async function initApp() {
       button.setAttribute('tabindex', '-1');
       button.style.pointerEvents = 'none';
     });
+    clone.querySelectorAll('.toast-enter').forEach((toast) => {
+      toast.classList.remove('toast-enter');
+      toast.style.animation = 'none';
+      toast.style.transform = '';
+      toast.style.opacity = '';
+    });
 
     return clone.outerHTML;
   }
@@ -5830,10 +5836,16 @@ async function initApp() {
       holdPreviousFrameUntilReady = false,
       deferCollaborationStart = false,
       preparedVideoPath = null,
-      allowMpvPilot = true
+      allowMpvPilot = true,
+      shouldContinue = null
     } = options;
+    const shouldContinueVideoLoad = typeof shouldContinue === 'function'
+      ? shouldContinue
+      : () => true;
     const loadToken = ++latestVideoLoadToken;
     const isStaleVideoLoad = () => loadToken !== latestVideoLoadToken;
+    const canContinueVideoLoad = () => !isStaleVideoLoad() && shouldContinueVideoLoad();
+    if (!canContinueVideoLoad()) return false;
     supersedeActiveTranscodeOverlay('새 영상 선택');
     if (!preserveContinuousSession && continuousPlaybackState.active) {
       stopContinuousPlayback();
@@ -5843,7 +5855,7 @@ async function initApp() {
     try {
       // 파일 정보 가져오기
       const fileInfo = await window.electronAPI.getFileInfo(filePath);
-      if (isStaleVideoLoad()) return false;
+      if (!canContinueVideoLoad()) return false;
 
       // ====== 오디오 파일 감지 ======
       const fileIsAudio = isAudioFile(fileInfo.name);
@@ -5855,7 +5867,7 @@ async function initApp() {
       let actualVideoPath = hasPreparedVideoPath ? preparedVideoPath : filePath;
       let thumbnailVideoPath = actualVideoPath;
       const useMpvPilot = allowMpvPilot && await shouldUseMpvPilot(filePath, { fileIsAudio, hasPreparedVideoPath: hasConvertedPreparedVideoPath });
-      if (isStaleVideoLoad()) return false;
+      if (!canContinueVideoLoad()) return false;
       if (hasPreparedVideoPath) {
         log.debug('준비된 연속 재생 미디어 경로 사용', { filePath, preparedVideoPath });
       }
@@ -5863,21 +5875,21 @@ async function initApp() {
 
       if (ffmpegAvailable) {
         const codecInfo = await window.electronAPI.ffmpegProbeCodec(filePath);
-        if (isStaleVideoLoad()) return false;
+        if (!canContinueVideoLoad()) return false;
 
         if (codecInfo.success && !codecInfo.isSupported) {
           log.info('미지원 코덱 감지, 트랜스코딩 필요', { codec: codecInfo.codecName });
 
           // 캐시 확인
           const cacheResult = await window.electronAPI.ffmpegCheckCache(filePath);
-          if (isStaleVideoLoad()) return false;
+          if (!canContinueVideoLoad()) return false;
           if (cacheResult.valid) {
             log.info('캐시된 변환 파일 사용', { path: cacheResult.convertedPath });
             actualVideoPath = cacheResult.convertedPath;
           } else {
             // 트랜스코딩 필요 - UI 표시
             const transcoded = await showTranscodeOverlay(filePath, codecInfo.codecName);
-            if (isStaleVideoLoad()) return false;
+            if (!canContinueVideoLoad()) return false;
             if (transcoded.stale) return false;
             if (transcoded.success) {
               actualVideoPath = transcoded.outputPath;
@@ -5899,7 +5911,7 @@ async function initApp() {
       if (reviewDataManager.hasUnsavedChanges()) {
         log.info('파일 전환 전 변경사항 저장 시도');
         const saved = await reviewDataManager.save();
-        if (isStaleVideoLoad()) return false;
+        if (!canContinueVideoLoad()) return false;
         if (!saved) {
           // 저장 실패 시 사용자에게 확인
           const proceed = confirm('현재 파일 저장에 실패했습니다. 저장하지 않고 전환할까요?');
@@ -5914,7 +5926,7 @@ async function initApp() {
       // ====== 이전 파일 감시 및 협업 세션 정리 (누적 방지) ======
       if (reviewDataManager.currentBframePath) {
         await window.electronAPI.watchFileStop(reviewDataManager.currentBframePath);
-        if (isStaleVideoLoad()) return false;
+        if (!canContinueVideoLoad()) return false;
         log.info('이전 파일 감시 중지', { path: reviewDataManager.currentBframePath });
         try {
           await liveblocksManager.stop();
@@ -5977,7 +5989,7 @@ async function initApp() {
         // 오디오를 <video> 엘리먼트로 재생 (HTML5 video는 audio도 재생 가능)
         try {
           await videoPlayer.load(actualVideoPath);
-          if (isStaleVideoLoad()) return false;
+          if (!canContinueVideoLoad()) return false;
         } catch (loadErr) {
           log.warn('videoPlayer.load 실패, 직접 src 설정으로 폴백', { error: loadErr.message });
           // 폴백: 직접 src 설정 (loadedmetadata 이벤트 없이)
@@ -6012,7 +6024,7 @@ async function initApp() {
               reject(new Error('미디어 로드 타임아웃 (3초)'));
             }, 3000);
           });
-          if (isStaleVideoLoad()) return false;
+          if (!canContinueVideoLoad()) return false;
         }
 
         // videoPlayer.load()가 display:block을 강제할 수 있으므로 다시 숨김
@@ -6030,7 +6042,7 @@ async function initApp() {
 
         try {
           await audioWaveform.loadAudio(filePath);
-          if (isStaleVideoLoad()) return false;
+          if (!canContinueVideoLoad()) return false;
         } catch (err) {
           log.error('웨이브폼 로드 실패', { error: err.message, stack: err.stack });
           showToast(`웨이브폼 로드 실패: ${err.message}`, 'error');
@@ -6088,10 +6100,10 @@ async function initApp() {
               loadToken,
               isStaleVideoLoad
             });
-            if (isStaleVideoLoad()) return false;
+            if (!canContinueVideoLoad()) return false;
             if (!mpvLoaded) return false;
           } catch (mpvError) {
-            if (isStaleVideoLoad()) return false;
+            if (!canContinueVideoLoad()) return false;
             log.warn('mpv 파일럿 로드 실패, 기존 재생 방식으로 재시도', { error: mpvError.message });
             showToast('mpv 재생에 실패해 기존 방식으로 다시 시도합니다.', 'warning');
             const fallbackOptions = {
@@ -6119,16 +6131,16 @@ async function initApp() {
 
           try {
             await videoPlayer.load(actualVideoPath);
-            if (isStaleVideoLoad()) return false;
+            if (!canContinueVideoLoad()) return false;
 
             if (shouldDelayVideoReveal) {
               await seekInitialVideoFrameBeforeReveal(initialFrame);
-              if (isStaleVideoLoad()) return false;
+              if (!canContinueVideoLoad()) return false;
             } else if (shouldHoldVideoReveal) {
               await waitForVideoRenderable(elements.videoPlayer);
-              if (isStaleVideoLoad()) return false;
+              if (!canContinueVideoLoad()) return false;
               await waitForNextVideoPaint(elements.videoPlayer);
-              if (isStaleVideoLoad()) return false;
+              if (!canContinueVideoLoad()) return false;
             }
           } finally {
             if (shouldHideVideoDuringLoad) {
@@ -6163,7 +6175,7 @@ async function initApp() {
       if (!keepVersionContext) {
         // VersionManager에 현재 파일 설정 (폴더 스캔 포함)
         await versionManager.setCurrentFile(filePath);
-        if (isStaleVideoLoad()) return false;
+        if (!canContinueVideoLoad()) return false;
       } else {
         log.info('버전 컨텍스트 유지 모드 - 폴더 스캔 건너뜀');
       }
@@ -6198,7 +6210,7 @@ async function initApp() {
           thumbnailVideoPath = await resolveMpvThumbnailVideoPath(filePath, {
             isStaleVideoLoad
           });
-          if (isStaleVideoLoad()) return false;
+          if (!canContinueVideoLoad()) return false;
           shouldGenerateThumbnails = Boolean(thumbnailVideoPath);
         }
         if (shouldGenerateThumbnails) {
@@ -6207,7 +6219,7 @@ async function initApp() {
           getThumbnailGenerator().clear();
           document.getElementById('videoLoadingOverlay')?.classList.remove('active');
         }
-        if (isStaleVideoLoad()) return false;
+        if (!canContinueVideoLoad()) return false;
       } else {
         // 오디오 파일 로드 시 이전 비디오의 썸네일 상태 정리
         getThumbnailGenerator().clear();
@@ -6215,7 +6227,7 @@ async function initApp() {
 
       // .bframe 파일 로드 시도 (이미 저장했으므로 skipSave: true)
       const hasExistingData = await reviewDataManager.setVideoFile(filePath, { skipSave: true });
-      if (isStaleVideoLoad()) return false;
+      if (!canContinueVideoLoad()) return false;
       const currentBframePath = reviewDataManager.currentBframePath;
 
       // keepVersionContext가 false일 때만 manualVersions 복원
@@ -6241,7 +6253,7 @@ async function initApp() {
         scheduleDeferredCollaborationStart(loadToken, currentBframePath);
       } else {
         await startCollaborationForVideoLoad(loadToken, currentBframePath);
-        if (isStaleVideoLoad()) return false;
+        if (!canContinueVideoLoad()) return false;
       }
 
       // 마커 및 그리기 렌더링 업데이트 (항상 실행)
@@ -6260,7 +6272,7 @@ async function initApp() {
       await refreshCommentRangesForCurrentMode({
         skipContinuousTimelineRefresh: preserveContinuousSession
       });
-      if (isStaleVideoLoad()) return false;
+      if (!canContinueVideoLoad()) return false;
 
       // ====== 최근 파일 목록에 추가 ======
       // fire-and-forget: manager 내부에서 자체 에러 처리함
@@ -15049,7 +15061,10 @@ async function initApp() {
 
     // 새 영상 로드
     if (!canContinuePlaylistLoad()) return false;
-    const loaded = await loadVideo(item.videoPath, loadOptions);
+    const loaded = await loadVideo(item.videoPath, {
+      ...loadOptions,
+      shouldContinue: canContinuePlaylistLoad
+    });
     if (!canContinuePlaylistLoad()) return false;
     return loaded === true;
   }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -368,6 +368,7 @@ async function initApp() {
   let playlistSelectionLoadToken = 0;
   let playlistReplacementToken = 0;
   let playlistReplacementCommitToken = 0;
+  let playlistContinuousNavigationToken = 0;
   const playlistMediaPreload = {
     element: null,
     itemId: null,
@@ -4598,7 +4599,8 @@ async function initApp() {
   });
 
   // 키보드 단축키
-  document.addEventListener('keydown', handleKeydown);
+  document.addEventListener('keydown', handleKeydown, true);
+  document.addEventListener('keyup', handleKeyup, true);
 
   // ====== 캔버스 오버레이 동기화 ======
 
@@ -5159,6 +5161,15 @@ async function initApp() {
 
   const MPV_HTML_OVERLAY_STYLE_PROPERTIES = [
     'align-items',
+    'animation',
+    'animation-delay',
+    'animation-direction',
+    'animation-duration',
+    'animation-fill-mode',
+    'animation-iteration-count',
+    'animation-name',
+    'animation-play-state',
+    'animation-timing-function',
     'backdrop-filter',
     'background',
     'background-color',
@@ -5490,6 +5501,21 @@ async function initApp() {
     return htmlOverlay.innerHTML;
   }
 
+  function serializeMpvOverlayToastHtml() {
+    const wrapperRect = elements.videoWrapper?.getBoundingClientRect();
+    if (!wrapperRect || !elements.toastContainer) return '';
+
+    const clone = cloneMpvHtmlOverlayElement(elements.toastContainer, wrapperRect);
+    if (!clone) return '';
+
+    clone.querySelectorAll('button').forEach((button) => {
+      button.setAttribute('tabindex', '-1');
+      button.style.pointerEvents = 'none';
+    });
+
+    return clone.outerHTML;
+  }
+
   function getMpvOverlayState() {
     const wrapperRect = elements.videoWrapper?.getBoundingClientRect();
     const canvasRect = elements.drawingCanvas?.getBoundingClientRect();
@@ -5501,6 +5527,7 @@ async function initApp() {
       markerHtml: serializeMpvOverlayMarkerHtml(),
       tooltipHtml: serializeMpvOverlayTooltipHtml(),
       htmlOverlayHtml: serializeMpvOverlayHtml(),
+      toastHtml: serializeMpvOverlayToastHtml(),
       markerTransform: markerContainer?.style.transform || '',
       markerTransformOrigin: markerContainer?.style.transformOrigin || 'center center',
       videoTransform: getMpvVideoTransform(),
@@ -7646,22 +7673,37 @@ async function initApp() {
     const item = playlistManager.getItems().find(candidate => candidate.id === range.itemId);
     if (!item) return false;
 
+    const navigationToken = ++playlistContinuousNavigationToken;
+    const isCurrentNavigation = () => (
+      navigationToken === playlistContinuousNavigationToken &&
+      playlistUIState.mode === 'continuous'
+    );
+    if (continuousPlaybackState.active) {
+      stopContinuousPlayback();
+    }
+
     suppressPlaylistSelectionLoad = true;
     try {
       playlistManager.selectItemById(item.id);
     } finally {
       suppressPlaylistSelectionLoad = false;
     }
+    if (!isCurrentNavigation()) return false;
 
-    const isAlreadyLoaded = state.currentFile === item.videoPath;
+    const isAlreadyLoaded = isSameFilePath(state.currentFile, item.videoPath);
     if (!isAlreadyLoaded) {
       const loaded = await loadVideoFromPlaylist(item, {
-        preserveContinuousSession: continuousPlaybackState.active,
-        shouldContinue: () => playlistUIState.mode === 'continuous'
+        preserveContinuousSession: true,
+        initialFrame: range.localStartFrame || 0,
+        revealAfterInitialSeek: true,
+        holdPreviousFrameUntilReady: true,
+        shouldContinue: isCurrentNavigation
       });
       if (!loaded) return;
+      if (!isCurrentNavigation()) return false;
     }
 
+    if (!isCurrentNavigation()) return false;
     videoPlayer.seekToFrame(range.localStartFrame || 0);
     videoPlayer.pause();
     timeline.setCurrentTime(range.globalStartTime || 0);
@@ -8880,6 +8922,8 @@ async function initApp() {
       toast.style.setProperty('--stack-opacity', entry.opacity);
       toast.style.setProperty('--stack-brightness', entry.brightness);
     });
+
+    scheduleMpvOverlayStateSync({ force: true });
   }
 
   function _dismissToast(toast, swipeDir) {
@@ -8900,6 +8944,7 @@ async function initApp() {
       toast.style.transform = 'translateY(-8px) scale(0.96)';
       toast.style.opacity = '0';
     }
+    scheduleMpvOverlayStateSync({ force: true });
 
     // 2단계: 페이드아웃 완료 후 공간 축소 (Sonner 방식)
     const fadeTime = swipeDir ? 250 : 200;
@@ -8926,6 +8971,7 @@ async function initApp() {
       // 공간 축소 완료 후 DOM 제거
       setTimeout(() => {
         toast.remove();
+        scheduleMpvOverlayStateSync({ force: true });
       }, 220);
     }, fadeTime);
   }
@@ -9119,6 +9165,7 @@ async function initApp() {
           icon.innerHTML = _toastIcons[newNormalType] || _toastIcons.info;
           msg.textContent = newMessage;
           progress.style.display = '';
+          scheduleMpvOverlayStateSync({ force: true });
           clearTimeout(toast._autoTimer);
           cancelAnimationFrame(toast._progressRaf);
           // 자동 닫기 재설정
@@ -9213,7 +9260,11 @@ async function initApp() {
   /**
    * 키보드 단축키 처리
    */
+  let suppressPlayPauseShortcutKeyup = false;
+
   async function handleKeydown(e) {
+    if (document.querySelector('.shortcut-key-btn.capturing')) return;
+
     const isPlayPauseShortcut = userSettings.matchShortcut('playPause', e);
     if (isPlayPauseShortcut && !shouldHandlePlayPauseShortcutFromTarget(e.target, e)) return;
 
@@ -9232,7 +9283,11 @@ async function initApp() {
 
     // 재생/일시정지
     if (isPlayPauseShortcut) {
+      if (e.code === 'Space') {
+        suppressPlayPauseShortcutKeyup = true;
+      }
       e.preventDefault();
+      e.stopPropagation();
       handleUserPlayPauseToggle();
       return;
     }
@@ -9563,6 +9618,13 @@ async function initApp() {
       }
       return;
     }
+  }
+
+  function handleKeyup(e) {
+    if (!suppressPlayPauseShortcutKeyup || e.code !== 'Space') return;
+    e.preventDefault();
+    e.stopPropagation();
+    suppressPlayPauseShortcutKeyup = false;
   }
 
   // 초기화 완료
@@ -10343,6 +10405,7 @@ async function initApp() {
       c.style.marginRight = 'auto';
       c.style.alignItems = 'center';
     }
+    scheduleMpvOverlayStateSync({ force: true });
   }
 
   // 초기 토스트 위치 적용
@@ -13093,9 +13156,9 @@ async function initApp() {
     const playlistManager = getPlaylistManager();
     const items = playlistManager.getItems?.() || [];
     const currentItem = playlistManager.getCurrentItem?.();
-    const itemId = currentItem?.videoPath === state.currentFile
+    const itemId = isSameFilePath(currentItem?.videoPath, state.currentFile)
       ? currentItem.id
-      : items.find(item => item.videoPath === state.currentFile)?.id;
+      : items.find(item => isSameFilePath(item.videoPath, state.currentFile))?.id;
     if (!itemId) return null;
     return timeline.playlistSegments?.find(segment => segment.itemId === itemId) || null;
   }
@@ -13124,6 +13187,18 @@ async function initApp() {
 
     const item = playlistManager.getItems()[mapped.segment.index];
     if (!item) return false;
+    const wasContinuousActive = continuousPlaybackState.active === true;
+    const shouldResumePlayback = videoPlayer.isPlaying === true || wasContinuousActive;
+    const manualSessionId = wasContinuousActive
+      ? restartContinuousPlaybackSessionForManualSeek()
+      : null;
+    const navigationToken = ++playlistContinuousNavigationToken;
+    const isCurrentNavigation = () => (
+      navigationToken === playlistContinuousNavigationToken &&
+      playlistUIState.mode === 'continuous' &&
+      timeline.playlistDuration > 0 &&
+      (manualSessionId === null || isContinuousSessionActive(manualSessionId))
+    );
 
     if (playlistManager.getCurrentItem?.()?.id !== item.id) {
       suppressPlaylistSelectionLoad = true;
@@ -13132,34 +13207,60 @@ async function initApp() {
       } finally {
         suppressPlaylistSelectionLoad = false;
       }
+      if (!isCurrentNavigation()) return false;
     }
 
-    const isAlreadyLoaded = state.currentFile === item.videoPath;
+    const isAlreadyLoaded = isSameFilePath(state.currentFile, item.videoPath);
+    const targetFrame = Math.max(0, Math.floor(mapped.localTime * (mapped.segment.fps || item.fps || videoPlayer.fps || 24)));
     if (!isAlreadyLoaded) {
       const loaded = await loadVideoFromPlaylist(item, {
-        preserveContinuousSession: continuousPlaybackState.active,
-        shouldContinue: () => playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0
+        preserveContinuousSession: true,
+        initialFrame: targetFrame,
+        revealAfterInitialSeek: true,
+        holdPreviousFrameUntilReady: true,
+        shouldContinue: isCurrentNavigation
       });
       if (!loaded) return false;
+      if (!isCurrentNavigation()) return false;
     }
 
+    if (!isCurrentNavigation()) return false;
     videoPlayer.seek(mapped.localTime);
     playbackSync.broadcastSeek(mapped.localTime);
     timeline.setCurrentTime(mapLocalTimeToGlobal(mapped.segment, mapped.localTime));
     updatePlaylistCurrentItem();
     updatePlaylistPosition();
+    if (manualSessionId !== null) {
+      prepareNextPlaylistItem(manualSessionId);
+    }
+    if (shouldResumePlayback) {
+      await playVideoAfterMediaLoad({
+        silent: true,
+        logContext: { fileName: item.fileName, continuousSeek: true }
+      });
+    }
     return true;
   }
 
-  function stopContinuousPlayback() {
-    continuousPlaybackState.sessionId += 1;
-    continuousPlaybackState.active = false;
+  function resetContinuousPlaybackRuntimeState(active) {
+    continuousPlaybackState.active = active;
     continuousPlaybackState.waiting = false;
     continuousPlaybackState.skippedBatch = [];
     continuousPlaybackState.loadingItemId = null;
     continuousPlaybackState.preparePromises.clear();
     continuousPlaybackState.preparedMediaPaths.clear();
     clearPlaylistMediaPreload();
+  }
+
+  function restartContinuousPlaybackSessionForManualSeek() {
+    continuousPlaybackState.sessionId += 1;
+    resetContinuousPlaybackRuntimeState(true);
+    return continuousPlaybackState.sessionId;
+  }
+
+  function stopContinuousPlayback() {
+    continuousPlaybackState.sessionId += 1;
+    resetContinuousPlaybackRuntimeState(false);
   }
 
   function isContinuousSessionActive(sessionId) {
@@ -13210,7 +13311,7 @@ async function initApp() {
   async function collectPlaylistMetadata(items) {
     const metadata = new Map();
     for (const item of items) {
-      if (state.currentFile === item.videoPath && videoPlayer.duration) {
+      if (isSameFilePath(state.currentFile, item.videoPath) && videoPlayer.duration) {
         metadata.set(item.id, { duration: videoPlayer.duration, fps: videoPlayer.fps || 24 });
         continue;
       }
@@ -13739,7 +13840,7 @@ async function initApp() {
         return;
       }
 
-      const alreadyLoaded = state.currentFile === currentItem.videoPath;
+      const alreadyLoaded = isSameFilePath(state.currentFile, currentItem.videoPath);
       if (!alreadyLoaded) {
         const loaded = await loadContinuousPlaylistItem(currentItem, sessionId);
         if (!isContinuousSessionActive(sessionId)) return;

--- a/scripts/tests/instance-policy.test.js
+++ b/scripts/tests/instance-policy.test.js
@@ -17,6 +17,24 @@ test('packaged mode stays single-instance by default', () => {
   assert.equal(shouldAllowMultipleInstances({ isDev: false, argv: [], env: {} }), false);
 });
 
+test('packaged file launches open in a new instance by default', () => {
+  assert.equal(shouldAllowMultipleInstances({
+    isDev: false,
+    argv: ['BFRAME_alpha_v2.exe', 'G:\\project\\review.bframe'],
+    env: {}
+  }), true);
+  assert.equal(shouldAllowMultipleInstances({
+    isDev: false,
+    argv: ['BFRAME_alpha_v2.exe', 'G:\\project\\playlist.bplaylist'],
+    env: {}
+  }), true);
+  assert.equal(shouldAllowMultipleInstances({
+    isDev: false,
+    argv: ['BFRAME_alpha_v2.exe', 'baeframe://playlist/G:/project/playlist.bplaylist'],
+    env: {}
+  }), true);
+});
+
 test('explicit multi-instance switches allow packaged comparison runs', () => {
   assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe', '--multi-instance'], env: {} }), true);
   assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe', '--multi-instance-profile=A'], env: {} }), true);

--- a/scripts/tests/instance-policy.test.js
+++ b/scripts/tests/instance-policy.test.js
@@ -35,6 +35,24 @@ test('packaged file launches open in a new instance by default', () => {
   }), true);
 });
 
+test('packaged non-project launches keep the existing single-instance router', () => {
+  assert.equal(shouldAllowMultipleInstances({
+    isDev: false,
+    argv: ['BFRAME_alpha_v2.exe', 'G:\\project\\review.mov'],
+    env: {}
+  }), false);
+  assert.equal(shouldAllowMultipleInstances({
+    isDev: false,
+    argv: ['BFRAME_alpha_v2.exe', 'G:\\project\\cuts.bcutlist'],
+    env: {}
+  }), false);
+  assert.equal(shouldAllowMultipleInstances({
+    isDev: false,
+    argv: ['BFRAME_alpha_v2.exe', 'baeframe://open?file=G%3A%5Cproject%5Creview.mov&comment=marker-1'],
+    env: {}
+  }), false);
+});
+
 test('explicit multi-instance switches allow packaged comparison runs', () => {
   assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe', '--multi-instance'], env: {} }), true);
   assert.equal(shouldAllowMultipleInstances({ argv: ['BFRAME_alpha_v2.exe', '--multi-instance-profile=A'], env: {} }), true);

--- a/scripts/tests/keyboard-shortcut-targets.test.js
+++ b/scripts/tests/keyboard-shortcut-targets.test.js
@@ -42,6 +42,20 @@ test('form controls only allow play/pause override for the Space shortcut', asyn
   assert.match(appSource, /shouldHandlePlayPauseShortcutFromTarget\(e\.target, e\)/);
 });
 
+test('Space play/pause shortcut suppresses focused control keyup activation', () => {
+  assert.match(appSource, /let suppressPlayPauseShortcutKeyup = false;/);
+  assert.match(
+    appSource,
+    /if \(isPlayPauseShortcut\) \{[\s\S]+if \(e\.code === 'Space'\) \{[\s\S]+suppressPlayPauseShortcutKeyup = true;[\s\S]+\}[\s\S]+e\.preventDefault\(\);[\s\S]+e\.stopPropagation\(\);[\s\S]+handleUserPlayPauseToggle\(\);/
+  );
+  assert.match(
+    appSource,
+    /function handleKeyup\(e\) \{[\s\S]+if \(!suppressPlayPauseShortcutKeyup \|\| e\.code !== 'Space'\) return;[\s\S]+e\.preventDefault\(\);[\s\S]+e\.stopPropagation\(\);[\s\S]+suppressPlayPauseShortcutKeyup = false;[\s\S]+\}/
+  );
+  assert.match(appSource, /document\.addEventListener\('keydown', handleKeydown, true\);/);
+  assert.match(appSource, /document\.addEventListener\('keyup', handleKeyup, true\);/);
+});
+
 test('non-playback shortcuts stay ignored for form controls', async () => {
   const {
     shouldIgnoreGlobalShortcutTarget

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -17,6 +17,7 @@ test('normalizes overlay state to bounded serializable fields', () => {
     markerHtml: '<div class="comment-marker"></div>',
     tooltipHtml: '<div class="comment-marker-tooltip visible"></div>',
     htmlOverlayHtml: '<div class="current-cut-overlay">Cut 01</div>',
+    toastHtml: '<div class="toast-container"><div class="toast success">Saved</div></div>',
     canvas: { left: 10.4, top: 20.6, width: 640.2, height: 360.7 },
     markerTransform: 'scale(2) translate(1px, 2px)',
     markerTransformOrigin: 'center center'
@@ -28,6 +29,7 @@ test('normalizes overlay state to bounded serializable fields', () => {
   assert.equal(state.markerHtml, '<div class="comment-marker"></div>');
   assert.equal(state.tooltipHtml, '<div class="comment-marker-tooltip visible"></div>');
   assert.equal(state.htmlOverlayHtml, '<div class="current-cut-overlay">Cut 01</div>');
+  assert.equal(state.toastHtml, '<div class="toast-container"><div class="toast success">Saved</div></div>');
   assert.equal(state.markerTransform, 'scale(2) translate(1px, 2px)');
   assert.equal(state.markerTransformOrigin, 'center center');
 });
@@ -112,6 +114,7 @@ test('creates a click-through overlay window above the viewer area', async () =>
   assert.equal(overlayHtml.includes('applyOverlayTransform'), true);
   assert.equal(overlayHtml.includes('htmlOverlay'), true);
   assert.equal(overlayHtml.includes('tooltipMirror'), true);
+  assert.equal(overlayHtml.includes('toastMirror'), true);
   assert.equal(overlayHtml.includes("applyImage('drawingCanvasMirror', nextState.drawingDataUrl, nextState.canvas)"), true);
   assert.doesNotMatch(
     overlayHtml,
@@ -120,6 +123,7 @@ test('creates a click-through overlay window above the viewer area', async () =>
   assert.equal(overlayHtml.includes("element.style.transform = 'none';"), true);
   assert.equal(overlayHtml.includes('tooltipMirror.innerHTML = nextState.tooltipHtml'), true);
   assert.equal(overlayHtml.includes('htmlOverlay.innerHTML = nextState.htmlOverlayHtml'), true);
+  assert.equal(overlayHtml.includes('toastMirror.innerHTML = nextState.toastHtml'), true);
   assert.equal(overlayHtml.includes("tooltipMirror.style.transform = 'none';"), true);
   assert.ok(events.some(([name]) => name === 'showInactive'));
   assert.ok(events.some(([name]) => name === 'moveTop'));
@@ -165,6 +169,7 @@ test('updates overlay state through the isolated overlay document', async () => 
   const result = await host.updateState({
     markerHtml: '<div class="comment-marker pending"></div>',
     htmlOverlayHtml: '<div class="current-cut-overlay">Cut 01</div>',
+    toastHtml: '<div class="toast-container"><div class="toast info">Ready</div></div>',
     drawingDataUrl: 'data:image/png;base64,draw',
     canvas: { left: 1, top: 2, width: 3, height: 4 }
   });
@@ -174,6 +179,7 @@ test('updates overlay state through the isolated overlay document', async () => 
   assert.match(scripts[0], /window\.__applyMpvOverlayState/);
   assert.match(scripts[0], /comment-marker pending/);
   assert.match(scripts[0], /current-cut-overlay/);
+  assert.match(scripts[0], /toast info/);
   assert.match(scripts[0], /data:image\/png;base64,draw/);
 });
 

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -275,6 +275,8 @@ test('mpv pilot mirrors DOM overlays into a click-through native overlay window'
   assert.match(appSource, /function serializeMpvOverlayTooltipHtml\(\) \{[\s\S]+const tooltipLayer = document\.createElement\('div'\);[\s\S]+document\.querySelectorAll\('\.comment-marker-tooltip'\)\.forEach\(\(tooltip\) => \{[\s\S]+tooltipClone\.style\.position = 'absolute';[\s\S]+tooltipClone\.style\.transform = 'none';[\s\S]+tooltipLayer\.appendChild\(tooltipClone\);[\s\S]+\}\);/);
   assert.match(appSource, /function serializeMpvOverlayTooltipHtml\(\) \{[\s\S]+if \(!isMpvMarkerOverlayVisible\(\)\) return '';/);
   assert.match(appSource, /function copyComputedMpvOverlayStyles\(source, target\) \{/);
+  assert.match(appSource, /function serializeMpvOverlayToastHtml\(\) \{/);
+  assert.match(appSource, /function getMpvOverlayState\(\) \{[\s\S]+toastHtml: serializeMpvOverlayToastHtml\(\)/);
   const htmlOverlayMatch = appSource.match(/function serializeMpvOverlayHtml\(\) \{([\s\S]*?)\n  \}\n\n  function getMpvOverlayState/);
   assert.ok(htmlOverlayMatch, 'serializeMpvOverlayHtml should exist');
   const htmlOverlaySource = htmlOverlayMatch[1];
@@ -302,6 +304,14 @@ test('mpv pilot mirrors DOM overlays into a click-through native overlay window'
   assert.match(appSource, /const hideTooltipHover = \(\) => \{[\s\S]+tooltip\.classList\.remove\('visible'\);[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}, 100\);/);
   assert.match(appSource, /function updateMarkerTooltipState\(marker\) \{[\s\S]+marker\.tooltipElement\.classList\.add\('visible', 'pinned'\);[\s\S]+scheduleMpvOverlayStateSync\(\);/);
   assert.match(appSource, /async function stopMpvPilotEngine\(\) \{[\s\S]+await window\.electronAPI\?\.mpvDestroyOverlay\?\.\(\);/);
+});
+
+test('mpv pilot keeps toast notifications visible above the native video host', () => {
+  assert.match(appSource, /function serializeMpvOverlayToastHtml\(\) \{[\s\S]+elements\.toastContainer[\s\S]+cloneMpvHtmlOverlayElement\(elements\.toastContainer, wrapperRect\)[\s\S]+return clone\.outerHTML;/);
+  assert.match(appSource, /function _updateToastStack\(\) \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);/);
+  assert.match(appSource, /function _dismissToast\(toast, swipeDir\) \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);/);
+  assert.match(appSource, /update: \(newMessage, newType = 'success', newDuration = 3000\) => \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);/);
+  assert.match(appSource, /function _applyToastPosition\(pos\) \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);/);
 });
 
 test('mpv overlay throttles live drawing snapshots but forces final drawing sync', () => {

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -308,6 +308,7 @@ test('mpv pilot mirrors DOM overlays into a click-through native overlay window'
 
 test('mpv pilot keeps toast notifications visible above the native video host', () => {
   assert.match(appSource, /function serializeMpvOverlayToastHtml\(\) \{[\s\S]+elements\.toastContainer[\s\S]+cloneMpvHtmlOverlayElement\(elements\.toastContainer, wrapperRect\)[\s\S]+return clone\.outerHTML;/);
+  assert.match(appSource, /clone\.querySelectorAll\('\.toast-enter'\)\.forEach\(\(toast\) => \{[\s\S]+toast\.classList\.remove\('toast-enter'\);[\s\S]+toast\.style\.animation = 'none';[\s\S]+toast\.style\.transform = '';[\s\S]+toast\.style\.opacity = '';[\s\S]+\}\);/);
   assert.match(appSource, /function _updateToastStack\(\) \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);/);
   assert.match(appSource, /function _dismissToast\(toast, swipeDir\) \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);/);
   assert.match(appSource, /update: \(newMessage, newType = 'success', newDuration = 3000\) => \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);/);

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -23,7 +23,7 @@ test('continuous metadata uses mpv before FFmpeg fallback for mpv pilot original
   assert.ok(metadataMatch, 'collectPlaylistMetadata should exist');
 
   const metadataSource = metadataMatch[1];
-  assert.match(metadataSource, /state\.currentFile === item\.videoPath && videoPlayer\.duration/);
+  assert.match(metadataSource, /isSameFilePath\(state\.currentFile, item\.videoPath\) && videoPlayer\.duration/);
   assert.match(metadataSource, /const useMpvPilotForMetadata = !hasDuration && item\.videoPath[\s\S]+await shouldUseMpvPilot\(item\.videoPath/);
   assert.match(metadataSource, /let metadataResolvedByMpv = false;/);
   assert.match(metadataSource, /if \(!hasDuration && item\.videoPath && useMpvPilotForMetadata\) \{[\s\S]+const mpvProbe = await window\.electronAPI\.mpvProbeMetadata\(item\.videoPath\);/);
@@ -221,12 +221,83 @@ test('aggregate comment clicks stop when playlist item load fails', () => {
   assert.notEqual(helperEnd, -1, 'aggregate comment open helper boundary should exist');
   const helperSource = appSource.slice(helperStart, helperEnd);
 
-  assert.match(helperSource, /const loaded = await loadVideoFromPlaylist\(item, \{[\s\S]+preserveContinuousSession: continuousPlaybackState\.active[\s\S]+\}\);/);
+  assert.match(helperSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+stopContinuousPlayback\(\);[\s\S]+\}/);
+  assert.match(helperSource, /const isCurrentNavigation = \(\) => \([\s\S]+navigationToken === playlistContinuousNavigationToken[\s\S]+\);/);
+  assert.match(helperSource, /const loaded = await loadVideoFromPlaylist\(item, \{[\s\S]+preserveContinuousSession: true[\s\S]+initialFrame: range\.localStartFrame \|\| 0[\s\S]+revealAfterInitialSeek: true[\s\S]+holdPreviousFrameUntilReady: true[\s\S]+shouldContinue: isCurrentNavigation[\s\S]+\}\);/);
   assert.match(helperSource, /if \(!loaded\) return;/);
   assert.ok(
     helperSource.indexOf('if (!loaded) return;') < helperSource.indexOf('videoPlayer.seekToFrame(range.localStartFrame || 0);'),
     'load failure guard should run before seeking'
   );
+});
+
+test('aggregate comment clicks cancel stale continuous navigation and hide first-frame flashes', () => {
+  const helperStart = appSource.indexOf('async function openPlaylistAggregateComment(key)');
+  const helperEnd = appSource.indexOf('  async function submitPlaylistAggregateReply', helperStart);
+  assert.notEqual(helperStart, -1, 'aggregate comment open helper should exist');
+  assert.notEqual(helperEnd, -1, 'aggregate comment open helper boundary should exist');
+  const helperSource = appSource.slice(helperStart, helperEnd);
+
+  assert.match(appSource, /let playlistContinuousNavigationToken = 0;/);
+  assert.match(helperSource, /const navigationToken = \+\+playlistContinuousNavigationToken;/);
+  assert.match(helperSource, /const isCurrentNavigation = \(\) =>[\s\S]+navigationToken === playlistContinuousNavigationToken/);
+  assert.match(helperSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+stopContinuousPlayback\(\);[\s\S]+\}/);
+  assert.match(helperSource, /initialFrame: range\.localStartFrame \|\| 0/);
+  assert.match(helperSource, /revealAfterInitialSeek: true/);
+  assert.match(helperSource, /holdPreviousFrameUntilReady: true/);
+  assert.match(helperSource, /preserveContinuousSession: true/);
+  assert.match(helperSource, /shouldContinue: isCurrentNavigation/);
+  assert.match(helperSource, /if \(!isCurrentNavigation\(\)\) return false;/);
+  assert.ok(
+    helperSource.indexOf('if (!isCurrentNavigation()) return false;') <
+      helperSource.indexOf('videoPlayer.seekToFrame(range.localStartFrame || 0);'),
+    'stale aggregate comment navigation must stop before the final seek/pause'
+  );
+});
+
+test('manual continuous timeline seeks restart active sessions and preserve the target frame', () => {
+  assert.match(appSource, /function restartContinuousPlaybackSessionForManualSeek\(\) \{/);
+
+  const seekStart = appSource.indexOf('async function seekContinuousTimeline(globalTime)');
+  const seekEnd = appSource.indexOf('  function stopContinuousPlayback', seekStart);
+  assert.notEqual(seekStart, -1, 'seekContinuousTimeline should exist');
+  assert.notEqual(seekEnd, -1, 'seekContinuousTimeline boundary should exist');
+  const seekSource = appSource.slice(seekStart, seekEnd);
+
+  assert.match(seekSource, /const navigationToken = \+\+playlistContinuousNavigationToken;/);
+  assert.match(seekSource, /const wasContinuousActive = continuousPlaybackState\.active === true;/);
+  assert.match(seekSource, /const shouldResumePlayback = videoPlayer\.isPlaying === true \|\| wasContinuousActive;/);
+  assert.match(seekSource, /const manualSessionId = wasContinuousActive[\s\S]+restartContinuousPlaybackSessionForManualSeek\(\)/);
+  assert.match(seekSource, /preserveContinuousSession: true/);
+  assert.match(seekSource, /initialFrame: targetFrame/);
+  assert.match(seekSource, /revealAfterInitialSeek: true/);
+  assert.match(seekSource, /holdPreviousFrameUntilReady: true/);
+  assert.match(seekSource, /shouldContinue: isCurrentNavigation/);
+  assert.match(seekSource, /if \(!isCurrentNavigation\(\)\) return false;/);
+  assert.match(seekSource, /if \(shouldResumePlayback\) \{[\s\S]+await playVideoAfterMediaLoad\(\{[\s\S]+silent: true/);
+  assert.ok(
+    seekSource.indexOf('if (!isCurrentNavigation()) return false;') <
+      seekSource.indexOf('videoPlayer.seek(mapped.localTime);'),
+    'stale manual timeline seeks must not move the player after a newer navigation'
+  );
+});
+
+test('continuous timeline maps current files with normalized Windows paths', () => {
+  const segmentStart = appSource.indexOf('function getCurrentContinuousSegment()');
+  const segmentEnd = appSource.indexOf('  function shouldIgnoreContinuousTimelineUpdateDuringSourceLoad', segmentStart);
+  assert.notEqual(segmentStart, -1, 'getCurrentContinuousSegment should exist');
+  assert.notEqual(segmentEnd, -1, 'getCurrentContinuousSegment boundary should exist');
+  const segmentSource = appSource.slice(segmentStart, segmentEnd);
+
+  assert.match(segmentSource, /isSameFilePath\(currentItem\?\.videoPath, state\.currentFile\)/);
+  assert.match(segmentSource, /items\.find\(item => isSameFilePath\(item\.videoPath, state\.currentFile\)\)/);
+  assert.doesNotMatch(segmentSource, /currentItem\?\.videoPath === state\.currentFile/);
+  assert.doesNotMatch(segmentSource, /item\.videoPath === state\.currentFile/);
+
+  const metadataMatch = appSource.match(/async function collectPlaylistMetadata\(items\) \{([\s\S]*?)\n  \}\n\n  async function updatePlaylistContinuousTimeline/);
+  assert.ok(metadataMatch, 'collectPlaylistMetadata should exist');
+  assert.match(metadataMatch[1], /isSameFilePath\(state\.currentFile, item\.videoPath\) && videoPlayer\.duration/);
+  assert.doesNotMatch(metadataMatch[1], /state\.currentFile === item\.videoPath/);
 });
 
 test('aggregate comment range rendering keeps the comment track header in sync', () => {

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -599,9 +599,12 @@ test('manual video loads cancel active continuous playback and stale loads', () 
   assert.match(appSource, /function invalidateActiveVideoLoad\(\) \{[\s\S]+supersedeActiveTranscodeOverlay\('재생목록 교체'\);[\s\S]+\}/);
   assert.match(loadVideoSource, /preserveContinuousSession = false/);
   assert.match(loadVideoSource, /const loadToken = \+\+latestVideoLoadToken;/);
+  assert.match(loadVideoSource, /shouldContinue = null/);
+  assert.match(loadVideoSource, /const shouldContinueVideoLoad = typeof shouldContinue === 'function'[\s\S]+: \(\) => true;/);
+  assert.match(loadVideoSource, /const canContinueVideoLoad = \(\) => !isStaleVideoLoad\(\) && shouldContinueVideoLoad\(\);/);
   assert.match(loadVideoSource, /if \(!preserveContinuousSession && continuousPlaybackState\.active\) \{[\s\S]+stopContinuousPlayback\(\);[\s\S]+\}/);
   assert.match(loadVideoSource, /const isStaleVideoLoad = \(\) => loadToken !== latestVideoLoadToken;/);
-  assert.match(loadVideoSource, /if \(isStaleVideoLoad\(\)\) return false;/);
+  assert.match(loadVideoSource, /if \(!canContinueVideoLoad\(\)\) return false;/);
 });
 
 test('rapid playlist item selections cannot let older pre-load checks win', () => {
@@ -623,9 +626,10 @@ test('rapid playlist item selections cannot let older pre-load checks win', () =
   assert.match(playlistLoaderSource, /if \(!canContinuePlaylistLoad\(\)\) return false;/);
   assert.ok(
     playlistLoaderSource.indexOf('if (!canContinuePlaylistLoad()) return false;') <
-      playlistLoaderSource.indexOf('const loaded = await loadVideo(item.videoPath, loadOptions);'),
+      playlistLoaderSource.indexOf('const loaded = await loadVideo(item.videoPath, {'),
     'stale playlist selections must stop before loadVideo can claim the latest load token'
   );
+  assert.match(playlistLoaderSource, /const loaded = await loadVideo\(item\.videoPath, \{[\s\S]+\.\.\.loadOptions,[\s\S]+shouldContinue: canContinuePlaylistLoad[\s\S]+\}\);/);
 });
 
 test('continuous completion flushes skipped batch before stopping playback', () => {
@@ -810,7 +814,7 @@ test('playlist loading returns the real loadVideo result', () => {
 
   const playlistLoaderSource = loadVideoFromPlaylistMatch[1];
   assert.match(playlistLoaderSource, /const \{ shouldContinue = null, \.\.\.loadOptions \} = options;/);
-  assert.match(playlistLoaderSource, /const loaded = await loadVideo\(item\.videoPath, loadOptions\);/);
+  assert.match(playlistLoaderSource, /const loaded = await loadVideo\(item\.videoPath, \{[\s\S]+\.\.\.loadOptions,[\s\S]+shouldContinue: canContinuePlaylistLoad[\s\S]+\}\);/);
   assert.match(playlistLoaderSource, /return loaded === true;/);
   assert.doesNotMatch(playlistLoaderSource, /await loadVideo\(item\.videoPath\);\s*return true;/);
 

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -239,9 +239,12 @@ test('aggregate comment clicks cancel stale continuous navigation and hide first
   const helperSource = appSource.slice(helperStart, helperEnd);
 
   assert.match(appSource, /let playlistContinuousNavigationToken = 0;/);
+  assert.match(appSource, /let activeVideoLoadPath = null;/);
+  assert.match(appSource, /function hasActiveVideoLoadForDifferentFile\(filePath\) \{[\s\S]+!isSameFilePath\(activeVideoLoadPath, filePath\);[\s\S]+\}/);
   assert.match(helperSource, /const navigationToken = \+\+playlistContinuousNavigationToken;/);
   assert.match(helperSource, /const isCurrentNavigation = \(\) =>[\s\S]+navigationToken === playlistContinuousNavigationToken/);
   assert.match(helperSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+stopContinuousPlayback\(\);[\s\S]+\}/);
+  assert.match(helperSource, /const isAlreadyLoaded = isSameFilePath\(state\.currentFile, item\.videoPath\) &&[\s\S]+!hasActiveVideoLoadForDifferentFile\(item\.videoPath\);/);
   assert.match(helperSource, /initialFrame: range\.localStartFrame \|\| 0/);
   assert.match(helperSource, /revealAfterInitialSeek: true/);
   assert.match(helperSource, /holdPreviousFrameUntilReady: true/);
@@ -268,6 +271,7 @@ test('manual continuous timeline seeks restart active sessions and preserve the 
   assert.match(seekSource, /const wasContinuousActive = continuousPlaybackState\.active === true;/);
   assert.match(seekSource, /const shouldResumePlayback = videoPlayer\.isPlaying === true \|\| wasContinuousActive;/);
   assert.match(seekSource, /const manualSessionId = wasContinuousActive[\s\S]+restartContinuousPlaybackSessionForManualSeek\(\)/);
+  assert.match(seekSource, /const isAlreadyLoaded = isSameFilePath\(state\.currentFile, item\.videoPath\) &&[\s\S]+!hasActiveVideoLoadForDifferentFile\(item\.videoPath\);/);
   assert.match(seekSource, /preserveContinuousSession: true/);
   assert.match(seekSource, /initialFrame: targetFrame/);
   assert.match(seekSource, /revealAfterInitialSeek: true/);
@@ -601,7 +605,11 @@ test('manual video loads cancel active continuous playback and stale loads', () 
   assert.match(loadVideoSource, /const loadToken = \+\+latestVideoLoadToken;/);
   assert.match(loadVideoSource, /shouldContinue = null/);
   assert.match(loadVideoSource, /const shouldContinueVideoLoad = typeof shouldContinue === 'function'[\s\S]+: \(\) => true;/);
-  assert.match(loadVideoSource, /const canContinueVideoLoad = \(\) => !isStaleVideoLoad\(\) && shouldContinueVideoLoad\(\);/);
+  assert.match(loadVideoSource, /let allowNavigationGuardAbort = true;/);
+  assert.match(loadVideoSource, /const canContinueVideoLoad = \(\) => \([\s\S]+!isStaleVideoLoad\(\) &&[\s\S]+\(!allowNavigationGuardAbort \|\| shouldContinueVideoLoad\(\)\)[\s\S]+\);/);
+  assert.match(loadVideoSource, /activeVideoLoadPath = filePath;/);
+  assert.match(loadVideoSource, /allowNavigationGuardAbort = false;[\s\S]+\/\/ ====== 이전 파일 감시 및 협업 세션 정리/);
+  assert.match(loadVideoSource, /finally \{[\s\S]+if \(loadToken === latestVideoLoadToken\) \{[\s\S]+activeVideoLoadPath = null;/);
   assert.match(loadVideoSource, /if \(!preserveContinuousSession && continuousPlaybackState\.active\) \{[\s\S]+stopContinuousPlayback\(\);[\s\S]+\}/);
   assert.match(loadVideoSource, /const isStaleVideoLoad = \(\) => loadToken !== latestVideoLoadToken;/);
   assert.match(loadVideoSource, /if \(!canContinueVideoLoad\(\)\) return false;/);


### PR DESCRIPTION
## 📋 업데이트 요약

- 💬 재생목록의 이어보기 화면에서 댓글을 눌렀을 때 엉뚱한 위치로 튀거나 이전 영상 화면이 잠깐 보이는 문제를 줄였습니다.
- ▶️ 재생목록 타임라인을 눌러 이어볼 때, 재생 위치와 영상 전환이 더 안정적으로 맞도록 보정했습니다.
- ⌨️ 버튼을 한 번 누른 뒤 스페이스바를 눌러도 버튼이 다시 눌리는 대신 영상 재생/일시정지가 되도록 고쳤습니다.
- 🪟 배프레임이 이미 켜져 있어도 `.bframe` 또는 `.bplaylist` 파일을 새로 열면 새 배프레임 창에서 열리도록 했습니다.
- 🔔 mpv 재생 화면 위에서도 저장/준비완료 같은 알림이 가려지지 않게 했습니다.
- ⚡ mpv 사용 시에는 재생 준비를 위해 불필요한 FFmpeg 변환 작업을 돌리지 않는 경로를 다시 확인했습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - `playlistContinuousNavigationToken`을 추가해 재생목록 댓글 이동과 수동 타임라인 이동 중 오래된 비동기 작업이 뒤늦게 플레이어 위치를 덮어쓰지 못하게 했습니다.
  - `openPlaylistAggregateComment()`에서 활성 이어보기 세션을 먼저 종료하고, `initialFrame`, `revealAfterInitialSeek`, `holdPreviousFrameUntilReady`, `shouldContinue`를 전달해 댓글 위치 이동 시 첫 프레임 깜빡임과 stale seek를 줄였습니다.
  - `seekContinuousTimeline()`에서 수동 이동 시 이어보기 세션 ID를 새로 발급하고, 목표 프레임을 먼저 맞춘 뒤 필요하면 재생을 재개하도록 정리했습니다.
  - `getCurrentContinuousSegment()`, `collectPlaylistMetadata()`, `startContinuousPlayback()`의 파일 비교를 직접 문자열 비교에서 `isSameFilePath()`로 바꿔 Windows 경로 표기 차이로 현재 컷을 못 찾는 문제를 막았습니다.
  - 스페이스바 재생/일시정지 단축키를 capture 단계에서 처리하고 keyup 기본 동작을 막아 focused button/checkbox가 다시 활성화되지 않게 했습니다.
  - `serializeMpvOverlayToastHtml()`을 추가해 DOM 토스트를 mpv 네이티브 오버레이 창으로 복제하고, 토스트 생성/갱신/정렬/닫힘 시 overlay sync를 강제로 예약했습니다.
- `main/mpv-overlay-host.js`
  - mpv overlay host에 `toastMirror` 레이어를 추가하고 `toastHtml` 상태를 정규화/반영하도록 했습니다.
- `main/instance-policy.js`
  - `.bframe`, `.bplaylist`, `baeframe://playlist/...` 같은 파일 실행 인자가 있으면 packaged 앱에서도 새 인스턴스를 허용하도록 했습니다.
- `package.json`, `scripts/tests/*`
  - 재생목록 테스트 묶음에 instance policy 테스트를 포함했습니다.
  - mpv 토스트 미러링, 스페이스바 keyup 억제, 이어보기 stale guard, Windows 경로 정규화, 파일 인자 새 인스턴스 정책을 소스 테스트로 추가했습니다.

## 🚧 개발 난항

- 증상이 하나로 보였지만 원인이 분리되어 있었습니다. 댓글 클릭, 타임라인 클릭, 다음 영상 자동 전환, 스페이스바 입력이 각각 다른 경로로 플레이어를 움직이고 있었습니다.
- 재생목록 이어보기는 “현재 세션이 아직 맞는지” 확인하지 않는 비동기 작업이 뒤늦게 돌아와 재생 위치를 되돌릴 수 있었습니다. 그래서 단순 seek 수정이 아니라 세션 토큰과 stale guard를 같이 넣었습니다.
- mpv 화면은 일반 DOM보다 위에 있는 네이티브 영상 창이라 z-index만 올려서는 알림이 보이지 않았습니다. 그래서 기존 mpv overlay host에 토스트 전용 미러 레이어를 추가했습니다.
- Windows에서는 같은 파일도 경로 표기가 조금 다를 수 있어 직접 문자열 비교가 불안정했습니다. 재생목록 현재 컷 판단은 기존 파일 경로 비교 헬퍼로 통일했습니다.

## ✅ 테스트 가이드

실사용자용

1. 배프레임을 켠 상태에서 `.bplaylist` 또는 `.bframe` 파일을 더블클릭해 새 창이 따로 뜨는지 확인합니다.
2. 재생목록에서 타임라인 이어보기를 켜고 댓글 바를 눌렀을 때 해당 댓글 위치로 바로 이동하는지 확인합니다.
3. 이어보기 타임라인의 다른 구간을 클릭해도 이전 영상 첫 장면이 잠깐 끼어들지 않는지 확인합니다.
4. 버튼을 누른 뒤 스페이스바를 눌러도 버튼이 다시 눌리지 않고 영상 재생/일시정지가 되는지 확인합니다.
5. 설정에서 mpv 재생을 켠 뒤, 재생 중 저장/준비완료 같은 알림이 영상 위에 보이는지 확인합니다.

개발자용

- `node --test scripts/tests/keyboard-shortcut-targets.test.js`
- `npm run test:mpv`
- `npm run test:playlist`
- `npm run test:comment-input`
- `npm run test:cluster`
- `npm run test:toast-stack`
- `npm run build`
- packaged smoke: `dist\win-unpacked\BFRAME_alpha_v2.exe` 실행 중 `.bplaylist` 파일 인자로 두 번째 실행, main process 2개 확인
