### PR TITLE
[v1.4.2] 열린 리뷰 댓글 실시간 반영 안정화

### DIFF
--- a/renderer/scripts/modules/comment-manager.js
+++ b/renderer/scripts/modules/comment-manager.js
@@ -127,11 +127,14 @@ export class CommentMarker {
    * 답글 추가
    */
   addReply(reply) {
+    const createdAt = reply.createdAt ? new Date(reply.createdAt) : new Date();
+    const updatedAt = reply.updatedAt ? new Date(reply.updatedAt) : createdAt;
     const newReply = {
       id: generateUUID(),
       text: reply.text,
       author: reply.author || '익명',
-      createdAt: new Date()
+      createdAt,
+      updatedAt
     };
 
     // 이미지 첨부 지원
@@ -142,6 +145,7 @@ export class CommentMarker {
     }
 
     this.replies.push(newReply);
+    this.updatedAt = updatedAt;
     return newReply;
   }
 
@@ -233,7 +237,8 @@ export class CommentMarker {
       colorKey: this.colorKey,
       replies: this.replies.map(r => ({
         ...r,
-        createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : r.createdAt
+        createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : r.createdAt,
+        updatedAt: r.updatedAt instanceof Date ? r.updatedAt.toISOString() : r.updatedAt
       }))
     };
 
@@ -259,7 +264,8 @@ export class CommentMarker {
       deletedAt: json.deletedAt ? new Date(json.deletedAt) : null,
       replies: (json.replies || []).map(r => ({
         ...r,
-        createdAt: new Date(r.createdAt)
+        createdAt: r.createdAt ? new Date(r.createdAt) : new Date(),
+        updatedAt: r.updatedAt ? new Date(r.updatedAt) : (r.createdAt ? new Date(r.createdAt) : new Date())
       }))
     });
   }
