### PR TITLE
[v1.4.0-beta] mpv 협업 커서 및 입력 포커스 개선

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -753,6 +753,23 @@ function setupIpcHandlers() {
     return isFullscreen();
   });
 
+  ipcMain.handle('window:focus-main', () => {
+    const mainWindow = getMainWindow();
+    if (!mainWindow || mainWindow.isDestroyed?.()) {
+      return { success: false, error: 'main window is not available' };
+    }
+
+    if (mainWindow.isMinimized?.()) {
+      mainWindow.restore();
+    }
+    if (mainWindow.isVisible?.() === false) {
+      mainWindow.show();
+    }
+    mainWindow.focus();
+    mainWindow.webContents?.focus?.();
+    return { success: true };
+  });
+
   // ====== 앱 관련 ======
 
   ipcMain.handle('app:get-version', () => {

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -1738,6 +1738,15 @@ function setupIpcHandlers() {
     }
   });
 
+  ipcMain.handle('mpv:update-overlay-remote-cursors', async (event, remoteCursorHtml) => {
+    try {
+      return await mpvOverlayHost.updateRemoteCursorState(remoteCursorHtml);
+    } catch (error) {
+      log.debug('mpv 오버레이 원격 커서 갱신 실패', { error: error.message });
+      return { success: false, error: error.message };
+    }
+  });
+
   ipcMain.handle('mpv:destroy-overlay', async () => {
     try {
       return mpvOverlayHost.destroy();

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -327,6 +327,43 @@ const OVERLAY_HTML = `
       element.style.transformOrigin = 'center center';
     }
 
+    function sanitizeRemoteCursorHtml(value) {
+      const allowedTags = new Set(['div', 'span', 'svg', 'path']);
+      const allowedAttrs = new Set([
+        'class',
+        'style',
+        'width',
+        'height',
+        'viewbox',
+        'fill',
+        'stroke',
+        'stroke-width',
+        'd'
+      ]);
+      const template = document.createElement('template');
+      template.innerHTML = typeof value === 'string' ? value : '';
+
+      template.content.querySelectorAll('*').forEach((element) => {
+        if (!allowedTags.has(element.localName)) {
+          element.remove();
+          return;
+        }
+
+        [...element.attributes].forEach((attribute) => {
+          const name = attribute.name.toLowerCase();
+          const attrValue = attribute.value || '';
+          const hasUnsafeValue = /javascript:/i.test(attrValue) ||
+            /expression\s*\(/i.test(attrValue) ||
+            (name === 'style' && /url\s*\(/i.test(attrValue));
+          if (!allowedAttrs.has(name) || name.startsWith('on') || hasUnsafeValue) {
+            element.removeAttribute(attribute.name);
+          }
+        });
+      });
+
+      return template.innerHTML;
+    }
+
     window.__applyMpvOverlayState = function applyMpvOverlayState(state) {
       const nextState = state || {};
       const htmlOverlay = document.getElementById('htmlOverlay');
@@ -339,7 +376,7 @@ const OVERLAY_HTML = `
       htmlOverlay.innerHTML = nextState.htmlOverlayHtml || '';
       markerMirror.innerHTML = nextState.markerHtml || '';
       tooltipMirror.innerHTML = nextState.tooltipHtml || '';
-      remoteCursorMirror.innerHTML = nextState.remoteCursorHtml || '';
+      remoteCursorMirror.innerHTML = sanitizeRemoteCursorHtml(nextState.remoteCursorHtml);
       toastMirror.innerHTML = nextState.toastHtml || '';
       applyOverlayTransform(markerMirror, nextState);
       tooltipMirror.style.transform = 'none';

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -77,6 +77,7 @@ const OVERLAY_HTML = `
     #markerMirror,
     #tooltipMirror,
     #toastMirror,
+    #remoteCursorMirror,
     #htmlOverlay {
       position: absolute;
       inset: 0;
@@ -92,10 +93,54 @@ const OVERLAY_HTML = `
     #toastMirror {
       z-index: 50;
     }
+    #remoteCursorMirror {
+      z-index: 45;
+    }
     #markerMirror *,
     #tooltipMirror *,
-    #toastMirror * {
+    #toastMirror *,
+    #remoteCursorMirror * {
       pointer-events: none !important;
+    }
+    .remote-cursors-container {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      z-index: 50;
+      overflow: hidden;
+    }
+    .remote-cursor {
+      position: absolute;
+      top: 0;
+      left: 0;
+      display: none;
+      transition: transform 120ms ease-out;
+      will-change: transform;
+      filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4));
+    }
+    .remote-cursor-icon {
+      display: block;
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+    .remote-cursor-label {
+      position: absolute;
+      top: 16px;
+      left: 10px;
+      display: inline-block;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 500;
+      line-height: 1.3;
+      color: #fff;
+      white-space: nowrap;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+      opacity: 0.92;
     }
     .comment-marker {
       width: 24px;
@@ -255,6 +300,7 @@ const OVERLAY_HTML = `
     <div id="htmlOverlay"></div>
     <div id="markerMirror"></div>
     <div id="tooltipMirror"></div>
+    <div id="remoteCursorMirror" class="remote-cursors-container"></div>
     <div id="toastMirror"></div>
   </div>
   <script>
@@ -286,12 +332,14 @@ const OVERLAY_HTML = `
       const htmlOverlay = document.getElementById('htmlOverlay');
       const markerMirror = document.getElementById('markerMirror');
       const tooltipMirror = document.getElementById('tooltipMirror');
+      const remoteCursorMirror = document.getElementById('remoteCursorMirror');
       const toastMirror = document.getElementById('toastMirror');
       applyImage('onionCanvasMirror', nextState.onionDataUrl, nextState.canvas);
       applyImage('drawingCanvasMirror', nextState.drawingDataUrl, nextState.canvas);
       htmlOverlay.innerHTML = nextState.htmlOverlayHtml || '';
       markerMirror.innerHTML = nextState.markerHtml || '';
       tooltipMirror.innerHTML = nextState.tooltipHtml || '';
+      remoteCursorMirror.innerHTML = nextState.remoteCursorHtml || '';
       toastMirror.innerHTML = nextState.toastHtml || '';
       applyOverlayTransform(markerMirror, nextState);
       tooltipMirror.style.transform = 'none';
@@ -330,6 +378,7 @@ function normalizeOverlayState(state = {}) {
     tooltipHtml: typeof state.tooltipHtml === 'string' ? state.tooltipHtml : '',
     htmlOverlayHtml: typeof state.htmlOverlayHtml === 'string' ? state.htmlOverlayHtml : '',
     toastHtml: typeof state.toastHtml === 'string' ? state.toastHtml : '',
+    remoteCursorHtml: typeof state.remoteCursorHtml === 'string' ? state.remoteCursorHtml : '',
     markerTransform: typeof state.markerTransform === 'string' ? state.markerTransform : '',
     markerTransformOrigin: typeof state.markerTransformOrigin === 'string'
       ? state.markerTransformOrigin

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -364,19 +364,28 @@ const OVERLAY_HTML = `
       return template.innerHTML;
     }
 
+    function applyRemoteCursorHtml(remoteCursorHtml) {
+      const remoteCursorMirror = document.getElementById('remoteCursorMirror');
+      if (!remoteCursorMirror) return;
+      remoteCursorMirror.innerHTML = sanitizeRemoteCursorHtml(remoteCursorHtml);
+    }
+
+    window.__applyMpvRemoteCursorState = function applyMpvRemoteCursorState(remoteCursorHtml) {
+      applyRemoteCursorHtml(remoteCursorHtml);
+    };
+
     window.__applyMpvOverlayState = function applyMpvOverlayState(state) {
       const nextState = state || {};
       const htmlOverlay = document.getElementById('htmlOverlay');
       const markerMirror = document.getElementById('markerMirror');
       const tooltipMirror = document.getElementById('tooltipMirror');
-      const remoteCursorMirror = document.getElementById('remoteCursorMirror');
       const toastMirror = document.getElementById('toastMirror');
       applyImage('onionCanvasMirror', nextState.onionDataUrl, nextState.canvas);
       applyImage('drawingCanvasMirror', nextState.drawingDataUrl, nextState.canvas);
       htmlOverlay.innerHTML = nextState.htmlOverlayHtml || '';
       markerMirror.innerHTML = nextState.markerHtml || '';
       tooltipMirror.innerHTML = nextState.tooltipHtml || '';
-      remoteCursorMirror.innerHTML = sanitizeRemoteCursorHtml(nextState.remoteCursorHtml);
+      applyRemoteCursorHtml(nextState.remoteCursorHtml);
       toastMirror.innerHTML = nextState.toastHtml || '';
       applyOverlayTransform(markerMirror, nextState);
       tooltipMirror.style.transform = 'none';
@@ -506,6 +515,24 @@ class MPVOverlayHost {
       return { success: true };
     } catch (error) {
       this.logger.debug('mpv overlay state update failed', { error: error.message });
+      return { success: false, error: error.message };
+    }
+  }
+
+  async updateRemoteCursorState(remoteCursorHtml) {
+    if (!this.window || this.window.isDestroyed?.()) {
+      return { success: false, error: 'mpv overlay host is not ready' };
+    }
+
+    const safeRemoteCursorHtml = typeof remoteCursorHtml === 'string' ? remoteCursorHtml : '';
+    try {
+      await this.window.webContents?.executeJavaScript?.(
+        `window.__applyMpvRemoteCursorState(${JSON.stringify(safeRemoteCursorHtml)});`,
+        true
+      );
+      return { success: true };
+    } catch (error) {
+      this.logger.debug('mpv overlay remote cursor update failed', { error: error.message });
       return { success: false, error: error.message };
     }
   }

--- a/preload/preload.js
+++ b/preload/preload.js
@@ -132,6 +132,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   mpvPrepareOverlay: (bounds) => ipcRenderer.invoke('mpv:prepare-overlay', bounds),
   mpvUpdateOverlayBounds: (bounds) => ipcRenderer.invoke('mpv:update-overlay-bounds', bounds),
   mpvUpdateOverlayState: (state) => ipcRenderer.invoke('mpv:update-overlay-state', state),
+  mpvUpdateOverlayRemoteCursors: (remoteCursorHtml) => ipcRenderer.invoke('mpv:update-overlay-remote-cursors', remoteCursorHtml),
   mpvDestroyOverlay: () => ipcRenderer.invoke('mpv:destroy-overlay'),
 
   // ====== 파일 관련 (유틸리티) ======

--- a/preload/preload.js
+++ b/preload/preload.js
@@ -22,6 +22,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   isMaximized: () => ipcRenderer.invoke('window:is-maximized'),
   toggleFullscreen: () => ipcRenderer.invoke('window:toggle-fullscreen'),
   isFullscreen: () => ipcRenderer.invoke('window:is-fullscreen'),
+  focusMainWindow: () => ipcRenderer.invoke('window:focus-main'),
 
   // ====== 앱 관련 ======
   getVersion: () => ipcRenderer.invoke('app:get-version'),

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -68,6 +68,7 @@ const SUPPORTED_PLAYLIST_EXTENSION = 'bplaylist';
 const SUPPORTED_CUTLIST_EXTENSION = 'bcutlist';
 const MPV_OVERLAY_LIVE_DRAW_SYNC_INTERVAL_MS = 48;
 const MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS = 350;
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 
 // 전역 에러 핸들러 설정
 setupGlobalErrorHandlers();
@@ -12749,6 +12750,35 @@ async function initApp() {
     scheduleMpvOverlayStateSync();
   }
 
+  function createRemoteCursorElement(collab) {
+    const cursorEl = document.createElement('div');
+    cursorEl.id = `cursor-${collab.connectionId}`;
+    cursorEl.className = 'remote-cursor';
+
+    const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+    svg.classList.add('remote-cursor-icon');
+    svg.setAttribute('width', '16');
+    svg.setAttribute('height', '16');
+    svg.setAttribute('viewBox', '0 0 16 16');
+    svg.setAttribute('fill', 'none');
+
+    const path = document.createElementNS(SVG_NAMESPACE, 'path');
+    path.setAttribute('d', 'M1 1L6 14L8 8L14 6L1 1Z');
+    path.setAttribute('fill', collab.userColor || '#ffd000');
+    path.setAttribute('stroke', 'rgba(0,0,0,0.3)');
+    path.setAttribute('stroke-width', '0.5');
+    svg.appendChild(path);
+
+    const label = document.createElement('span');
+    label.className = 'remote-cursor-label';
+    label.style.backgroundColor = collab.userColor || '#ffd000';
+    label.textContent = collab.userName || '알 수 없음';
+
+    cursorEl.appendChild(svg);
+    cursorEl.appendChild(label);
+    return cursorEl;
+  }
+
   function renderRemoteCursors(collaborators = []) {
     if (!remoteCursorsContainer) return;
 
@@ -12773,15 +12803,7 @@ async function initApp() {
       let cursorEl = document.getElementById(cursorId);
 
       if (!cursorEl) {
-        cursorEl = document.createElement('div');
-        cursorEl.id = cursorId;
-        cursorEl.className = 'remote-cursor';
-        cursorEl.innerHTML = `
-          <svg class="remote-cursor-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
-            <path d="M1 1L6 14L8 8L14 6L1 1Z" fill="${collab.userColor}" stroke="rgba(0,0,0,0.3)" stroke-width="0.5"/>
-          </svg>
-          <span class="remote-cursor-label" style="background-color: ${collab.userColor}">${collab.userName}</span>
-        `;
+        cursorEl = createRemoteCursorElement(collab);
         remoteCursorsContainer.appendChild(cursorEl);
       }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5178,6 +5178,7 @@ async function initApp() {
   let mpvPilotHostPreparing = false;
   let fullscreenTimecodeOverlay = null;
   let fullscreenScrubOverlay = null;
+  let remoteCursorsContainer = null;
 
   const MPV_BLOCKING_OVERLAY_SELECTOR = [
     '.modal-overlay.active',
@@ -5591,6 +5592,20 @@ async function initApp() {
     return clone.outerHTML;
   }
 
+  function serializeMpvOverlayRemoteCursorHtml() {
+    if (!remoteCursorsContainer || !userSettings.getShowRemoteCursors()) return '';
+
+    const clone = remoteCursorsContainer.cloneNode(true);
+    clone.querySelectorAll('[id]').forEach((el) => {
+      el.removeAttribute('id');
+    });
+    clone.querySelectorAll('.remote-cursor').forEach((cursor) => {
+      cursor.style.pointerEvents = 'none';
+    });
+
+    return clone.innerHTML;
+  }
+
   function getMpvOverlayState() {
     const wrapperRect = elements.videoWrapper?.getBoundingClientRect();
     const canvasRect = elements.drawingCanvas?.getBoundingClientRect();
@@ -5603,6 +5618,7 @@ async function initApp() {
       tooltipHtml: serializeMpvOverlayTooltipHtml(),
       htmlOverlayHtml: serializeMpvOverlayHtml(),
       toastHtml: serializeMpvOverlayToastHtml(),
+      remoteCursorHtml: serializeMpvOverlayRemoteCursorHtml(),
       markerTransform: markerContainer?.style.transform || '',
       markerTransformOrigin: markerContainer?.style.transformOrigin || 'center center',
       videoTransform: getMpvVideoTransform(),
@@ -12715,7 +12731,7 @@ async function initApp() {
   /**
    * 원격 커서 렌더링
    */
-  const remoteCursorsContainer = (() => {
+  remoteCursorsContainer = (() => {
     let container = document.getElementById('remoteCursorsContainer');
     if (!container) {
       container = document.createElement('div');
@@ -12730,6 +12746,7 @@ async function initApp() {
   function clearRemoteCursors() {
     if (!remoteCursorsContainer) return;
     remoteCursorsContainer.querySelectorAll('.remote-cursor').forEach(el => el.remove());
+    scheduleMpvOverlayStateSync();
   }
 
   function renderRemoteCursors(collaborators = []) {
@@ -12777,6 +12794,7 @@ async function initApp() {
         cursorEl.style.display = 'block';
       }
     }
+    scheduleMpvOverlayStateSync();
   }
 
   userSettings.addEventListener('showRemoteCursorsChanged', (event) => {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -55,6 +55,9 @@ import { getRecentFilesManager } from './modules/recent-files-manager.js';
 import * as recentFilesView from './modules/recent-files-view.js';
 import { computeToastStackLayout, computeToastTimerPlan } from './modules/toast-stack-core.js';
 import {
+  getEffectiveKeyboardShortcutTarget,
+  isTextEntryShortcutTarget,
+  shouldIgnoreComposingKeyboardEvent,
   shouldHandlePlayPauseShortcutFromTarget,
   shouldIgnoreGlobalShortcutTarget
 } from './modules/keyboard-shortcut-targets.js';
@@ -260,6 +263,13 @@ async function initApp() {
     return standardEditable || target.closest('.playlist-comment-reply-input');
   }
 
+  function getTextEntryFocusableTarget(target) {
+    if (!(target instanceof Element)) return null;
+    const editable = target.closest('textarea, input, [contenteditable="true"], [contenteditable="plaintext-only"]');
+    if (!editable || editable.disabled || editable.readOnly) return null;
+    return isTextEntryShortcutTarget(editable) ? editable : null;
+  }
+
   function resizeReplyEditorToContent(editor) {
     if (!editor) return;
 
@@ -279,21 +289,39 @@ async function initApp() {
     }
   }
 
-  function installCommentEditableFocusRecovery() {
+  function installTextEntryFocusRecovery() {
     let pendingEditable = null;
 
-    document.addEventListener('pointerdown', handleEditablePointerDown, true);
-    document.addEventListener('mousedown', handleEditablePointerDown, true);
+    document.addEventListener('pointerdown', handleTextEntryPointerDown, true);
+    document.addEventListener('mousedown', handleTextEntryPointerDown, true);
 
-    function handleEditablePointerDown(e) {
-      const editable = getCommentEditableTarget(e.target);
-      if (!editable || editable.disabled || editable.readOnly) return;
+    function requestMainWindowFocusForTextEntry() {
+      try {
+        const focusRequest = window.electronAPI?.focusMainWindow?.();
+        if (focusRequest && typeof focusRequest.catch === 'function') {
+          focusRequest.catch((error) => {
+            log.debug('입력 포커스 회복 중 메인창 포커스 요청 실패', { error: error.message });
+          });
+        }
+        return focusRequest;
+      } catch (error) {
+        log.debug('입력 포커스 회복 중 메인창 포커스 요청 실패', { error: error.message });
+        return null;
+      }
+    }
+
+    function handleTextEntryPointerDown(e) {
+      const editable = getTextEntryFocusableTarget(e.target);
+      if (!editable) return;
 
       pendingEditable = editable;
-      window.setTimeout(() => {
+      void requestMainWindowFocusForTextEntry();
+      window.setTimeout(async () => {
         if (pendingEditable !== editable) return;
         pendingEditable = null;
         if (!document.contains(editable) || document.activeElement === editable) return;
+
+        await requestMainWindowFocusForTextEntry();
 
         editable.focus({ preventScroll: true });
         if (
@@ -307,7 +335,7 @@ async function initApp() {
     }
   }
 
-  installCommentEditableFocusRecovery();
+  installTextEntryFocusRecovery();
 
   // 상태
   const state = {
@@ -9568,9 +9596,11 @@ async function initApp() {
 
   async function handleKeydown(e) {
     if (document.querySelector('.shortcut-key-btn.capturing')) return;
+    if (shouldIgnoreComposingKeyboardEvent(e)) return;
 
+    const shortcutTarget = getEffectiveKeyboardShortcutTarget(e, document);
     const isPlayPauseShortcut = userSettings.matchShortcut('playPause', e);
-    if (isPlayPauseShortcut && !shouldHandlePlayPauseShortcutFromTarget(e.target, e)) return;
+    if (isPlayPauseShortcut && !shouldHandlePlayPauseShortcutFromTarget(shortcutTarget, e)) return;
 
     // pending 마커 입력 중이면 단축키 무시 (textarea 포커스 전에도 적용)
     if (commentManager.pendingMarker) return;
@@ -9597,7 +9627,7 @@ async function initApp() {
     }
 
     // 폼 컨트롤에서는 Space 재생을 제외한 전역 단축키를 무시한다.
-    if (shouldIgnoreGlobalShortcutTarget(e.target)) return;
+    if (shouldIgnoreGlobalShortcutTarget(shortcutTarget)) return;
 
     // 댓글 모드
     if (userSettings.matchShortcut('commentMode', e)) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5200,6 +5200,7 @@ async function initApp() {
   let mpvEmbedBoundsSyncPending = false;
   let mpvVideoTransformSyncPending = false;
   let mpvOverlayStateSyncPending = false;
+  let mpvOverlayRemoteCursorSyncPending = false;
   let mpvOverlayStateSyncTimer = null;
   let mpvOverlayLastLiveDrawSyncAt = 0;
   let mpvHostVisibilitySyncPending = false;
@@ -5677,6 +5678,28 @@ async function initApp() {
         log.debug('mpv 오버레이 상태 갱신 실패', { error: error.message });
       }
     });
+  }
+
+  function syncMpvOverlayRemoteCursorState() {
+    if (!document.body.classList.contains('mpv-pilot-mode')) return;
+    if (!window.electronAPI?.mpvUpdateOverlayRemoteCursors) return;
+    if (mpvOverlayRemoteCursorSyncPending) return;
+
+    mpvOverlayRemoteCursorSyncPending = true;
+    requestAnimationFrame(async () => {
+      mpvOverlayRemoteCursorSyncPending = false;
+      const remoteCursorHtml = serializeMpvOverlayRemoteCursorHtml();
+
+      try {
+        await window.electronAPI.mpvUpdateOverlayRemoteCursors(remoteCursorHtml);
+      } catch (error) {
+        log.debug('mpv 오버레이 원격 커서 갱신 실패', { error: error.message });
+      }
+    });
+  }
+
+  function scheduleMpvOverlayRemoteCursorStateSync() {
+    syncMpvOverlayRemoteCursorState();
   }
 
   function scheduleMpvOverlayStateSync(options = {}) {
@@ -12777,7 +12800,7 @@ async function initApp() {
   function clearRemoteCursors() {
     if (!remoteCursorsContainer) return;
     remoteCursorsContainer.querySelectorAll('.remote-cursor').forEach(el => el.remove());
-    scheduleMpvOverlayStateSync();
+    scheduleMpvOverlayRemoteCursorStateSync();
   }
 
   function createRemoteCursorElement(collab) {
@@ -12846,7 +12869,7 @@ async function initApp() {
         cursorEl.style.display = 'block';
       }
     }
-    scheduleMpvOverlayStateSync();
+    scheduleMpvOverlayRemoteCursorStateSync();
   }
 
   userSettings.addEventListener('showRemoteCursorsChanged', (event) => {

--- a/renderer/scripts/modules/keyboard-shortcut-targets.js
+++ b/renderer/scripts/modules/keyboard-shortcut-targets.js
@@ -53,6 +53,20 @@ export function isTextEntryShortcutTarget(target) {
   return TEXT_ENTRY_INPUT_TYPES.has(getInputType(target));
 }
 
+export function getEffectiveKeyboardShortcutTarget(event, ownerDocument = globalThis.document) {
+  const target = event?.target || null;
+  const tagName = getTagName(target);
+  if (target && tagName !== 'BODY' && tagName !== 'HTML' && tagName !== '') {
+    return target;
+  }
+
+  return ownerDocument?.activeElement || target;
+}
+
+export function shouldIgnoreComposingKeyboardEvent(event) {
+  return event?.isComposing === true || event?.key === 'Process' || event?.code === 'Process';
+}
+
 export function shouldHandlePlayPauseShortcutFromTarget(target, event = null) {
   if (isTextEntryShortcutTarget(target)) return false;
 

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -697,6 +697,10 @@ body {
   overflow: hidden;
 }
 
+body.mpv-pilot-mode .video-wrapper.mpv-pilot-mode > .remote-cursors-container {
+  visibility: hidden !important;
+}
+
 .remote-cursor {
   position: absolute;
   top: 0;

--- a/scripts/tests/collaboration-cursors-source.test.js
+++ b/scripts/tests/collaboration-cursors-source.test.js
@@ -30,3 +30,10 @@ test('remote cursor renderer clears cursors when the setting is off', () => {
   assert.match(appSource, /if \(!userSettings\.getShowRemoteCursors\(\)\) \{[\s\S]+clearRemoteCursors\(\);[\s\S]+return;/);
   assert.match(appSource, /userSettings\.addEventListener\('showRemoteCursorsChanged'/);
 });
+
+test('remote cursor labels are built as text before mpv mirroring', () => {
+  assert.match(appSource, /const SVG_NAMESPACE = 'http:\/\/www\.w3\.org\/2000\/svg';/);
+  assert.match(appSource, /const label = document\.createElement\('span'\);[\s\S]+label\.textContent = collab\.userName \|\| '알 수 없음';/);
+  assert.match(appSource, /const svg = document\.createElementNS\(SVG_NAMESPACE, 'svg'\);/);
+  assert.doesNotMatch(appSource, /cursorEl\.innerHTML = `[\s\S]*\$\{collab\.userName\}/);
+});

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -8,12 +8,20 @@ const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
 const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
 const htmlSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
 const cssSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
