### PR TITLE
[v1.4.1] mpv 합성 메뉴 표시 및 Drive 로딩 안내 개선

### DIFF
--- a/DEVLOG/2026-06-29-mpv-composition-menu-drive-loading.md
+++ b/DEVLOG/2026-06-29-mpv-composition-menu-drive-loading.md
@@ -1,0 +1,36 @@
+# mpv 합성 레이어 메뉴 및 Drive 로딩 피드백 수정
+
+## 요약
+
+| 항목 | 수정 파일 | 이유 | 우선순위 | 상태 |
+|------|----------|------|---------|------|
+| Phase 1 | `renderer/scripts/modules/composition-layer-manager.js` | 합성 레이어 설정 메뉴가 패널 내부에 갇히지 않게 분리 | 높음 | 완료 |
+| Phase 2 | `renderer/scripts/app.js` | mpv 재생 중 설정 메뉴와 Drive 로딩 상태를 화면에 안정적으로 표시 | 높음 | 완료 |
+| Phase 3 | `scripts/tests/*` | 재발 방지용 source 테스트 추가 | 높음 | 완료 |
+
+## 배경 및 목적
+
+합성 레이어 설정 메뉴가 패널의 작은 영역 안에서 잘리거나, mpv 직접 재생 모드에서 native 영상 뒤로 가려질 수 있었다.
+또 Google Drive 경로의 영상은 파일 확인과 재생 준비에 시간이 걸릴 수 있는데, 사용자에게 즉시 로딩 상태를 보여주는 피드백이 부족했다.
+
+## 구현 내용
+
+- 합성 레이어 설정 메뉴를 패널 리스트 내부가 아니라 `document.body`에 붙는 portal로 렌더링한다.
+- mpv native host 표시 제어 조건에 `.composition-layer-context-menu`를 추가해 메뉴가 열릴 때 영상 뒤로 가려지지 않게 한다.
+- Google Drive 경로 감지 시 `videoLoadingOverlay`에 `Google Drive에서 영상 불러오는 중...` 문구를 먼저 표시한다.
+- Drive 로딩 표시와 썸네일 로딩 표시가 같은 오버레이를 공유하므로 `data-loading-kind`로 상태를 구분한다.
+
+## 리스크 및 우려 사항
+
+| 리스크 | 심각도 | 완화 방안 |
+|--------|--------|----------|
+| 포털 메뉴 이벤트가 기존 패널 이벤트와 달라질 수 있음 | 중간 | 메뉴 click, pointerdown, input, change 이벤트를 portal에도 연결 |
+| mpv host가 메뉴 표시 중 과하게 숨을 수 있음 | 낮음 | 기존 blocking overlay 흐름에 selector만 추가 |
+| Drive 로딩 표시가 썸네일 표시와 충돌할 수 있음 | 중간 | `data-loading-kind`로 Drive/thumbnail 상태 분리 |
+
+## 테스트 방법
+
+- `node --test scripts/tests/composition-layer-runtime-source.test.js`
+- `npm run test:mpv`
+- `npm run test:playlist`
+- `npm run build`

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -2225,6 +2225,44 @@ async function initApp() {
            lowerPath.includes('google drive');
   }
 
