### PR TITLE
[v1.4.1] 재생목록 이어붙이기 전환 안정화

### DIFF
--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -12849,7 +12849,6 @@ async function initApp() {
 
   playbackSync.addEventListener('remotePause', (e) => {
     const { time, playlistContinuous } = e.detail;
-    videoPlayer.pause();
     if (playlistContinuous) {
       if (!canHandleRemoteContinuousSync()) {
         warnRemoteContinuousSyncUnavailable('pause', time);
@@ -12858,9 +12857,11 @@ async function initApp() {
       if (continuousPlaybackState.active) {
         stopContinuousPlayback();
       }
+      videoPlayer.pause();
       void seekContinuousTimeline(time, { resumePlayback: false });
       return;
     }
+    videoPlayer.pause();
     videoPlayer.seek(time);
   });
 
@@ -13279,6 +13280,16 @@ async function initApp() {
     return { time: localTime, options: {} };
   }
 
+  function getPlaylistContinuousSyncPositionForItem(item, localTime = videoPlayer.currentTime) {
+    if (playlistUIState.mode !== 'continuous' || !timeline.playlistDuration || !item?.id) return null;
+    const segment = timeline.playlistSegments?.find(candidate => candidate.itemId === item.id);
+    if (!segment) return null;
+    return {
+      time: mapLocalTimeToGlobal(segment, localTime),
+      options: { playlistContinuous: true }
+    };
+  }
+
   function broadcastCurrentPlaybackPause() {
     const position = getPlaybackSyncPosition(videoPlayer.currentTime);
     playbackSync.broadcastPause(position.time, position.options);
@@ -13289,7 +13300,21 @@ async function initApp() {
     playbackSync.broadcastPlay(position.time, position.options);
   }
 
-  function handleUserPlayPauseToggle() {
+  function broadcastPlaylistContinuousPlaybackPlay(item, localTime = videoPlayer.currentTime) {
+    const position = getPlaylistContinuousSyncPositionForItem(item, localTime);
+    if (!position) {
+      log.warn('타임라인 이어붙이기 재생 위치를 공유할 수 없습니다', {
+        itemId: item?.id || null,
+        filePath: item?.videoPath || null,
+        playlistDuration: timeline.playlistDuration,
+        localTime
+      });
+      return;
+    }
+    playbackSync.broadcastPlay(position.time, position.options);
+  }
+
+  async function handleUserPlayPauseToggle() {
     const wasPlaying = videoPlayer.isPlaying;
     if (wasPlaying) {
       if (continuousPlaybackState.active) {
@@ -13310,8 +13335,10 @@ async function initApp() {
     }
 
     if (shouldStartPlaylistContinuousAutoPlayback()) {
-      void startContinuousPlayback();
-      broadcastCurrentPlaybackPlay();
+      const startedItem = await startContinuousPlayback();
+      if (startedItem) {
+        broadcastPlaylistContinuousPlaybackPlay(startedItem, videoPlayer.currentTime);
+      }
       return;
     }
 
@@ -14015,7 +14042,7 @@ async function initApp() {
     const playlistManager = getPlaylistManager();
     if (!playlistManager.isActive() || playlistManager.isEmpty()) {
       showToast('재생목록에 영상을 먼저 추가해주세요.', 'warning');
-      return;
+      return null;
     }
 
     continuousPlaybackState.sessionId += 1;
@@ -14027,90 +14054,87 @@ async function initApp() {
 
     try {
       const currentItem = playlistManager.getCurrentItem() || selectPlaylistItemForContinuous(0);
-      if (!isContinuousSessionActive(sessionId)) return;
+      if (!isContinuousSessionActive(sessionId)) return null;
       if (!currentItem) {
         stopContinuousPlayback();
-        return;
+        return null;
       }
 
       const checked = await quickCheckPlaylistForContinuous(sessionId, [currentItem]);
-      if (!isContinuousSessionActive(sessionId) || !checked) return;
+      if (!isContinuousSessionActive(sessionId) || !checked) return null;
       const remainingItems = playlistManager.getItems().filter(item => item.id !== currentItem.id);
       if (remainingItems.length > 0) {
         void quickCheckPlaylistForContinuous(sessionId, remainingItems);
       }
 
       const ready = await waitForPreparedOrSkip(currentItem, sessionId);
-      if (!isContinuousSessionActive(sessionId)) return;
+      if (!isContinuousSessionActive(sessionId)) return null;
       if (!ready) {
-        await playNextContinuousItem(sessionId);
-        return;
+        return await playNextContinuousItem(sessionId);
       }
 
       const alreadyLoaded = isSameFilePath(state.currentFile, currentItem.videoPath);
       if (!alreadyLoaded) {
         const loaded = await loadContinuousPlaylistItem(currentItem, sessionId);
-        if (!isContinuousSessionActive(sessionId)) return;
+        if (!isContinuousSessionActive(sessionId)) return null;
         if (!loaded) {
-          await playNextContinuousItem(sessionId);
-          return;
+          return await playNextContinuousItem(sessionId);
         }
         videoPlayer.seekToFrame(0);
       }
-      if (!isContinuousSessionActive(sessionId)) return;
+      if (!isContinuousSessionActive(sessionId)) return null;
       prepareNextPlaylistItem(sessionId);
       const started = await playContinuousItemWithWatchdog(currentItem, sessionId);
-      if (!isContinuousSessionActive(sessionId)) return;
+      if (!isContinuousSessionActive(sessionId)) return null;
       if (!started) {
-        await playNextContinuousItem(sessionId);
-        return;
+        return await playNextContinuousItem(sessionId);
       }
+      return currentItem;
     } catch (error) {
-      if (!isContinuousSessionActive(sessionId)) return;
+      if (!isContinuousSessionActive(sessionId)) return null;
       log.warn('타임라인 이어붙이기 시작 실패', { error: error.message });
       stopContinuousPlayback();
       showToast('타임라인 이어붙이기를 시작할 수 없습니다.', 'error');
+      return null;
     }
   }
 
   async function playNextContinuousItem(sessionId) {
-    if (!isContinuousSessionActive(sessionId)) return;
+    if (!isContinuousSessionActive(sessionId)) return null;
     const playlistManager = getPlaylistManager();
     const items = playlistManager.getItems();
     const settings = playlistManager.getContinuousSettings();
     const nextIndex = findNextPlayableIndex(items, playlistManager.currentIndex, { loop: settings.loop });
 
     if (nextIndex < 0) {
-      if (!isContinuousSessionActive(sessionId)) return;
+      if (!isContinuousSessionActive(sessionId)) return null;
       flushSkippedToastBatch();
       stopContinuousPlayback();
       showToast('재생목록 재생 완료', 'success');
-      return;
+      return null;
     }
 
     const nextItem = selectPlaylistItemForContinuous(nextIndex);
-    if (!isContinuousSessionActive(sessionId)) return;
+    if (!isContinuousSessionActive(sessionId)) return null;
     const ready = await waitForPreparedOrSkip(nextItem, sessionId);
-    if (!isContinuousSessionActive(sessionId)) return;
+    if (!isContinuousSessionActive(sessionId)) return null;
     if (!ready) {
-      await playNextContinuousItem(sessionId);
-      return;
+      return await playNextContinuousItem(sessionId);
     }
 
     flushSkippedToastBatch();
     const loaded = await loadContinuousPlaylistItem(nextItem, sessionId);
-    if (!isContinuousSessionActive(sessionId)) return;
+    if (!isContinuousSessionActive(sessionId)) return null;
     if (!loaded) {
-      await playNextContinuousItem(sessionId);
-      return;
+      return await playNextContinuousItem(sessionId);
     }
     prepareNextPlaylistItem(sessionId);
     const started = await playContinuousItemWithWatchdog(nextItem, sessionId);
-    if (!isContinuousSessionActive(sessionId)) return;
+    if (!isContinuousSessionActive(sessionId)) return null;
     if (!started) {
-      await playNextContinuousItem(sessionId);
-      return;
+      return await playNextContinuousItem(sessionId);
     }
+    return nextItem;
   }
 
   function setPlaylistMode(mode) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -14047,10 +14047,13 @@ async function initApp() {
     if (advanced) return true;
 
     log.warn('연속 재생이 멈춘 상태라 다시 시도합니다', { fileName: item?.fileName });
-    await waitForContinuousDelay(40);
+    if (videoPlayer.isPlaying === true) {
+      videoPlayer.pause();
+      await waitForContinuousDelay(40);
+    }
     await waitForContinuousMediaReady(250);
     if (!isContinuousSessionActive(sessionId)) return false;
-    const retryStarted = videoPlayer.isPlaying === true || await videoPlayer.play();
+    const retryStarted = await videoPlayer.play();
     if (!isContinuousSessionActive(sessionId)) return false;
     if (!retryStarted && !videoPlayer.isPlaying) {
       markPlaylistItemStatus(item, CONTINUOUS_STATUS.ERROR, '건너뜀');

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -13270,8 +13270,13 @@ async function initApp() {
     );
   }
 
-  function getPlaybackSyncPosition(localTime = videoPlayer.currentTime) {
-    if (playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0) {
+  function getPlaybackSyncPosition(localTime = videoPlayer.currentTime, options = {}) {
+    const { forceContinuous = false } = options;
+    if (
+      (forceContinuous || continuousPlaybackState.active === true) &&
+      playlistUIState.mode === 'continuous' &&
+      timeline.playlistDuration > 0
+    ) {
       const segment = getCurrentContinuousSegment();
       if (!segment) return { time: localTime, options: {} };
       return {
@@ -13292,8 +13297,8 @@ async function initApp() {
     };
   }
 
-  function broadcastCurrentPlaybackPause() {
-    const position = getPlaybackSyncPosition(videoPlayer.currentTime);
+  function broadcastCurrentPlaybackPause(options = {}) {
+    const position = getPlaybackSyncPosition(videoPlayer.currentTime, options);
     playbackSync.broadcastPause(position.time, position.options);
   }
 
@@ -13319,12 +13324,19 @@ async function initApp() {
   async function handleUserPlayPauseToggle() {
     const wasPlaying = videoPlayer.isPlaying;
     if (wasPlaying) {
+      const continuousPausePosition = continuousPlaybackState.active
+        ? getPlaybackSyncPosition(videoPlayer.currentTime, { forceContinuous: true })
+        : null;
       if (continuousPlaybackState.active) {
         stopContinuousPlayback();
         invalidateActiveVideoLoad();
       }
       videoPlayer.togglePlay();
-      broadcastCurrentPlaybackPause();
+      if (continuousPausePosition) {
+        playbackSync.broadcastPause(continuousPausePosition.time, continuousPausePosition.options);
+      } else {
+        broadcastCurrentPlaybackPause();
+      }
       return;
     }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -12806,10 +12806,28 @@ async function initApp() {
     });
   }
 
+  function canHandleRemoteContinuousSync() {
+    return playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0;
+  }
+
+  function warnRemoteContinuousSyncUnavailable(action, time) {
+    log.warn('리모트 연속 재생 동기화를 처리할 수 없습니다', {
+      action,
+      time,
+      mode: playlistUIState.mode,
+      playlistDuration: timeline.playlistDuration
+    });
+    showToast('상대방의 재생목록 위치를 따라갈 수 없습니다.', 'warning');
+  }
+
   // 리모트 이벤트 수신 → 로컬 재생 제어
   playbackSync.addEventListener('remotePlay', (e) => {
     const { time, playlistContinuous } = e.detail;
-    if (playlistContinuous && playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0) {
+    if (playlistContinuous) {
+      if (!canHandleRemoteContinuousSync()) {
+        warnRemoteContinuousSyncUnavailable('play', time);
+        return;
+      }
       void (async () => {
         const followed = await seekContinuousTimeline(time);
         if (!followed) {
@@ -12832,7 +12850,11 @@ async function initApp() {
   playbackSync.addEventListener('remotePause', (e) => {
     const { time, playlistContinuous } = e.detail;
     videoPlayer.pause();
-    if (playlistContinuous && playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0) {
+    if (playlistContinuous) {
+      if (!canHandleRemoteContinuousSync()) {
+        warnRemoteContinuousSyncUnavailable('pause', time);
+        return;
+      }
       if (continuousPlaybackState.active) {
         stopContinuousPlayback();
       }
@@ -12844,7 +12866,11 @@ async function initApp() {
 
   playbackSync.addEventListener('remoteSeek', (e) => {
     const { time, playlistContinuous } = e.detail;
-    if (playlistContinuous && playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0) {
+    if (playlistContinuous) {
+      if (!canHandleRemoteContinuousSync()) {
+        warnRemoteContinuousSyncUnavailable('seek', time);
+        return;
+      }
       void seekContinuousTimeline(time);
       return;
     }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5851,6 +5851,11 @@ async function initApp() {
       }
     }
 
+    if (isStaleVideoLoad()) {
+      await cleanupPendingMpvPilot();
+      return false;
+    }
+
     mpvPilotHostPreparing = false;
     syncMpvHostVisibilityWithDom();
 
@@ -12826,7 +12831,7 @@ async function initApp() {
       if (continuousPlaybackState.active) {
         stopContinuousPlayback();
       }
-      void seekContinuousTimeline(time);
+      void seekContinuousTimeline(time, { resumePlayback: false });
       return;
     }
     videoPlayer.seek(time);
@@ -13315,7 +13320,8 @@ async function initApp() {
     return mapLocalTimeToGlobal(segment, localTime);
   }
 
-  async function seekContinuousTimeline(globalTime) {
+  async function seekContinuousTimeline(globalTime, options = {}) {
+    const { resumePlayback = true } = options;
     const playlistManager = getPlaylistManager();
     const mapped = mapGlobalTimeToSegment(timeline.playlistSegments, globalTime);
     if (!mapped) return false;
@@ -13323,7 +13329,7 @@ async function initApp() {
     const item = playlistManager.getItems()[mapped.segment.index];
     if (!item) return false;
     const wasContinuousActive = continuousPlaybackState.active === true;
-    const shouldResumePlayback = videoPlayer.isPlaying === true || wasContinuousActive;
+    const shouldResumePlayback = resumePlayback && (videoPlayer.isPlaying === true || wasContinuousActive);
     const manualSessionId = wasContinuousActive
       ? restartContinuousPlaybackSessionForManualSeek()
       : null;

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -359,6 +359,7 @@ async function initApp() {
     skippedBatch: [],
     preparePromises: new Map(),
     loadingItemId: null,
+    loadingSessionId: null,
     preparedMediaPaths: new Map(),
     sessionId: 0
   };
@@ -12856,6 +12857,7 @@ async function initApp() {
       }
       if (continuousPlaybackState.active) {
         stopContinuousPlayback();
+        invalidateActiveVideoLoad();
       }
       videoPlayer.pause();
       void seekContinuousTimeline(time, { resumePlayback: false });
@@ -13415,10 +13417,12 @@ async function initApp() {
       !hasActiveVideoLoadForDifferentFile(item.videoPath);
     const targetFrame = Math.max(0, Math.floor(mapped.localTime * (mapped.segment.fps || item.fps || videoPlayer.fps || 24)));
     const previousLoadingItemId = continuousPlaybackState.loadingItemId;
+    const previousLoadingSessionId = continuousPlaybackState.loadingSessionId;
     let setManualLoadingItem = false;
     try {
       if (!isAlreadyLoaded) {
         continuousPlaybackState.loadingItemId = item.id;
+        continuousPlaybackState.loadingSessionId = manualSessionId;
         setManualLoadingItem = true;
         const loaded = await loadVideoFromPlaylist(item, {
           preserveContinuousSession: true,
@@ -13440,8 +13444,13 @@ async function initApp() {
       updatePlaylistCurrentItem();
       updatePlaylistPosition();
     } finally {
-      if (setManualLoadingItem && continuousPlaybackState.loadingItemId === item.id) {
+      if (
+        setManualLoadingItem &&
+        continuousPlaybackState.loadingItemId === item.id &&
+        continuousPlaybackState.loadingSessionId === manualSessionId
+      ) {
         continuousPlaybackState.loadingItemId = previousLoadingItemId;
+        continuousPlaybackState.loadingSessionId = previousLoadingSessionId;
       }
     }
     if (manualSessionId !== null) {
@@ -13461,6 +13470,7 @@ async function initApp() {
     continuousPlaybackState.waiting = false;
     continuousPlaybackState.skippedBatch = [];
     continuousPlaybackState.loadingItemId = null;
+    continuousPlaybackState.loadingSessionId = null;
     continuousPlaybackState.preparePromises.clear();
     continuousPlaybackState.preparedMediaPaths.clear();
     clearPlaylistMediaPreload();
@@ -13844,6 +13854,7 @@ async function initApp() {
     if (!isContinuousSessionActive(sessionId)) return false;
 
     continuousPlaybackState.loadingItemId = item.id;
+    continuousPlaybackState.loadingSessionId = sessionId;
     try {
       prepareNextPlaylistItem(sessionId);
       const preparedVideoPath = continuousPlaybackState.preparedMediaPaths.get(item.id);
@@ -13863,7 +13874,13 @@ async function initApp() {
       }
       return true;
     } finally {
-      continuousPlaybackState.loadingItemId = null;
+      if (
+        continuousPlaybackState.loadingItemId === item.id &&
+        continuousPlaybackState.loadingSessionId === sessionId
+      ) {
+        continuousPlaybackState.loadingItemId = null;
+        continuousPlaybackState.loadingSessionId = null;
+      }
     }
   }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -13243,8 +13243,10 @@ async function initApp() {
 
   function getPlaybackSyncPosition(localTime = videoPlayer.currentTime) {
     if (playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0) {
+      const segment = getCurrentContinuousSegment();
+      if (!segment) return { time: localTime, options: {} };
       return {
-        time: getContinuousTimelinePlaybackTime(localTime),
+        time: mapLocalTimeToGlobal(segment, localTime),
         options: { playlistContinuous: true }
       };
     }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5320,7 +5320,7 @@ async function initApp() {
     const targetTime = frame / fps;
     videoPlayer.seekToFrame(frame);
     return waitForMpvPlaybackTime(targetTime, {
-      tolerance: Math.max(0.08, (1 / fps) * 2)
+      tolerance: Math.max(0.004, (1 / fps) * 0.45)
     });
   }
 
@@ -13341,10 +13341,11 @@ async function initApp() {
     }
 
     if (continuousPlaybackState.active) {
+      const continuousPausePosition = getPlaybackSyncPosition(videoPlayer.currentTime, { forceContinuous: true });
       stopContinuousPlayback();
       invalidateActiveVideoLoad();
       videoPlayer.pause();
-      broadcastCurrentPlaybackPause();
+      playbackSync.broadcastPause(continuousPausePosition.time, continuousPausePosition.options);
       return;
     }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5256,7 +5256,7 @@ async function initApp() {
     mpvHostVisibilitySyncPending = true;
     requestAnimationFrame(async () => {
       mpvHostVisibilitySyncPending = false;
-      const shouldShowMpvHost = !hasBlockingOverlayForMpv();
+      const shouldShowMpvHost = !mpvPilotHostPreparing && !hasBlockingOverlayForMpv();
       if (mpvHostLastRequestedVisible === shouldShowMpvHost) return;
 
       try {
@@ -5286,6 +5286,42 @@ async function initApp() {
   }
 
   installMpvBlockingOverlayObserver();
+
+  async function waitForMpvPlaybackTime(targetTime, { timeoutMs = 700, tolerance = 0.12 } = {}) {
+    if (!window.electronAPI?.mpvGetStatus) return false;
+    const target = Number(targetTime);
+    if (!Number.isFinite(target)) return false;
+
+    const startedAt = performance.now();
+    while (performance.now() - startedAt < timeoutMs) {
+      try {
+        const status = await window.electronAPI.mpvGetStatus();
+        const current = Number(status?.time);
+        if (status?.success && Number.isFinite(current) && Math.abs(current - target) <= tolerance) {
+          return true;
+        }
+      } catch (error) {
+        log.debug('mpv 초기 프레임 대기 실패', { error: error.message });
+        return false;
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    return false;
+  }
+
+  async function seekMpvInitialFrameBeforeReveal(initialFrame) {
+    const frame = Number(initialFrame);
+    if (!Number.isFinite(frame) || frame <= 0 || !videoPlayer.isLoaded) return false;
+
+    const fps = Math.max(1, Number(videoPlayer.fps) || 24);
+    const targetTime = frame / fps;
+    videoPlayer.seekToFrame(frame);
+    return waitForMpvPlaybackTime(targetTime, {
+      tolerance: Math.max(0.08, (1 / fps) * 2)
+    });
+  }
 
   function getMpvEmbedBounds() {
     syncMpvFullscreenViewportInset();
@@ -5802,16 +5838,21 @@ async function initApp() {
 
     elements.videoWrapper?.classList.add('mpv-pilot-mode');
     document.body.classList.add('mpv-pilot-mode');
-    mpvPilotHostPreparing = false;
-    syncMpvHostVisibilityWithDom();
     syncCanvasOverlay();
     syncMpvEmbedBounds();
     syncMpvVideoTransform();
     scheduleMpvOverlayStateSync();
 
     if (Number.isFinite(Number(initialFrame)) && Number(initialFrame) > 0) {
-      videoPlayer.seekToFrame(Number(initialFrame));
+      const initialSeekReady = await seekMpvInitialFrameBeforeReveal(initialFrame);
+      if (!initialSeekReady) {
+        log.debug('mpv 초기 프레임 확인 시간 초과, 호스트 공개 전 한 프레임 더 대기', { filePath, initialFrame });
+        await new Promise(resolve => requestAnimationFrame(resolve));
+      }
     }
+
+    mpvPilotHostPreparing = false;
+    syncMpvHostVisibilityWithDom();
 
     showToast(
       embedHost?.wid
@@ -6136,7 +6177,7 @@ async function initApp() {
           const shouldHoldVideoReveal = holdPreviousFrameUntilReady || shouldDelayVideoReveal;
           const previousVideoVisibility = elements.videoPlayer.style.visibility;
           const transitionFreezeCaptured = shouldHoldVideoReveal && captureVideoTransitionFreezeFrame();
-          const shouldHideVideoDuringLoad = shouldDelayVideoReveal || transitionFreezeCaptured;
+          const shouldHideVideoDuringLoad = shouldHoldVideoReveal;
           if (shouldHideVideoDuringLoad) {
             elements.videoPlayer.style.visibility = 'hidden';
           }
@@ -6170,7 +6211,7 @@ async function initApp() {
       elements.filePath.textContent = fileInfo.dir;
       elements.dropZone.classList.add('hidden');
 
-      if (playWhenMediaReady) {
+      if (playWhenMediaReady && shouldContinueVideoLoad()) {
         await playVideoAfterMediaLoad({ silent: true });
       }
 
@@ -12762,19 +12803,41 @@ async function initApp() {
 
   // 리모트 이벤트 수신 → 로컬 재생 제어
   playbackSync.addEventListener('remotePlay', (e) => {
-    const { time } = e.detail;
+    const { time, playlistContinuous } = e.detail;
+    if (playlistContinuous && playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0) {
+      void (async () => {
+        await seekContinuousTimeline(time);
+        if (!continuousPlaybackState.active) {
+          await startContinuousPlayback();
+          return;
+        }
+        await playVideoAfterMediaLoad({ silent: true, logContext: { remoteContinuousPlay: true } });
+      })();
+      return;
+    }
     videoPlayer.seek(time);
     videoPlayer.play();
   });
 
   playbackSync.addEventListener('remotePause', (e) => {
-    const { time } = e.detail;
+    const { time, playlistContinuous } = e.detail;
     videoPlayer.pause();
+    if (playlistContinuous && playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0) {
+      if (continuousPlaybackState.active) {
+        stopContinuousPlayback();
+      }
+      void seekContinuousTimeline(time);
+      return;
+    }
     videoPlayer.seek(time);
   });
 
   playbackSync.addEventListener('remoteSeek', (e) => {
-    const { time } = e.detail;
+    const { time, playlistContinuous } = e.detail;
+    if (playlistContinuous && playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0) {
+      void seekContinuousTimeline(time);
+      return;
+    }
     videoPlayer.seek(time);
   });
 
@@ -13074,11 +13137,24 @@ async function initApp() {
     media.load();
   }
 
-  function preloadPlaylistMediaForItem(item, options = {}) {
+  async function preloadPlaylistMediaForItem(item, options = {}) {
     const { continuous = false, sessionId = null } = options;
     if (!item?.videoPath) return;
     if (continuous && !isContinuousSessionActive(sessionId)) return;
     if (isSameFilePath(state.currentFile, item.videoPath)) return;
+    const useMpvPilot = await shouldUseMpvPilot(item.videoPath, {
+      fileIsAudio: isAudioFile(item.fileName || item.videoPath),
+      hasPreparedVideoPath: false
+    });
+    if (continuous && !isContinuousSessionActive(sessionId)) return;
+    if (isSameFilePath(state.currentFile, item.videoPath)) return;
+    if (useMpvPilot) {
+      log.debug('mpv 파일럿 재생목록 HTML 사전 로드 건너뜀', {
+        fileName: item.fileName,
+        continuous
+      });
+      return;
+    }
     if (
       playlistMediaPreload.itemId === item.id &&
       playlistMediaPreload.path === item.videoPath
@@ -13135,7 +13211,7 @@ async function initApp() {
       return;
     }
 
-    preloadPlaylistMediaForItem(nextItem);
+    void preloadPlaylistMediaForItem(nextItem);
   }
 
   function warmPlaylistAutoPlayQueue() {
@@ -13148,10 +13224,31 @@ async function initApp() {
     const playlistManager = getPlaylistManager();
     return (
       playlistUIState.mode === 'continuous' &&
+      !continuousPlaybackState.active &&
       playlistManager.isActive() &&
       userSettings.getPlaylistAutoPlay() &&
       !playlistManager.isEmpty()
     );
+  }
+
+  function getPlaybackSyncPosition(localTime = videoPlayer.currentTime) {
+    if (playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0) {
+      return {
+        time: getContinuousTimelinePlaybackTime(localTime),
+        options: { playlistContinuous: true }
+      };
+    }
+    return { time: localTime, options: {} };
+  }
+
+  function broadcastCurrentPlaybackPause() {
+    const position = getPlaybackSyncPosition(videoPlayer.currentTime);
+    playbackSync.broadcastPause(position.time, position.options);
+  }
+
+  function broadcastCurrentPlaybackPlay() {
+    const position = getPlaybackSyncPosition(videoPlayer.currentTime);
+    playbackSync.broadcastPlay(position.time, position.options);
   }
 
   function handleUserPlayPauseToggle() {
@@ -13159,21 +13256,30 @@ async function initApp() {
     if (wasPlaying) {
       if (continuousPlaybackState.active) {
         stopContinuousPlayback();
+        invalidateActiveVideoLoad();
       }
       videoPlayer.togglePlay();
-      playbackSync.broadcastPause(videoPlayer.currentTime);
+      broadcastCurrentPlaybackPause();
+      return;
+    }
+
+    if (continuousPlaybackState.active) {
+      stopContinuousPlayback();
+      invalidateActiveVideoLoad();
+      videoPlayer.pause();
+      broadcastCurrentPlaybackPause();
       return;
     }
 
     if (shouldStartPlaylistContinuousAutoPlayback()) {
       void startContinuousPlayback();
-      playbackSync.broadcastPlay(videoPlayer.currentTime);
+      broadcastCurrentPlaybackPlay();
       return;
     }
 
     warmPlaylistAutoPlayQueue();
     videoPlayer.togglePlay();
-    playbackSync.broadcastPlay(videoPlayer.currentTime);
+    broadcastCurrentPlaybackPlay();
   }
 
   // ============================================================================
@@ -13242,24 +13348,36 @@ async function initApp() {
     const isAlreadyLoaded = isSameFilePath(state.currentFile, item.videoPath) &&
       !hasActiveVideoLoadForDifferentFile(item.videoPath);
     const targetFrame = Math.max(0, Math.floor(mapped.localTime * (mapped.segment.fps || item.fps || videoPlayer.fps || 24)));
-    if (!isAlreadyLoaded) {
-      const loaded = await loadVideoFromPlaylist(item, {
-        preserveContinuousSession: true,
-        initialFrame: targetFrame,
-        revealAfterInitialSeek: true,
-        holdPreviousFrameUntilReady: true,
-        shouldContinue: isCurrentNavigation
-      });
-      if (!loaded) return false;
-      if (!isCurrentNavigation()) return false;
-    }
+    const previousLoadingItemId = continuousPlaybackState.loadingItemId;
+    let setManualLoadingItem = false;
+    try {
+      if (!isAlreadyLoaded) {
+        continuousPlaybackState.loadingItemId = item.id;
+        setManualLoadingItem = true;
+        const loaded = await loadVideoFromPlaylist(item, {
+          preserveContinuousSession: true,
+          initialFrame: targetFrame,
+          revealAfterInitialSeek: true,
+          holdPreviousFrameUntilReady: true,
+          shouldContinue: isCurrentNavigation
+        });
+        if (!loaded) return false;
+        if (!isCurrentNavigation()) return false;
+      }
 
-    if (!isCurrentNavigation()) return false;
-    videoPlayer.seek(mapped.localTime);
-    playbackSync.broadcastSeek(mapped.localTime);
-    timeline.setCurrentTime(mapLocalTimeToGlobal(mapped.segment, mapped.localTime));
-    updatePlaylistCurrentItem();
-    updatePlaylistPosition();
+      if (!isCurrentNavigation()) return false;
+      videoPlayer.seek(mapped.localTime);
+      playbackSync.broadcastSeek(mapLocalTimeToGlobal(mapped.segment, mapped.localTime), {
+        playlistContinuous: true
+      });
+      timeline.setCurrentTime(mapLocalTimeToGlobal(mapped.segment, mapped.localTime));
+      updatePlaylistCurrentItem();
+      updatePlaylistPosition();
+    } finally {
+      if (setManualLoadingItem && continuousPlaybackState.loadingItemId === item.id) {
+        continuousPlaybackState.loadingItemId = previousLoadingItemId;
+      }
+    }
     if (manualSessionId !== null) {
       prepareNextPlaylistItem(manualSessionId);
     }
@@ -13336,6 +13454,17 @@ async function initApp() {
     if (continuousPlaybackState.skippedBatch.length === 0) return;
     showToast(createSkippedToastMessage(continuousPlaybackState.skippedBatch), 'warning');
     continuousPlaybackState.skippedBatch = [];
+  }
+
+  async function canReusePreparedContinuousItem(item) {
+    if (!item || item.continuousStatus !== CONTINUOUS_STATUS.READY) return false;
+    if (continuousPlaybackState.preparedMediaPaths.has(item.id)) return true;
+
+    const useMpvPilot = await shouldUseMpvPilot(item.videoPath, {
+      fileIsAudio: isAudioFile(item.fileName || item.videoPath),
+      hasPreparedVideoPath: false
+    });
+    return useMpvPilot === true;
   }
 
   async function collectPlaylistMetadata(items) {
@@ -13504,8 +13633,11 @@ async function initApp() {
       return existingPrepare.promise;
     }
 
-    if (item.continuousStatus === CONTINUOUS_STATUS.READY) {
+    if (item.continuousStatus === CONTINUOUS_STATUS.READY && await canReusePreparedContinuousItem(item)) {
       return { ready: true, cached: true };
+    }
+    if (item.continuousStatus === CONTINUOUS_STATUS.READY) {
+      markPlaylistItemStatus(item, CONTINUOUS_STATUS.IDLE, '');
     }
 
     if ([
@@ -13594,15 +13726,19 @@ async function initApp() {
     const settings = playlistManager.getContinuousSettings();
     const nextIndex = findNextPlayableIndex(items, playlistManager.currentIndex, { loop: settings.loop });
     if (nextIndex >= 0) {
-      preloadPlaylistMediaForItem(items[nextIndex], { continuous: true, sessionId });
+      void preloadPlaylistMediaForItem(items[nextIndex], { continuous: true, sessionId });
       preparePlaylistItemInBackground(items[nextIndex], sessionId);
     }
   }
 
   async function waitForPreparedOrSkip(item, sessionId) {
     if (!isContinuousSessionActive(sessionId)) return false;
-    if (item?.continuousStatus === CONTINUOUS_STATUS.READY) {
+    if (!item) return false;
+    if (item?.continuousStatus === CONTINUOUS_STATUS.READY && await canReusePreparedContinuousItem(item)) {
       return true;
+    }
+    if (item?.continuousStatus === CONTINUOUS_STATUS.READY) {
+      markPlaylistItemStatus(item, CONTINUOUS_STATUS.IDLE, '');
     }
     if ([
       CONTINUOUS_STATUS.MISSING,
@@ -13792,7 +13928,10 @@ async function initApp() {
   async function playContinuousItemWithWatchdog(item, sessionId) {
     if (!isContinuousSessionActive(sessionId)) return false;
 
-    const started = await videoPlayer.play();
+    let started = videoPlayer.isPlaying === true;
+    if (!started) {
+      started = await videoPlayer.play();
+    }
     if (!isContinuousSessionActive(sessionId)) return false;
     if (!started && !videoPlayer.isPlaying) {
       await waitForContinuousMediaReady(250);
@@ -13812,11 +13951,10 @@ async function initApp() {
     if (advanced) return true;
 
     log.warn('연속 재생이 멈춘 상태라 다시 시도합니다', { fileName: item?.fileName });
-    videoPlayer.pause();
     await waitForContinuousDelay(40);
     await waitForContinuousMediaReady(250);
     if (!isContinuousSessionActive(sessionId)) return false;
-    const retryStarted = await videoPlayer.play();
+    const retryStarted = videoPlayer.isPlaying === true || await videoPlayer.play();
     if (!isContinuousSessionActive(sessionId)) return false;
     if (!retryStarted && !videoPlayer.isPlaying) {
       markPlaylistItemStatus(item, CONTINUOUS_STATUS.ERROR, '건너뜀');

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -12811,7 +12811,12 @@ async function initApp() {
     const { time, playlistContinuous } = e.detail;
     if (playlistContinuous && playlistUIState.mode === 'continuous' && timeline.playlistDuration > 0) {
       void (async () => {
-        await seekContinuousTimeline(time);
+        const followed = await seekContinuousTimeline(time);
+        if (!followed) {
+          log.warn('리모트 연속 재생 위치를 따라갈 수 없습니다', { time });
+          showToast('상대방의 재생목록 위치를 따라갈 수 없습니다.', 'warning');
+          return;
+        }
         if (!continuousPlaybackState.active) {
           await startContinuousPlayback();
           return;

--- a/renderer/scripts/modules/playback-sync.js
+++ b/renderer/scripts/modules/playback-sync.js
@@ -40,7 +40,7 @@ export class PlaybackSync extends EventTarget {
 
     // 탐색 쓰로틀
     this._seekThrottleTimer = null;
-    this._pendingSeekTime = null;
+    this._pendingSeekEvent = null;
     this._seekThrottleMs = 100;
 
     // 이벤트 핸들러 바인딩
@@ -68,6 +68,7 @@ export class PlaybackSync extends EventTarget {
       clearTimeout(this._seekThrottleTimer);
       this._seekThrottleTimer = null;
     }
+    this._pendingSeekEvent = null;
     if (this._remoteUpdateTimer) {
       clearTimeout(this._remoteUpdateTimer);
       this._remoteUpdateTimer = null;
@@ -111,26 +112,26 @@ export class PlaybackSync extends EventTarget {
   // 로컬 → 리모트 (브로드캐스트 송신)
   // ============================================================================
 
-  broadcastPlay(time) {
+  broadcastPlay(time, options = {}) {
     if (!this._canSend()) return;
-    this._lm.broadcastEvent({ type: `${PREFIX}PLAY`, time });
+    this._lm.broadcastEvent({ type: `${PREFIX}PLAY`, time, ...options });
     log.info('재생 브로드캐스트', { time });
   }
 
-  broadcastPause(time) {
+  broadcastPause(time, options = {}) {
     if (!this._canSend()) return;
-    this._lm.broadcastEvent({ type: `${PREFIX}PAUSE`, time });
+    this._lm.broadcastEvent({ type: `${PREFIX}PAUSE`, time, ...options });
     log.info('일시정지 브로드캐스트', { time });
   }
 
-  broadcastSeek(time) {
+  broadcastSeek(time, options = {}) {
     if (!this._canSend()) return;
-    this._pendingSeekTime = time;
+    this._pendingSeekEvent = { time, ...options };
     if (!this._seekThrottleTimer) {
       this._flushSeek();
       this._seekThrottleTimer = setTimeout(() => {
         this._seekThrottleTimer = null;
-        if (this._pendingSeekTime !== null) {
+        if (this._pendingSeekEvent !== null) {
           this._flushSeek();
         }
       }, this._seekThrottleMs);
@@ -138,15 +139,15 @@ export class PlaybackSync extends EventTarget {
   }
 
   _flushSeek() {
-    if (this._pendingSeekTime === null) return;
+    if (this._pendingSeekEvent === null) return;
     // 쓰로틀 대기 중 동기화 해제/follow 전환 등 대비 재검증
     if (!this._canSend()) {
-      this._pendingSeekTime = null;
+      this._pendingSeekEvent = null;
       return;
     }
-    const time = this._pendingSeekTime;
-    this._pendingSeekTime = null;
-    this._lm.broadcastEvent({ type: `${PREFIX}SEEK`, time });
+    const event = this._pendingSeekEvent;
+    this._pendingSeekEvent = null;
+    this._lm.broadcastEvent({ type: `${PREFIX}SEEK`, ...event });
   }
 
   // ============================================================================
@@ -168,7 +169,7 @@ export class PlaybackSync extends EventTarget {
         log.info('리모트 재생 수신', { time: event.time });
         this._setRemoteGuard();
         this.dispatchEvent(new CustomEvent('remotePlay', {
-          detail: { time: event.time }
+          detail: { time: event.time, playlistContinuous: event.playlistContinuous === true }
         }));
         break;
 
@@ -176,7 +177,7 @@ export class PlaybackSync extends EventTarget {
         log.info('리모트 일시정지 수신', { time: event.time });
         this._setRemoteGuard();
         this.dispatchEvent(new CustomEvent('remotePause', {
-          detail: { time: event.time }
+          detail: { time: event.time, playlistContinuous: event.playlistContinuous === true }
         }));
         break;
 
@@ -184,7 +185,7 @@ export class PlaybackSync extends EventTarget {
         log.info('리모트 탐색 수신', { time: event.time });
         this._setRemoteGuard();
         this.dispatchEvent(new CustomEvent('remoteSeek', {
-          detail: { time: event.time }
+          detail: { time: event.time, playlistContinuous: event.playlistContinuous === true }
         }));
         break;
     }

--- a/scripts/tests/cutlist-runtime-source.test.js
+++ b/scripts/tests/cutlist-runtime-source.test.js
@@ -228,7 +228,7 @@ test('cutlist hidden source switches hold the previous frame instead of flashing
   assert.match(appSource, /drawImage\(video,\s*0,\s*0,\s*canvas\.width,\s*canvas\.height\)/);
   assert.match(appSource, /const shouldHoldVideoReveal = holdPreviousFrameUntilReady \|\| shouldDelayVideoReveal/);
   assert.match(appSource, /const transitionFreezeCaptured = shouldHoldVideoReveal && captureVideoTransitionFreezeFrame\(\)/);
-  assert.match(appSource, /const shouldHideVideoDuringLoad = shouldDelayVideoReveal \|\| transitionFreezeCaptured/);
+  assert.match(appSource, /const shouldHideVideoDuringLoad = shouldHoldVideoReveal/);
   assert.match(appSource, /releaseVideoTransitionFreezeFrame\(transitionFreezeCaptured\)/);
   assert.match(mainStyles, /\.video-transition-freeze-canvas/);
   assert.match(mainStyles, /z-index:\s*1/);

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -216,6 +216,7 @@ test('mpv pilot waits for the requested initial frame before revealing the nativ
 
   assert.match(appSource, /async function waitForMpvPlaybackTime\(targetTime, \{ timeoutMs = 700, tolerance = 0\.12 \} = \{\}\)/);
   assert.match(appSource, /async function seekMpvInitialFrameBeforeReveal\(initialFrame\)/);
+  assert.match(appSource, /tolerance: Math\.max\(0\.004, \(1 \/ fps\) \* 0\.45\)/);
   assert.match(loadMpvSource, /const initialSeekReady = await seekMpvInitialFrameBeforeReveal\(initialFrame\);/);
   assert.match(loadMpvSource, /if \(!initialSeekReady\) \{[\s\S]+requestAnimationFrame\(resolve\)/);
   const initialSeekIndex = loadMpvSource.indexOf('const initialSeekReady = await seekMpvInitialFrameBeforeReveal(initialFrame);');

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -200,13 +200,35 @@ test('mpv pilot hides native host while DOM blocking overlays are open', () => {
   assert.match(appSource, /let mpvPilotHostPreparing = false;/);
   assert.match(appSource, /function didMpvHostVisibilityApply\(result, shouldShowMpvHost\) \{[\s\S]+if \(!result\?\.success\) return false;[\s\S]+if \(shouldShowMpvHost\) return true;[\s\S]+return result\.embed\?\.ready === true && result\.overlay\?\.ready === true;/);
   assert.match(appSource, /function forceMpvHostVisibilitySync\(\) \{[\s\S]+mpvHostLastRequestedVisible = null;[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+\}/);
-  assert.match(appSource, /function syncMpvHostVisibilityWithDom\(\) \{[\s\S]+if \(!mpvPilotHostPreparing && !document\.body\.classList\.contains\('mpv-pilot-mode'\)\) return;[\s\S]+const shouldShowMpvHost = !hasBlockingOverlayForMpv\(\);[\s\S]+window\.electronAPI\.mpvSetHostVisible\(shouldShowMpvHost\);[\s\S]+didMpvHostVisibilityApply\(result, shouldShowMpvHost\)/);
+  assert.match(appSource, /function syncMpvHostVisibilityWithDom\(\) \{[\s\S]+if \(!mpvPilotHostPreparing && !document\.body\.classList\.contains\('mpv-pilot-mode'\)\) return;[\s\S]+const shouldShowMpvHost = !mpvPilotHostPreparing && !hasBlockingOverlayForMpv\(\);[\s\S]+window\.electronAPI\.mpvSetHostVisible\(shouldShowMpvHost\);[\s\S]+didMpvHostVisibilityApply\(result, shouldShowMpvHost\)/);
   assert.match(appSource, /function installMpvBlockingOverlayObserver\(\) \{[\s\S]+new MutationObserver\(\(mutations\) => \{[\s\S]+if \(!mpvPilotHostPreparing && !document\.body\.classList\.contains\('mpv-pilot-mode'\)\) return;[\s\S]+syncMpvHostVisibilityWithDom\(\);[\s\S]+\}\);[\s\S]+attributeFilter: \['class', 'style', 'hidden'\]/);
   assert.match(appSource, /installMpvBlockingOverlayObserver\(\);/);
   assert.match(appSource, /async function prepareMpvEmbedHost\(\) \{[\s\S]+if \(result\?\.success && result\.wid\) \{[\s\S]+forceMpvHostVisibilitySync\(\);[\s\S]+return result;/);
   assert.match(appSource, /async function prepareMpvOverlayHost\(\) \{[\s\S]+if \(result\?\.success\) \{[\s\S]+forceMpvHostVisibilitySync\(\);[\s\S]+return result;/);
   assert.match(appSource, /videoPlayer\.addEventListener\('externalstopped', \(\) => \{[\s\S]+mpvHostLastRequestedVisible = null;/);
   assert.match(appSource, /async function stopMpvPilotEngine\(\) \{[\s\S]+finally \{[\s\S]+mpvHostLastRequestedVisible = null;/);
+});
+
+test('mpv pilot waits for the requested initial frame before revealing the native host', () => {
+  const loadMpvMatch = appSource.match(/async function loadVideoWithMpvPilot\(filePath, \{([\s\S]*?)\n  \}\n\n  async function resolveMpvThumbnailVideoPath/);
+  assert.ok(loadMpvMatch, 'loadVideoWithMpvPilot should exist');
+  const loadMpvSource = loadMpvMatch[1];
+
+  assert.match(appSource, /async function waitForMpvPlaybackTime\(targetTime, \{ timeoutMs = 700, tolerance = 0\.12 \} = \{\}\)/);
+  assert.match(appSource, /async function seekMpvInitialFrameBeforeReveal\(initialFrame\)/);
+  assert.match(loadMpvSource, /const initialSeekReady = await seekMpvInitialFrameBeforeReveal\(initialFrame\);/);
+  assert.match(loadMpvSource, /if \(!initialSeekReady\) \{[\s\S]+requestAnimationFrame\(resolve\)/);
+  const initialSeekIndex = loadMpvSource.indexOf('const initialSeekReady = await seekMpvInitialFrameBeforeReveal(initialFrame);');
+  const revealReadyIndex = loadMpvSource.indexOf('mpvPilotHostPreparing = false;', initialSeekIndex);
+  const visibilitySyncIndex = loadMpvSource.indexOf('syncMpvHostVisibilityWithDom();', revealReadyIndex);
+  assert.ok(
+    initialSeekIndex < revealReadyIndex,
+    'the mpv host should stay hidden until the initial seek has been requested and observed'
+  );
+  assert.ok(
+    revealReadyIndex < visibilitySyncIndex,
+    'mpv visibility should be synced only after preparation is marked complete'
+  );
 });
 
 test('mpv pilot routes audio and viewport controls through mpv IPC', () => {

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -219,8 +219,14 @@ test('mpv pilot waits for the requested initial frame before revealing the nativ
   assert.match(loadMpvSource, /const initialSeekReady = await seekMpvInitialFrameBeforeReveal\(initialFrame\);/);
   assert.match(loadMpvSource, /if \(!initialSeekReady\) \{[\s\S]+requestAnimationFrame\(resolve\)/);
   const initialSeekIndex = loadMpvSource.indexOf('const initialSeekReady = await seekMpvInitialFrameBeforeReveal(initialFrame);');
+  const staleRecheckIndex = loadMpvSource.indexOf('if (isStaleVideoLoad()) {', initialSeekIndex);
   const revealReadyIndex = loadMpvSource.indexOf('mpvPilotHostPreparing = false;', initialSeekIndex);
   const visibilitySyncIndex = loadMpvSource.indexOf('syncMpvHostVisibilityWithDom();', revealReadyIndex);
+  assert.match(loadMpvSource, /if \(isStaleVideoLoad\(\)\) \{[\s\S]+await cleanupPendingMpvPilot\(\);[\s\S]+return false;[\s\S]+\}/);
+  assert.ok(
+    initialSeekIndex < staleRecheckIndex && staleRecheckIndex < revealReadyIndex,
+    'stale mpv loads should be cleaned up after initial-frame waits and before host reveal'
+  );
   assert.ok(
     initialSeekIndex < revealReadyIndex,
     'the mpv host should stay hidden until the initial seek has been requested and observed'

--- a/scripts/tests/playlist-autoplay-source.test.js
+++ b/scripts/tests/playlist-autoplay-source.test.js
@@ -49,7 +49,8 @@ test('playlist panel close hides the panel without clearing the active playlist'
 test('starting playback warms the next autoplay item for button and spacebar playback', () => {
   assert.match(appSource, /function warmPlaylistAutoPlayQueue\(\) \{[\s\S]*?playlistManager\.isActive\(\)[\s\S]*?userSettings\.getPlaylistAutoPlay\(\)[\s\S]*?preloadNextPlaylistMedia\(\);[\s\S]*?\}/);
   assert.match(appSource, /function shouldStartPlaylistContinuousAutoPlayback\(\) \{[\s\S]*?playlistUIState\.mode === 'continuous'[\s\S]*?userSettings\.getPlaylistAutoPlay\(\)[\s\S]*?\}/);
-  assert.match(appSource, /function handleUserPlayPauseToggle\(\) \{[\s\S]*?void startContinuousPlayback\(\);[\s\S]*?warmPlaylistAutoPlayQueue\(\);[\s\S]*?\}/);
+  assert.match(appSource, /async function handleUserPlayPauseToggle\(\) \{[\s\S]*?const startedItem = await startContinuousPlayback\(\);[\s\S]*?broadcastPlaylistContinuousPlaybackPlay\(startedItem, videoPlayer\.currentTime\);[\s\S]*?warmPlaylistAutoPlayQueue\(\);[\s\S]*?\}/);
+  assert.doesNotMatch(appSource, /void startContinuousPlayback\(\);[\s\S]*?broadcastCurrentPlaybackPlay\(\);/);
 
   assert.match(appSource, /elements\.btnPlay\.addEventListener\('click', handleUserPlayPauseToggle\);/);
 

--- a/scripts/tests/playlist-autoplay-source.test.js
+++ b/scripts/tests/playlist-autoplay-source.test.js
@@ -63,8 +63,10 @@ test('continuous playlist playback starts immediately before falling back to rea
   const watchdogMatch = appSource.match(/async function playContinuousItemWithWatchdog\(item, sessionId\) \{([\s\S]*?)\n  \}\n\n  async function startContinuousPlayback/);
   assert.ok(watchdogMatch, 'continuous playback watchdog should exist');
   const watchdogSource = watchdogMatch[1];
+  assert.match(watchdogSource, /let started = videoPlayer\.isPlaying === true;/);
+  assert.match(watchdogSource, /if \(!started\) \{[\s\S]+started = await videoPlayer\.play\(\);[\s\S]+\}/);
   assert.ok(
-    watchdogSource.indexOf('const started = await videoPlayer.play();') <
+    watchdogSource.indexOf('started = await videoPlayer.play();') <
       watchdogSource.indexOf('await waitForContinuousMediaReady(250);'),
     'play should be attempted before waiting for canplay/loadeddata'
   );

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -915,9 +915,14 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(playbackSyncSource, /this\._pendingSeekEvent = \{ time, \.\.\.options \};/);
   assert.match(playbackSyncSource, /this\._lm\.broadcastEvent\(\{ type: `\$\{PREFIX\}SEEK`, \.\.\.event \}\);/);
   assert.match(playbackSyncSource, /detail: \{ time: event\.time, playlistContinuous: event\.playlistContinuous === true \}/);
+  assert.match(appSource, /function canHandleRemoteContinuousSync\(\) \{[\s\S]+playlistUIState\.mode === 'continuous' && timeline\.playlistDuration > 0;[\s\S]+\}/);
+  assert.match(appSource, /function warnRemoteContinuousSyncUnavailable\(action, time\) \{[\s\S]+상대방의 재생목록 위치를 따라갈 수 없습니다\./);
   assert.match(appSource, /playbackSync\.addEventListener\('remotePlay', \(e\) => \{[\s\S]+const followed = await seekContinuousTimeline\(time\);[\s\S]+if \(!followed\) \{[\s\S]+상대방의 재생목록 위치를 따라갈 수 없습니다\.[\s\S]+return;[\s\S]+\}[\s\S]+if \(!continuousPlaybackState\.active\) \{[\s\S]+await startContinuousPlayback\(\);/);
+  assert.match(appSource, /playbackSync\.addEventListener\('remotePlay', \(e\) => \{[\s\S]+if \(playlistContinuous\) \{[\s\S]+if \(!canHandleRemoteContinuousSync\(\)\) \{[\s\S]+warnRemoteContinuousSyncUnavailable\('play', time\);[\s\S]+return;[\s\S]+\}/);
   assert.match(appSource, /playbackSync\.addEventListener\('remotePause', \(e\) => \{[\s\S]+seekContinuousTimeline\(time, \{ resumePlayback: false \}\);/);
+  assert.match(appSource, /playbackSync\.addEventListener\('remotePause', \(e\) => \{[\s\S]+if \(playlistContinuous\) \{[\s\S]+if \(!canHandleRemoteContinuousSync\(\)\) \{[\s\S]+warnRemoteContinuousSyncUnavailable\('pause', time\);[\s\S]+return;[\s\S]+\}/);
   assert.match(appSource, /playbackSync\.addEventListener\('remoteSeek', \(e\) => \{[\s\S]+const \{ time, playlistContinuous \} = e\.detail;[\s\S]+seekContinuousTimeline\(time\);/);
+  assert.match(appSource, /playbackSync\.addEventListener\('remoteSeek', \(e\) => \{[\s\S]+if \(playlistContinuous\) \{[\s\S]+if \(!canHandleRemoteContinuousSync\(\)\) \{[\s\S]+warnRemoteContinuousSyncUnavailable\('seek', time\);[\s\S]+return;[\s\S]+\}/);
 });
 
 test('playlist segment boundaries navigate through timeline seek', () => {

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -8,6 +8,7 @@ const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
 const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
 const timelineSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/timeline.js'), 'utf8'));
 const playlistManagerSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/playlist-manager.js'), 'utf8'));
+const playbackSyncSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/playback-sync.js'), 'utf8'));
 const ffmpegManagerSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'main/ffmpeg-manager.js'), 'utf8'));
 const preloadSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'preload/preload.js'), 'utf8'));
 const splitViewSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/split-view-manager.js'), 'utf8'));
@@ -286,6 +287,28 @@ test('manual continuous timeline seeks restart active sessions and preserve the 
   );
 });
 
+test('manual continuous timeline seeks suppress zero-time updates while cross-file loads settle', () => {
+  const seekStart = appSource.indexOf('async function seekContinuousTimeline(globalTime)');
+  const seekEnd = appSource.indexOf('  function resetContinuousPlaybackRuntimeState', seekStart);
+  assert.notEqual(seekStart, -1, 'seekContinuousTimeline should exist');
+  assert.notEqual(seekEnd, -1, 'seekContinuousTimeline boundary should exist');
+  const seekSource = appSource.slice(seekStart, seekEnd);
+
+  assert.match(seekSource, /const previousLoadingItemId = continuousPlaybackState\.loadingItemId;/);
+  assert.match(seekSource, /continuousPlaybackState\.loadingItemId = item\.id;/);
+  assert.match(seekSource, /const loaded = await loadVideoFromPlaylist\(item, \{[\s\S]+holdPreviousFrameUntilReady: true[\s\S]+\}\);/);
+  assert.ok(
+    seekSource.indexOf('continuousPlaybackState.loadingItemId = item.id;') <
+      seekSource.indexOf('const loaded = await loadVideoFromPlaylist(item, {'),
+    'manual seek should mark the loading item before the async cross-file load starts'
+  );
+  assert.ok(
+    seekSource.indexOf('timeline.setCurrentTime(mapLocalTimeToGlobal(mapped.segment, mapped.localTime));') <
+      seekSource.indexOf('continuousPlaybackState.loadingItemId = previousLoadingItemId;'),
+    'manual seek should keep zero-time suppression active until the target global playhead is restored'
+  );
+});
+
 test('continuous timeline maps current files with normalized Windows paths', () => {
   const segmentStart = appSource.indexOf('function getCurrentContinuousSegment()');
   const segmentEnd = appSource.indexOf('  function shouldIgnoreContinuousTimelineUpdateDuringSourceLoad', segmentStart);
@@ -453,12 +476,18 @@ test('open dialog exposes saved playlist files', () => {
 test('continuous playback verifies that native playback actually advances', () => {
   assert.match(appSource, /function waitForContinuousPlaybackAdvance\(sessionId/);
   assert.match(appSource, /async function playContinuousItemWithWatchdog\(item, sessionId\)/);
-  assert.match(appSource, /await videoPlayer\.play\(\)/);
+  assert.match(appSource, /let started = videoPlayer\.isPlaying === true;/);
+  assert.match(appSource, /if \(!started\) \{[\s\S]+started = await videoPlayer\.play\(\);[\s\S]+\}/);
   assert.match(appSource, /waitForContinuousPlaybackAdvance\(sessionId/);
   assert.match(appSource, /연속 재생이 멈춘 상태라 다시 시도합니다/);
   assert.match(appSource, /showToast\('영상을 재생할 수 없어 다음 영상으로 넘어갑니다\.', 'warning'\)/);
   assert.match(appSource, /const started = await playContinuousItemWithWatchdog\(currentItem, sessionId\);[\s\S]+if \(!started\) \{[\s\S]+await playNextContinuousItem\(sessionId\);/);
   assert.match(appSource, /const started = await playContinuousItemWithWatchdog\(nextItem, sessionId\);[\s\S]+if \(!started\) \{[\s\S]+await playNextContinuousItem\(sessionId\);/);
+
+  const watchdogMatch = appSource.match(/async function playContinuousItemWithWatchdog\(item, sessionId\) \{([\s\S]*?)\n  \}\n\n  async function startContinuousPlayback/);
+  assert.ok(watchdogMatch, 'playContinuousItemWithWatchdog should exist');
+  assert.doesNotMatch(watchdogMatch[1], /videoPlayer\.pause\(\)/);
+  assert.match(watchdogMatch[1], /const retryStarted = videoPlayer\.isPlaying === true \|\| await videoPlayer\.play\(\);/);
 });
 
 test('continuous playback watchdog uses VideoPlayer state for external engines', () => {
@@ -513,9 +542,31 @@ test('continuous mode keeps timeline tools separate from autoplay control', () =
   assert.doesNotMatch(appSource, /btnPlaylistContinuousPlay/);
 });
 
-test('prepared continuous items skip redundant preparation checks at cut boundaries', () => {
-  assert.match(appSource, /if \(item\?\.continuousStatus === CONTINUOUS_STATUS\.READY\) \{[\s\S]+return true;[\s\S]+\}/);
-  assert.match(appSource, /if \(item\.continuousStatus === CONTINUOUS_STATUS\.READY\) \{[\s\S]+return \{ ready: true, cached: true \};[\s\S]+\}/);
+test('spacebar pauses an active continuous handoff instead of starting a duplicate session', () => {
+  const shouldStartMatch = appSource.match(/function shouldStartPlaylistContinuousAutoPlayback\(\) \{([\s\S]*?)\n  \}/);
+  assert.ok(shouldStartMatch, 'continuous autoplay start predicate should exist');
+  assert.match(shouldStartMatch[1], /!continuousPlaybackState\.active/);
+
+  const handleMatch = appSource.match(/function handleUserPlayPauseToggle\(\) \{([\s\S]*?)\n  \}/);
+  assert.ok(handleMatch, 'play/pause toggle handler should exist');
+  const handleSource = handleMatch[1];
+  assert.match(handleSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+stopContinuousPlayback\(\);[\s\S]+invalidateActiveVideoLoad\(\);[\s\S]+videoPlayer\.pause\(\);[\s\S]+broadcastCurrentPlaybackPause\(\);[\s\S]+return;/);
+  assert.ok(
+    handleSource.indexOf('if (continuousPlaybackState.active)') <
+      handleSource.indexOf('if (shouldStartPlaylistContinuousAutoPlayback())'),
+    'active continuous handoffs should be cancelled before the handler can start a new session'
+  );
+});
+
+test('prepared continuous items are reused only when a prepared path or mpv path is still valid', () => {
+  assert.match(appSource, /async function canReusePreparedContinuousItem\(item\) \{/);
+  assert.match(appSource, /continuousPlaybackState\.preparedMediaPaths\.has\(item\.id\)/);
+  assert.match(appSource, /const useMpvPilot = await shouldUseMpvPilot\(item\.videoPath/);
+  assert.match(appSource, /if \(item\?\.continuousStatus === CONTINUOUS_STATUS\.READY && await canReusePreparedContinuousItem\(item\)\) \{[\s\S]+return true;[\s\S]+\}/);
+  assert.match(appSource, /if \(!item\) return false;/);
+  assert.match(appSource, /if \(item\.continuousStatus === CONTINUOUS_STATUS\.READY && await canReusePreparedContinuousItem\(item\)\) \{[\s\S]+return \{ ready: true, cached: true \};[\s\S]+\}/);
+  assert.match(appSource, /if \(item\?\.continuousStatus === CONTINUOUS_STATUS\.READY\) \{[\s\S]+markPlaylistItemStatus\(item, CONTINUOUS_STATUS\.IDLE, ''\);[\s\S]+\}/);
+  assert.match(appSource, /if \(item\.continuousStatus === CONTINUOUS_STATUS\.READY\) \{[\s\S]+markPlaylistItemStatus\(item, CONTINUOUS_STATUS\.IDLE, ''\);[\s\S]+\}/);
 });
 
 test('continuous playback starts next-item preparation before playback watchdog waits', () => {
@@ -613,6 +664,8 @@ test('manual video loads cancel active continuous playback and stale loads', () 
   assert.match(loadVideoSource, /if \(!preserveContinuousSession && continuousPlaybackState\.active\) \{[\s\S]+stopContinuousPlayback\(\);[\s\S]+\}/);
   assert.match(loadVideoSource, /const isStaleVideoLoad = \(\) => loadToken !== latestVideoLoadToken;/);
   assert.match(loadVideoSource, /if \(!canContinueVideoLoad\(\)\) return false;/);
+  assert.match(loadVideoSource, /if \(playWhenMediaReady && shouldContinueVideoLoad\(\)\) \{[\s\S]+await playVideoAfterMediaLoad\(\{ silent: true \}\);[\s\S]+\}/);
+  assert.doesNotMatch(loadVideoSource, /if \(playWhenMediaReady\) \{\s*\n\s*await playVideoAfterMediaLoad\(\{ silent: true \}\);/);
 });
 
 test('rapid playlist item selections cannot let older pre-load checks win', () => {
@@ -779,18 +832,28 @@ test('continuous source switches suppress stale zero-time timeline updates', () 
   assert.match(continuousLoadMatch[1], /finally \{[\s\S]*continuousPlaybackState\.loadingItemId = null/);
 });
 
-test('continuous playback warms the next source with the hidden playlist preload video', () => {
-  assert.match(appSource, /function preloadPlaylistMediaForItem\(item, options = \{\}\)/);
+test('continuous playback skips hidden HTML preload for mpv pilot items', () => {
+  assert.match(appSource, /async function preloadPlaylistMediaForItem\(item, options = \{\}\)/);
+  const preloadMatch = appSource.match(/async function preloadPlaylistMediaForItem\(item, options = \{\}\) \{([\s\S]*?)\n  \}\n\n  function preloadNextPlaylistMedia/);
+  assert.ok(preloadMatch, 'playlist preload helper should exist');
+  const preloadSource = preloadMatch[1];
+  assert.match(preloadSource, /const useMpvPilot = await shouldUseMpvPilot\(item\.videoPath/);
+  assert.match(preloadSource, /if \(isSameFilePath\(state\.currentFile, item\.videoPath\)\) return;/);
+  assert.match(preloadSource, /if \(useMpvPilot\) \{[\s\S]+mpv 파일럿 재생목록 HTML 사전 로드 건너뜀[\s\S]+return;[\s\S]+\}/);
+  assert.ok(
+    preloadSource.indexOf('if (useMpvPilot)') < preloadSource.indexOf('media.src = toLocalMediaUrl(item.videoPath);'),
+    'mpv pilot items should not be routed through the hidden Chromium video preload path'
+  );
 
   const prepareNextMatch = appSource.match(/function prepareNextPlaylistItem\(sessionId\) \{([\s\S]*?)\n  \}\n\n  async function waitForPreparedOrSkip/);
   assert.ok(prepareNextMatch, 'prepareNextPlaylistItem should exist');
   const prepareNextSource = prepareNextMatch[1];
 
-  assert.match(prepareNextSource, /preloadPlaylistMediaForItem\(items\[nextIndex\], \{[\s\S]*continuous: true,[\s\S]*sessionId[\s\S]*\}\);/);
+  assert.match(prepareNextSource, /void preloadPlaylistMediaForItem\(items\[nextIndex\], \{[\s\S]*continuous: true,[\s\S]*sessionId[\s\S]*\}\);/);
   assert.ok(
-    prepareNextSource.indexOf('preloadPlaylistMediaForItem(items[nextIndex]') <
+    prepareNextSource.indexOf('void preloadPlaylistMediaForItem(items[nextIndex]') <
       prepareNextSource.indexOf('preparePlaylistItemInBackground(items[nextIndex], sessionId);'),
-    'hidden media preload should start before background preparation'
+    'eligible hidden media preload should start before background preparation'
   );
 });
 
@@ -835,6 +898,8 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(appSource, /mapGlobalTimeToSegment[\s\S]+mapLocalTimeToGlobal[\s\S]+from '\.\/modules\/playlist-continuous-core\.js'/);
   assert.match(appSource, /function getContinuousTimelinePlaybackTime\(localTime = videoPlayer\.currentTime\)/);
   assert.match(appSource, /mapLocalTimeToGlobal\(segment, localTime\)/);
+  assert.match(appSource, /function getPlaybackSyncPosition\(localTime = videoPlayer\.currentTime\)/);
+  assert.match(appSource, /options: \{ playlistContinuous: true \}/);
   assert.match(appSource, /function getActiveTimelinePlaybackTime\(currentTime = videoPlayer\.currentTime,\s*currentFrame = videoPlayer\.currentFrame\)/);
   assert.match(appSource, /playlistUIState\.mode === 'continuous'[\s\S]+return getContinuousTimelinePlaybackTime\(currentTime\);/);
   assert.match(appSource, /timeline\.setCurrentTime\(getActiveTimelinePlaybackTime\(currentTime,\s*currentFrame\)\);/);
@@ -842,6 +907,13 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(appSource, /async function seekContinuousTimeline\(globalTime\)/);
   assert.match(appSource, /mapGlobalTimeToSegment\(timeline\.playlistSegments, globalTime\)/);
   assert.match(appSource, /videoPlayer\.seek\(mapped\.localTime\);/);
+  assert.match(appSource, /playbackSync\.broadcastSeek\(mapLocalTimeToGlobal\(mapped\.segment, mapped\.localTime\), \{[\s\S]+playlistContinuous: true[\s\S]+\}\);/);
+  assert.match(playbackSyncSource, /broadcastSeek\(time, options = \{\}\)/);
+  assert.match(playbackSyncSource, /this\._pendingSeekEvent = \{ time, \.\.\.options \};/);
+  assert.match(playbackSyncSource, /this\._lm\.broadcastEvent\(\{ type: `\$\{PREFIX\}SEEK`, \.\.\.event \}\);/);
+  assert.match(playbackSyncSource, /detail: \{ time: event\.time, playlistContinuous: event\.playlistContinuous === true \}/);
+  assert.match(appSource, /playbackSync\.addEventListener\('remotePlay', \(e\) => \{[\s\S]+await seekContinuousTimeline\(time\);[\s\S]+if \(!continuousPlaybackState\.active\) \{[\s\S]+await startContinuousPlayback\(\);/);
+  assert.match(appSource, /playbackSync\.addEventListener\('remoteSeek', \(e\) => \{[\s\S]+const \{ time, playlistContinuous \} = e\.detail;[\s\S]+seekContinuousTimeline\(time\);/);
 });
 
 test('playlist segment boundaries navigate through timeline seek', () => {

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -899,6 +899,8 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(appSource, /function getContinuousTimelinePlaybackTime\(localTime = videoPlayer\.currentTime\)/);
   assert.match(appSource, /mapLocalTimeToGlobal\(segment, localTime\)/);
   assert.match(appSource, /function getPlaybackSyncPosition\(localTime = videoPlayer\.currentTime\)/);
+  assert.match(appSource, /const segment = getCurrentContinuousSegment\(\);[\s\S]+if \(!segment\) return \{ time: localTime, options: \{\} \};/);
+  assert.match(appSource, /time: mapLocalTimeToGlobal\(segment, localTime\)/);
   assert.match(appSource, /options: \{ playlistContinuous: true \}/);
   assert.match(appSource, /function getActiveTimelinePlaybackTime\(currentTime = videoPlayer\.currentTime,\s*currentFrame = videoPlayer\.currentFrame\)/);
   assert.match(appSource, /playlistUIState\.mode === 'continuous'[\s\S]+return getContinuousTimelinePlaybackTime\(currentTime\);/);

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -554,6 +554,8 @@ test('spacebar pauses an active continuous handoff instead of starting a duplica
   const handleMatch = appSource.match(/async function handleUserPlayPauseToggle\(\) \{([\s\S]*?)\n  \}/);
   assert.ok(handleMatch, 'play/pause toggle handler should exist');
   const handleSource = handleMatch[1];
+  assert.match(handleSource, /const continuousPausePosition = continuousPlaybackState\.active[\s\S]+getPlaybackSyncPosition\(videoPlayer\.currentTime, \{ forceContinuous: true \}\)/);
+  assert.match(handleSource, /playbackSync\.broadcastPause\(continuousPausePosition\.time, continuousPausePosition\.options\);/);
   assert.match(handleSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+stopContinuousPlayback\(\);[\s\S]+invalidateActiveVideoLoad\(\);[\s\S]+videoPlayer\.pause\(\);[\s\S]+broadcastCurrentPlaybackPause\(\);[\s\S]+return;/);
   assert.match(handleSource, /const startedItem = await startContinuousPlayback\(\);[\s\S]+broadcastPlaylistContinuousPlaybackPlay\(startedItem, videoPlayer\.currentTime\);/);
   assert.doesNotMatch(handleSource, /void startContinuousPlayback\(\);[\s\S]+broadcastCurrentPlaybackPlay\(\);/);
@@ -911,7 +913,9 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(appSource, /mapGlobalTimeToSegment[\s\S]+mapLocalTimeToGlobal[\s\S]+from '\.\/modules\/playlist-continuous-core\.js'/);
   assert.match(appSource, /function getContinuousTimelinePlaybackTime\(localTime = videoPlayer\.currentTime\)/);
   assert.match(appSource, /mapLocalTimeToGlobal\(segment, localTime\)/);
-  assert.match(appSource, /function getPlaybackSyncPosition\(localTime = videoPlayer\.currentTime\)/);
+  assert.match(appSource, /function getPlaybackSyncPosition\(localTime = videoPlayer\.currentTime, options = \{\}\)/);
+  assert.match(appSource, /const \{ forceContinuous = false \} = options;/);
+  assert.match(appSource, /\(forceContinuous \|\| continuousPlaybackState\.active === true\) &&[\s\S]+playlistUIState\.mode === 'continuous'/);
   assert.match(appSource, /const segment = getCurrentContinuousSegment\(\);[\s\S]+if \(!segment\) return \{ time: localTime, options: \{\} \};/);
   assert.match(appSource, /time: mapLocalTimeToGlobal\(segment, localTime\)/);
   assert.match(appSource, /options: \{ playlistContinuous: true \}/);

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -556,7 +556,7 @@ test('spacebar pauses an active continuous handoff instead of starting a duplica
   const handleSource = handleMatch[1];
   assert.match(handleSource, /const continuousPausePosition = continuousPlaybackState\.active[\s\S]+getPlaybackSyncPosition\(videoPlayer\.currentTime, \{ forceContinuous: true \}\)/);
   assert.match(handleSource, /playbackSync\.broadcastPause\(continuousPausePosition\.time, continuousPausePosition\.options\);/);
-  assert.match(handleSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+stopContinuousPlayback\(\);[\s\S]+invalidateActiveVideoLoad\(\);[\s\S]+videoPlayer\.pause\(\);[\s\S]+broadcastCurrentPlaybackPause\(\);[\s\S]+return;/);
+  assert.match(handleSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+const continuousPausePosition = getPlaybackSyncPosition\(videoPlayer\.currentTime, \{ forceContinuous: true \}\);[\s\S]+stopContinuousPlayback\(\);[\s\S]+invalidateActiveVideoLoad\(\);[\s\S]+videoPlayer\.pause\(\);[\s\S]+playbackSync\.broadcastPause\(continuousPausePosition\.time, continuousPausePosition\.options\);[\s\S]+return;/);
   assert.match(handleSource, /const startedItem = await startContinuousPlayback\(\);[\s\S]+broadcastPlaylistContinuousPlaybackPlay\(startedItem, videoPlayer\.currentTime\);/);
   assert.doesNotMatch(handleSource, /void startContinuousPlayback\(\);[\s\S]+broadcastCurrentPlaybackPlay\(\);/);
   assert.ok(

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -295,7 +295,9 @@ test('manual continuous timeline seeks suppress zero-time updates while cross-fi
   const seekSource = appSource.slice(seekStart, seekEnd);
 
   assert.match(seekSource, /const previousLoadingItemId = continuousPlaybackState\.loadingItemId;/);
+  assert.match(seekSource, /const previousLoadingSessionId = continuousPlaybackState\.loadingSessionId;/);
   assert.match(seekSource, /continuousPlaybackState\.loadingItemId = item\.id;/);
+  assert.match(seekSource, /continuousPlaybackState\.loadingSessionId = manualSessionId;/);
   assert.match(seekSource, /const loaded = await loadVideoFromPlaylist\(item, \{[\s\S]+holdPreviousFrameUntilReady: true[\s\S]+\}\);/);
   assert.ok(
     seekSource.indexOf('continuousPlaybackState.loadingItemId = item.id;') <
@@ -307,6 +309,8 @@ test('manual continuous timeline seeks suppress zero-time updates while cross-fi
       seekSource.indexOf('continuousPlaybackState.loadingItemId = previousLoadingItemId;'),
     'manual seek should keep zero-time suppression active until the target global playhead is restored'
   );
+  assert.match(seekSource, /continuousPlaybackState\.loadingItemId === item\.id &&[\s\S]+continuousPlaybackState\.loadingSessionId === manualSessionId/);
+  assert.match(seekSource, /continuousPlaybackState\.loadingSessionId = previousLoadingSessionId;/);
 });
 
 test('continuous timeline maps current files with normalized Windows paths', () => {
@@ -822,6 +826,7 @@ test('continuous playlist starts playback as soon as the next media is renderabl
 
 test('continuous source switches suppress stale zero-time timeline updates', () => {
   assert.match(appSource, /loadingItemId:\s*null/);
+  assert.match(appSource, /loadingSessionId:\s*null/);
   assert.match(appSource, /function shouldIgnoreContinuousTimelineUpdateDuringSourceLoad\(\)/);
 
   const timeupdateMatch = appSource.match(/videoPlayer\.addEventListener\('timeupdate', \(e\) => \{([\s\S]*?)\n  \}\);/);
@@ -835,7 +840,9 @@ test('continuous source switches suppress stale zero-time timeline updates', () 
   const continuousLoadMatch = appSource.match(/async function loadContinuousPlaylistItem\(item, sessionId\) \{([\s\S]*?)\n  \}\n\n  function waitForContinuousDelay/);
   assert.ok(continuousLoadMatch, 'continuous playlist loader should exist');
   assert.match(continuousLoadMatch[1], /continuousPlaybackState\.loadingItemId = item\.id/);
-  assert.match(continuousLoadMatch[1], /finally \{[\s\S]*continuousPlaybackState\.loadingItemId = null/);
+  assert.match(continuousLoadMatch[1], /continuousPlaybackState\.loadingSessionId = sessionId/);
+  assert.match(continuousLoadMatch[1], /finally \{[\s\S]*continuousPlaybackState\.loadingItemId === item\.id &&[\s\S]*continuousPlaybackState\.loadingSessionId === sessionId[\s\S]*continuousPlaybackState\.loadingItemId = null/);
+  assert.match(continuousLoadMatch[1], /continuousPlaybackState\.loadingSessionId = null/);
 });
 
 test('continuous playback skips hidden HTML preload for mpv pilot items', () => {
@@ -933,6 +940,7 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(appSource, /playbackSync\.addEventListener\('remotePause', \(e\) => \{[\s\S]+if \(playlistContinuous\) \{[\s\S]+if \(!canHandleRemoteContinuousSync\(\)\) \{[\s\S]+warnRemoteContinuousSyncUnavailable\('pause', time\);[\s\S]+return;[\s\S]+\}/);
   const remotePauseMatch = appSource.match(/playbackSync\.addEventListener\('remotePause', \(e\) => \{([\s\S]*?)\n  \}\);/);
   assert.ok(remotePauseMatch, 'remotePause handler should exist');
+  assert.match(remotePauseMatch[1], /stopContinuousPlayback\(\);[\s\S]+invalidateActiveVideoLoad\(\);/);
   assert.ok(
     remotePauseMatch[1].indexOf('if (!canHandleRemoteContinuousSync())') <
       remotePauseMatch[1].indexOf('videoPlayer.pause();'),

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -547,10 +547,12 @@ test('spacebar pauses an active continuous handoff instead of starting a duplica
   assert.ok(shouldStartMatch, 'continuous autoplay start predicate should exist');
   assert.match(shouldStartMatch[1], /!continuousPlaybackState\.active/);
 
-  const handleMatch = appSource.match(/function handleUserPlayPauseToggle\(\) \{([\s\S]*?)\n  \}/);
+  const handleMatch = appSource.match(/async function handleUserPlayPauseToggle\(\) \{([\s\S]*?)\n  \}/);
   assert.ok(handleMatch, 'play/pause toggle handler should exist');
   const handleSource = handleMatch[1];
   assert.match(handleSource, /if \(continuousPlaybackState\.active\) \{[\s\S]+stopContinuousPlayback\(\);[\s\S]+invalidateActiveVideoLoad\(\);[\s\S]+videoPlayer\.pause\(\);[\s\S]+broadcastCurrentPlaybackPause\(\);[\s\S]+return;/);
+  assert.match(handleSource, /const startedItem = await startContinuousPlayback\(\);[\s\S]+broadcastPlaylistContinuousPlaybackPlay\(startedItem, videoPlayer\.currentTime\);/);
+  assert.doesNotMatch(handleSource, /void startContinuousPlayback\(\);[\s\S]+broadcastCurrentPlaybackPlay\(\);/);
   assert.ok(
     handleSource.indexOf('if (continuousPlaybackState.active)') <
       handleSource.indexOf('if (shouldStartPlaylistContinuousAutoPlayback())'),
@@ -578,6 +580,8 @@ test('continuous playback starts next-item preparation before playback watchdog 
       startSource.indexOf('const started = await playContinuousItemWithWatchdog(currentItem, sessionId);'),
     'next item preparation should begin before playback watchdog waits'
   );
+  assert.match(startSource, /return await playNextContinuousItem\(sessionId\);/);
+  assert.match(startSource, /return currentItem;/);
 
   const nextMatch = appSource.match(/async function playNextContinuousItem\(sessionId\) \{([\s\S]*?)\n  \}\n\n  function setPlaylistMode/);
   assert.ok(nextMatch, 'playNextContinuousItem should exist');
@@ -587,6 +591,8 @@ test('continuous playback starts next-item preparation before playback watchdog 
       nextSource.indexOf('const started = await playContinuousItemWithWatchdog(nextItem, sessionId);'),
     'following item preparation should begin before playback watchdog waits'
   );
+  assert.match(nextSource, /return await playNextContinuousItem\(sessionId\);/);
+  assert.match(nextSource, /return nextItem;/);
 });
 
 test('continuous video loads preserve aggregate timeline comment ranges', () => {
@@ -902,6 +908,10 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(appSource, /const segment = getCurrentContinuousSegment\(\);[\s\S]+if \(!segment\) return \{ time: localTime, options: \{\} \};/);
   assert.match(appSource, /time: mapLocalTimeToGlobal\(segment, localTime\)/);
   assert.match(appSource, /options: \{ playlistContinuous: true \}/);
+  assert.match(appSource, /function getPlaylistContinuousSyncPositionForItem\(item, localTime = videoPlayer\.currentTime\)/);
+  assert.match(appSource, /timeline\.playlistSegments\?\.find\(candidate => candidate\.itemId === item\.id\)/);
+  assert.match(appSource, /function broadcastPlaylistContinuousPlaybackPlay\(item, localTime = videoPlayer\.currentTime\)/);
+  assert.match(appSource, /playbackSync\.broadcastPlay\(position\.time, position\.options\);/);
   assert.match(appSource, /function getActiveTimelinePlaybackTime\(currentTime = videoPlayer\.currentTime,\s*currentFrame = videoPlayer\.currentFrame\)/);
   assert.match(appSource, /playlistUIState\.mode === 'continuous'[\s\S]+return getContinuousTimelinePlaybackTime\(currentTime\);/);
   assert.match(appSource, /timeline\.setCurrentTime\(getActiveTimelinePlaybackTime\(currentTime,\s*currentFrame\)\);/);
@@ -921,6 +931,13 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(appSource, /playbackSync\.addEventListener\('remotePlay', \(e\) => \{[\s\S]+if \(playlistContinuous\) \{[\s\S]+if \(!canHandleRemoteContinuousSync\(\)\) \{[\s\S]+warnRemoteContinuousSyncUnavailable\('play', time\);[\s\S]+return;[\s\S]+\}/);
   assert.match(appSource, /playbackSync\.addEventListener\('remotePause', \(e\) => \{[\s\S]+seekContinuousTimeline\(time, \{ resumePlayback: false \}\);/);
   assert.match(appSource, /playbackSync\.addEventListener\('remotePause', \(e\) => \{[\s\S]+if \(playlistContinuous\) \{[\s\S]+if \(!canHandleRemoteContinuousSync\(\)\) \{[\s\S]+warnRemoteContinuousSyncUnavailable\('pause', time\);[\s\S]+return;[\s\S]+\}/);
+  const remotePauseMatch = appSource.match(/playbackSync\.addEventListener\('remotePause', \(e\) => \{([\s\S]*?)\n  \}\);/);
+  assert.ok(remotePauseMatch, 'remotePause handler should exist');
+  assert.ok(
+    remotePauseMatch[1].indexOf('if (!canHandleRemoteContinuousSync())') <
+      remotePauseMatch[1].indexOf('videoPlayer.pause();'),
+    'unhandled continuous pause should return before touching local playback'
+  );
   assert.match(appSource, /playbackSync\.addEventListener\('remoteSeek', \(e\) => \{[\s\S]+const \{ time, playlistContinuous \} = e\.detail;[\s\S]+seekContinuousTimeline\(time\);/);
   assert.match(appSource, /playbackSync\.addEventListener\('remoteSeek', \(e\) => \{[\s\S]+if \(playlistContinuous\) \{[\s\S]+if \(!canHandleRemoteContinuousSync\(\)\) \{[\s\S]+warnRemoteContinuousSyncUnavailable\('seek', time\);[\s\S]+return;[\s\S]+\}/);
 });

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -913,7 +913,7 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(playbackSyncSource, /this\._pendingSeekEvent = \{ time, \.\.\.options \};/);
   assert.match(playbackSyncSource, /this\._lm\.broadcastEvent\(\{ type: `\$\{PREFIX\}SEEK`, \.\.\.event \}\);/);
   assert.match(playbackSyncSource, /detail: \{ time: event\.time, playlistContinuous: event\.playlistContinuous === true \}/);
-  assert.match(appSource, /playbackSync\.addEventListener\('remotePlay', \(e\) => \{[\s\S]+await seekContinuousTimeline\(time\);[\s\S]+if \(!continuousPlaybackState\.active\) \{[\s\S]+await startContinuousPlayback\(\);/);
+  assert.match(appSource, /playbackSync\.addEventListener\('remotePlay', \(e\) => \{[\s\S]+const followed = await seekContinuousTimeline\(time\);[\s\S]+if \(!followed\) \{[\s\S]+상대방의 재생목록 위치를 따라갈 수 없습니다\.[\s\S]+return;[\s\S]+\}[\s\S]+if \(!continuousPlaybackState\.active\) \{[\s\S]+await startContinuousPlayback\(\);/);
   assert.match(appSource, /playbackSync\.addEventListener\('remotePause', \(e\) => \{[\s\S]+seekContinuousTimeline\(time, \{ resumePlayback: false \}\);/);
   assert.match(appSource, /playbackSync\.addEventListener\('remoteSeek', \(e\) => \{[\s\S]+const \{ time, playlistContinuous \} = e\.detail;[\s\S]+seekContinuousTimeline\(time\);/);
 });

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -490,8 +490,13 @@ test('continuous playback verifies that native playback actually advances', () =
 
   const watchdogMatch = appSource.match(/async function playContinuousItemWithWatchdog\(item, sessionId\) \{([\s\S]*?)\n  \}\n\n  async function startContinuousPlayback/);
   assert.ok(watchdogMatch, 'playContinuousItemWithWatchdog should exist');
-  assert.doesNotMatch(watchdogMatch[1], /videoPlayer\.pause\(\)/);
-  assert.match(watchdogMatch[1], /const retryStarted = videoPlayer\.isPlaying === true \|\| await videoPlayer\.play\(\);/);
+  assert.match(watchdogMatch[1], /if \(videoPlayer\.isPlaying === true\) \{[\s\S]+videoPlayer\.pause\(\);[\s\S]+await waitForContinuousDelay\(40\);[\s\S]+\}/);
+  assert.match(watchdogMatch[1], /const retryStarted = await videoPlayer\.play\(\);/);
+  assert.ok(
+    watchdogMatch[1].indexOf('videoPlayer.pause();') <
+      watchdogMatch[1].indexOf('const retryStarted = await videoPlayer.play();'),
+    'stalled playback should be paused before retrying play'
+  );
 });
 
 test('continuous playback watchdog uses VideoPlayer state for external engines', () => {

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -262,7 +262,7 @@ test('aggregate comment clicks cancel stale continuous navigation and hide first
 test('manual continuous timeline seeks restart active sessions and preserve the target frame', () => {
   assert.match(appSource, /function restartContinuousPlaybackSessionForManualSeek\(\) \{/);
 
-  const seekStart = appSource.indexOf('async function seekContinuousTimeline(globalTime)');
+  const seekStart = appSource.indexOf('async function seekContinuousTimeline(globalTime, options = {})');
   const seekEnd = appSource.indexOf('  function stopContinuousPlayback', seekStart);
   assert.notEqual(seekStart, -1, 'seekContinuousTimeline should exist');
   assert.notEqual(seekEnd, -1, 'seekContinuousTimeline boundary should exist');
@@ -270,7 +270,7 @@ test('manual continuous timeline seeks restart active sessions and preserve the 
 
   assert.match(seekSource, /const navigationToken = \+\+playlistContinuousNavigationToken;/);
   assert.match(seekSource, /const wasContinuousActive = continuousPlaybackState\.active === true;/);
-  assert.match(seekSource, /const shouldResumePlayback = videoPlayer\.isPlaying === true \|\| wasContinuousActive;/);
+  assert.match(seekSource, /const shouldResumePlayback = resumePlayback && \(videoPlayer\.isPlaying === true \|\| wasContinuousActive\);/);
   assert.match(seekSource, /const manualSessionId = wasContinuousActive[\s\S]+restartContinuousPlaybackSessionForManualSeek\(\)/);
   assert.match(seekSource, /const isAlreadyLoaded = isSameFilePath\(state\.currentFile, item\.videoPath\) &&[\s\S]+!hasActiveVideoLoadForDifferentFile\(item\.videoPath\);/);
   assert.match(seekSource, /preserveContinuousSession: true/);
@@ -288,7 +288,7 @@ test('manual continuous timeline seeks restart active sessions and preserve the 
 });
 
 test('manual continuous timeline seeks suppress zero-time updates while cross-file loads settle', () => {
-  const seekStart = appSource.indexOf('async function seekContinuousTimeline(globalTime)');
+  const seekStart = appSource.indexOf('async function seekContinuousTimeline(globalTime, options = {})');
   const seekEnd = appSource.indexOf('  function resetContinuousPlaybackRuntimeState', seekStart);
   assert.notEqual(seekStart, -1, 'seekContinuousTimeline should exist');
   assert.notEqual(seekEnd, -1, 'seekContinuousTimeline boundary should exist');
@@ -904,7 +904,8 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(appSource, /playlistUIState\.mode === 'continuous'[\s\S]+return getContinuousTimelinePlaybackTime\(currentTime\);/);
   assert.match(appSource, /timeline\.setCurrentTime\(getActiveTimelinePlaybackTime\(currentTime,\s*currentFrame\)\);/);
   assert.match(appSource, /timeline\.setCurrentTime\(getActiveTimelinePlaybackTime\(time,\s*frame\)\);/);
-  assert.match(appSource, /async function seekContinuousTimeline\(globalTime\)/);
+  assert.match(appSource, /async function seekContinuousTimeline\(globalTime, options = \{\}\)/);
+  assert.match(appSource, /const \{ resumePlayback = true \} = options;/);
   assert.match(appSource, /mapGlobalTimeToSegment\(timeline\.playlistSegments, globalTime\)/);
   assert.match(appSource, /videoPlayer\.seek\(mapped\.localTime\);/);
   assert.match(appSource, /playbackSync\.broadcastSeek\(mapLocalTimeToGlobal\(mapped\.segment, mapped\.localTime\), \{[\s\S]+playlistContinuous: true[\s\S]+\}\);/);
@@ -913,6 +914,7 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(playbackSyncSource, /this\._lm\.broadcastEvent\(\{ type: `\$\{PREFIX\}SEEK`, \.\.\.event \}\);/);
   assert.match(playbackSyncSource, /detail: \{ time: event\.time, playlistContinuous: event\.playlistContinuous === true \}/);
   assert.match(appSource, /playbackSync\.addEventListener\('remotePlay', \(e\) => \{[\s\S]+await seekContinuousTimeline\(time\);[\s\S]+if \(!continuousPlaybackState\.active\) \{[\s\S]+await startContinuousPlayback\(\);/);
+  assert.match(appSource, /playbackSync\.addEventListener\('remotePause', \(e\) => \{[\s\S]+seekContinuousTimeline\(time, \{ resumePlayback: false \}\);/);
   assert.match(appSource, /playbackSync\.addEventListener\('remoteSeek', \(e\) => \{[\s\S]+const \{ time, playlistContinuous \} = e\.detail;[\s\S]+seekContinuousTimeline\(time\);/);
 });
 


### PR DESCRIPTION
## 📋 업데이트 요약

- 🎬 재생목록의 `타임라인 이어붙이기`가 영상 사이를 넘어갈 때 더 부드럽게 이어지도록 안정화했습니다.
- ⏯️ 이어붙이기 재생 중 Space 키를 눌렀을 때 같은 재생 흐름이 두 번 시작되지 않게 막았습니다. 사용자가 멈추면 뒤늦게 다음 영상이 튀어나오거나 자동으로 다시 재생되는 상황을 줄였습니다.
- 🧭 이어붙인 타임라인에서 원하는 위치를 클릭했을 때, 영상이 바뀌는 순간 재생바가 0초로 잠깐 튀는 현상을 방지했습니다.
- ⚡ mpv를 쓰는 경우에는 다음 영상을 미리 준비할 때 불필요하게 기본 영상 재생 경로를 한 번 더 태우지 않게 했습니다. 정상 mpv 경로에서는 FFmpeg 변환 준비를 하지 않습니다.
- 💬 기존에 추가된 재생목록 댓글 답글과 사이드 댓글 입력창 자동 높이 조정 동작도 회귀 테스트로 다시 확인했습니다.
- 🪟 기존에 추가된 파일 열기 새 창 동작도 재생목록 테스트 묶음에서 함께 확인했습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - `seekContinuousTimeline()`에서 다른 파일로 이동하는 수동 탐색 중 `continuousPlaybackState.loadingItemId`를 설정해, 로드 중 발생하는 0초 `timeupdate/frameUpdate`가 통합 타임라인을 덮어쓰지 않게 했습니다.
  - `handleUserPlayPauseToggle()`과 `shouldStartPlaylistContinuousAutoPlayback()`에 active session guard를 추가해 Space 키가 전환 중인 이어붙이기 세션을 중복 시작하지 않도록 했습니다.
  - Space로 이어붙이기를 멈출 때 `invalidateActiveVideoLoad()`를 호출해, 이미 시작된 오래된 로드가 나중에 재생을 되살리는 경로를 차단했습니다.
  - `playWhenMediaReady` 실행 전 `shouldContinueVideoLoad()`를 다시 확인해, 취소된 연속 재생 세션이 뒤늦게 `playVideoAfterMediaLoad()`로 재생을 시작하지 않게 했습니다.
  - `canReusePreparedContinuousItem()`을 추가해 `READY` 표시만 남고 실제 준비 경로가 사라진 항목은 다시 준비하도록 했습니다. mpv 원본 재생 가능 항목은 변환 파일 없이도 재사용 가능하게 유지했습니다.
  - `preloadPlaylistMediaForItem()`을 mpv-aware로 바꿔 mpv 파일럿 항목은 숨겨진 Chromium `<video>` preload를 건너뛰게 했습니다.
  - mpv 초기 프레임 전환 시 `waitForMpvPlaybackTime()`과 `seekMpvInitialFrameBeforeReveal()`로 목표 프레임 근처에 도달한 뒤 native host를 공개하도록 했습니다.
  - HTML5 경로에서도 `holdPreviousFrameUntilReady`가 켜져 있으면 freeze 캡처 실패 여부와 상관없이 새 영상이 준비될 때까지 video element를 숨겨 첫 프레임 깜빡임을 줄였습니다.
- `renderer/scripts/modules/playback-sync.js`
  - `broadcastPlay/Pause/Seek()`가 `playlistContinuous` 메타데이터를 함께 보낼 수 있도록 확장했습니다.
  - `remotePlay/Pause/Seek` 수신 시 이어붙이기 모드라면 로컬 시간이 아니라 통합 타임라인 시간으로 다시 매핑해 같은 위치로 이동하게 했습니다.
- `scripts/tests/*`
  - mpv 초기 프레임 reveal, 이어붙이기 수동 탐색, Space 중복 세션 방지, stale READY 재준비, mpv HTML preload skip, 협업 seek 메타데이터 전파를 회귀 테스트로 추가했습니다.

## 🚧 개발 난항

- 이번 변경은 새 기능 추가보다 비동기 타이밍 안정화가 핵심이었습니다. 영상 로드, 준비 상태, Space 키 입력, mpv host 공개, 협업 seek가 서로 다른 이벤트 흐름에서 동시에 움직여서 한 지점만 고치면 다른 지점에서 다시 튈 수 있었습니다.
- 특히 `READY` 상태는 화면에는 좋아 보이지만, 내부 준비 경로가 이미 지워진 경우가 있어 그대로 믿으면 다음 컷에서 다시 준비 작업이 시작될 수 있었습니다. 그래서 상태 문자열이 아니라 실제 재사용 가능한 조건을 확인하도록 바꿨습니다.
- mpv는 FFmpeg 변환은 피하고 있었지만, 이어붙이기 예열에서 숨겨진 HTML video preload가 남아 있었습니다. 변환 작업은 아니지만 mpv 사용 목적과 맞지 않아 별도로 차단했습니다.
- 협업 재생 동기화는 기존처럼 초 단위 숫자만 보내면 단일 영상에서는 맞지만, 이어붙인 타임라인에서는 몇 번째 영상의 시간인지가 달라질 수 있어 `playlistContinuous` 표시를 추가했습니다.

## ✅ 테스트 가이드

실사용자용

1. 재생목록을 열고 `타임라인 이어붙이기 모드`로 전환합니다.
2. 자동 재생을 켠 뒤 재생하고, 영상이 다음 영상으로 넘어갈 때 검은 화면이나 0초 튐이 줄었는지 확인합니다.
3. 넘어가는 중 Space를 눌러 멈춰봅니다. 멈춘 뒤 다음 영상이 뒤늦게 튀어나오거나 다시 재생되지 않아야 합니다.
4. 이어붙인 타임라인 중간을 클릭해 다른 영상 구간으로 이동합니다. 재생바가 목표 위치를 유지해야 합니다.
5. 설정에서 mpv를 켠 뒤 같은 재생목록을 열어봅니다. 정상 mpv 경로에서는 FFmpeg 변환 준비가 뜨지 않아야 합니다.
6. 재생목록 댓글에서 바로 답글을 달고, 사이드 댓글바 답글을 길게 입력했을 때 입력칸이 내용에 맞게 커지는지 확인합니다.

개발자용

- `node --test scripts/tests/playlist-continuous-runtime.test.js`
- `npm run test:playlist`
- `npm run test:mpv`
- `npm run test:comment-input`
- `npm run test:cutlist`
- `npm run test:collaboration`
- `git diff --check`
- `npm run build`