+const preloadSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'preload/preload.js'), 'utf8'));
+const ipcHandlersSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'main/ipc-handlers.js'), 'utf8'));
 
 test('comment editable fields recover focus when a parent pointer handler blocks default focus', () => {
   assert.match(appSource, /function getCommentEditableTarget\(target\) \{[\s\S]+target\.closest\('\.comment-input, \.comment-marker-input, \.comment-reply-input, \.comment-edit-textarea, \.comment-reply-edit-textarea, \.thread-editor\[contenteditable="true"\]'\)/);
-  assert.match(appSource, /function installCommentEditableFocusRecovery\(\) \{[\s\S]+document\.addEventListener\('pointerdown', handleEditablePointerDown, true\);[\s\S]+editable\.focus\(\{ preventScroll: true \}\);/);
-  assert.match(appSource, /document\.addEventListener\('mousedown', handleEditablePointerDown, true\);/);
-  assert.match(appSource, /installCommentEditableFocusRecovery\(\);/);
+  assert.match(appSource, /function getTextEntryFocusableTarget\(target\) \{[\s\S]+target\.closest\('textarea, input, \[contenteditable="true"\], \[contenteditable="plaintext-only"\]'\)/);
+  assert.match(appSource, /function installTextEntryFocusRecovery\(\) \{[\s\S]+document\.addEventListener\('pointerdown', handleTextEntryPointerDown, true\);[\s\S]+window\.electronAPI\?\.focusMainWindow\?\.\(\);[\s\S]+editable\.focus\(\{ preventScroll: true \}\);/);
+  assert.match(appSource, /document\.addEventListener\('mousedown', handleTextEntryPointerDown, true\);/);
+  assert.match(appSource, /installTextEntryFocusRecovery\(\);/);
+});
+
+test('text entry focus recovery can reactivate the main Electron window', () => {
+  assert.match(preloadSource, /focusMainWindow: \(\) => ipcRenderer\.invoke\('window:focus-main'\)/);
+  assert.match(ipcHandlersSource, /ipcMain\.handle\('window:focus-main', \(\) => \{[\s\S]+mainWindow\.focus\(\);[\s\S]+mainWindow\.webContents\?\.focus\?\.\(\);[\s\S]+success: true/);
 });
 
 test('right sidebar comment input is covered by the same focus recovery path', () => {

--- a/scripts/tests/keyboard-shortcut-targets.test.js
+++ b/scripts/tests/keyboard-shortcut-targets.test.js
@@ -39,7 +39,7 @@ test('form controls only allow play/pause override for the Space shortcut', asyn
     shouldHandlePlayPauseShortcutFromTarget({ tagName: 'INPUT', type: 'checkbox' }, { code: 'KeyK' }),
     false
   );
-  assert.match(appSource, /shouldHandlePlayPauseShortcutFromTarget\(e\.target, e\)/);
+  assert.match(appSource, /shouldHandlePlayPauseShortcutFromTarget\(shortcutTarget, e\)/);
 });
 
 test('Space play/pause shortcut suppresses focused control keyup activation', () => {
@@ -69,4 +69,31 @@ test('non-playback shortcuts stay ignored for form controls', async () => {
 
   assert.equal(shouldIgnoreGlobalShortcutTarget({ tagName: 'BUTTON' }), false);
   assert.equal(shouldIgnoreGlobalShortcutTarget({ tagName: 'DIV' }), false);
+});
+
+test('global shortcuts use active text entry when keyboard target is the page shell', async () => {
+  const {
+    getEffectiveKeyboardShortcutTarget,
+    shouldIgnoreComposingKeyboardEvent
+  } = await import('../../renderer/scripts/modules/keyboard-shortcut-targets.js');
+
+  const activeInput = { tagName: 'TEXTAREA' };
+  const bodyTarget = { tagName: 'BODY' };
+  assert.equal(
+    getEffectiveKeyboardShortcutTarget({ target: bodyTarget }, { activeElement: activeInput }),
+    activeInput
+  );
+  assert.equal(
+    getEffectiveKeyboardShortcutTarget({ target: { tagName: 'INPUT', type: 'text' } }, { activeElement: activeInput })?.tagName,
+    'INPUT'
+  );
+  assert.equal(shouldIgnoreComposingKeyboardEvent({ isComposing: true }), true);
+  assert.equal(shouldIgnoreComposingKeyboardEvent({ key: 'Process' }), true);
+  assert.equal(shouldIgnoreComposingKeyboardEvent({ code: 'Process' }), true);
+  assert.equal(shouldIgnoreComposingKeyboardEvent({ key: 'a', code: 'KeyA' }), false);
+
+  assert.match(appSource, /if \(shouldIgnoreComposingKeyboardEvent\(e\)\) return;/);
+  assert.match(appSource, /const shortcutTarget = getEffectiveKeyboardShortcutTarget\(e, document\);/);
+  assert.match(appSource, /shouldHandlePlayPauseShortcutFromTarget\(shortcutTarget, e\)/);
+  assert.match(appSource, /shouldIgnoreGlobalShortcutTarget\(shortcutTarget\)/);
 });

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -118,6 +118,7 @@ test('creates a click-through overlay window above the viewer area', async () =>
   assert.equal(overlayHtml.includes('tooltipMirror'), true);
   assert.equal(overlayHtml.includes('toastMirror'), true);
   assert.equal(overlayHtml.includes('remoteCursorMirror'), true);
+  assert.equal(overlayHtml.includes('__applyMpvRemoteCursorState'), true);
   assert.equal(overlayHtml.includes('.remote-cursors-container'), true);
   assert.equal(overlayHtml.includes("applyImage('drawingCanvasMirror', nextState.drawingDataUrl, nextState.canvas)"), true);
   assert.doesNotMatch(
@@ -129,9 +130,11 @@ test('creates a click-through overlay window above the viewer area', async () =>
   assert.equal(overlayHtml.includes('htmlOverlay.innerHTML = nextState.htmlOverlayHtml'), true);
   assert.equal(overlayHtml.includes('toastMirror.innerHTML = nextState.toastHtml'), true);
   assert.equal(overlayHtml.includes('function sanitizeRemoteCursorHtml'), true);
+  assert.equal(overlayHtml.includes('function applyRemoteCursorHtml'), true);
   assert.equal(overlayHtml.includes("const allowedTags = new Set(['div', 'span', 'svg', 'path'])"), true);
   assert.equal(overlayHtml.includes("name.startsWith('on')"), true);
-  assert.equal(overlayHtml.includes('remoteCursorMirror.innerHTML = sanitizeRemoteCursorHtml(nextState.remoteCursorHtml)'), true);
+  assert.equal(overlayHtml.includes('remoteCursorMirror.innerHTML = sanitizeRemoteCursorHtml(remoteCursorHtml)'), true);
+  assert.equal(overlayHtml.includes('applyRemoteCursorHtml(nextState.remoteCursorHtml)'), true);
   assert.equal(overlayHtml.includes("tooltipMirror.style.transform = 'none';"), true);
   assert.ok(events.some(([name]) => name === 'showInactive'));
   assert.ok(events.some(([name]) => name === 'moveTop'));
@@ -191,6 +194,13 @@ test('updates overlay state through the isolated overlay document', async () => 
   assert.match(scripts[0], /toast info/);
   assert.match(scripts[0], /remote-cursor/);
   assert.match(scripts[0], /data:image\/png;base64,draw/);
+
+  const cursorOnlyResult = await host.updateRemoteCursorState('<div class="remote-cursor" style="display:block"></div>');
+  assert.equal(cursorOnlyResult.success, true);
+  assert.equal(scripts.length, 2);
+  assert.match(scripts[1], /window\.__applyMpvRemoteCursorState/);
+  assert.match(scripts[1], /remote-cursor/);
+  assert.doesNotMatch(scripts[1], /drawingDataUrl|markerHtml|toastHtml/);
 });
 
 test('hides and restores the native overlay host with the mpv embed host', async () => {

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -18,6 +18,7 @@ test('normalizes overlay state to bounded serializable fields', () => {
     tooltipHtml: '<div class="comment-marker-tooltip visible"></div>',
     htmlOverlayHtml: '<div class="current-cut-overlay">Cut 01</div>',
     toastHtml: '<div class="toast-container"><div class="toast success">Saved</div></div>',
+    remoteCursorHtml: '<div class="remote-cursor"></div>',
     canvas: { left: 10.4, top: 20.6, width: 640.2, height: 360.7 },
     markerTransform: 'scale(2) translate(1px, 2px)',
     markerTransformOrigin: 'center center'
@@ -30,6 +31,7 @@ test('normalizes overlay state to bounded serializable fields', () => {
   assert.equal(state.tooltipHtml, '<div class="comment-marker-tooltip visible"></div>');
   assert.equal(state.htmlOverlayHtml, '<div class="current-cut-overlay">Cut 01</div>');
   assert.equal(state.toastHtml, '<div class="toast-container"><div class="toast success">Saved</div></div>');
+  assert.equal(state.remoteCursorHtml, '<div class="remote-cursor"></div>');
   assert.equal(state.markerTransform, 'scale(2) translate(1px, 2px)');
   assert.equal(state.markerTransformOrigin, 'center center');
 });
@@ -115,6 +117,8 @@ test('creates a click-through overlay window above the viewer area', async () =>
   assert.equal(overlayHtml.includes('htmlOverlay'), true);
   assert.equal(overlayHtml.includes('tooltipMirror'), true);
   assert.equal(overlayHtml.includes('toastMirror'), true);
+  assert.equal(overlayHtml.includes('remoteCursorMirror'), true);
+  assert.equal(overlayHtml.includes('.remote-cursors-container'), true);
   assert.equal(overlayHtml.includes("applyImage('drawingCanvasMirror', nextState.drawingDataUrl, nextState.canvas)"), true);
   assert.doesNotMatch(
     overlayHtml,
@@ -124,6 +128,7 @@ test('creates a click-through overlay window above the viewer area', async () =>
   assert.equal(overlayHtml.includes('tooltipMirror.innerHTML = nextState.tooltipHtml'), true);
   assert.equal(overlayHtml.includes('htmlOverlay.innerHTML = nextState.htmlOverlayHtml'), true);
   assert.equal(overlayHtml.includes('toastMirror.innerHTML = nextState.toastHtml'), true);
+  assert.equal(overlayHtml.includes('remoteCursorMirror.innerHTML = nextState.remoteCursorHtml'), true);
   assert.equal(overlayHtml.includes("tooltipMirror.style.transform = 'none';"), true);
   assert.ok(events.some(([name]) => name === 'showInactive'));
   assert.ok(events.some(([name]) => name === 'moveTop'));
@@ -170,6 +175,7 @@ test('updates overlay state through the isolated overlay document', async () => 
     markerHtml: '<div class="comment-marker pending"></div>',
     htmlOverlayHtml: '<div class="current-cut-overlay">Cut 01</div>',
     toastHtml: '<div class="toast-container"><div class="toast info">Ready</div></div>',
+    remoteCursorHtml: '<div class="remote-cursor" style="display:block"></div>',
     drawingDataUrl: 'data:image/png;base64,draw',
     canvas: { left: 1, top: 2, width: 3, height: 4 }
   });
@@ -180,6 +186,7 @@ test('updates overlay state through the isolated overlay document', async () => 
   assert.match(scripts[0], /comment-marker pending/);
   assert.match(scripts[0], /current-cut-overlay/);
   assert.match(scripts[0], /toast info/);
+  assert.match(scripts[0], /remote-cursor/);
   assert.match(scripts[0], /data:image\/png;base64,draw/);
 });
 

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -128,7 +128,10 @@ test('creates a click-through overlay window above the viewer area', async () =>
   assert.equal(overlayHtml.includes('tooltipMirror.innerHTML = nextState.tooltipHtml'), true);
   assert.equal(overlayHtml.includes('htmlOverlay.innerHTML = nextState.htmlOverlayHtml'), true);
   assert.equal(overlayHtml.includes('toastMirror.innerHTML = nextState.toastHtml'), true);
-  assert.equal(overlayHtml.includes('remoteCursorMirror.innerHTML = nextState.remoteCursorHtml'), true);
+  assert.equal(overlayHtml.includes('function sanitizeRemoteCursorHtml'), true);
+  assert.equal(overlayHtml.includes("const allowedTags = new Set(['div', 'span', 'svg', 'path'])"), true);
+  assert.equal(overlayHtml.includes("name.startsWith('on')"), true);
+  assert.equal(overlayHtml.includes('remoteCursorMirror.innerHTML = sanitizeRemoteCursorHtml(nextState.remoteCursorHtml)'), true);
   assert.equal(overlayHtml.includes("tooltipMirror.style.transform = 'none';"), true);
   assert.ok(events.some(([name]) => name === 'showInactive'));
   assert.ok(events.some(([name]) => name === 'moveTop'));

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -43,6 +43,7 @@ test('preload exposes a narrow mpv API surface', () => {
   assert.match(preloadSource, /mpvPrepareOverlay: \(bounds\) => ipcRenderer\.invoke\('mpv:prepare-overlay', bounds\)/);
   assert.match(preloadSource, /mpvUpdateOverlayBounds: \(bounds\) => ipcRenderer\.invoke\('mpv:update-overlay-bounds', bounds\)/);
   assert.match(preloadSource, /mpvUpdateOverlayState: \(state\) => ipcRenderer\.invoke\('mpv:update-overlay-state', state\)/);
+  assert.match(preloadSource, /mpvUpdateOverlayRemoteCursors: \(remoteCursorHtml\) => ipcRenderer\.invoke\('mpv:update-overlay-remote-cursors', remoteCursorHtml\)/);
   assert.match(preloadSource, /mpvDestroyOverlay: \(\) => ipcRenderer\.invoke\('mpv:destroy-overlay'\)/);
 });
 
@@ -70,6 +71,7 @@ test('main process registers mpv IPC handlers through the manager and embed host
     'mpv:prepare-overlay',
     'mpv:update-overlay-bounds',
     'mpv:update-overlay-state',
+    'mpv:update-overlay-remote-cursors',
     'mpv:destroy-overlay'
   ]) {
     assert.match(ipcSource, new RegExp(`ipcMain\\.handle\\('${channel}'`));
@@ -84,6 +86,7 @@ test('main process registers mpv IPC handlers through the manager and embed host
   assert.match(ipcSource, /mpvOverlayHost\.setVisible\(nextVisible\)/);
   assert.match(ipcSource, /mpvOverlayHost\.updateBounds\(bounds\)/);
   assert.match(ipcSource, /mpvOverlayHost\.updateState\(state\)/);
+  assert.match(ipcSource, /mpvOverlayHost\.updateRemoteCursorState\(remoteCursorHtml\)/);
   assert.match(ipcSource, /mpvOverlayHost\.destroy\(\)/);
 });
 
@@ -308,8 +311,14 @@ test('mpv pilot mirrors DOM overlays into a click-through native overlay window'
   assert.match(appSource, /function getMpvOverlayState\(\) \{[\s\S]+toastHtml: serializeMpvOverlayToastHtml\(\)/);
   assert.match(appSource, /function serializeMpvOverlayRemoteCursorHtml\(\) \{[\s\S]+remoteCursorsContainer\.cloneNode\(true\)[\s\S]+return clone\.innerHTML;/);
   assert.match(appSource, /function getMpvOverlayState\(\) \{[\s\S]+remoteCursorHtml: serializeMpvOverlayRemoteCursorHtml\(\)/);
-  assert.match(appSource, /function renderRemoteCursors\(collaborators = \[\]\) \{[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}/);
-  assert.match(appSource, /function clearRemoteCursors\(\) \{[\s\S]+remoteCursorsContainer\.querySelectorAll\('\.remote-cursor'\)\.forEach\(el => el\.remove\(\)\);[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}/);
+  assert.match(appSource, /function syncMpvOverlayRemoteCursorState\(\) \{[\s\S]+const remoteCursorHtml = serializeMpvOverlayRemoteCursorHtml\(\);[\s\S]+window\.electronAPI\.mpvUpdateOverlayRemoteCursors\(remoteCursorHtml\)/);
+  assert.match(appSource, /function scheduleMpvOverlayRemoteCursorStateSync\(\) \{[\s\S]+syncMpvOverlayRemoteCursorState\(\);[\s\S]+\}/);
+  const clearRemoteCursorsSource = appSource.match(/function clearRemoteCursors\(\) \{([\s\S]*?)\n  \}/)?.[1] || '';
+  const renderRemoteCursorsSource = appSource.match(/function renderRemoteCursors\(collaborators = \[\]\) \{([\s\S]*?)\n  \}\n\n  userSettings\.addEventListener/)?.[1] || '';
+  assert.match(clearRemoteCursorsSource, /remoteCursorsContainer\.querySelectorAll\('\.remote-cursor'\)\.forEach\(el => el\.remove\(\)\);[\s\S]+scheduleMpvOverlayRemoteCursorStateSync\(\);/);
+  assert.match(renderRemoteCursorsSource, /scheduleMpvOverlayRemoteCursorStateSync\(\);/);
+  assert.doesNotMatch(clearRemoteCursorsSource, /scheduleMpvOverlayStateSync\(/);
+  assert.doesNotMatch(renderRemoteCursorsSource, /scheduleMpvOverlayStateSync\(/);
   assert.match(mainStyles, /body\.mpv-pilot-mode \.video-wrapper\.mpv-pilot-mode > \.remote-cursors-container \{[\s\S]+visibility: hidden !important;/);
   const htmlOverlayMatch = appSource.match(/function serializeMpvOverlayHtml\(\) \{([\s\S]*?)\n  \}\n\n  function getMpvOverlayState/);
   assert.ok(htmlOverlayMatch, 'serializeMpvOverlayHtml should exist');

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -306,6 +306,11 @@ test('mpv pilot mirrors DOM overlays into a click-through native overlay window'
   assert.match(appSource, /function copyComputedMpvOverlayStyles\(source, target\) \{/);
   assert.match(appSource, /function serializeMpvOverlayToastHtml\(\) \{/);
   assert.match(appSource, /function getMpvOverlayState\(\) \{[\s\S]+toastHtml: serializeMpvOverlayToastHtml\(\)/);
+  assert.match(appSource, /function serializeMpvOverlayRemoteCursorHtml\(\) \{[\s\S]+remoteCursorsContainer\.cloneNode\(true\)[\s\S]+return clone\.innerHTML;/);
+  assert.match(appSource, /function getMpvOverlayState\(\) \{[\s\S]+remoteCursorHtml: serializeMpvOverlayRemoteCursorHtml\(\)/);
+  assert.match(appSource, /function renderRemoteCursors\(collaborators = \[\]\) \{[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}/);
+  assert.match(appSource, /function clearRemoteCursors\(\) \{[\s\S]+remoteCursorsContainer\.querySelectorAll\('\.remote-cursor'\)\.forEach\(el => el\.remove\(\)\);[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+\}/);
+  assert.match(mainStyles, /body\.mpv-pilot-mode \.video-wrapper\.mpv-pilot-mode > \.remote-cursors-container \{[\s\S]+visibility: hidden !important;/);
   const htmlOverlayMatch = appSource.match(/function serializeMpvOverlayHtml\(\) \{([\s\S]*?)\n  \}\n\n  function getMpvOverlayState/);
   assert.ok(htmlOverlayMatch, 'serializeMpvOverlayHtml should exist');
   const htmlOverlaySource = htmlOverlayMatch[1];


### PR DESCRIPTION
## 📋 업데이트 요약

- 🖱️ mpv 직접 재생 모드에서 다른 사람의 Liveblocks 커서가 영상 위에 제대로 보이도록 개선했습니다.
- 👀 mpv 영상 레이어와 앱 화면 레이어가 겹치면서 커서나 안내 표시가 가려지는 상황을 줄였습니다.
- ⌨️ 텍스트 입력창이 간헐적으로 키 입력을 받지 못하다가 알트탭 후에야 풀리는 문제를 완화했습니다.
- 🚀 협업 커서가 자주 움직여도 큰 화면 요소를 매번 다시 처리하지 않도록 가볍게 갱신합니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - `serializeMpvOverlayRemoteCursorHtml()`를 추가하고 `getMpvOverlayState()`에 `remoteCursorHtml`을 포함해 Liveblocks 원격 커서를 mpv overlay window로 전달했습니다.
  - 원격 커서 DOM을 `innerHTML` 문자열 대신 `createElement`, `createElementNS`, `textContent`로 생성하도록 바꿔 협업 사용자 이름이 HTML로 실행되지 않게 했습니다.
  - `syncMpvOverlayRemoteCursorState()`와 `scheduleMpvOverlayRemoteCursorStateSync()`를 추가해 커서 이동 시 전체 overlay snapshot 대신 커서 HTML만 갱신합니다.
  - 모든 텍스트 입력 대상에 `installTextEntryFocusRecovery()`를 적용해 입력 필드 클릭 시 메인 Electron 창 포커스를 회복하도록 했습니다.
  - 전역 단축키 처리에서 IME 조합 키를 무시하고, 이벤트 타깃이 `BODY`로 흔들릴 때 `document.activeElement` 기준으로 입력창 여부를 판단하도록 했습니다.
- `main/mpv-overlay-host.js`
  - `remoteCursorMirror` 레이어를 추가하고, 원격 커서 HTML은 허용된 태그/속성만 남기는 `sanitizeRemoteCursorHtml()`을 거쳐 반영하도록 했습니다.
  - `updateRemoteCursorState()`와 overlay document의 `__applyMpvRemoteCursorState()`를 추가해 커서만 부분 갱신할 수 있게 했습니다.
- `main/ipc-handlers.js`, `preload/preload.js`
  - renderer에서 안전하게 메인창 포커스를 되찾을 수 있도록 `window:focus-main` IPC와 `focusMainWindow()` preload API를 추가했습니다.
  - 원격 커서 전용 갱신을 위한 `mpv:update-overlay-remote-cursors` IPC와 preload API를 추가했습니다.
- `renderer/styles/main.css`
  - mpv 모드에서는 원래 renderer DOM의 `.remote-cursors-container`를 숨겨 native mpv 영상 레이어와 중복 표시되지 않게 했습니다.
- 테스트
  - `mpv-runtime-source`, `mpv-overlay-host`, `collaboration-cursors`, `comment-input-focus`, `keyboard-shortcut-targets` 테스트로 커서 mirror, 보안 처리, 입력 포커스 회복, 단축키 타깃 보정, 커서 전용 부분 갱신을 검증했습니다.

## 🚧 개발 난항

- mpv는 일반 HTML 영상이 아니라 별도 native 영상 창 위에 붙는 구조라, 앱 안의 DOM 요소가 단순히 `z-index`만으로는 영상 위에 올라오지 않습니다.
- Codex 1차 리뷰에서 원격 커서 이름을 HTML 문자열로 복사하는 보안 문제가 지적되어, 커서 생성 방식을 텍스트 노드 기반으로 바꾸고 overlay host에도 정리 로직을 추가했습니다.
- 입력 막힘은 특정 입력창 하나의 문제가 아니라 Windows 포커스, mpv native child window, 전역 단축키 처리, IME 조합 상태가 함께 얽힌 문제라 포커스 회복과 키 이벤트 분류를 같이 보강했습니다.
- Codex 2차 리뷰에서 커서 이동마다 전체 overlay snapshot이 돌며 캔버스 `toDataURL()` 비용이 발생할 수 있다는 지적이 있어, 커서 전용 IPC 업데이트로 분리했습니다.

## ✅ 테스트 가이드

실사용자용

1. 앱 설정에서 mpv 직접 재생 파일럿을 켭니다.
2. 협업 세션이 연결된 상태에서 영상을 엽니다.
3. 다른 사용자의 커서가 mpv 영상 위에 자연스럽게 보이는지 확인합니다.
4. 댓글 입력창, 답글 입력창, 이름/검색 입력창을 클릭한 뒤 한글과 영어를 입력해 봅니다.
5. 입력이 막힌 느낌이 들던 상황에서 알트탭 없이 다시 입력이 이어지는지 확인합니다.

개발자용

- `node --test scripts/tests/keyboard-shortcut-targets.test.js`
- `npm run test:comment-input`
- `npm run test:collaboration`
- `npm run test:mpv`
- `npm run build`