### PR TITLE
[v1.4.0-beta] 재생 프레임 이동과 재생목록 댓글 경험 개선

### DIFF
--- a/main/launch-routing.js
+++ b/main/launch-routing.js
@@ -111,6 +111,22 @@ function classifyLaunchArgument(arg) {
     return '';
   }
 
+  const openRoute = resolveRoutedFileUrl(arg, 'open');
+  if (openRoute.filePath) {
+    if (hasExtension(openRoute.filePath, '.bcutlist')) {
+      return 'cutlist';
+    }
+    if (hasExtension(openRoute.filePath, '.bplaylist')) {
+      return 'playlist';
+    }
+    if (hasExtension(openRoute.filePath, '.bframe')) {
+      return 'project';
+    }
+    if (isSupportedVideoPath(openRoute.filePath)) {
+      return 'video';
+    }
+  }
+
   const cutlistRoute = resolveRoutedFileUrl(arg, 'cutlist');
   if (cutlistRoute.filePath) {
     return 'cutlist';

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:playlist": "node --test scripts/tests/playlist-ordering.test.js scripts/tests/playlist-continuous-core.test.js scripts/tests/playlist-continuous-runtime.test.js scripts/tests/playlist-comment-index.test.js scripts/tests/playlist-autoplay-source.test.js scripts/tests/bplaylist-file-association-source.test.js scripts/tests/project-file-associations.test.js scripts/tests/instance-policy.test.js",
     "test:cutlist": "node --test scripts/tests/cutlist-manager.test.js scripts/tests/cutlist-schema.test.js scripts/tests/moho-scene-info-parser.test.js scripts/tests/cutlist-core.test.js scripts/tests/cutlist-runtime-source.test.js scripts/tests/cutlist-comment-index.test.js",
     "test:drawing": "node --test scripts/tests/drawing-stroke-records.test.js scripts/tests/drawing-runtime-source.test.js scripts/tests/keyframe-multi-select-source.test.js",
-    "test:video-pan": "node --test scripts/tests/video-pan-controls.test.js",
+    "test:video-pan": "node --test scripts/tests/video-pan-controls.test.js scripts/tests/playhead-frame-step-source.test.js",
     "test:mpv": "node --test scripts/tests/mpv-manager.test.js scripts/tests/mpv-embed-host.test.js scripts/tests/mpv-overlay-host.test.js scripts/tests/mpv-runtime-source.test.js",
     "test:audio-waveform": "node --test scripts/tests/audio-waveform-hit-area.test.js",
     "test:collaboration": "node --test scripts/tests/collaboration-cursors-source.test.js",

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -348,6 +348,8 @@ async function initApp() {
     mode: 'review'
   };
 
+  let suppressCommentRangeRefreshOnce = false;
+
   const cutlistUIState = {
     active: false,
     lastIgnored: []
@@ -370,6 +372,7 @@ async function initApp() {
   let playlistReplacementToken = 0;
   let playlistReplacementCommitToken = 0;
   let playlistContinuousNavigationToken = 0;
+  const playlistExpandedReplyKeys = new Set();
   const playlistMediaPreload = {
     element: null,
     itemId: null,
@@ -433,6 +436,16 @@ async function initApp() {
 
   function invalidatePlaylistBackgroundWork() {
     playlistBackgroundWorkToken += 1;
+  }
+
+  async function cancelPlaylistBackgroundTranscodesForMpvPilot(reason = 'mpv 파일럿 사용') {
+    invalidatePlaylistBackgroundWork();
+    try {
+      await window.electronAPI.ffmpegCancel();
+      log.info('mpv 파일럿 사용으로 FFmpeg 백그라운드 준비 취소', { reason });
+    } catch (error) {
+      log.warn('mpv 파일럿 FFmpeg 백그라운드 준비 취소 실패', { reason, error: error.message });
+    }
   }
 
   function resetPlaylistContinuousTimelineState() {
@@ -925,10 +938,12 @@ async function initApp() {
   });
 
   // ====== 모듈 이벤트 연결 ======
+  let lastFrameConsumerSyncFrame = null;
 
   // 비디오 메타데이터 로드됨
   videoPlayer.addEventListener('loadedmetadata', (e) => {
     const { duration, totalFrames, fps } = e.detail;
+    lastFrameConsumerSyncFrame = null;
     timeline.setVideoInfo(duration, fps);
     if (!shouldIgnoreContinuousTimelineUpdateDuringSourceLoad()) {
       updateTimecodeDisplay();
@@ -956,61 +971,63 @@ async function initApp() {
     log.info('비디오 정보', { duration, totalFrames, fps });
   });
 
-  // 비디오 시간 업데이트 (일반 timeupdate - 타임라인 및 표시용)
-  videoPlayer.addEventListener('timeupdate', (e) => {
-    const { currentTime, currentFrame } = e.detail;
+  function syncPlaybackPositionUI(currentTime, currentFrame, options = {}) {
+    const {
+      updatePresence = false,
+      updateDrawing = false
+    } = options;
+
     if (!shouldIgnoreContinuousTimelineUpdateDuringSourceLoad()) {
       timeline.setCurrentTime(getActiveTimelinePlaybackTime(currentTime, currentFrame));
       updateTimecodeDisplay();
-      updateFullscreenTimecode(); // 전체화면 타임코드 업데이트
-      updateFullscreenSeekbar(); // 전체화면 시크바 업데이트
+      updateFullscreenTimecode();
+      updateFullscreenSeekbar();
     }
 
-    // 오디오 웨이브폼 동기화
     if (state.isAudioMode) {
       const audioWaveform = getAudioWaveform();
       audioWaveform.updateTime(currentTime);
       audioWaveform.setPlaying(videoPlayer.isPlaying);
     }
 
-    // 댓글 매니저에 현재 프레임 전달 (마커 가시성 업데이트)
-    commentManager.setCurrentFrame(currentFrame);
-    void handleCutlistPlaybackFrame(currentFrame);
-    refreshCurrentCutFromPlayback(currentFrame);
+    const shouldSyncFrameConsumers = !videoPlayer.isPlaying || currentFrame !== lastFrameConsumerSyncFrame;
+    if (shouldSyncFrameConsumers) {
+      lastFrameConsumerSyncFrame = currentFrame;
+      commentManager.setCurrentFrame(currentFrame);
+      void handleCutlistPlaybackFrame(currentFrame);
+      refreshCurrentCutFromPlayback(currentFrame);
+    }
 
-    // Liveblocks Presence에 현재 프레임 전달 (원격 타임라인 표시용)
-    if (liveblocksManager.isConnected) {
+    if (updatePresence && liveblocksManager.isConnected) {
       liveblocksManager.updatePresence({ currentFrame });
     }
 
-    // 비디오 댓글 범위 오버레이 플레이헤드 업데이트
     if (typeof updateVideoCommentPlayhead === 'function') {
       updateVideoCommentPlayhead();
     }
 
-    // 재생 중이 아닐 때 (seeking)만 그리기 업데이트
-    // 재생 중에는 frameUpdate 이벤트에서 처리
-    if (!videoPlayer.isPlaying) {
+    if (updateDrawing) {
       drawingManager.setCurrentFrame(currentFrame);
     }
+  }
+
+  // 비디오 시간 업데이트 (일반 timeupdate - 타임라인 및 표시용)
+  videoPlayer.addEventListener('timeupdate', (e) => {
+    const { currentTime, currentFrame } = e.detail;
+    syncPlaybackPositionUI(currentTime, currentFrame, {
+      updatePresence: true,
+      updateDrawing: !videoPlayer.isPlaying
+    });
   });
 
-  // 프레임 정확한 업데이트 (requestVideoFrameCallback 기반 - 그리기 동기화용)
+  // 프레임 정확한 업데이트 (requestVideoFrameCallback 기반 - 재생 중 표시/그리기 동기화용)
   videoPlayer.addEventListener('frameUpdate', (e) => {
     const { frame, time } = e.detail;
 
-    // 타임라인 플레이헤드 실시간 업데이트 (재생 중)
-    if (!shouldIgnoreContinuousTimelineUpdateDuringSourceLoad()) {
-      timeline.setCurrentTime(getActiveTimelinePlaybackTime(time, frame));
-    }
-
-    // 그리기 레이어를 프레임 정확하게 동기화 (재생 중)
-    drawingManager.setCurrentFrame(frame);
-    void handleCutlistPlaybackFrame(frame);
-    refreshCurrentCutFromPlayback(frame);
-
-    // 타임코드/프레임레이트 실시간 업데이트 (스플릿 뷰와 동일하게)
-    updateTimecodeDisplay();
+    syncPlaybackPositionUI(time, frame, {
+      updatePresence: false,
+      updateDrawing: true
+    });
   });
 
   // 재생 아이콘 SVG
@@ -1406,8 +1423,11 @@ async function initApp() {
     } else {
       elements.videoWrapper.classList.remove('comment-mode');
       markerContainer.style.pointerEvents = 'none';
+      markerContainer.style.zIndex = '15';
       removePendingMarkerUI();
     }
+
+    markerContainer.style.zIndex = isCommentMode ? '30' : '15';
 
     // 버튼 상태 업데이트
     elements.btnAddComment?.classList.toggle('active', isCommentMode);
@@ -1521,6 +1541,9 @@ async function initApp() {
     renderVideoMarkers();
     updateTimelineMarkers();
     updateCommentList();
+    if (getPlaylistManager().isActive?.()) {
+      void updatePlaylistUI();
+    }
   });
 
   // 프레임 변경 시 마커 가시성 업데이트
@@ -4336,6 +4359,10 @@ async function initApp() {
   });
 
   commentManager.addEventListener('markerUpdated', () => {
+    if (suppressCommentRangeRefreshOnce) {
+      suppressCommentRangeRefreshOnce = false;
+      return;
+    }
     void refreshCommentRangesForCurrentMode();
   });
 
@@ -5925,6 +5952,10 @@ async function initApp() {
       let thumbnailVideoPath = actualVideoPath;
       const useMpvPilot = allowMpvPilot && await shouldUseMpvPilot(filePath, { fileIsAudio, hasPreparedVideoPath: hasConvertedPreparedVideoPath });
       if (!canContinueVideoLoad()) return false;
+      if (useMpvPilot) {
+        await cancelPlaylistBackgroundTranscodesForMpvPilot('mpv 직접 재생 시작');
+        if (!canContinueVideoLoad()) return false;
+      }
       if (hasPreparedVideoPath) {
         log.debug('준비된 연속 재생 미디어 경로 사용', { filePath, preparedVideoPath });
       }
@@ -6853,6 +6884,7 @@ async function initApp() {
    */
   function renderPendingMarker(marker) {
     removePendingMarkerUI();
+    elements.videoWrapper?.classList.add('comment-pending');
 
     // 마커 동그라미 생성
     const markerEl = document.createElement('div');
@@ -6869,6 +6901,9 @@ async function initApp() {
     // 인라인 입력창 생성 (textarea로 변경 - 여러 줄 지원)
     const inputWrapper = document.createElement('div');
     inputWrapper.className = 'comment-marker-input-wrapper';
+    inputWrapper.classList.toggle('align-left', marker.x > 0.68);
+    inputWrapper.classList.toggle('align-above', marker.y > 0.72);
+    inputWrapper.classList.toggle('align-below', marker.y < 0.22);
     inputWrapper.innerHTML = `
       <textarea class="comment-marker-input" placeholder="댓글 입력..." rows="1"></textarea>
       <div class="comment-marker-input-hint">Enter 확인 · Shift+Enter 줄바꿈 · Esc 취소</div>
@@ -6960,6 +6995,7 @@ async function initApp() {
     if (pending) {
       pending.remove();
     }
+    elements.videoWrapper?.classList.remove('comment-pending');
     scheduleMpvOverlayStateSync();
   }
 
@@ -7790,6 +7826,144 @@ async function initApp() {
     return true;
   }
 
+  function findMarkerRecordInBframeData(bframeData, markerId, layerId = null) {
+    const layers = Array.isArray(bframeData?.comments?.layers) ? bframeData.comments.layers : [];
+    for (const layer of layers) {
+      if (layerId && layer?.id !== layerId) continue;
+      const markers = Array.isArray(layer?.markers) ? layer.markers : [];
+      const marker = markers.find(candidate => candidate?.id === markerId && !candidate.deleted);
+      if (marker) return marker;
+    }
+    return null;
+  }
+
+  function snapshotMarkerResolution(marker) {
+    return {
+      resolved: marker?.resolved === true,
+      resolvedBy: marker?.resolvedBy || null,
+      resolvedAt: marker?.resolvedAt || null,
+      updatedAt: marker?.updatedAt || null
+    };
+  }
+
+  function applyMarkerResolutionToggle(marker) {
+    if (!marker) return null;
+    const previous = snapshotMarkerResolution(marker);
+    marker.resolved = !previous.resolved;
+    marker.resolvedAt = marker.resolved ? new Date() : null;
+    marker.resolvedBy = marker.resolved ? userName : null;
+    marker.updatedAt = new Date();
+    return previous;
+  }
+
+  function restoreMarkerResolution(marker, previous) {
+    if (!marker || !previous) return;
+    marker.resolved = previous.resolved;
+    marker.resolvedBy = previous.resolvedBy;
+    marker.resolvedAt = previous.resolvedAt;
+    marker.updatedAt = previous.updatedAt;
+  }
+
+  async function togglePlaylistAggregateResolvedWithoutNavigation(range) {
+    const playlistManager = getPlaylistManager();
+    const item = playlistManager.getItems().find(candidate => candidate.id === range.itemId);
+    if (!item) {
+      throw new Error('재생목록 항목을 찾을 수 없습니다.');
+    }
+
+    const bframePath = await playlistManager.ensureItemBframePath(item);
+    if (!bframePath) {
+      throw new Error('댓글 파일을 찾을 수 없습니다.');
+    }
+
+    const currentBframePath = reviewDataManager.getBframePath();
+    if (currentBframePath && isSameFilePath(currentBframePath, bframePath)) {
+      const marker = commentManager.getMarker(range.markerId);
+      if (!marker || marker.deleted) {
+        throw new Error('원본 댓글을 찾을 수 없습니다.');
+      }
+      const previous = applyMarkerResolutionToggle(marker);
+      suppressCommentRangeRefreshOnce = true;
+      commentManager._emit('markerUpdated', { marker });
+      commentManager._emit('markersChanged');
+      const saved = await reviewDataManager.save();
+      if (!saved) {
+        restoreMarkerResolution(marker, previous);
+        suppressCommentRangeRefreshOnce = true;
+        commentManager._emit('markerUpdated', { marker });
+        commentManager._emit('markersChanged');
+        throw new Error('해결 상태 저장에 실패했습니다.');
+      }
+      return marker;
+    }
+
+    const bframeData = await window.electronAPI.loadReview(bframePath);
+    const marker = findMarkerRecordInBframeData(bframeData, range.markerId, range.layerId);
+    if (!marker) {
+      throw new Error('원본 댓글을 찾을 수 없습니다.');
+    }
+
+    const previous = applyMarkerResolutionToggle(marker);
+    try {
+      const saved = await window.electronAPI.saveReview(bframePath, bframeData);
+      if (saved === false) {
+        restoreMarkerResolution(marker, previous);
+        throw new Error('해결 상태 저장에 실패했습니다.');
+      }
+    } catch (error) {
+      restoreMarkerResolution(marker, previous);
+      throw error;
+    }
+    return marker;
+  }
+
+  function renderPlaylistAggregateReplies(range, normalizedSearch) {
+    const replies = range.replies || [];
+    if (replies.length === 0) return '';
+
+    return replies.map(reply => {
+      const author = reply.author || '익명';
+      const imageUrl = reply.image ? escapeHtmlAttribute(reply.image) : '';
+      return `
+        <div class="playlist-comment-reply" data-reply-id="${escapeHtmlAttribute(reply.id || '')}">
+          <div class="playlist-comment-reply-header">
+            <span class="comment-reply-author ${getAuthorColorClass(author)}" ${getAuthorColorStyle(author)}>${highlightCommentSearchMatches(author, normalizedSearch)}</span>
+            ${reply.createdAt ? `<span class="comment-reply-time">${formatRelativeTime(reply.createdAt)}</span>` : ''}
+          </div>
+          <p class="comment-reply-text">${reply.text ? highlightMentions(renderGDriveLinks(highlightCommentSearchMatches(reply.text, normalizedSearch))) : ''}</p>
+          ${imageUrl ? `<div class="comment-attached-image"><img src="${imageUrl}" alt="첨부 이미지" data-full-image="${imageUrl}"></div>` : ''}
+        </div>
+      `;
+    }).join('');
+  }
+
+  async function togglePlaylistAggregateResolved(key) {
+    const range = playlistAggregateCommentRanges.find(item => getPlaylistAggregateCommentKey(item) === key);
+    if (!range) {
+      showToast('해결 상태를 바꿀 댓글을 찾을 수 없습니다.', 'warning');
+      return false;
+    }
+
+    let marker;
+    try {
+      marker = await togglePlaylistAggregateResolvedWithoutNavigation(range);
+    } catch (error) {
+      showToast(error.message || '해결 상태 저장에 실패했습니다.', 'warning');
+      return false;
+    }
+
+    range.resolved = marker.resolved === true;
+    range.resolvedBy = marker.resolvedBy || '';
+    range.resolvedAt = marker.resolvedAt || null;
+
+    await refreshCommentRangesForCurrentMode();
+    void updatePlaylistUI();
+    renderPlaylistContinuousCommentList(commentFilterState.status);
+    highlightPlaylistAggregateComment(key);
+    showToast(marker.resolved ? '해결됨으로 표시했습니다.' : '미해결로 다시 표시했습니다.', 'success');
+    return true;
+  }
+
   async function submitPlaylistAggregateReply(key, textarea) {
     const text = textarea?.value?.trim() || '';
     if (!text) return false;
@@ -7811,6 +7985,7 @@ async function initApp() {
     }
 
     activeRange.replies = [...(activeRange.replies || []), reply];
+    playlistExpandedReplyKeys.add(key);
     textarea.value = '';
     resizeReplyEditorToContent(textarea);
     renderPlaylistContinuousCommentList(commentFilterState.status);
@@ -7872,13 +8047,21 @@ async function initApp() {
       const author = range.author || '알 수 없음';
       const authorColor = getAuthorColor(range.authorId || author || 'unknown');
       const replyCount = range.replies?.length || 0;
+      const repliesExpanded = playlistExpandedReplyKeys.has(key);
+      const repliesHtml = renderPlaylistAggregateReplies(range, normalizedSearch);
+      const resolveTitle = range.resolved ? '미해결로 변경' : '해결됨으로 변경';
+      const imageUrl = range.image ? escapeHtmlAttribute(range.image) : '';
 
       return `
-      <div class="comment-item playlist-aggregate-comment ${range.resolved ? 'resolved' : ''}"
-        data-aggregate-comment-key="${escapeHtml(key)}"
-        data-marker-id="${escapeHtml(range.markerId)}"
-        data-item-id="${escapeHtml(range.itemId)}"
+      <div class="comment-item playlist-aggregate-comment ${range.resolved ? 'resolved' : ''} ${replyCount > 0 ? 'has-replies' : ''}"
+        data-aggregate-comment-key="${escapeHtmlAttribute(key)}"
+        data-marker-id="${escapeHtmlAttribute(range.markerId)}"
+        data-item-id="${escapeHtmlAttribute(range.itemId)}"
         title="${title}">
+        <button type="button" class="comment-resolve-toggle playlist-comment-resolve-toggle" title="${resolveTitle}" aria-label="${resolveTitle}">
+          ${range.resolved ? '✓ 해결됨' : '○ 미해결'}
+          ${range.resolved && range.resolvedBy ? `<span class="resolve-tooltip"><span class="resolve-tooltip-who">해결됨 by ${escapeHtml(range.resolvedBy)}</span><span class="resolve-tooltip-date">${formatResolvedDate(range.resolvedAt)}</span></span>` : ''}
+        </button>
         <div class="playlist-comment-time-row">
           <span class="comment-timecode">${highlightCommentSearchMatches(range.cutLabel, normalizedSearch)} ${highlightCommentSearchMatches(range.localStartTimecode, normalizedSearch)}</span>
           <span class="playlist-comment-global-time">전체 ${highlightCommentSearchMatches(range.globalStartTimecode, normalizedSearch)}</span>
@@ -7886,16 +8069,18 @@ async function initApp() {
         </div>
         <div class="comment-content">
           <p class="comment-text">${highlightMentions(renderGDriveLinks(highlightCommentSearchMatches(range.text || '댓글', normalizedSearch)))}</p>
-          ${range.image ? `<div class="comment-attached-image"><img src="${range.image}" alt="첨부 이미지" data-full-image="${range.image}"></div>` : ''}
+          ${imageUrl ? `<div class="comment-attached-image"><img src="${imageUrl}" alt="첨부 이미지" data-full-image="${imageUrl}"></div>` : ''}
         </div>
         <div class="comment-actions playlist-comment-readonly-actions">
           <span class="comment-author-inline ${getAuthorColorClass(author)}" style="color: ${authorColor.color}; font-weight: bold;">${highlightCommentSearchMatches(author, normalizedSearch)}</span>
           ${range.createdAt ? `<span class="comment-time-inline">${formatRelativeTime(range.createdAt)}</span>` : ''}
-          <button type="button" class="comment-action-btn playlist-comment-reply-toggle" title="답글">답글</button>
-          ${replyCount > 0 ? `<span class="playlist-comment-reply-count">답글 ${replyCount}개</span>` : ''}
+          <button type="button" class="comment-action-btn playlist-comment-reply-toggle${repliesExpanded ? ' expanded' : ''}" title="${replyCount > 0 ? '답글 보기/작성' : '답글 작성'}" aria-expanded="${repliesExpanded ? 'true' : 'false'}" data-reply-count="${replyCount}">
+            ${replyCount > 0 ? (repliesExpanded ? '답글 접기' : `답글 ${replyCount}개`) : '답글'}
+          </button>
           <span class="playlist-comment-source">${highlightCommentSearchMatches(range.fileName, normalizedSearch)}</span>
         </div>
-        <div class="playlist-comment-reply-form" hidden>
+        ${replyCount > 0 ? `<div class="playlist-comment-replies${repliesExpanded ? ' expanded' : ''}" ${repliesExpanded ? '' : 'hidden'}>${repliesHtml}</div>` : ''}
+        <div class="playlist-comment-reply-form" ${repliesExpanded ? '' : 'hidden'}>
           <textarea class="playlist-comment-reply-input" placeholder="답글 입력..." rows="1" data-max-auto-height="140"></textarea>
           <button type="button" class="playlist-comment-reply-submit">전송</button>
         </div>
@@ -7907,10 +8092,11 @@ async function initApp() {
       const replyToggle = item.querySelector('.playlist-comment-reply-toggle');
       const replyForm = item.querySelector('.playlist-comment-reply-form');
       const replyInput = item.querySelector('.playlist-comment-reply-input');
+      const replies = item.querySelector('.playlist-comment-replies');
 
       item.addEventListener('click', async (e) => {
         if (e.target.closest('.gdrive-link-btn')) return;
-        if (e.target.closest('.playlist-comment-reply-form, .playlist-comment-reply-toggle')) return;
+        if (e.target.closest('.playlist-comment-reply-form, .playlist-comment-reply-toggle, .playlist-comment-replies, .playlist-comment-resolve-toggle')) return;
         await openPlaylistAggregateComment(item.dataset.aggregateCommentKey);
       });
 
@@ -7922,10 +8108,35 @@ async function initApp() {
       replyToggle?.addEventListener('click', (e) => {
         e.stopPropagation();
         if (!replyForm || !replyInput) return;
-        replyForm.hidden = !replyForm.hidden;
-        if (!replyForm.hidden) {
+        const key = item.dataset.aggregateCommentKey;
+        const nextExpanded = !playlistExpandedReplyKeys.has(key);
+        if (nextExpanded) {
+          playlistExpandedReplyKeys.add(key);
+        } else {
+          playlistExpandedReplyKeys.delete(key);
+        }
+        replyForm.hidden = !nextExpanded;
+        if (replies) replies.hidden = !nextExpanded;
+        replyToggle.classList.toggle('expanded', nextExpanded);
+        replyToggle.setAttribute('aria-expanded', nextExpanded ? 'true' : 'false');
+        const replyCount = Number(replyToggle.dataset.replyCount) || 0;
+        replyToggle.textContent = replyCount > 0
+          ? (nextExpanded ? '답글 접기' : `답글 ${replyCount}개`)
+          : '답글';
+        if (nextExpanded) {
           replyInput.focus();
           resizeReplyEditorToContent(replyInput);
+        }
+      });
+
+      item.querySelector('.playlist-comment-resolve-toggle')?.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const resolveBtn = e.currentTarget;
+        resolveBtn.disabled = true;
+        try {
+          await togglePlaylistAggregateResolved(item.dataset.aggregateCommentKey);
+        } finally {
+          if (document.contains(resolveBtn)) resolveBtn.disabled = false;
         }
       });
 
@@ -9374,6 +9585,7 @@ async function initApp() {
     // 댓글 모드
     if (userSettings.matchShortcut('commentMode', e)) {
       e.preventDefault();
+      if (!state.isCommentMode && !(await ensureCutlistCommentTargetReady())) return;
       toggleCommentMode();
       return;
     }
@@ -9556,19 +9768,14 @@ async function initApp() {
     if (userSettings.matchShortcut('prevFrameFast', e)) {
       e.preventDefault();
       const frameAmount = userSettings.getFrameSkipAmount();
-      const currentFrame = videoPlayer.currentFrame || 0;
-      const newFrame = Math.max(0, currentFrame - frameAmount);
-      videoPlayer.seekToFrame(newFrame);
+      videoPlayer.stepFrames(-frameAmount);
       timeline.scrollToPlayhead();
       return;
     }
     if (userSettings.matchShortcut('nextFrameFast', e)) {
       e.preventDefault();
       const frameAmount = userSettings.getFrameSkipAmount();
-      const currentFrame = videoPlayer.currentFrame || 0;
-      const totalFrames = videoPlayer.totalFrames || 0;
-      const newFrame = Math.min(totalFrames - 1, currentFrame + frameAmount);
-      videoPlayer.seekToFrame(newFrame);
+      videoPlayer.stepFrames(frameAmount);
       timeline.scrollToPlayhead();
       return;
     }
@@ -13508,8 +13715,15 @@ async function initApp() {
     const playlistManager = getPlaylistManager();
     const items = playlistManager.getItems?.() || [];
     const readyCount = items.filter(item => item.continuousStatus === CONTINUOUS_STATUS.READY).length;
+    const mpvReadyCount = items.filter(item =>
+      item.continuousStatus === CONTINUOUS_STATUS.READY &&
+      String(item.continuousMessage || '').toLowerCase().includes('mpv')
+    ).length;
     if (elements.playlistPrepareSummaryText) {
-      elements.playlistPrepareSummaryText.textContent = `${readyCount}/${items.length}개 준비됨`;
+      const baseText = `${readyCount}/${items.length}개 바로 재생 가능`;
+      elements.playlistPrepareSummaryText.textContent = mpvReadyCount > 0
+        ? `${baseText} (mpv 원본 ${mpvReadyCount}개)`
+        : baseText;
     }
   }
 
@@ -13574,7 +13788,6 @@ async function initApp() {
           hasPreparedVideoPath: false
         })
         : false;
-      let metadataResolvedByMpv = false;
 
       if (!hasDuration && item.videoPath && useMpvPilotForMetadata) {
         try {
@@ -13586,20 +13799,19 @@ async function initApp() {
               duration = probeDuration;
               fps = Number.isFinite(probeFps) && probeFps > 0
                 ? probeFps
-                : (Number.isFinite(fps) && fps > 0 ? fps : 24);
+              : (Number.isFinite(fps) && fps > 0 ? fps : 24);
               item.duration = duration;
               item.fps = fps;
-              metadataResolvedByMpv = true;
             }
           } else {
-            log.warn('mpv 타임라인 메타데이터 수집 실패', { fileName: item.fileName, error: mpvProbe?.error || 'probe failed' });
+            log.warn('mpv 타임라인 메타데이터 수집 실패: FFmpeg 없이 건너뜀', { fileName: item.fileName, error: mpvProbe?.error || 'probe failed' });
           }
         } catch (error) {
-          log.warn('mpv 타임라인 메타데이터 수집 실패', { fileName: item.fileName, error: error.message });
+          log.warn('mpv 타임라인 메타데이터 수집 실패: FFmpeg 없이 건너뜀', { fileName: item.fileName, error: error.message });
         }
       }
 
-      if (!hasDuration && item.videoPath && (!useMpvPilotForMetadata || !metadataResolvedByMpv)) {
+      if (!hasDuration && item.videoPath && !useMpvPilotForMetadata) {
         try {
           const probe = await window.electronAPI.ffmpegProbeCodec(item.videoPath);
           if (probe?.success) {
@@ -13753,6 +13965,8 @@ async function initApp() {
         });
         if (!shouldContinuePreparing()) return { ready: false, stale: true };
         if (useMpvPilot) {
+          await cancelPlaylistBackgroundTranscodesForMpvPilot('mpv 재생목록 원본 준비');
+          if (!shouldContinuePreparing()) return { ready: false, stale: true };
           continuousPlaybackState.preparedMediaPaths.delete(item.id);
           markPlaylistItemStatus(item, CONTINUOUS_STATUS.READY, 'mpv 원본 준비');
           return { ready: true, mpv: true };
@@ -15445,6 +15659,35 @@ async function initApp() {
     }
   }
 
+  function applyPlaylistItemCommentState(el, progress) {
+    if (!el) return;
+    const total = Math.max(0, Number(progress?.total) || 0);
+    const resolved = Math.max(0, Number(progress?.resolved) || 0);
+    const unresolved = Math.max(0, total - resolved);
+    const hasComments = total > 0;
+    const allResolved = hasComments && unresolved === 0;
+
+    el.classList.toggle('has-comments', hasComments);
+    el.classList.toggle('has-unresolved-comments', unresolved > 0);
+    el.classList.toggle('comments-resolved', allResolved);
+    el.dataset.commentState = !hasComments ? 'none' : (allResolved ? 'resolved' : 'unresolved');
+
+    const statusEl = el.querySelector('.playlist-item-comment-state');
+    if (statusEl) {
+      statusEl.textContent = !hasComments
+        ? ''
+        : (unresolved > 0 ? `미해결 ${unresolved}` : '모두 해결');
+      statusEl.hidden = !hasComments;
+    }
+
+    const commentsEl = el.querySelector('.playlist-item-comments');
+    if (commentsEl) {
+      commentsEl.title = hasComments
+        ? `댓글 ${total}개, 해결 ${resolved}개, 미해결 ${unresolved}개`
+        : '피드백 없음';
+    }
+  }
+
   // 아이템 렌더링
   async function renderPlaylistItems() {
     const playlistManager = getPlaylistManager();
@@ -15517,6 +15760,7 @@ async function initApp() {
               </div>
               ${progress.total > 0 ? `${progress.percent}%` : '-'}
             </span>
+            <span class="playlist-item-comment-state" hidden></span>
             <span class="playlist-item-continuous-status">${item.continuousMessage || ''}</span>
           </div>
         </div>
@@ -15526,6 +15770,7 @@ async function initApp() {
           </svg>
         </button>
       `;
+      applyPlaylistItemCommentState(el, progress);
 
       // 클릭 이벤트
       el.addEventListener('click', (e) => {
@@ -15592,6 +15837,7 @@ async function initApp() {
         textNode.textContent = `\n              ${progress.total > 0 ? `${progress.percent}%` : '-'}`;
       }
     }
+    applyPlaylistItemCommentState(el, progress);
   }
 
   // 위치 표시 업데이트

--- a/renderer/scripts/modules/playlist-manager.js
+++ b/renderer/scripts/modules/playlist-manager.js
@@ -651,6 +651,7 @@ export class PlaylistManager {
         for (const layer of bframeData.comments.layers) {
           if (layer?.markers && Array.isArray(layer.markers)) {
             for (const marker of layer.markers) {
+              if (!marker || marker.deleted) continue;
               total++;
               if (marker.resolved) resolved++;
             }

--- a/renderer/scripts/modules/video-player.js
+++ b/renderer/scripts/modules/video-player.js
@@ -49,14 +49,23 @@ export class VideoPlayer extends EventTarget {
     // 수동 seek 중 플래그 (timeupdate가 프레임을 덮어쓰지 않도록)
     this._isSeeking = false;
     this._seekTimeout = null;
+    this._seekTargetFrame = null;
+    this._seekTargetTime = null;
+    this._seekToken = 0;
 
     // seeked 이벤트 핸들러 (seek 완료 시 플래그 해제)
     this._onSeeked = () => {
+      if (this._seekTargetFrame !== null) {
+        const actualFrame = this._timeToFrame(this.videoElement?.currentTime || 0);
+        if (Math.abs(actualFrame - this._seekTargetFrame) > 0) {
+          return;
+        }
+      }
       if (this._seekTimeout) {
         clearTimeout(this._seekTimeout);
         this._seekTimeout = null;
       }
-      this._isSeeking = false;
+      this._finishManualSeek();
     };
 
     // 프레임 콜백 상태
@@ -70,6 +79,24 @@ export class VideoPlayer extends EventTarget {
     this._setupEventListeners();
 
     log.info('VideoPlayer 초기화됨', { fps: this.fps });
+  }
+
+  _clampFrame(frame) {
+    const maxFrame = Math.max(0, (this.totalFrames || 1) - 1);
+    const normalized = Math.round(Number(frame) || 0);
+    return Math.max(0, Math.min(normalized, maxFrame));
+  }
+
+  _timeToFrame(time) {
+    const fps = Math.max(1, Number(this.fps) || 24);
+    const frame = Math.floor((Number(time) || 0) * fps + 1e-4);
+    return this._clampFrame(frame);
+  }
+
+  _finishManualSeek() {
+    this._isSeeking = false;
+    this._seekTargetFrame = null;
+    this._seekTargetTime = null;
   }
 
   _handleLoopRestartIfNeeded() {
@@ -153,8 +180,7 @@ export class VideoPlayer extends EventTarget {
 
       this.currentTime = video.currentTime;
       // 프레임 계산: floor 사용 (프레임은 0-indexed, 시간 t는 frame floor(t*fps)에 속함)
-      this.currentFrame = Math.floor(this.currentTime * this.fps);
-      this.currentFrame = Math.max(0, Math.min(this.currentFrame, this.totalFrames - 1));
+      this.currentFrame = this._timeToFrame(this.currentTime);
 
       if (this._handleLoopRestartIfNeeded()) {
         return;
@@ -289,7 +315,7 @@ export class VideoPlayer extends EventTarget {
         if (!this.isPlaying) return;
 
         // 정확한 프레임 번호 계산 (floor 사용)
-        const frame = Math.floor(metadata.mediaTime * this.fps);
+        const frame = this._timeToFrame(metadata.mediaTime);
 
         if (frame !== this._lastEmittedFrame) {
           this._lastEmittedFrame = frame;
@@ -313,7 +339,7 @@ export class VideoPlayer extends EventTarget {
       const onFrame = () => {
         if (!this.isPlaying) return;
 
-        const frame = Math.floor(video.currentTime * this.fps);
+        const frame = this._timeToFrame(video.currentTime);
 
         if (frame !== this._lastEmittedFrame) {
           this._lastEmittedFrame = frame;
@@ -491,10 +517,20 @@ export class VideoPlayer extends EventTarget {
     time = Math.max(0, Math.min(time, this.duration));
     this._externalEndedEmitted = false;
     this.externalEofReached = false;
+    this._seekToken += 1;
+    if (this._seekDebounceId) {
+      cancelAnimationFrame(this._seekDebounceId);
+      this._seekDebounceId = null;
+    }
+    if (this._seekTimeout) {
+      clearTimeout(this._seekTimeout);
+      this._seekTimeout = null;
+    }
+    this._finishManualSeek();
 
     // 내부 상태 즉시 업데이트 (timeupdate 이벤트 전에)
     this.currentTime = time;
-    this.currentFrame = Math.floor(time * this.fps);
+    this.currentFrame = this._timeToFrame(time);
 
     if (this.engine !== 'html5') {
       this.externalControls.seek(time).catch?.((error) => {
@@ -518,11 +554,12 @@ export class VideoPlayer extends EventTarget {
   seekToFrame(frame) {
     if (!this.isLoaded) return;
 
-    frame = Math.max(0, Math.min(frame, this.totalFrames - 1));
+    frame = this._clampFrame(frame);
 
     // 프레임의 시작 시간 + 작은 오프셋 (프레임 경계 부동소수점 오차 방지)
     const frameDuration = 1 / this.fps;
     const time = (frame * frameDuration) + 0.001;
+    const seekToken = ++this._seekToken;
 
     // 이전 rAF seek 취소 (빠른 연속 입력 시 마지막 프레임만 실제 seek)
     if (this._seekDebounceId) {
@@ -531,6 +568,8 @@ export class VideoPlayer extends EventTarget {
 
     // seeking 플래그 설정 (timeupdate가 프레임을 덮어쓰지 않도록)
     this._isSeeking = true;
+    this._seekTargetFrame = frame;
+    this._seekTargetTime = time;
     if (this._seekTimeout) {
       clearTimeout(this._seekTimeout);
     }
@@ -546,8 +585,15 @@ export class VideoPlayer extends EventTarget {
     });
 
     if (this.engine !== 'html5') {
-      this.seek(time);
-      this._isSeeking = false;
+      this._externalEndedEmitted = false;
+      this.externalEofReached = false;
+      this.externalControls.seek(time).catch?.((error) => {
+        log.warn('외부 플레이어 프레임 이동 실패', { error: error.message });
+      });
+      this._seekTimeout = setTimeout(() => {
+        if (seekToken !== this._seekToken) return;
+        this._finishManualSeek();
+      }, 300);
       log.debug('프레임 이동', { frame, time });
       return;
     }
@@ -560,24 +606,33 @@ export class VideoPlayer extends EventTarget {
 
     // seeked 이벤트 또는 타임아웃으로 플래그 해제
     this._seekTimeout = setTimeout(() => {
-      this._isSeeking = false;
+      if (seekToken !== this._seekToken) return;
+      this._finishManualSeek();
     }, 200);
 
     log.debug('프레임 이동', { frame, time });
+  }
+
+  stepFrames(delta) {
+    if (!this.isLoaded) return;
+    const baseFrame = this._seekTargetFrame !== null
+      ? this._seekTargetFrame
+      : this.currentFrame;
+    this.seekToFrame(baseFrame + delta);
   }
 
   /**
    * 이전 프레임으로 이동
    */
   prevFrame() {
-    this.seekToFrame(this.currentFrame - 1);
+    this.stepFrames(-1);
   }
 
   /**
    * 다음 프레임으로 이동
    */
   nextFrame() {
-    this.seekToFrame(this.currentFrame + 1);
+    this.stepFrames(1);
   }
 
   /**
@@ -665,7 +720,7 @@ export class VideoPlayer extends EventTarget {
    * @returns {number}
    */
   getCurrentFrame() {
-    return Math.floor(this.currentTime * this.fps);
+    return this._timeToFrame(this.currentTime);
   }
 
   /**
@@ -894,7 +949,16 @@ export class VideoPlayer extends EventTarget {
         metadataChanged = true;
       }
       if (Number.isFinite(nextTime)) {
-        this.currentTime = Math.max(0, Math.min(nextTime, this.duration || nextTime));
+        const candidateTime = Math.max(0, Math.min(nextTime, this.duration || nextTime));
+        if (this._isSeeking && this._seekTargetFrame !== null) {
+          const candidateFrame = this._timeToFrame(candidateTime);
+          if (candidateFrame === this._seekTargetFrame) {
+            this.currentTime = candidateTime;
+            this._finishManualSeek();
+          }
+        } else {
+          this.currentTime = candidateTime;
+        }
       }
       this.totalFrames = Math.max(0, Math.floor((this.duration || 0) * this.fps));
       const hasKnownDuration = this.duration > 0;
@@ -910,7 +974,7 @@ export class VideoPlayer extends EventTarget {
           engine: this.engine
         });
       }
-      const nextFrame = Math.floor(this.currentTime * this.fps);
+      const nextFrame = this._timeToFrame(this.currentTime);
       const wasPlaying = this.isPlaying;
       const externalIsPlaying = status.paused === false;
       const nextIsPlaying = !eofReached && externalIsPlaying;

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -4456,6 +4456,10 @@ body.app-fullscreen .video-comment-overlay-controls {
   padding-top: 12px;
 }
 
+.playlist-aggregate-comment .playlist-comment-resolve-toggle {
+  margin-bottom: 8px;
+}
+
 .playlist-comment-time-row {
   display: flex;
   flex-wrap: wrap;
@@ -4488,6 +4492,53 @@ body.app-fullscreen .video-comment-overlay-controls {
   padding: 2px 6px;
   min-height: 22px;
   font-size: 11px;
+}
+
+.playlist-comment-reply-toggle.expanded {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+.playlist-comment-replies {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+}
+
+.playlist-comment-replies[hidden] {
+  display: none;
+}
+
+.playlist-comment-reply {
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.playlist-comment-reply:last-child {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.playlist-comment-reply-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  font-size: 11px;
+}
+
+.playlist-comment-reply .comment-reply-text {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .playlist-comment-reply-form {
@@ -5965,6 +6016,51 @@ body.resizing .comment-panel {
   cursor: crosshair;
 }
 
+.video-wrapper.comment-mode::before {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border: 2px solid var(--accent-primary);
+  border-radius: 8px;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.16),
+    inset 0 0 72px rgba(0, 0, 0, 0.24),
+    0 0 24px var(--accent-shadow-strong);
+  pointer-events: none;
+  z-index: 16;
+}
+
+.video-wrapper.comment-mode::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 46px;
+  height: 46px;
+  transform: translate(-50%, -50%);
+  border: 2px solid rgba(255, 255, 255, 0.92);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at center, var(--accent-primary) 0 3px, transparent 4px),
+    linear-gradient(90deg, transparent 0 46%, rgba(255, 255, 255, 0.9) 47% 53%, transparent 54% 100%),
+    linear-gradient(0deg, transparent 0 46%, rgba(255, 255, 255, 0.9) 47% 53%, transparent 54% 100%);
+  box-shadow:
+    0 0 0 4px rgba(0, 0, 0, 0.52),
+    0 0 22px var(--accent-shadow-strong);
+  opacity: 0.82;
+  pointer-events: none;
+  z-index: 17;
+  animation: commentModeReticle 1.4s ease-in-out infinite;
+}
+
+.video-wrapper.comment-mode .comment-markers-container {
+  z-index: 30 !important;
+}
+
+.video-wrapper.comment-mode.comment-pending::after {
+  display: none;
+}
+
 .video-wrapper.comment-mode .drawing-overlay {
   pointer-events: none;
 }
@@ -6007,7 +6103,36 @@ body.resizing .comment-panel {
 
 .comment-marker.pending {
   background: var(--accent-primary);
-  animation: pulse 1.5s infinite;
+  border-color: rgba(0, 0, 0, 0.82);
+  box-shadow:
+    0 0 0 4px rgba(255, 255, 255, 0.92),
+    0 0 0 8px rgba(0, 0, 0, 0.52),
+    0 0 22px var(--accent-shadow-strong);
+  animation: commentMarkerPulse 1.5s ease-in-out infinite;
+}
+
+.comment-marker.pending::before,
+.comment-marker.pending::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  pointer-events: none;
+}
+
+.comment-marker.pending::before {
+  width: 42px;
+  height: 42px;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.comment-marker.pending::after {
+  width: 2px;
+  height: 50px;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.88), transparent);
+  transform: translate(-50%, -50%);
 }
 
 .comment-marker.dragging {
@@ -6018,40 +6143,102 @@ body.resizing .comment-panel {
   opacity: 1 !important;
 }
 
-@keyframes pulse {
+@keyframes commentMarkerPulse {
   0%, 100% {
-    box-shadow: 0 0 0 0 var(--accent-shadow-strong);
+    box-shadow:
+      0 0 0 4px rgba(255, 255, 255, 0.92),
+      0 0 0 8px rgba(0, 0, 0, 0.52),
+      0 0 22px var(--accent-shadow-strong);
   }
   50% {
-    box-shadow: 0 0 0 8px transparent;
+    box-shadow:
+      0 0 0 4px rgba(255, 255, 255, 0.96),
+      0 0 0 10px rgba(0, 0, 0, 0.42),
+      0 0 0 18px rgba(255, 208, 0, 0),
+      0 0 30px var(--accent-shadow-strong);
+  }
+}
+
+@keyframes commentModeReticle {
+  0%, 100% {
+    opacity: 0.62;
+    transform: translate(-50%, -50%) scale(0.94);
+  }
+  50% {
+    opacity: 0.92;
+    transform: translate(-50%, -50%) scale(1);
   }
 }
 
 /* 마커 입력창 */
 .comment-marker-input-wrapper {
   position: absolute;
-  left: 20px;
+  left: calc(100% + 16px);
   top: 50%;
   transform: translateY(-50%);
-  background: var(--bg-elevated);
-  border: 1px solid var(--accent-primary);
+  width: min(320px, calc(100vw - 48px));
+  background: rgba(12, 12, 12, 0.96);
+  border: 2px solid var(--accent-primary);
   border-radius: 8px;
-  padding: 8px;
-  min-width: 200px;
-  box-shadow: var(--shadow-lg);
+  padding: 10px;
+  box-shadow:
+    0 14px 42px rgba(0, 0, 0, 0.62),
+    0 0 0 1px rgba(255, 255, 255, 0.16),
+    0 0 28px var(--accent-shadow-strong);
   z-index: 100;
+}
+
+.comment-marker-input-wrapper.align-left {
+  left: auto;
+  right: calc(100% + 16px);
+}
+
+.comment-marker-input-wrapper.align-above {
+  top: auto;
+  bottom: calc(100% + 16px);
+  transform: none;
+}
+
+.comment-marker-input-wrapper.align-below {
+  top: calc(100% + 16px);
+  bottom: auto;
+  transform: none;
+}
+
+.comment-marker-input-wrapper::before {
+  content: '';
+  position: absolute;
+  left: -9px;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  background: inherit;
+  border-left: 2px solid var(--accent-primary);
+  border-bottom: 2px solid var(--accent-primary);
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.comment-marker-input-wrapper.align-left::before {
+  left: auto;
+  right: -9px;
+  transform: translateY(-50%) rotate(225deg);
+}
+
+.comment-marker-input-wrapper.align-above::before,
+.comment-marker-input-wrapper.align-below::before {
+  display: none;
 }
 
 .comment-marker-input {
   width: 100%;
-  min-width: 180px;
-  padding: 8px 10px;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-subtle);
+  min-width: 0;
+  padding: 10px 12px;
+  background: #050505;
+  border: 1px solid rgba(255, 255, 255, 0.22);
   border-radius: 4px;
-  color: var(--text-primary);
+  color: #fff;
   font-family: inherit;
-  font-size: 13px;
+  font-size: 14px;
   outline: none;
   resize: none;
   line-height: 1.4;
@@ -6061,16 +6248,17 @@ body.resizing .comment-panel {
 
 .comment-marker-input:focus {
   border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
 .comment-marker-input::placeholder {
-  color: var(--text-tertiary);
+  color: rgba(255, 255, 255, 0.62);
 }
 
 .comment-marker-input-hint {
-  margin-top: 6px;
+  margin-top: 8px;
   font-size: 11px;
-  color: var(--text-tertiary);
+  color: rgba(255, 255, 255, 0.66);
   text-align: center;
 }
 
@@ -8370,11 +8558,17 @@ body.app-fullscreen .video-wrapper.comment-mode::after {
   position: absolute;
   top: 16px;
   left: 50%;
+  width: auto;
+  height: auto;
   transform: translateX(-50%);
   background: var(--accent-primary);
+  border: none;
   color: #000;
   padding: 8px 16px;
   border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+  opacity: 1;
+  animation: none;
   font-size: 14px;
   font-weight: 600;
   z-index: 200;

--- a/renderer/styles/playlist-panel.css
+++ b/renderer/styles/playlist-panel.css
@@ -291,6 +291,34 @@
   box-shadow: 0 0 0 1px var(--accent-primary);
 }
 
+.playlist-item.has-comments {
+  border-left-width: 3px;
+}
+
+.playlist-item.has-unresolved-comments {
+  border-left-color: var(--warning, #f59e0b);
+  background:
+    linear-gradient(90deg, rgba(245, 158, 11, 0.12), transparent 46%),
+    var(--bg-tertiary);
+}
+
+.playlist-item.has-unresolved-comments:hover,
+.playlist-item.has-unresolved-comments.active {
+  background:
+    linear-gradient(90deg, rgba(245, 158, 11, 0.16), transparent 48%),
+    var(--bg-elevated);
+}
+
+.playlist-item.comments-resolved {
+  border-left-color: var(--success, #22c55e);
+}
+
+.playlist-item.comments-resolved:not(.active) {
+  background:
+    linear-gradient(90deg, rgba(34, 197, 94, 0.08), transparent 44%),
+    var(--bg-tertiary);
+}
+
 .playlist-item.dragging {
   opacity: 0.5;
 }
@@ -396,6 +424,7 @@
 .playlist-item-stats {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
   font-size: 11px;
   color: var(--text-secondary);
@@ -414,6 +443,27 @@
 }
 
 .playlist-item-progress.completed {
+  color: var(--success, #22c55e);
+}
+
+.playlist-item-comment-state {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.playlist-item.has-unresolved-comments .playlist-item-comment-state {
+  background: rgba(245, 158, 11, 0.18);
+  color: #fbbf24;
+}
+
+.playlist-item.comments-resolved .playlist-item-comment-state {
+  background: rgba(34, 197, 94, 0.14);
   color: var(--success, #22c55e);
 }
 

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -7,6 +7,7 @@ const rootDir = path.resolve(__dirname, '../..');
 const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
 const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
 const htmlSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
+const cssSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
 
 test('comment editable fields recover focus when a parent pointer handler blocks default focus', () => {
   assert.match(appSource, /function getCommentEditableTarget\(target\) \{[\s\S]+target\.closest\('\.comment-input, \.comment-marker-input, \.comment-reply-input, \.comment-edit-textarea, \.comment-reply-edit-textarea, \.thread-editor\[contenteditable="true"\]'\)/);
@@ -43,6 +44,43 @@ test('pending marker input stops pointer events from bubbling into video panning
   assert.match(pendingMarkerSource, /inputWrapper\.addEventListener\('mousedown', \(e\) => e\.stopPropagation\(\)\);/);
 });
 
+test('comment mode is visibly marked on the video surface outside fullscreen', () => {
+  assert.match(cssSource, /\.video-wrapper\.comment-mode::before\s*\{[\s\S]+border:\s*2px solid var\(--accent-primary\);/);
+  assert.match(cssSource, /\.video-wrapper\.comment-mode::after\s*\{[\s\S]+radial-gradient\(circle at center, var\(--accent-primary\)/);
+  assert.match(cssSource, /\.video-wrapper\.comment-mode \.comment-markers-container\s*\{[\s\S]+z-index:\s*30 !important;/);
+  assert.match(cssSource, /body\.app-fullscreen \.video-wrapper\.comment-mode::after\s*\{[\s\S]+width:\s*auto;[\s\S]+height:\s*auto;[\s\S]+animation:\s*none;/);
+});
+
+test('pending comment editor stays visible near video edges', () => {
+  const pendingMarkerMatch = appSource.match(/function renderPendingMarker\(marker\) \{([\s\S]*?)\n  \}\n\n  \/\*\*\n   \* Pending 마커 UI 제거/);
+  assert.ok(pendingMarkerMatch, 'pending marker renderer should exist');
+  const pendingMarkerSource = pendingMarkerMatch[1];
+
+  assert.match(pendingMarkerSource, /elements\.videoWrapper\?\.classList\.add\('comment-pending'\);/);
+  assert.match(pendingMarkerSource, /inputWrapper\.classList\.toggle\('align-left', marker\.x > 0\.68\);/);
+  assert.match(pendingMarkerSource, /inputWrapper\.classList\.toggle\('align-above', marker\.y > 0\.72\);/);
+  assert.match(pendingMarkerSource, /inputWrapper\.classList\.toggle\('align-below', marker\.y < 0\.22\);/);
+  assert.match(cssSource, /\.comment-marker-input-wrapper\.align-left\s*\{[\s\S]+right:\s*calc\(100% \+ 16px\);/);
+  assert.match(cssSource, /\.comment-marker-input-wrapper\.align-above\s*\{[\s\S]+bottom:\s*calc\(100% \+ 16px\);/);
+  assert.match(cssSource, /\.comment-marker-input-wrapper\.align-below\s*\{[\s\S]+top:\s*calc\(100% \+ 16px\);/);
+  assert.match(cssSource, /\.video-wrapper\.comment-mode\.comment-pending::after\s*\{[\s\S]+display:\s*none;/);
+
+  const removePendingMatch = appSource.match(/function removePendingMarkerUI\(\) \{([\s\S]*?)\n  \}/);
+  assert.ok(removePendingMatch, 'pending marker cleanup should exist');
+  assert.match(removePendingMatch[1], /elements\.videoWrapper\?\.classList\.remove\('comment-pending'\);/);
+});
+
+test('comment mode shortcut follows the same readiness guard as the toolbar button', () => {
+  const buttonHandlerMatch = appSource.match(/elements\.btnAddComment\.addEventListener\('click', \(\) => \{([\s\S]*?)\n  \}\);/);
+  assert.ok(buttonHandlerMatch, 'toolbar comment button handler should exist');
+  assert.match(buttonHandlerMatch[1], /if \(!state\.isCommentMode && !\(await ensureCutlistCommentTargetReady\(\)\)\) return;/);
+
+  const shortcutMatch = appSource.match(/if \(userSettings\.matchShortcut\('commentMode', e\)\) \{([\s\S]*?)\n    \}/);
+  assert.ok(shortcutMatch, 'comment shortcut branch should exist');
+  assert.match(shortcutMatch[1], /if \(!state\.isCommentMode && !\(await ensureCutlistCommentTargetReady\(\)\)\) return;/);
+  assert.match(shortcutMatch[1], /toggleCommentMode\(\);/);
+});
+
 test('loading review comments refreshes the right sidebar comment list', () => {
   const loadedHandlerMatch = appSource.match(/commentManager\.addEventListener\('loaded', \(\) => \{([\s\S]*?)\n  \}\);/);
   assert.ok(loadedHandlerMatch, 'commentManager loaded handler should exist');
@@ -67,6 +105,7 @@ test('playlist aggregate comments can submit inline replies from the sidebar lis
   assert.match(appSource, /const activeRange = playlistAggregateCommentRanges\.find\(item => getPlaylistAggregateCommentKey\(item\) === key\) \|\| range;/);
   assert.match(appSource, /commentManager\.addReplyToMarker\(activeRange\.markerId, text, commentManager\.getAuthor\(\)\)/);
   assert.match(appSource, /activeRange\.replies = \[\.\.\.\(activeRange\.replies \|\| \[\]\), reply\];/);
+  assert.match(appSource, /playlistExpandedReplyKeys\.add\(key\);/);
 });
 
 test('playlist aggregate comment rerenders detach reply editors before empty state', () => {
@@ -81,4 +120,47 @@ test('playlist aggregate comment rerenders detach reply editors before empty sta
   assert.ok(detachIndex >= 0, 'reply editors should be detached during playlist comment rerender');
   assert.ok(emptyIndex >= 0, 'playlist comment renderer should handle empty results');
   assert.ok(detachIndex < emptyIndex, 'reply editors should be detached before empty-state innerHTML replacement');
+});
+
+test('playlist aggregate replies can expand and resolved state can be toggled from sidebar', () => {
+  const replyRenderStart = appSource.indexOf('  function renderPlaylistAggregateReplies');
+  assert.ok(replyRenderStart >= 0, 'playlist aggregate reply renderer should exist');
+  const replyRenderEnd = appSource.indexOf('  async function togglePlaylistAggregateResolved', replyRenderStart);
+  assert.ok(replyRenderEnd > replyRenderStart, 'playlist aggregate reply renderer should have a bounded body');
+  const replyRenderSource = appSource.slice(replyRenderStart, replyRenderEnd);
+
+  const renderStart = appSource.indexOf('  function renderPlaylistContinuousCommentList');
+  assert.ok(renderStart >= 0, 'playlist aggregate comment renderer should exist');
+  const renderEnd = appSource.indexOf('  function getCutlistAggregateCommentKey', renderStart);
+  assert.ok(renderEnd > renderStart, 'playlist aggregate comment renderer should have a bounded body');
+  const renderSource = appSource.slice(renderStart, renderEnd);
+
+  assert.match(appSource, /const playlistExpandedReplyKeys = new Set\(\);/);
+  assert.match(appSource, /let suppressCommentRangeRefreshOnce = false;/);
+  assert.match(appSource, /function renderPlaylistAggregateReplies\(range, normalizedSearch\) \{/);
+  assert.match(appSource, /class="playlist-comment-replies\$\{repliesExpanded \? ' expanded' : ''\}"/);
+  assert.match(appSource, /playlistExpandedReplyKeys\.has\(key\)/);
+  assert.match(appSource, /playlistExpandedReplyKeys\.add\(key\);[\s\S]+playlistExpandedReplyKeys\.delete\(key\);/);
+  assert.match(appSource, /async function togglePlaylistAggregateResolved\(key\) \{/);
+  assert.match(appSource, /async function togglePlaylistAggregateResolvedWithoutNavigation\(range\) \{/);
+  assert.match(appSource, /const bframePath = await playlistManager\.ensureItemBframePath\(item\);/);
+  assert.match(appSource, /commentManager\.getMarker\(range\.markerId\)/);
+  assert.match(appSource, /window\.electronAPI\.loadReview\(bframePath\)/);
+  assert.match(appSource, /window\.electronAPI\.saveReview\(bframePath, bframeData\)/);
+  assert.match(appSource, /marker\.resolved = !previous\.resolved;/);
+  assert.match(appSource, /restoreMarkerResolution\(marker, previous\);/);
+  assert.match(appSource, /marker\.updatedAt = new Date\(\);/);
+  assert.match(appSource, /suppressCommentRangeRefreshOnce = true;/);
+  assert.doesNotMatch(appSource.match(/async function togglePlaylistAggregateResolved\(key\) \{([\s\S]*?)\n  \}/)?.[1] || '', /openPlaylistAggregateComment/);
+  assert.match(appSource, /class="comment-resolve-toggle playlist-comment-resolve-toggle"/);
+  assert.match(appSource, /item\.querySelector\('\.playlist-comment-resolve-toggle'\)\?\.addEventListener\('click'/);
+  assert.match(replyRenderSource, /const imageUrl = reply\.image \? escapeHtmlAttribute\(reply\.image\) : '';/);
+  assert.match(renderSource, /const imageUrl = range\.image \? escapeHtmlAttribute\(range\.image\) : '';/);
+  assert.match(renderSource, /data-aggregate-comment-key="\$\{escapeHtmlAttribute\(key\)\}"/);
+  assert.match(renderSource, /data-marker-id="\$\{escapeHtmlAttribute\(range\.markerId\)\}"/);
+  assert.match(renderSource, /data-item-id="\$\{escapeHtmlAttribute\(range\.itemId\)\}"/);
+  assert.doesNotMatch(replyRenderSource, /<img src="\$\{reply\.image\}"/);
+  assert.doesNotMatch(renderSource, /<img src="\$\{range\.image\}"/);
+  assert.match(cssSource, /\.playlist-comment-replies/);
+  assert.match(cssSource, /\.playlist-comment-reply-toggle\.expanded/);
 });

--- a/scripts/tests/cutlist-runtime-source.test.js
+++ b/scripts/tests/cutlist-runtime-source.test.js
@@ -38,6 +38,14 @@ function extractBalancedBlock(source, startNeedle) {
   assert.fail(`Missing block end for: ${startNeedle}`);
 }
 
+function extractSyncPlaybackPositionUiBody() {
+  const match = appSource.match(
+    /function syncPlaybackPositionUI\(currentTime, currentFrame, options = \{\}\) \{([\s\S]*?)\n  \}\n\n  \/\/ 비디오 시간 업데이트/
+  );
+  assert.ok(match, 'Missing source section: function syncPlaybackPositionUI');
+  return match[1];
+}
+
 test('main process exposes cutlist file handlers', () => {
   assert.match(mainIpc, /cutlist:read/);
   assert.match(mainIpc, /cutlist:write/);
@@ -161,8 +169,9 @@ test('generic timeline seeking routes through cutlist global time when cutlist i
 test('cutlist playback uses global cutlist timeline time for playhead', () => {
   assert.match(appSource, /function getCutlistTimelinePlaybackTime/);
   assert.match(appSource, /function getActiveTimelinePlaybackTime/);
-  assert.match(appSource, /timeline\.setCurrentTime\(getActiveTimelinePlaybackTime\(currentTime,\s*currentFrame\)\)/);
-  assert.match(appSource, /timeline\.setCurrentTime\(getActiveTimelinePlaybackTime\(time,\s*frame\)\)/);
+  const syncBody = extractSyncPlaybackPositionUiBody();
+  assert.match(syncBody, /timeline\.setCurrentTime\(getActiveTimelinePlaybackTime\(currentTime,\s*currentFrame\)\)/);
+  assert.match(appSource, /syncPlaybackPositionUI\(time,\s*frame,\s*\{/);
 
   const seekStartBody = extractBalancedBlock(appSource, 'async function seekPlaybackToCutStart');
   assert.match(seekStartBody, /await seekCutlistTimeline\(segment\.globalStartTime\)/);
@@ -173,13 +182,15 @@ test('cutlist playback advances to the next ordered cut instead of the next cut 
   const timeUpdateBody = extractBalancedBlock(appSource, "videoPlayer.addEventListener('timeupdate'");
   const frameUpdateBody = extractBalancedBlock(appSource, "videoPlayer.addEventListener('frameUpdate'");
   const endedBody = extractBalancedBlock(appSource, "videoPlayer.addEventListener('ended'");
+  const syncBody = extractSyncPlaybackPositionUiBody();
   const refreshBody = extractBalancedBlock(appSource, 'function refreshCurrentCutFromPlayback');
   const advanceBody = extractBalancedBlock(appSource, 'async function advanceCutlistPlaybackFromCut');
 
   assert.match(appSource, /function getNextCutlistCut\(cut\)/);
   assert.match(appSource, /async function handleCutlistPlaybackFrame\(frame/);
-  assert.match(timeUpdateBody, /handleCutlistPlaybackFrame\(currentFrame\)/);
-  assert.match(frameUpdateBody, /handleCutlistPlaybackFrame\(frame\)/);
+  assert.match(timeUpdateBody, /syncPlaybackPositionUI\(currentTime,\s*currentFrame/);
+  assert.match(frameUpdateBody, /syncPlaybackPositionUI\(time,\s*frame/);
+  assert.match(syncBody, /handleCutlistPlaybackFrame\(currentFrame\)/);
   assert.match(endedBody, /advanceCutlistPlaybackFromCut\(currentCut\)/);
   assert.match(advanceBody, /getNextCutlistCut\(cut\)/);
   assert.match(advanceBody, /await seekPlaybackToCutStart\(nextCut\)/);

--- a/scripts/tests/instance-policy.test.js
+++ b/scripts/tests/instance-policy.test.js
@@ -8,6 +8,7 @@ const {
   sanitizeProfileName,
   shouldAllowMultipleInstances
 } = require('../../main/instance-policy');
+const { classifyLaunchArgument } = require('../../main/launch-routing');
 
 test('development mode allows multiple instances without a switch', () => {
   assert.equal(shouldAllowMultipleInstances({ isDev: true, argv: [], env: {} }), true);
@@ -33,6 +34,16 @@ test('packaged file launches open in a new instance by default', () => {
     argv: ['BFRAME_alpha_v2.exe', 'baeframe://playlist/G:/project/playlist.bplaylist'],
     env: {}
   }), true);
+  assert.equal(shouldAllowMultipleInstances({
+    isDev: false,
+    argv: ['BFRAME_alpha_v2.exe', 'baeframe://open?file=G%3A%5Cproject%5Creview.bframe&comment=marker-1'],
+    env: {}
+  }), true);
+  assert.equal(shouldAllowMultipleInstances({
+    isDev: false,
+    argv: ['BFRAME_alpha_v2.exe', 'baeframe://open?file=G%3A%5Cproject%5Cplaylist.bplaylist&comment=marker-1'],
+    env: {}
+  }), true);
 });
 
 test('packaged non-project launches keep the existing single-instance router', () => {
@@ -51,6 +62,13 @@ test('packaged non-project launches keep the existing single-instance router', (
     argv: ['BFRAME_alpha_v2.exe', 'baeframe://open?file=G%3A%5Cproject%5Creview.mov&comment=marker-1'],
     env: {}
   }), false);
+});
+
+test('open deeplinks classify project files before the single-instance router', () => {
+  assert.equal(classifyLaunchArgument('baeframe://open?file=G%3A%5Cproject%5Creview.bframe&comment=marker-1'), 'project');
+  assert.equal(classifyLaunchArgument('baeframe://open?file=G%3A%5Cproject%5Cplaylist.bplaylist&comment=marker-1'), 'playlist');
+  assert.equal(classifyLaunchArgument('baeframe://open?file=G%3A%5Cproject%5Ccuts.bcutlist&comment=marker-1'), 'cutlist');
+  assert.equal(classifyLaunchArgument('baeframe://open?file=G%3A%5Cproject%5Creview.mov&comment=marker-1'), 'video');
 });
 
 test('explicit multi-instance switches allow packaged comparison runs', () => {

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -367,7 +367,10 @@ test('mpv external playback preserves frame seek and loop behavior', () => {
 
   const seekToFrameMatch = videoPlayerSource.match(/seekToFrame\(frame\) \{([\s\S]*?)\n  \}/);
   assert.ok(seekToFrameMatch, 'seekToFrame should exist');
-  assert.match(seekToFrameMatch[1], /if \(this\.engine !== 'html5'\) \{[\s\S]+this\.seek\(time\);[\s\S]+return;/);
+  assert.match(seekToFrameMatch[1], /this\._seekTargetFrame = frame;/);
+  assert.match(seekToFrameMatch[1], /if \(this\.engine !== 'html5'\) \{[\s\S]+this\.externalControls\.seek\(time\)[\s\S]+this\._finishManualSeek\(\);[\s\S]+return;/);
+  assert.doesNotMatch(seekToFrameMatch[1], /if \(this\.engine !== 'html5'\) \{[\s\S]+this\.seek\(time\);[\s\S]+return;/);
+  assert.match(videoPlayerSource, /if \(this\._isSeeking && this\._seekTargetFrame !== null\) \{[\s\S]+const candidateFrame = this\._timeToFrame\(candidateTime\);[\s\S]+if \(candidateFrame === this\._seekTargetFrame\) \{[\s\S]+this\._finishManualSeek\(\);[\s\S]+return;[\s\S]+\}/);
 });
 
 test('mpv external playback emits ended when keep-open reaches EOF', () => {

--- a/scripts/tests/playhead-frame-step-source.test.js
+++ b/scripts/tests/playhead-frame-step-source.test.js
@@ -1,0 +1,68 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
+const videoPlayerSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/video-player.js'), 'utf8'));
+
+test('playback frame updates drive the same UI path as timeupdate ticks', () => {
+  assert.match(appSource, /function syncPlaybackPositionUI\(currentTime, currentFrame, options = \{\}\) \{/);
+  assert.match(appSource, /let lastFrameConsumerSyncFrame = null;/);
+  assert.match(appSource, /videoPlayer\.addEventListener\('loadedmetadata', \(e\) => \{[\s\S]+lastFrameConsumerSyncFrame = null;/);
+
+  const syncMatch = appSource.match(/function syncPlaybackPositionUI\(currentTime, currentFrame, options = \{\}\) \{([\s\S]*?)\n  \}\n\n  \/\/ 비디오 시간 업데이트/);
+  assert.ok(syncMatch, 'shared playback UI sync helper should be defined before video time handlers');
+  const syncSource = syncMatch[1];
+  assert.match(syncSource, /timeline\.setCurrentTime\(getActiveTimelinePlaybackTime\(currentTime, currentFrame\)\);/);
+  assert.match(syncSource, /updateTimecodeDisplay\(\);/);
+  assert.match(syncSource, /updateFullscreenTimecode\(\);/);
+  assert.match(syncSource, /updateFullscreenSeekbar\(\);/);
+  assert.match(syncSource, /commentManager\.setCurrentFrame\(currentFrame\);/);
+  assert.match(syncSource, /updateVideoCommentPlayhead\(\);/);
+
+  const timeupdateMatch = appSource.match(/videoPlayer\.addEventListener\('timeupdate', \(e\) => \{([\s\S]*?)\n  \}\);/);
+  assert.ok(timeupdateMatch, 'timeupdate handler should exist');
+  assert.match(timeupdateMatch[1], /syncPlaybackPositionUI\(currentTime, currentFrame, \{[\s\S]*updatePresence: true,[\s\S]*updateDrawing: !videoPlayer\.isPlaying/);
+
+  const frameUpdateMatch = appSource.match(/videoPlayer\.addEventListener\('frameUpdate', \(e\) => \{([\s\S]*?)\n  \}\);/);
+  assert.ok(frameUpdateMatch, 'frameUpdate handler should exist');
+  assert.match(frameUpdateMatch[1], /syncPlaybackPositionUI\(time, frame, \{[\s\S]*updatePresence: false,[\s\S]*updateDrawing: true/);
+  assert.doesNotMatch(frameUpdateMatch[1], /updateTimecodeDisplay\(\);\s*$/);
+});
+
+test('rapid frame stepping accumulates from the last requested frame', () => {
+  assert.match(videoPlayerSource, /this\._seekTargetFrame = null;/);
+  assert.match(videoPlayerSource, /this\._seekToken = 0;/);
+  assert.match(videoPlayerSource, /_timeToFrame\(time\) \{[\s\S]+Math\.floor\(\(Number\(time\) \|\| 0\) \* fps \+ 1e-4\)/);
+
+  const seekToFrameMatch = videoPlayerSource.match(/seekToFrame\(frame\) \{([\s\S]*?)\n  \}\n\n  stepFrames/);
+  assert.ok(seekToFrameMatch, 'seekToFrame should exist before stepFrames');
+  const seekToFrameSource = seekToFrameMatch[1];
+  assert.match(seekToFrameSource, /frame = this\._clampFrame\(frame\);/);
+  assert.match(seekToFrameSource, /const seekToken = \+\+this\._seekToken;/);
+  assert.match(seekToFrameSource, /this\._seekTargetFrame = frame;/);
+  assert.match(seekToFrameSource, /if \(seekToken !== this\._seekToken\) return;/);
+  assert.match(seekToFrameSource, /if \(this\.engine !== 'html5'\) \{[\s\S]+this\.externalControls\.seek\(time\)/);
+  assert.doesNotMatch(seekToFrameSource, /if \(this\.engine !== 'html5'\) \{[\s\S]+this\.seek\(time\);/);
+
+  const externalStatusMatch = videoPlayerSource.match(/async _syncExternalStatus\(\) \{([\s\S]*?)\n  \}\n\n  \/\/ ====== 영상 어니언 스킨/);
+  assert.ok(externalStatusMatch, 'external status polling should exist');
+  assert.match(externalStatusMatch[1], /this\._isSeeking && this\._seekTargetFrame !== null/);
+  assert.match(externalStatusMatch[1], /candidateFrame === this\._seekTargetFrame/);
+
+  const stepMatch = videoPlayerSource.match(/stepFrames\(delta\) \{([\s\S]*?)\n  \}\n\n  \/\*\*/);
+  assert.ok(stepMatch, 'stepFrames should exist');
+  assert.match(stepMatch[1], /this\._seekTargetFrame !== null[\s\S]+this\._seekTargetFrame[\s\S]+this\.currentFrame/);
+  assert.match(stepMatch[1], /this\.seekToFrame\(baseFrame \+ delta\);/);
+  assert.match(videoPlayerSource, /prevFrame\(\) \{[\s\S]+this\.stepFrames\(-1\);/);
+  assert.match(videoPlayerSource, /nextFrame\(\) \{[\s\S]+this\.stepFrames\(1\);/);
+});
+
+test('keyboard frame skip shortcuts use VideoPlayer frame stepping', () => {
+  assert.match(appSource, /if \(userSettings\.matchShortcut\('prevFrameFast', e\)\) \{[\s\S]+videoPlayer\.stepFrames\(-frameAmount\);/);
+  assert.match(appSource, /if \(userSettings\.matchShortcut\('nextFrameFast', e\)\) \{[\s\S]+videoPlayer\.stepFrames\(frameAmount\);/);
+  assert.doesNotMatch(appSource, /const currentFrame = videoPlayer\.currentFrame \|\| 0;[\s\S]+const newFrame = Math\.max\(0, currentFrame - frameAmount\);/);
+});

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -19,17 +19,16 @@ test('continuous runtime imports the shared helper module', () => {
   assert.match(appSource, /CONTINUOUS_STATUS[\s\S]+findNextPlayableIndex[\s\S]+createSkippedToastMessage[\s\S]+from '\.\/modules\/playlist-continuous-core\.js'/);
 });
 
-test('continuous metadata uses mpv before FFmpeg fallback for mpv pilot originals', () => {
+test('continuous metadata keeps mpv pilot originals off FFmpeg probing', () => {
   const metadataMatch = appSource.match(/async function collectPlaylistMetadata\(items\) \{([\s\S]*?)\n  \}\n\n  async function updatePlaylistContinuousTimeline/);
   assert.ok(metadataMatch, 'collectPlaylistMetadata should exist');
 
   const metadataSource = metadataMatch[1];
   assert.match(metadataSource, /isSameFilePath\(state\.currentFile, item\.videoPath\) && videoPlayer\.duration/);
   assert.match(metadataSource, /const useMpvPilotForMetadata = !hasDuration && item\.videoPath[\s\S]+await shouldUseMpvPilot\(item\.videoPath/);
-  assert.match(metadataSource, /let metadataResolvedByMpv = false;/);
   assert.match(metadataSource, /if \(!hasDuration && item\.videoPath && useMpvPilotForMetadata\) \{[\s\S]+const mpvProbe = await window\.electronAPI\.mpvProbeMetadata\(item\.videoPath\);/);
-  assert.match(metadataSource, /metadataResolvedByMpv = true;/);
-  assert.match(metadataSource, /if \(!hasDuration && item\.videoPath && \(!useMpvPilotForMetadata \|\| !metadataResolvedByMpv\)\) \{/);
+  assert.match(metadataSource, /mpv 타임라인 메타데이터 수집 실패: FFmpeg 없이 건너뜀/);
+  assert.match(metadataSource, /if \(!hasDuration && item\.videoPath && !useMpvPilotForMetadata\) \{/);
   assert.ok(
     metadataSource.indexOf('const useMpvPilotForMetadata') <
       metadataSource.indexOf('window.electronAPI.mpvProbeMetadata(item.videoPath)') &&
@@ -37,6 +36,7 @@ test('continuous metadata uses mpv before FFmpeg fallback for mpv pilot original
       metadataSource.indexOf('ffmpegProbeCodec(item.videoPath)'),
     'mpv eligibility and mpv metadata probing should run before FFmpeg probing'
   );
+  assert.doesNotMatch(metadataSource, /!metadataResolvedByMpv/);
   assert.match(metadataSource, /ffmpegProbeCodec\(item\.videoPath\)/);
   assert.match(metadataSource, /probe\.duration/);
   assert.match(metadataSource, /probe\.frameRate/);
@@ -462,6 +462,19 @@ test('continuous aggregate comments update the right comment panel', () => {
   assert.match(appSource, /data-aggregate-comment-key/);
   assert.match(appSource, /전체 \$\{highlightCommentSearchMatches\(range\.globalStartTimecode/);
   assert.match(appSource, /컷 \$\{highlightCommentSearchMatches\(range\.localStartTimecode/);
+  assert.match(appSource, /playlist-comment-resolve-toggle/);
+  assert.match(appSource, /playlist-comment-replies/);
+});
+
+test('continuous preparation summary distinguishes mpv-ready originals', () => {
+  const summaryMatch = appSource.match(/function updatePlaylistPrepareSummary\(\) \{([\s\S]*?)\n  \}\n\n  function setPlaylistContinuousTimelineBusy/);
+  assert.ok(summaryMatch, 'updatePlaylistPrepareSummary should exist');
+
+  const summarySource = summaryMatch[1];
+  assert.match(summarySource, /const mpvReadyCount = items\.filter/);
+  assert.match(summarySource, /개 바로 재생 가능/);
+  assert.match(summarySource, /mpv 원본 \$\{mpvReadyCount\}개/);
+  assert.doesNotMatch(summarySource, /개 준비됨/);
 });
 
 test('normal file open paths route bplaylist files into playlist open flow', () => {
@@ -835,14 +848,17 @@ test('continuous source switches suppress stale zero-time timeline updates', () 
   assert.match(appSource, /loadingItemId:\s*null/);
   assert.match(appSource, /loadingSessionId:\s*null/);
   assert.match(appSource, /function shouldIgnoreContinuousTimelineUpdateDuringSourceLoad\(\)/);
+  const playbackSyncMatch = appSource.match(/function syncPlaybackPositionUI\(currentTime, currentFrame, options = \{\}\) \{([\s\S]*?)\n  \}\n\n  \/\/ 비디오 시간 업데이트/);
+  assert.ok(playbackSyncMatch, 'shared playback UI sync helper should exist');
+  assert.match(playbackSyncMatch[1], /if \(!shouldIgnoreContinuousTimelineUpdateDuringSourceLoad\(\)\) \{[\s\S]*timeline\.setCurrentTime/);
 
   const timeupdateMatch = appSource.match(/videoPlayer\.addEventListener\('timeupdate', \(e\) => \{([\s\S]*?)\n  \}\);/);
   assert.ok(timeupdateMatch, 'timeupdate handler should exist');
-  assert.match(timeupdateMatch[1], /if \(!shouldIgnoreContinuousTimelineUpdateDuringSourceLoad\(\)\) \{[\s\S]*timeline\.setCurrentTime/);
+  assert.match(timeupdateMatch[1], /syncPlaybackPositionUI\(currentTime, currentFrame/);
 
   const frameUpdateMatch = appSource.match(/videoPlayer\.addEventListener\('frameUpdate', \(e\) => \{([\s\S]*?)\n  \}\);/);
   assert.ok(frameUpdateMatch, 'frameUpdate handler should exist');
-  assert.match(frameUpdateMatch[1], /if \(!shouldIgnoreContinuousTimelineUpdateDuringSourceLoad\(\)\) \{[\s\S]*timeline\.setCurrentTime/);
+  assert.match(frameUpdateMatch[1], /syncPlaybackPositionUI\(time, frame/);
 
   const continuousLoadMatch = appSource.match(/async function loadContinuousPlaylistItem\(item, sessionId\) \{([\s\S]*?)\n  \}\n\n  function waitForContinuousDelay/);
   assert.ok(continuousLoadMatch, 'continuous playlist loader should exist');
@@ -931,7 +947,7 @@ test('continuous timeline uses aggregate time for playback and seek', () => {
   assert.match(appSource, /function getActiveTimelinePlaybackTime\(currentTime = videoPlayer\.currentTime,\s*currentFrame = videoPlayer\.currentFrame\)/);
   assert.match(appSource, /playlistUIState\.mode === 'continuous'[\s\S]+return getContinuousTimelinePlaybackTime\(currentTime\);/);
   assert.match(appSource, /timeline\.setCurrentTime\(getActiveTimelinePlaybackTime\(currentTime,\s*currentFrame\)\);/);
-  assert.match(appSource, /timeline\.setCurrentTime\(getActiveTimelinePlaybackTime\(time,\s*frame\)\);/);
+  assert.match(appSource, /syncPlaybackPositionUI\(time, frame, \{/);
   assert.match(appSource, /async function seekContinuousTimeline\(globalTime, options = \{\}\)/);
   assert.match(appSource, /const \{ resumePlayback = true \} = options;/);
   assert.match(appSource, /mapGlobalTimeToSegment\(timeline\.playlistSegments, globalTime\)/);
@@ -1016,6 +1032,19 @@ test('playlist rows render and color continuous status text', () => {
   assert.match(playlistCss, /\[data-continuous-status="preparing"\]/);
   assert.match(playlistCss, /\[data-continuous-status="ready"\]/);
   assert.match(playlistCss, /\[data-continuous-status="missing"\]/);
+});
+
+test('playlist rows highlight videos with comments by resolved state', () => {
+  assert.match(appSource, /function applyPlaylistItemCommentState\(el, progress\) \{/);
+  assert.match(appSource, /el\.classList\.toggle\('has-comments', hasComments\);/);
+  assert.match(appSource, /el\.classList\.toggle\('has-unresolved-comments', unresolved > 0\);/);
+  assert.match(appSource, /el\.classList\.toggle\('comments-resolved', allResolved\);/);
+  assert.match(playlistManagerSource, /if \(!marker \|\| marker\.deleted\) continue;[\s\S]+total\+\+;/);
+  assert.match(appSource, /<span class="playlist-item-comment-state" hidden><\/span>/);
+  assert.match(appSource, /applyPlaylistItemCommentState\(el, progress\);/);
+  assert.match(playlistCss, /\.playlist-item\.has-unresolved-comments/);
+  assert.match(playlistCss, /\.playlist-item\.comments-resolved/);
+  assert.match(playlistCss, /\.playlist-item-comment-state/);
 });
 
 test('modified-date sort refreshes stats and preserves current selection without loading', () => {
@@ -1220,13 +1249,14 @@ test('mpv pilot playlist preparation skips background transcode work', () => {
   assert.ok(prepareMatch, 'preparePlaylistItemInBackground should exist');
 
   const prepareSource = prepareMatch[1];
+  assert.match(appSource, /async function cancelPlaylistBackgroundTranscodesForMpvPilot\(reason = 'mpv 파일럿 사용'\) \{[\s\S]+invalidatePlaylistBackgroundWork\(\);[\s\S]+await window\.electronAPI\.ffmpegCancel\(\);/);
   assert.match(prepareSource, /const useMpvPilot = await shouldUseMpvPilot\(item\.videoPath, \{[\s\S]+fileIsAudio: isAudioFile\(item\.fileName \|\| item\.videoPath\),[\s\S]+hasPreparedVideoPath: false[\s\S]+\}\);/);
   assert.ok(
     prepareSource.indexOf('const useMpvPilot = await shouldUseMpvPilot') <
       prepareSource.indexOf('const ffmpegAvailable = await window.electronAPI.ffmpegIsAvailable();'),
     'mpv pilot eligibility should be checked before FFmpeg probing'
   );
-  assert.match(prepareSource, /if \(useMpvPilot\) \{[\s\S]+continuousPlaybackState\.preparedMediaPaths\.delete\(item\.id\);[\s\S]+markPlaylistItemStatus\(item, CONTINUOUS_STATUS\.READY, 'mpv 원본 준비'\);[\s\S]+return \{ ready: true, mpv: true \};[\s\S]+\}/);
+  assert.match(prepareSource, /if \(useMpvPilot\) \{[\s\S]+await cancelPlaylistBackgroundTranscodesForMpvPilot\('mpv 재생목록 원본 준비'\);[\s\S]+continuousPlaybackState\.preparedMediaPaths\.delete\(item\.id\);[\s\S]+markPlaylistItemStatus\(item, CONTINUOUS_STATUS\.READY, 'mpv 원본 준비'\);[\s\S]+return \{ ready: true, mpv: true \};[\s\S]+\}/);
   const mpvReadyBlock = prepareSource.match(/if \(useMpvPilot\) \{([\s\S]*?)\n        \}/);
   assert.ok(mpvReadyBlock, 'mpv ready block should exist');
   assert.doesNotMatch(mpvReadyBlock[1], /preparedMediaPaths\.set/);
@@ -1234,6 +1264,20 @@ test('mpv pilot playlist preparation skips background transcode work', () => {
     prepareSource.indexOf('if (useMpvPilot)') <
       prepareSource.indexOf('window.electronAPI.ffmpegPreTranscode(item.videoPath)'),
     'mpv-ready playlist items must return before background transcode starts'
+  );
+});
+
+test('mpv pilot video loads cancel already-running FFmpeg background work before playback', () => {
+  const loadVideoStart = appSource.indexOf('  async function loadVideo(filePath, options = {}) {');
+  assert.notEqual(loadVideoStart, -1, 'loadVideo should exist');
+
+  const loadVideoSource = appSource.slice(loadVideoStart, loadVideoStart + 3600);
+  assert.match(loadVideoSource, /const useMpvPilot = allowMpvPilot && await shouldUseMpvPilot/);
+  assert.match(loadVideoSource, /if \(useMpvPilot\) \{[\s\S]+await cancelPlaylistBackgroundTranscodesForMpvPilot\('mpv 직접 재생 시작'\);[\s\S]+if \(!canContinueVideoLoad\(\)\) return false;[\s\S]+\}/);
+  assert.ok(
+    loadVideoSource.indexOf("await cancelPlaylistBackgroundTranscodesForMpvPilot('mpv 직접 재생 시작')") <
+      loadVideoSource.indexOf('const ffmpegAvailable = !useMpvPilot'),
+    'mpv direct playback should cancel stale FFmpeg background work before any FFmpeg branch'
   );
 });
 


### PR DESCRIPTION
📋 업데이트 요약

- 🎬 재생 중 화면 아래 프레임 숫자가 더 촘촘하게 따라오도록 고쳤습니다. 이제 플레이헤드에 보이는 프레임이 2프레임씩 건너뛰는 느낌이 줄어듭니다.
- ⌨️ 좌/우 방향키로 한 프레임씩 움직일 때 반응이 막히던 부분을 안정화했습니다. 빠르게 여러 번 눌러도 마지막으로 요청한 프레임을 기준으로 차근차근 이동합니다.
- 💬 재생목록의 타임라인 이어보기 댓글에서 답글을 펼쳐 보고, 바로 답글을 달 수 있게 했습니다.
- ✅ 재생목록 댓글의 해결/미해결 상태를 사이드 댓글바에서 바로 바꿀 수 있게 했습니다. 이때 영상이 갑자기 해당 댓글 위치로 이동하지 않도록 했습니다.
- 👀 댓글이 있는 영상은 재생목록에서 더 눈에 띄게 보이고, 미해결 댓글이 남아 있는지 / 모두 해결됐는지 구분해서 표시됩니다.
- ✍️ 화면에서 C를 눌러 댓글을 달 때, 댓글 작성 위치와 입력창이 더 명확하게 보이도록 대비와 위치 처리를 강화했습니다.
- 🪟 이미 배프레임 창이 떠 있어도 새 .bframe 또는 .bplaylist 파일을 열면 새 배프레임 창에서 열리도록 보강했습니다.
- ⚡ mpv 직접 재생을 사용할 때는 FFmpeg 준비 작업이 뒤에서 섞이지 않도록 정리했습니다. mpv는 아직 파일럿 기능이므로 필요한 분만 켜서 쓰는 흐름은 그대로 유지합니다.

🔧 상세 기술 설명

- `renderer/scripts/modules/video-player.js`
  - `_seekTargetFrame`, `_seekTargetTime`, `_seekToken`을 추가해 빠른 연속 프레임 이동이 현재 표시 프레임이 아니라 마지막 요청 프레임을 기준으로 누적되게 했습니다.
  - `stepFrames(delta)`를 새로 만들고 `prevFrame()`, `nextFrame()`이 이를 사용하게 변경했습니다.
  - mpv 같은 외부 재생 엔진에서는 `seekToFrame()`이 `this.seek()`를 거치며 수동 seek 상태를 바로 지우지 않도록, `externalControls.seek(time)`을 직접 호출하게 했습니다.
  - `_syncExternalStatus()`가 stale mpv 상태로 사용자가 요청한 프레임을 덮어쓰지 않도록 수동 seek target을 존중합니다.

- `renderer/scripts/app.js`
  - `syncPlaybackPositionUI()`를 추가해 `timeupdate`와 `frameUpdate`가 같은 UI 갱신 경로를 타도록 정리했습니다.
  - `lastFrameConsumerSyncFrame`을 source 로드마다 초기화해 새 영상이 같은 프레임 번호에서 시작해도 댓글/컷 동기화가 누락되지 않게 했습니다.
  - `playlistExpandedReplyKeys`, `renderPlaylistAggregateReplies()`, `submitPlaylistAggregateReply()`를 통해 재생목록 통합 댓글의 답글 펼침/작성 흐름을 추가했습니다.
  - `togglePlaylistAggregateResolvedWithoutNavigation()`을 추가해 사이드바 해결 체크가 재생 위치를 바꾸지 않고 원본 `.bframe`의 댓글 해결 상태만 저장하게 했습니다.
  - 저장 실패 시 현재 열린 댓글과 다른 항목 댓글 모두 해결 상태를 되돌리고 실패 메시지를 띄우도록 처리했습니다.
  - `cancelPlaylistBackgroundTranscodesForMpvPilot()`을 추가해 mpv 직접 재생 경로에서 기존 FFmpeg 백그라운드 준비를 무효화하고 취소합니다.
  - `collectPlaylistMetadata()`에서 mpv 파일럿 사용 중에는 mpv 메타데이터 수집 실패를 FFmpeg probe로 이어가지 않게 분리했습니다.
  - 댓글 입력 위치가 영상 가장자리 근처여도 입력창이 화면 밖으로 밀리지 않도록 `align-left`, `align-above`, `align-below` 배치를 추가했습니다.

- `renderer/scripts/modules/playlist-manager.js`
  - 삭제된 댓글 marker는 재생목록 댓글 집계에서 제외해, 이미 지운 댓글 때문에 영상이 강조되는 문제를 막았습니다.

- `main/launch-routing.js`
  - `baeframe://open?file=...` 딥링크도 `.bframe`, `.bplaylist`, `.bcutlist`, 영상 파일로 정확히 분류하게 했습니다.
  - 프로젝트 파일은 single-instance 라우터로 기존 창에 흡수되지 않고 새 인스턴스 정책을 타도록 보강했습니다.

- `renderer/styles/main.css`, `renderer/styles/playlist-panel.css`
  - 댓글 작성 모드 표시, pending 입력창, 재생목록 댓글 답글/해결 버튼, 댓글 상태별 재생목록 row 강조 스타일을 추가했습니다.

- 테스트
  - `scripts/tests/playhead-frame-step-source.test.js`를 추가하고 `package.json`의 `test:video-pan`에 포함했습니다.
  - `comment-input`, `playlist-continuous-runtime`, `instance-policy`, `mpv-runtime`, `cutlist-runtime` 테스트를 확장했습니다.

🚧 개발 난항

- 프레임 숫자 건너뜀은 단순 표시 문제가 아니라 `timeupdate`와 `requestVideoFrameCallback` 기반 갱신이 서로 다른 경로로 움직이는 문제였습니다. 두 경로를 하나의 UI 동기화 함수로 묶고, 댓글/컷/그리기 동기화가 중복되거나 빠지지 않게 분리했습니다.
- 빠른 방향키 입력은 영상 태그가 실제 seek를 완료하기 전에 다음 입력이 들어오면서 기준 프레임이 낡아지는 문제가 있었습니다. 마지막 요청 프레임을 별도로 보관해 사용자가 누른 횟수대로 이동하도록 고쳤습니다.
- 재생목록 사이드바의 해결 체크는 처음에는 댓글 열기 동작과 연결될 수 있어 영상 위치가 움직일 위험이 있었습니다. 체크는 이제 파일의 해결 상태만 저장하고 재생 위치는 건드리지 않습니다.
- mpv 사용 중 “준비 완료”처럼 보이던 흐름은 FFmpeg 준비 작업과 헷갈릴 수 있었습니다. mpv 경로에서는 FFmpeg 변환/메타데이터 보조 경로를 명시적으로 끊고, 기존 백그라운드 작업도 취소하도록 정리했습니다.
- 새 `.bframe`/`.bplaylist`가 기존 창에 흡수되는 문제는 일반 파일 인자뿐 아니라 `baeframe://open?file=...` 형태의 딥링크도 같이 분류해야 했습니다.

✅ 테스트 가이드

실사용자용

1. 영상을 재생하면서 아래 프레임 숫자가 이전보다 부드럽게 따라오는지 확인합니다.
2. 일시정지 후 좌/우 방향키를 빠르게 여러 번 눌러도 한 프레임씩 정확히 움직이는지 확인합니다.
3. 재생목록 타임라인 이어보기에서 댓글이 있는 영상을 열고, 사이드 댓글바에서 답글을 펼치고 답글을 달아봅니다.
4. 사이드 댓글바에서 해결 체크를 눌렀을 때 영상 위치가 갑자기 이동하지 않고 해결 상태만 바뀌는지 확인합니다.
5. 댓글이 있는 영상이 재생목록에서 더 눈에 띄고, 미해결/모두 해결 상태가 구분되는지 확인합니다.
6. C를 눌러 화면 위에 댓글을 달 때 작성 위치와 입력창이 명확하게 보이는지 확인합니다.
7. 배프레임 창이 이미 떠 있는 상태에서 다른 `.bframe` 또는 `.bplaylist` 파일을 열면 새 창으로 열리는지 확인합니다.
8. 설정에서 mpv 직접 재생을 켠 뒤 영상이 바로 열리는지 확인합니다. 문제가 있으면 다시 끄면 기존 방식으로 돌아갑니다.

개발자용

- `node --check main\\launch-routing.js; node --check renderer\\scripts\\app.js; node --check renderer\\scripts\\modules\\video-player.js; node --check renderer\\scripts\\modules\\playlist-manager.js`
- `git diff --check`
- `npm run test:comment-input`
- `npm run test:playlist`
- `npm run test:video-pan`
- `npm run test:cutlist`
- `npm run test:mpv`
- `npm run build`
