### PR TITLE
[v1.4.1] 해결됨 버튼 툴팁 작성자 표시 수정

### DIFF
--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -7049,6 +7049,7 @@ async function initApp() {
     tooltip.className = 'comment-marker-tooltip';
     tooltip.dataset.markerId = marker.id;
     const authorClass = getAuthorColorClass(marker.author);
+    const resolveTitle = getResolveButtonLabel(marker.resolved, marker.resolvedBy);
     tooltip.innerHTML = `
       <div class="tooltip-header">
         <span class="tooltip-timecode">${marker.startTimecode}</span>
@@ -7056,7 +7057,7 @@ async function initApp() {
       </div>
       <div class="tooltip-text">${renderGDriveLinks(escapeHtml(marker.text))}</div>
       <div class="tooltip-actions">
-        <button class="tooltip-btn resolve" title="${marker.resolved ? '미해결로 변경' : '해결'}">
+        <button class="tooltip-btn resolve" title="${escapeHtmlAttribute(resolveTitle)}" aria-label="${escapeHtmlAttribute(resolveTitle)}">
           ${marker.resolved ? '↩️' : '✓'}
         </button>
         <button class="tooltip-btn delete" title="삭제">🗑️</button>
@@ -8049,7 +8050,8 @@ async function initApp() {
       const replyCount = range.replies?.length || 0;
       const repliesExpanded = playlistExpandedReplyKeys.has(key);
       const repliesHtml = renderPlaylistAggregateReplies(range, normalizedSearch);
-      const resolveTitle = range.resolved ? '미해결로 변경' : '해결됨으로 변경';
+      const resolveTitle = getResolveButtonLabel(range.resolved, range.resolvedBy);
+      const resolveTooltipHtml = range.resolved ? getResolveTooltipHtml(range.resolvedBy, range.resolvedAt) : '';
       const imageUrl = range.image ? escapeHtmlAttribute(range.image) : '';
 
       return `
@@ -8058,9 +8060,9 @@ async function initApp() {
         data-marker-id="${escapeHtmlAttribute(range.markerId)}"
         data-item-id="${escapeHtmlAttribute(range.itemId)}"
         title="${title}">
-        <button type="button" class="comment-resolve-toggle playlist-comment-resolve-toggle" title="${resolveTitle}" aria-label="${resolveTitle}">
+        <button type="button" class="comment-resolve-toggle playlist-comment-resolve-toggle" title="${escapeHtmlAttribute(resolveTitle)}" aria-label="${escapeHtmlAttribute(resolveTitle)}">
           ${range.resolved ? '✓ 해결됨' : '○ 미해결'}
-          ${range.resolved && range.resolvedBy ? `<span class="resolve-tooltip"><span class="resolve-tooltip-who">해결됨 by ${escapeHtml(range.resolvedBy)}</span><span class="resolve-tooltip-date">${formatResolvedDate(range.resolvedAt)}</span></span>` : ''}
+          ${resolveTooltipHtml}
         </button>
         <div class="playlist-comment-time-row">
           <span class="comment-timecode">${highlightCommentSearchMatches(range.cutLabel, normalizedSearch)} ${highlightCommentSearchMatches(range.localStartTimecode, normalizedSearch)}</span>
@@ -8459,6 +8461,8 @@ async function initApp() {
       const cutlistCommentLabel = getCutlistCommentLabelForMarker(marker);
       const commentTimeLabel = cutlistCommentLabel || marker.startTimecode;
       const commentPanelLine = getCutlistCommentPanelLineForMarker(marker);
+      const resolveTitle = getResolveButtonLabel(marker.resolved, marker.resolvedBy);
+      const resolveTooltipHtml = marker.resolved ? getResolveTooltipHtml(marker.resolvedBy, marker.resolvedAt) : '';
       const repliesHtml = (marker.replies || []).map(reply => {
         const canEditReply = commentManager.canEdit(reply);
         return `
@@ -8505,9 +8509,9 @@ async function initApp() {
       return `
       <div class="comment-item ${marker.resolved ? 'resolved' : ''} ${avatarImage ? 'has-avatar' : ''} ${thumbnailUrl ? 'has-thumbnail' : ''} ${marker.image ? 'has-image' : ''}" data-marker-id="${marker.id}" data-start-frame="${marker.startFrame}"${commentPanelLine ? ` title="${escapeHtmlAttribute(commentPanelLine)}"` : ''}>
         ${avatarImage ? `<div class="comment-avatar-bg" style="background-image: url('${avatarImage}')"></div>` : ''}
-        <button class="comment-resolve-toggle resolve-btn" title="${marker.resolved ? '미해결로 변경' : '해결됨으로 변경'}">
+        <button class="comment-resolve-toggle resolve-btn" title="${escapeHtmlAttribute(resolveTitle)}" aria-label="${escapeHtmlAttribute(resolveTitle)}">
           ${marker.resolved ? '✓ 해결됨' : '○ 미해결'}
-          ${marker.resolved && marker.resolvedBy ? `<span class="resolve-tooltip"><span class="resolve-tooltip-who">해결됨 by ${escapeHtml(marker.resolvedBy)}</span><span class="resolve-tooltip-date">${formatResolvedDate(marker.resolvedAt)}</span></span>` : ''}
+          ${resolveTooltipHtml}
         </button>
         ${thumbnailHtml}
         <div class="comment-header">
@@ -9132,6 +9136,28 @@ async function initApp() {
     const ampm = hours >= 12 ? 'PM' : 'AM';
     hours = hours % 12 || 12;
     return `${month}월 ${day}일 ${hours}:${minutes} ${ampm}`;
+  }
+
+  function getResolveButtonLabel(isResolved, resolvedBy) {
+    if (!isResolved) return '해결됨으로 변경';
+
+    const resolver = typeof resolvedBy === 'string' ? resolvedBy.trim() : resolvedBy;
+    return resolver
+      ? `${resolver}님이 해결함 - 미해결로 변경`
+      : '해결한 사람 기록 없음 - 미해결로 변경';
+  }
+
+  function getResolveTooltipHtml(resolvedBy, resolvedAt) {
+    const resolver = typeof resolvedBy === 'string' ? resolvedBy.trim() : resolvedBy;
+    const resolverText = resolver ? `해결됨 by ${escapeHtml(resolver)}` : '해결한 사람 기록 없음';
+    const resolvedDateText = formatResolvedDate(resolvedAt);
+
+    return `
+      <span class="resolve-tooltip">
+        <span class="resolve-tooltip-who">${resolverText}</span>
+        ${resolvedDateText ? `<span class="resolve-tooltip-date">${resolvedDateText}</span>` : ''}
+      </span>
+    `;
   }
 
   /**

--- a/renderer/scripts/modules/comment-manager.js
+++ b/renderer/scripts/modules/comment-manager.js
@@ -954,11 +954,11 @@ export class CommentManager extends EventTarget {
 
     const allowedFields = [
       'text', 'startFrame', 'endFrame', 'resolved', 'x', 'y',
-      'colorKey', 'updatedAt', 'image', 'author', 'authorId'
+      'resolvedBy', 'resolvedAt', 'colorKey', 'updatedAt', 'image', 'author', 'authorId'
     ];
     for (const key of allowedFields) {
       if (fields[key] !== undefined) {
-        marker[key] = fields[key];
+        marker[key] = key === 'resolvedAt' && fields[key] ? new Date(fields[key]) : fields[key];
       }
     }
 

--- a/renderer/scripts/modules/comment-sync.js
+++ b/renderer/scripts/modules/comment-sync.js
@@ -117,7 +117,7 @@ export class CommentSync {
         text: marker.text || marker.content || '',
         resolved: marker.resolved || false,
         resolvedBy: marker.resolved ? (marker.resolvedBy || '') : null,
-        resolvedAt: marker.resolved ? (this._toISOString(marker.resolvedAt) || new Date().toISOString()) : null,
+        resolvedAt: marker.resolved ? this._toISOString(marker.resolvedAt) : null,
         x: marker.x,
         y: marker.y,
         startFrame: marker.startFrame ?? marker.frame,

--- a/renderer/scripts/modules/comment-sync.js
+++ b/renderer/scripts/modules/comment-sync.js
@@ -116,6 +116,8 @@ export class CommentSync {
       fields: {
         text: marker.text || marker.content || '',
         resolved: marker.resolved || false,
+        resolvedBy: marker.resolved ? (marker.resolvedBy || '') : null,
+        resolvedAt: marker.resolved ? (this._toISOString(marker.resolvedAt) || new Date().toISOString()) : null,
         x: marker.x,
         y: marker.y,
         startFrame: marker.startFrame ?? marker.frame,
@@ -371,6 +373,8 @@ export class CommentSync {
       createdAt: this._toISOString(marker.createdAt) || new Date().toISOString(),
       updatedAt: this._toISOString(marker.updatedAt) || new Date().toISOString(),
       resolved: marker.resolved || false,
+      resolvedBy: marker.resolved ? (marker.resolvedBy || '') : null,
+      resolvedAt: marker.resolved ? this._toISOString(marker.resolvedAt) : null,
       colorKey: marker.colorKey || 'default',
       image: marker.image || null,
       replies

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -171,7 +171,8 @@ test('resolved author metadata is synced and visible for every resolved tooltip'
   const updateBroadcastMatch = commentSyncSource.match(/type: 'COMMENT_MARKER_UPDATED'[\s\S]*?fields: \{([\s\S]*?)\n      \}/);
   assert.ok(updateBroadcastMatch, 'comment marker update broadcast should include a fields payload');
   assert.match(updateBroadcastMatch[1], /resolvedBy:/);
-  assert.match(updateBroadcastMatch[1], /resolvedAt:/);
+  assert.match(updateBroadcastMatch[1], /resolvedAt:\s*marker\.resolved \? this\._toISOString\(marker\.resolvedAt\) : null/);
+  assert.doesNotMatch(updateBroadcastMatch[1], /resolvedAt:\s*marker\.resolved \? \(this\._toISOString\(marker\.resolvedAt\) \|\| new Date\(\)\.toISOString\(\)\) : null/);
 
   const serializedMarkerMatch = commentSyncSource.match(/return \{([\s\S]*?)\n    \};\n  \}\n\n  \/\*\*/);
   assert.ok(serializedMarkerMatch, 'comment marker serialization should exist');

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -8,6 +8,8 @@ const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
 const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
 const htmlSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
 const cssSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
+const commentManagerSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/comment-manager.js'), 'utf8'));
+const commentSyncSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/comment-sync.js'), 'utf8'));
 
 test('comment editable fields recover focus when a parent pointer handler blocks default focus', () => {
   assert.match(appSource, /function getCommentEditableTarget\(target\) \{[\s\S]+target\.closest\('\.comment-input, \.comment-marker-input, \.comment-reply-input, \.comment-edit-textarea, \.comment-reply-edit-textarea, \.thread-editor\[contenteditable="true"\]'\)/);
@@ -163,4 +165,27 @@ test('playlist aggregate replies can expand and resolved state can be toggled fr
   assert.doesNotMatch(renderSource, /<img src="\$\{range\.image\}"/);
   assert.match(cssSource, /\.playlist-comment-replies/);
   assert.match(cssSource, /\.playlist-comment-reply-toggle\.expanded/);
+});
+
+test('resolved author metadata is synced and visible for every resolved tooltip', () => {
+  const updateBroadcastMatch = commentSyncSource.match(/type: 'COMMENT_MARKER_UPDATED'[\s\S]*?fields: \{([\s\S]*?)\n      \}/);
+  assert.ok(updateBroadcastMatch, 'comment marker update broadcast should include a fields payload');
+  assert.match(updateBroadcastMatch[1], /resolvedBy:/);
+  assert.match(updateBroadcastMatch[1], /resolvedAt:/);
+
+  const serializedMarkerMatch = commentSyncSource.match(/return \{([\s\S]*?)\n    \};\n  \}\n\n  \/\*\*/);
+  assert.ok(serializedMarkerMatch, 'comment marker serialization should exist');
+  assert.match(serializedMarkerMatch[1], /resolvedBy:/);
+  assert.match(serializedMarkerMatch[1], /resolvedAt:/);
+
+  const remoteAllowedFieldsMatch = commentManagerSource.match(/applyRemoteMarkerUpdate\(markerId, fields\) \{[\s\S]*?const allowedFields = \[([\s\S]*?)\];/);
+  assert.ok(remoteAllowedFieldsMatch, 'remote marker update allowed fields should exist');
+  assert.match(remoteAllowedFieldsMatch[1], /'resolvedBy'/);
+  assert.match(remoteAllowedFieldsMatch[1], /'resolvedAt'/);
+
+  assert.match(appSource, /function getResolveButtonLabel\(isResolved, resolvedBy\) \{/);
+  assert.match(appSource, /function getResolveTooltipHtml\(resolvedBy, resolvedAt\) \{/);
+  assert.match(appSource, /해결한 사람 기록 없음/);
+  assert.match(appSource, /marker\.resolved \? getResolveTooltipHtml\(marker\.resolvedBy, marker\.resolvedAt\) : ''/);
+  assert.match(appSource, /range\.resolved \? getResolveTooltipHtml\(range\.resolvedBy, range\.resolvedAt\) : ''/);
 });


### PR DESCRIPTION
## 📋 업데이트 요약
- ✅ 해결됨 버튼에 누가 해결했는지 다른 사람 화면에서도 보이도록 수정했습니다.
- 🕒 해결 시간이 있으면 함께 표시됩니다.
- ℹ️ 예전 데이터처럼 해결한 사람 기록이 없는 댓글도 툴팁이 비어 보이지 않고 "해결한 사람 기록 없음"으로 표시됩니다.

## 🔧 상세 기술 설명
- `renderer/scripts/modules/comment-sync.js`: `COMMENT_MARKER_UPDATED`와 마커 직렬화 payload에 `resolvedBy`, `resolvedAt`을 포함하도록 수정했습니다.
- `renderer/scripts/modules/comment-manager.js`: 원격 마커 업데이트 허용 필드에 `resolvedBy`, `resolvedAt`을 추가하고 `resolvedAt`은 `Date`로 복원합니다.
- `renderer/scripts/app.js`: `getResolveButtonLabel()`, `getResolveTooltipHtml()` helper를 추가하고 일반 댓글, 재생목록 통합 댓글, 마커 툴팁 resolve 버튼 title에 해결자 정보를 반영했습니다.
- `scripts/tests/comment-input-focus-source.test.js`: 해결자 메타데이터가 동기화되고 해결됨 툴팁에 항상 표시되는지 확인하는 회귀 테스트를 추가했습니다.

## 🚧 개발 난항
- 원인은 UI만이 아니라 동기화 payload 누락이었습니다. 로컬에서 내가 누른 해결됨은 `resolvedBy`가 남아 보이지만, 다른 사용자에게는 `resolved`만 전달되어 기본 버튼 설명만 보였습니다.
- 툴팁이 `resolvedBy`가 있을 때만 생성되어 오래된 데이터나 누락된 데이터에서는 안내가 완전히 사라지는 문제가 함께 있었습니다.

## ✅ 테스트 가이드
실사용자용
- 두 명이 같은 리뷰에 들어가 한 명이 댓글을 해결됨으로 바꿉니다.
- 다른 사용자 화면에서 해당 해결됨 버튼에 마우스를 올렸을 때 누가 해결했는지 또는 "해결한 사람 기록 없음"이 보이는지 확인합니다.
- 다시 미해결로 바꿨을 때 상태가 정상 전환되는지 확인합니다.

개발자용
- `npm run test:comment-input`
- `npm run test:playlist-comments`
- `npm run test:collaboration`
- `npm run build`