@@ -717,9 +723,11 @@ export class CommentManager extends EventTarget {
     if (updates.text !== undefined) {
       reply.text = updates.text;
     }
-    marker.updatedAt = new Date();
+    const revision = new Date();
+    reply.updatedAt = revision;
+    marker.updatedAt = revision;
 
-    this._emit('replyUpdated', { markerId, replyId, updates });
+    this._emit('replyUpdated', { marker, markerId, replyId, reply, updates });
     this._emit('markerUpdated', { marker });
     this._emit('markersChanged');
     return true;
@@ -1000,7 +1008,7 @@ export class CommentManager extends EventTarget {
   /**
    * 원격 델타: 답글 추가
    */
-  applyRemoteReplyAdd(markerId, replyData) {
+  applyRemoteReplyAdd(markerId, replyData, markerUpdatedAt = null) {
     const marker = this.getMarker(markerId);
     if (!marker) return false;
 
@@ -1009,18 +1017,57 @@ export class CommentManager extends EventTarget {
 
     const reply = {
       ...replyData,
-      createdAt: replyData.createdAt ? new Date(replyData.createdAt) : new Date()
+      createdAt: replyData.createdAt ? new Date(replyData.createdAt) : new Date(),
+      updatedAt: replyData.updatedAt ? new Date(replyData.updatedAt) : (replyData.createdAt ? new Date(replyData.createdAt) : new Date())
     };
     if (!marker.replies) marker.replies = [];
     marker.replies.push(reply);
+    marker.updatedAt = markerUpdatedAt ? new Date(markerUpdatedAt) : reply.updatedAt;
     this._emit('replyAdded', { marker, reply, remote: true });
+    this._emit('markerUpdated', { marker, remote: true });
+    this._emit('markersChanged');
+    return true;
+  }
+
+  /**
+   * 원격 델타: 답글 수정
+   */
+  applyRemoteReplyUpdate(markerId, replyId, updates = {}, markerUpdatedAt = null) {
+    const marker = this.getMarker(markerId);
+    if (!marker || !marker.replies) return false;
+
+    const reply = marker.replies.find(r => r.id === replyId);
+    if (!reply) return false;
+
+    if (updates.text !== undefined) {
+      reply.text = updates.text;
+    }
+    if (updates.image !== undefined) {
+      reply.image = updates.image;
+    }
+    if (updates.imageWidth !== undefined) {
+      reply.imageWidth = updates.imageWidth;
+    }
+    if (updates.imageHeight !== undefined) {
+      reply.imageHeight = updates.imageHeight;
+    }
+
+    const revision = markerUpdatedAt
+      ? new Date(markerUpdatedAt)
+      : (updates.updatedAt ? new Date(updates.updatedAt) : new Date());
+    reply.updatedAt = updates.updatedAt ? new Date(updates.updatedAt) : revision;
+    marker.updatedAt = revision;
+
+    this._emit('replyUpdated', { marker, markerId, replyId, reply, updates, remote: true });
+    this._emit('markerUpdated', { marker, remote: true });
+    this._emit('markersChanged');
     return true;
   }
 
   /**
    * 원격 델타: 답글 삭제
    */
-  applyRemoteReplyDelete(markerId, replyId) {
+  applyRemoteReplyDelete(markerId, replyId, markerUpdatedAt = null) {
     const marker = this.getMarker(markerId);
     if (!marker || !marker.replies) return false;
 
@@ -1028,7 +1075,10 @@ export class CommentManager extends EventTarget {
     if (idx === -1) return false;
 
     marker.replies.splice(idx, 1);
+    marker.updatedAt = markerUpdatedAt ? new Date(markerUpdatedAt) : new Date();
     this._emit('replyDeleted', { marker, replyId, remote: true });
+    this._emit('markerUpdated', { marker, remote: true });
+    this._emit('markersChanged');
     return true;
   }
 

--- a/renderer/scripts/modules/comment-sync.js
+++ b/renderer/scripts/modules/comment-sync.js
@@ -149,11 +149,13 @@ export class CommentSync {
     this._lm.broadcastEvent({
       type: 'COMMENT_REPLY_ADDED',
       markerId,
+      updatedAt: this._toISOString(detail.marker?.updatedAt) || this._toISOString(reply.updatedAt) || new Date().toISOString(),
       reply: {
         id: reply.id,
         text: reply.text || reply.content || '',
         author: reply.author || '',
         createdAt: this._toISOString(reply.createdAt) || new Date().toISOString(),
+        updatedAt: this._toISOString(reply.updatedAt) || this._toISOString(reply.createdAt) || new Date().toISOString(),
         image: reply.image || null,
         imageWidth: reply.imageWidth || null,
         imageHeight: reply.imageHeight || null
@@ -169,11 +171,16 @@ export class CommentSync {
     const updates = detail.updates;
     if (!markerId || !replyId) return;
 
+    const updatedAt = this._toISOString(detail.marker?.updatedAt) || this._toISOString(detail.reply?.updatedAt) || new Date().toISOString();
     this._lm.broadcastEvent({
       type: 'COMMENT_REPLY_UPDATED',
       markerId,
       replyId,
-      updates: { text: updates?.text }
+      updatedAt,
+      updates: {
+        text: updates?.text,
+        updatedAt
+      }
     });
   }
 
@@ -187,7 +194,8 @@ export class CommentSync {
     this._lm.broadcastEvent({
       type: 'COMMENT_REPLY_DELETED',
       markerId,
-      replyId
+      replyId,
+      updatedAt: this._toISOString(detail.marker?.updatedAt) || new Date().toISOString()
     });
   }
 
@@ -292,38 +300,26 @@ export class CommentSync {
   }
 
   _applyRemoteReplyAdd(event) {
-    const { markerId, reply } = event;
+    const { markerId, reply, updatedAt } = event;
     if (!markerId || !reply) return;
 
-    this._cm.applyRemoteReplyAdd(markerId, reply);
+    this._cm.applyRemoteReplyAdd(markerId, reply, updatedAt);
     log.debug('원격 답글 추가 적용', { markerId, replyId: reply.id });
   }
 
   _applyRemoteReplyUpdate(event) {
-    const { markerId, replyId, updates } = event;
+    const { markerId, replyId, updates, updatedAt } = event;
     if (!markerId || !replyId || !updates) return;
 
-    const marker = this._cm.getMarker(markerId);
-    if (!marker) return;
-
-    const reply = marker.replies?.find(r => r.id === replyId);
-    if (!reply) return;
-
-    if (updates.text !== undefined) {
-      reply.text = updates.text;
-    }
-    marker.updatedAt = new Date().toISOString();
-
-    this._cm._emit('markerUpdated', { marker });
-    this._cm._emit('markersChanged');
+    this._cm.applyRemoteReplyUpdate(markerId, replyId, updates, updatedAt);
     log.debug('원격 답글 수정 적용', { markerId, replyId });
   }
 
   _applyRemoteReplyDelete(event) {
-    const { markerId, replyId } = event;
+    const { markerId, replyId, updatedAt } = event;
     if (!markerId || !replyId) return;
 
-    this._cm.applyRemoteReplyDelete(markerId, replyId);
+    this._cm.applyRemoteReplyDelete(markerId, replyId, updatedAt);
     log.debug('원격 답글 삭제 적용', { markerId, replyId });
   }
 
@@ -356,6 +352,7 @@ export class CommentSync {
       text: r.text || r.content || '',
       author: r.author || '',
       createdAt: this._toISOString(r.createdAt) || new Date().toISOString(),
+      updatedAt: this._toISOString(r.updatedAt) || this._toISOString(r.createdAt) || new Date().toISOString(),
       image: r.image || null,
       imageWidth: r.imageWidth || null,
       imageHeight: r.imageHeight || null

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -15,6 +15,31 @@ import {
   extractFileNameWithoutExt
 } from '../../../shared/schema.js';
 // 오프라인 머지 유틸리티 (Liveblocks 비활성 시 폴백)
+
+function toTime(value) {
+  if (!value) return 0;
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
+function getCommentRevisionTime(comment) {
+  const ownRevision = Math.max(
+    toTime(comment.updatedAt),
+    toTime(comment.createdAt),
+    toTime(comment.deletedAt)
+  );
+  const replyRevision = (comment.replies || []).reduce((latest, reply) => {
+    return Math.max(
+      latest,
+      toTime(reply.updatedAt),
+      toTime(reply.createdAt),
+      toTime(reply.deletedAt)
+    );
+  }, 0);
+
+  return Math.max(ownRevision, replyRevision);
+}
+
 function mergeComments(localComments, remoteComments) {
   const localMap = new Map(localComments.map(c => [c.id, c]));
   const remoteMap = new Map(remoteComments.map(c => [c.id, c]));
@@ -33,8 +58,8 @@ function mergeComments(localComments, remoteComments) {
     } else if (local && !remote) {
       merged.push(local);
     } else if (local && remote) {
-      const localTime = new Date(local.updatedAt || local.createdAt).getTime();
-      const remoteTime = new Date(remote.updatedAt || remote.createdAt).getTime();
+      const localTime = getCommentRevisionTime(local);
+      const remoteTime = getCommentRevisionTime(remote);
       if (remoteTime > localTime) {
         merged.push(remote);
         updated++;

--- a/scripts/tests/comment-realtime-sync.test.js
+++ b/scripts/tests/comment-realtime-sync.test.js
@@ -1,0 +1,116 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+if (typeof global.CustomEvent === 'undefined') {
+  global.CustomEvent = class CustomEvent extends Event {
+    constructor(type, options = {}) {
+      super(type, options);
+      this.detail = options.detail;
+    }
+  };
+}
+
+global.window = global.window || {};
+
+test('adding a reply advances the parent marker revision time for file sync', async () => {
+  const { CommentMarker } = await import('../../renderer/scripts/modules/comment-manager.js');
+  const oldRevision = new Date('2026-01-01T00:00:00.000Z');
+  const marker = new CommentMarker({
+    id: 'marker-1',
+    text: '원댓글',
+    createdAt: oldRevision,
+    updatedAt: oldRevision
+  });
+
+  const reply = marker.addReply({ text: '새 대댓글', author: '민지' });
+
+  assert.ok(reply.updatedAt, 'reply should carry its own revision time');
+  assert.ok(new Date(marker.updatedAt).getTime() > oldRevision.getTime());
+  assert.equal(new Date(marker.updatedAt).getTime(), new Date(reply.updatedAt).getTime());
+});
+
+test('remote reply add and delete emit the same refresh signals as local changes', async () => {
+  const { CommentManager, CommentMarker } = await import('../../renderer/scripts/modules/comment-manager.js');
+  const manager = new CommentManager({ author: '테스터' });
+  const marker = new CommentMarker({
+    id: 'marker-1',
+    text: '원댓글',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z')
+  });
+  manager.getActiveLayer().addMarker(marker);
+
+  const events = [];
+  ['replyAdded', 'replyDeleted', 'markerUpdated', 'markersChanged'].forEach(eventName => {
+    manager.addEventListener(eventName, () => events.push(eventName));
+  });
+
+  const addRevision = '2026-01-01T00:01:00.000Z';
+  assert.equal(manager.applyRemoteReplyAdd('marker-1', {
+    id: 'reply-1',
+    text: '원격 대댓글',
+    author: '수현',
+    createdAt: addRevision,
+    updatedAt: addRevision
+  }, addRevision), true);
+
+  assert.deepEqual(events, ['replyAdded', 'markerUpdated', 'markersChanged']);
+  assert.equal(marker.replies.length, 1);
+  assert.equal(new Date(marker.updatedAt).toISOString(), addRevision);
+
+  events.length = 0;
+  const deleteRevision = '2026-01-01T00:02:00.000Z';
+  assert.equal(manager.applyRemoteReplyDelete('marker-1', 'reply-1', deleteRevision), true);
+
+  assert.deepEqual(events, ['replyDeleted', 'markerUpdated', 'markersChanged']);
+  assert.equal(marker.replies.length, 0);
+  assert.equal(new Date(marker.updatedAt).toISOString(), deleteRevision);
+});
+
+test('file reload merge accepts newer remote replies even when marker updatedAt is unchanged', async () => {
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const localMarker = {
+    id: 'marker-1',
+    text: '원댓글',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    replies: []
+  };
+  const remoteMarker = {
+    ...localMarker,
+    replies: [{
+      id: 'reply-1',
+      text: '원격 대댓글',
+      author: '수현',
+      createdAt: '2026-01-01T00:01:00.000Z'
+    }]
+  };
+
+  let appliedComments = null;
+  const commentManager = {
+    toJSON: () => ({
+      layers: [{ id: 'layer-1', markers: [localMarker] }]
+    }),
+    fromJSON: comments => {
+      appliedComments = comments;
+    }
+  };
+
+  window.electronAPI = {
+    loadReview: async () => ({
+      comments: {
+        layers: [{ id: 'layer-1', markers: [remoteMarker] }]
+      }
+    })
+  };
+
+  const manager = new ReviewDataManager({ commentManager });
+  manager.currentBframePath = 'C:/review.bframe';
+
+  const result = await manager.reloadAndMerge({ merge: true, force: true });
+
+  assert.equal(result.success, true);
+  assert.equal(result.updated, 1);
+  assert.equal(appliedComments.layers[0].markers[0].replies.length, 1);
+  assert.equal(appliedComments.layers[0].markers[0].replies[0].text, '원격 대댓글');
+});


### PR DESCRIPTION
## 📋 업데이트 요약
- 💬 같은 리뷰를 열어둔 상태에서 다른 사람이 댓글이나 대댓글을 바꿨을 때 화면 반영이 늦는 문제를 줄였습니다.
- ⚡ 특히 대댓글 추가/수정/삭제가 열린 화면에서 즉시 다시 그려지도록 안정화했습니다.
- 🔄 실시간 연결이 약하거나 파일 변경 감지로 따라오는 상황에서도 대댓글 변경을 최신 변경으로 인식하도록 보강했습니다.

## 🔧 상세 기술 설명
- `renderer/scripts/modules/comment-manager.js`
  - `CommentMarker.addReply()`가 답글 `updatedAt`과 부모 마커 `updatedAt`을 함께 갱신하도록 수정했습니다.
  - 원격 답글 추가/수정/삭제 경로에서 `replyAdded/replyUpdated/replyDeleted`뿐 아니라 `markerUpdated`, `markersChanged`도 발생시켜 열린 UI 전체 갱신 경로를 통일했습니다.
  - 답글의 `updatedAt` 직렬화/역직렬화를 추가했습니다.
- `renderer/scripts/modules/comment-sync.js`
  - Liveblocks broadcast의 답글 추가/수정/삭제 payload에 변경 시각을 포함했습니다.
  - 원격 답글 수정은 직접 객체를 만지는 대신 `CommentManager.applyRemoteReplyUpdate()` 경로로 적용하도록 정리했습니다.
- `renderer/scripts/modules/review-data-manager.js`
  - 파일 기반 `reloadAndMerge()`가 댓글 본문 시간만 보지 않고 답글의 `createdAt/updatedAt/deletedAt`까지 포함해 최신 여부를 판단하게 했습니다.
- `scripts/tests/comment-realtime-sync.test.js`
  - 대댓글이 부모 댓글 revision을 갱신하는지, 원격 대댓글 변경이 전체 갱신 이벤트를 발생시키는지, 파일 머지가 답글 추가를 최신 변경으로 받아들이는지 검증합니다.

## 🚧 개발 난항
- 증상이 UI 렌더링 문제처럼 보였지만 실제 원인은 두 겹이었습니다.
- 첫째, 대댓글 추가 경로 일부가 부모 댓글의 수정 시간을 갱신하지 않아 파일 머지에서 기존 댓글과 같은 상태로 오판될 수 있었습니다.
- 둘째, 원격 대댓글 변경은 답글 이벤트만 내고 전체 댓글 목록 갱신 이벤트까지 보내지 않아 일부 화면에서는 다른 이벤트가 생길 때까지 늦게 보일 수 있었습니다.

## ✅ 테스트 가이드
실사용자용
- A와 B가 같은 리뷰 파일을 열고, A가 댓글에 대댓글을 추가합니다.
- B 화면에서 새 대댓글이 바로 보이는지 확인합니다.
- A가 대댓글을 수정/삭제했을 때 B 화면도 늦지 않게 바뀌는지 확인합니다.

개발자용
- `node --test scripts/tests/comment-realtime-sync.test.js`
- `npm run test:comment-input`
- `npm run test:playlist-comments`
- `npm run test:collaboration`
- `npm run build`