+  function showVideoLoadingOverlay(message, options = {}) {
+    const loadingOverlay = document.getElementById('videoLoadingOverlay');
+    const loadingText = document.getElementById('loadingText');
+    const loadingProgress = document.getElementById('loadingProgressFill');
+    if (!loadingOverlay) return false;
+
+    loadingOverlay.classList.add('active');
+    if (options.kind) {
+      loadingOverlay.dataset.loadingKind = options.kind;
+    }
+    if (loadingText) {
+      loadingText.textContent = message;
+    }
+    if (loadingProgress && Number.isFinite(Number(options.progress))) {
+      const progress = Math.max(0, Math.min(100, Number(options.progress)));
+      loadingProgress.style.width = `${progress}%`;
+    }
+    return true;
+  }
+
+  function hideVideoLoadingOverlay(kind = '') {
+    const loadingOverlay = document.getElementById('videoLoadingOverlay');
+    if (!loadingOverlay) return;
+    if (kind && loadingOverlay.dataset.loadingKind && loadingOverlay.dataset.loadingKind !== kind) return;
+
+    loadingOverlay.classList.remove('active');
+    delete loadingOverlay.dataset.loadingKind;
+  }
+
+  function showDriveVideoLoadingFeedback(filePath, options = {}) {
+    const isDriveBacked = isGoogleDrivePath(filePath) || isGoogleDrivePath(options.preparedVideoPath);
+    if (!isDriveBacked) return false;
+    return showVideoLoadingOverlay('Google Drive에서 영상 불러오는 중...', {
+      kind: 'drive',
+      progress: 12
+    });
+  }
+
   // 저장된 Google Drive 링크 (파일별)
   const storedDriveLinks = {
     videoUrl: null,
@@ -5452,7 +5490,8 @@ async function initApp() {
     '.codec-error-overlay.active',
     '.app-saving-overlay.active',
     '#videoLoadingOverlay.active',
-    '.transcode-overlay.active'
+    '.transcode-overlay.active',
+    '.composition-layer-context-menu'
   ].join(',');
 
   const MPV_HTML_OVERLAY_STYLE_PROPERTIES = [
@@ -6239,6 +6278,7 @@ async function initApp() {
       stopContinuousPlayback();
     }
 
+    const driveLoadingFeedbackShown = showDriveVideoLoadingFeedback(filePath, { preparedVideoPath });
     const trace = log.trace('loadVideo');
     try {
       // 파일 정보 가져오기
@@ -6469,6 +6509,9 @@ async function initApp() {
 
         elements.videoWrapper?.classList.add('audio-mode');
         document.body.classList.add('audio-mode');
+        if (driveLoadingFeedbackShown && fileIsAudio) {
+          hideVideoLoadingOverlay('drive');
+        }
       } else {
         // 비디오 모드
         state.isAudioMode = false;
@@ -6611,6 +6654,9 @@ async function initApp() {
           await generateThumbnails(thumbnailVideoPath);
         } else {
           getThumbnailGenerator().clear();
+          if (driveLoadingFeedbackShown) {
+            hideVideoLoadingOverlay('drive');
+          }
           document.getElementById('videoLoadingOverlay')?.classList.remove('active');
         }
         if (!canContinueVideoLoad()) return false;
@@ -6693,6 +6739,9 @@ async function initApp() {
       trace.error(error);
       // 에러 발생 시에도 자동 저장 재개
       reviewDataManager.resumeAutoSave();
+      if (driveLoadingFeedbackShown) {
+        hideVideoLoadingOverlay('drive');
+      }
       showToast('파일을 로드할 수 없습니다.', 'error');
       return false;
     } finally {
@@ -6755,6 +6804,7 @@ async function initApp() {
         if (!overlayShown) {
           overlayShown = true;
           loadingOverlay?.classList.add('active');
+          if (loadingOverlay) loadingOverlay.dataset.loadingKind = 'thumbnail';
           loadingProgress.style.width = '0%';
         }
 
@@ -6780,6 +6830,7 @@ async function initApp() {
 
         // 로딩 오버레이 숨김 (외부 파일 열기 등에서 미리 표시된 경우도 포함)
         loadingOverlay?.classList.remove('active');
+        if (loadingOverlay) delete loadingOverlay.dataset.loadingKind;
 
         if (fromCache) {
           log.info('썸네일 캐시에서 로드 완료');
@@ -6830,6 +6881,7 @@ async function initApp() {
       showToast('썸네일 생성에 실패했습니다.', 'warning');
       // 실패 시에도 오버레이 숨김
       loadingOverlay?.classList.remove('active');
+      if (loadingOverlay) delete loadingOverlay.dataset.loadingKind;
     }
   }
 

--- a/renderer/scripts/modules/composition-layer-manager.js
+++ b/renderer/scripts/modules/composition-layer-manager.js
@@ -515,6 +515,7 @@ export class CompositionLayerManager extends EventTarget {
     this.panelReorderState = null;
     this.panelResizeState = null;
     this.contextMenuState = null;
+    this.contextMenuPortal = null;
     this.panelContinuousEdit = null;
 
     this._onDocumentPointerMove = this._onDocumentPointerMove.bind(this);
@@ -876,6 +877,7 @@ export class CompositionLayerManager extends EventTarget {
     }
     if (ordered.length === 0) {
       list.innerHTML = '<div class="composition-layer-empty">합성 레이어 없음</div>';
+      this._renderContextMenuPortal();
       return;
     }
 
@@ -926,7 +928,8 @@ export class CompositionLayerManager extends EventTarget {
       `;
     }).join('');
 
-    list.innerHTML = `${itemsHtml}${this._renderContextMenuHtml()}`;
+    list.innerHTML = itemsHtml;
+    this._renderContextMenuPortal();
   }
 
   _getPanelOrderedLayers() {
@@ -966,6 +969,30 @@ export class CompositionLayerManager extends EventTarget {
         </div>
       </div>
     `;
+  }
+
+  _ensureContextMenuPortal() {
+    if (typeof document === 'undefined') return null;
+    if (!this.contextMenuPortal) {
+      this.contextMenuPortal = document.createElement('div');
+      this.contextMenuPortal.className = 'composition-layer-context-menu-portal';
+      this.contextMenuPortal.addEventListener('click', (event) => this._handlePanelClick(event));
+      this.contextMenuPortal.addEventListener('pointerdown', (event) => this._handlePanelPointerDown(event));
+      this.contextMenuPortal.addEventListener('input', (event) => this._handlePanelInput(event));
+      this.contextMenuPortal.addEventListener('change', (event) => this._handlePanelInput(event, { commit: true }));
+      this.contextMenuPortal.addEventListener('wheel', (event) => event.stopPropagation());
+    }
+    if (!this.contextMenuPortal.isConnected) {
+      document.body.appendChild(this.contextMenuPortal);
+    }
+    return this.contextMenuPortal;
+  }
+
+  _renderContextMenuPortal() {
+    const portal = this._ensureContextMenuPortal();
+    if (!portal) return;
+    this.contextMenuPortal.innerHTML = this._renderContextMenuHtml();
+    this.contextMenuPortal.hidden = !this.contextMenuPortal.firstElementChild;
   }
 
   renderOverlay(_options = {}) {

--- a/scripts/tests/composition-layer-runtime-source.test.js
+++ b/scripts/tests/composition-layer-runtime-source.test.js
@@ -191,6 +191,15 @@ test('composition layer panel uses svg media icons and reliable menu opening', (
   assert.match(mainStyles, /\.composition-layer-opacity input\[type="range"\]/);
 });
 
+test('composition layer context menu is portaled outside the clipped panel', () => {
+  assert.match(compositionManagerSource, /this\.contextMenuPortal = null;/);
+  assert.match(compositionManagerSource, /_renderContextMenuPortal\(\)/);
+  assert.match(compositionManagerSource, /document\.body\.appendChild\(this\.contextMenuPortal\)/);
+  assert.match(compositionManagerSource, /this\.contextMenuPortal\.innerHTML = this\._renderContextMenuHtml\(\);/);
+  assert.match(compositionManagerSource, /list\.innerHTML = itemsHtml;/);
+  assert.doesNotMatch(compositionManagerSource, /list\.innerHTML = `\$\{itemsHtml\}\$\{this\._renderContextMenuHtml\(\)\}`;/);
+});
+
 test('composition file drop asks whether video should open or overlay', () => {
   assert.match(appSource, /async function chooseDroppedVideoAction\(filePath\)/);
   assert.match(appSource, /기준 영상으로 열기/);

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -143,6 +143,19 @@ test('mpv pilot falls back to the normal playback path when mpv load fails', () 
   assert.match(loadVideoSource, /catch \(mpvError\) \{[\s\S]+mpv 파일럿 로드 실패, 기존 재생 방식으로 재시도[\s\S]+allowMpvPilot: false,[\s\S]+preparedVideoPath: preparedVideoPathIsOriginal \? null : preparedVideoPath[\s\S]+return loadVideo\(filePath, fallbackOptions\);[\s\S]+\}/);
 });
 
+test('loadVideo shows Google Drive loading feedback before media preparation', () => {
+  const loadVideoMatch = appSource.match(/async function loadVideo\(filePath, options = \{\}\) \{([\s\S]*?)\n  \}\n\n  \/\//);
+  assert.ok(loadVideoMatch, 'loadVideo should exist');
+  const loadVideoSource = loadVideoMatch[1];
+
+  assert.match(appSource, /function showDriveVideoLoadingFeedback\(filePath, options = \{\}\) \{/);
+  assert.match(appSource, /isGoogleDrivePath\(filePath\) \|\| isGoogleDrivePath\(options\.preparedVideoPath\)/);
+  assert.match(appSource, /Google Drive에서 영상 불러오는 중/);
+  assert.match(loadVideoSource, /const driveLoadingFeedbackShown = showDriveVideoLoadingFeedback\(filePath, \{ preparedVideoPath \}\);/);
+  assert.match(loadVideoSource, /if \(driveLoadingFeedbackShown && fileIsAudio\) \{[\s\S]+hideVideoLoadingOverlay\('drive'\);[\s\S]+\}/);
+  assert.match(loadVideoSource, /if \(driveLoadingFeedbackShown\) \{[\s\S]+hideVideoLoadingOverlay\('drive'\);[\s\S]+\}/);
+});
+
 test('mpv pilot can be enabled from app playback settings without an env var', () => {
   assert.match(userSettingsSource, /mpvPilotEnabled:\s*false/);
   assert.match(userSettingsSource, /getMpvPilotEnabled\(\) \{[\s\S]+return this\.settings\.mpvPilotEnabled === true;/);
@@ -193,7 +206,8 @@ test('mpv pilot hides native host while DOM blocking overlays are open', () => {
     '.codec-error-overlay.active',
     '.app-saving-overlay.active',
     '#videoLoadingOverlay.active',
-    '.transcode-overlay.active'
+    '.transcode-overlay.active',
+    '.composition-layer-context-menu'
   ].forEach((selector) => {
     assert.match(appSource, new RegExp(`'${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
   });


### PR DESCRIPTION
📋 업데이트 요약

- 🧩 합성 레이어 설정 메뉴가 작은 패널 안에 갇히거나 잘리는 문제를 고쳤습니다.
- 🎬 mpv 직접 재생 중에도 합성 레이어 설정 메뉴가 영상 뒤에 묻히지 않게 했습니다.
- ☁️ Google Drive에 있는 영상을 여는 동안 `Google Drive에서 영상 불러오는 중...` 안내가 먼저 보이게 했습니다.

🔧 상세 기술 설명

- `renderer/scripts/modules/composition-layer-manager.js`
  - `.composition-layer-context-menu`를 기존 `compositionLayerList` 내부 렌더링에서 `document.body` 포털 렌더링으로 변경했습니다.
  - 포털에도 `click`, `pointerdown`, `input`, `change`, `wheel` 이벤트를 연결해 기존 이름/색상/복제/삭제/재연결 동작을 유지했습니다.
- `renderer/scripts/app.js`
  - `MPV_BLOCKING_OVERLAY_SELECTOR`에 `.composition-layer-context-menu`를 추가해 mpv native host가 메뉴를 가리지 않도록 했습니다.
  - `showVideoLoadingOverlay`, `hideVideoLoadingOverlay`, `showDriveVideoLoadingFeedback`를 추가해 Drive 경로의 초기 로딩 피드백을 분리했습니다.
  - 썸네일 로딩과 Drive 로딩이 같은 오버레이를 공유하므로 `data-loading-kind`로 상태를 구분했습니다.
- `scripts/tests/composition-layer-runtime-source.test.js`, `scripts/tests/mpv-runtime-source.test.js`
  - 합성 레이어 메뉴 포털화, mpv 차단 selector, Drive 로딩 피드백 회귀 테스트를 추가했습니다.

🚧 개발 난항

- 합성 레이어 설정 메뉴는 겉으로는 `position: fixed`였지만 패널 내부에서 렌더링되어 패널의 화면 영역 영향을 받을 수 있었습니다. 그래서 위치 스타일만 조정하지 않고 메뉴 DOM 자체를 body 레벨로 분리했습니다.
- mpv 재생은 일반 DOM 영상이 아니라 native host가 화면 위에 붙는 구조라, 단순 z-index 조정만으로는 메뉴가 항상 보장되지 않았습니다. 기존 blocking overlay 흐름에 메뉴 selector를 넣는 방식으로 맞췄습니다.
- Drive 로딩 표시는 기존 썸네일 로딩 오버레이를 재사용하되, 서로 덮어쓰는 상황을 피하기 위해 상태 구분값을 추가했습니다.

✅ 테스트 가이드

실사용자용

- mpv 직접 재생을 켠 상태에서 합성 레이어 패널을 열고 레이어 설정 메뉴를 눌러 메뉴가 영상 위에 보이는지 확인합니다.
- 합성 레이어 패널을 작게 만든 뒤에도 설정 메뉴가 패널 안에서 잘리지 않는지 확인합니다.
- Google Drive 경로의 영상을 열 때 초기 대기 구간에 `Google Drive에서 영상 불러오는 중...` 안내가 보이는지 확인합니다.

개발자용

- `node --test scripts/tests/composition-layer-runtime-source.test.js`
- `npm run test:mpv`
- `npm run test:playlist`
- `npm run build`
