### PR TITLE
[v1.4.1] mpv 재생 중 댓글/도구 오버레이 표시 안정화

### DIFF
--- a/DEVLOG/2026-06-29-mpv-overlay-visibility.md
+++ b/DEVLOG/2026-06-29-mpv-overlay-visibility.md
@@ -1,0 +1,36 @@
+# mpv 댓글/도구 오버레이 표시 안정화
+
+## 요약
+
+| 항목 | 수정 파일 | 이유 | 우선순위 | 상태 |
+|------|----------|------|---------|------|
+| Phase 1 | `renderer/scripts/app.js` | mpv 재생 중 댓글 입력창, 드롭다운, 도구 팝업이 영상 뒤로 가려지지 않게 감지 범위 확장 | 높음 | 완료 |
+| Phase 2 | `renderer/scripts/app.js` | 댓글 범위, 툴팁, 마커 같은 복제 오버레이 상태가 바뀔 때 mpv 오버레이를 자동 갱신 | 높음 | 완료 |
+| Phase 3 | `scripts/tests/mpv-runtime-source.test.js` | 같은 유형의 가림 문제가 재발하지 않도록 source 테스트 보강 | 높음 | 완료 |
+
+## 배경 및 목적
+
+mpv 직접 재생 모드는 영상을 네이티브 창으로 띄우기 때문에 Chromium DOM UI가 영상 뒤로 가려질 수 있다.
+기존에는 큰 모달과 일부 오버레이만 mpv 차단 대상으로 잡혀 있어, 댓글 입력창이나 도구 팝업처럼 영상 위에서 직접 조작하는 UI가 가려질 여지가 있었다.
+
+## 구현 내용
+
+- mpv host 숨김 대상에 댓글 입력창, 드롭 선택창, 드로잉 도구, 마커/하이라이트/레이어 팝업, 멘션/필터/설정 드롭다운 등을 추가했다.
+- 단순히 UI가 열렸다는 이유만으로 영상을 숨기지 않고, 실제 영상 영역과 겹칠 때만 mpv host를 숨기도록 overlap 검사를 추가했다.
+- 댓글 마커, 댓글 툴팁, 영상 하단 댓글 범위, 줌/전체화면/토스트/합성 레이어 오버레이는 DOM 변화가 생기면 mpv 투명 오버레이에 다시 복제되도록 MutationObserver를 추가했다.
+
+## 리스크 및 우려 사항
+
+| 리스크 | 심각도 | 완화 방안 |
+|--------|--------|----------|
+| 너무 많은 UI가 mpv host를 숨길 수 있음 | 중간 | 영상 영역과 실제로 겹치는 경우에만 숨기도록 제한 |
+| DOM 변경 감시가 과하게 자주 실행될 수 있음 | 중간 | mpv 모드에서만 동작하고, 복제 대상 selector에 걸리는 변화만 반응 |
+| 댓글 범위/툴팁 복제 타이밍이 늦을 수 있음 | 낮음 | 감지 시 `force` sync로 즉시 갱신 |
+
+## 테스트 방법
+
+- `node --test scripts/tests/mpv-runtime-source.test.js`
+- `npm run test:mpv`
+- `node --test scripts/tests/comment-input-focus-source.test.js`
+- `npm run test:playlist`
+- `npm run build`

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5491,7 +5491,33 @@ async function initApp() {
     '.app-saving-overlay.active',
     '#videoLoadingOverlay.active',
     '.transcode-overlay.active',
-    '.composition-layer-context-menu'
+    '.composition-layer-context-menu',
+    '.comment-marker-input-wrapper',
+    '.composition-drop-choice-overlay',
+    '.drawing-tools.visible',
+    '.marker-popup',
+    '.layer-settings-popup',
+    '.highlight-popup',
+    '.shortcuts-menu.visible',
+    '.comment-settings-dropdown.open',
+    '.filter-dropdown-menu.open',
+    '.mention-dropdown',
+    '.recent-dropdown-menu.open',
+    '.version-dropdown.open .version-dropdown-menu',
+    '.split-version-selector.open .split-version-menu'
+  ].join(',');
+
+  const MPV_MIRRORED_OVERLAY_SELECTOR = [
+    '.comment-markers-container',
+    '.comment-marker',
+    '.comment-marker-tooltip',
+    '.video-comment-range-overlay',
+    '.current-cut-overlay',
+    '.zoom-indicator-overlay',
+    '.fullscreen-timecode-overlay',
+    '.fullscreen-scrub-overlay',
+    '.toast-container',
+    '#compositionLayerOverlay'
   ].join(',');
 
   const MPV_HTML_OVERLAY_STYLE_PROPERTIES = [
@@ -5552,6 +5578,15 @@ async function initApp() {
     '-webkit-backdrop-filter'
   ];
 
+  function doesRectOverlapMpvHost(rect) {
+    const hostRect = elements.videoWrapper?.getBoundingClientRect();
+    if (!hostRect || hostRect.width <= 0 || hostRect.height <= 0) return false;
+    return rect.right > hostRect.left &&
+      rect.left < hostRect.right &&
+      rect.bottom > hostRect.top &&
+      rect.top < hostRect.bottom;
+  }
+
   function isElementVisiblyBlockingMpv(element) {
     if (!element) return false;
     const style = window.getComputedStyle(element);
@@ -5559,6 +5594,7 @@ async function initApp() {
       return false;
     }
     const rect = element.getBoundingClientRect();
+    if (!doesRectOverlapMpvHost(rect)) return false;
     return rect.width > 0 && rect.height > 0;
   }
 
@@ -5616,6 +5652,45 @@ async function initApp() {
   }
 
   installMpvBlockingOverlayObserver();
+
+  function getMutationElementTarget(target) {
+    if (!target) return null;
+    if (target.nodeType === Node.ELEMENT_NODE) return target;
+    return target.parentElement || null;
+  }
+
+  function isMpvMirroredOverlayMutation(mutation) {
+    const target = getMutationElementTarget(mutation.target);
+    if (target && target.matches?.(MPV_MIRRORED_OVERLAY_SELECTOR)) return true;
+    if (target && target.closest?.(MPV_MIRRORED_OVERLAY_SELECTOR)) return true;
+
+    return Array.from(mutation.addedNodes || []).some((node) => (
+      node.nodeType === Node.ELEMENT_NODE &&
+      (node.matches?.(MPV_MIRRORED_OVERLAY_SELECTOR) ||
+        node.querySelector?.(MPV_MIRRORED_OVERLAY_SELECTOR))
+    )) || Array.from(mutation.removedNodes || []).some((node) => (
+      node.nodeType === Node.ELEMENT_NODE &&
+      (node.matches?.(MPV_MIRRORED_OVERLAY_SELECTOR) ||
+        node.querySelector?.(MPV_MIRRORED_OVERLAY_SELECTOR))
+    ));
+  }
+
+  function installMpvMirroredOverlayObserver() {
+    const observer = new MutationObserver((mutations) => {
+      if (!document.body.classList.contains('mpv-pilot-mode')) return;
+      if (!mutations.some(isMpvMirroredOverlayMutation)) return;
+      scheduleMpvOverlayStateSync({ force: true });
+    });
+    observer.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      characterData: true,
+      attributeFilter: ['class', 'style', 'hidden', 'aria-hidden']
+    });
+  }
+
+  installMpvMirroredOverlayObserver();
 
   async function waitForMpvPlaybackTime(targetTime, { timeoutMs = 700, tolerance = 0.12 } = {}) {
     if (!window.electronAPI?.mpvGetStatus) return false;

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -207,12 +207,27 @@ test('mpv pilot hides native host while DOM blocking overlays are open', () => {
     '.app-saving-overlay.active',
     '#videoLoadingOverlay.active',
     '.transcode-overlay.active',
-    '.composition-layer-context-menu'
+    '.composition-layer-context-menu',
+    '.comment-marker-input-wrapper',
+    '.composition-drop-choice-overlay',
+    '.drawing-tools.visible',
+    '.marker-popup',
+    '.layer-settings-popup',
+    '.highlight-popup',
+    '.shortcuts-menu.visible',
+    '.comment-settings-dropdown.open',
+    '.filter-dropdown-menu.open',
+    '.mention-dropdown',
+    '.recent-dropdown-menu.open',
+    '.version-dropdown.open .version-dropdown-menu',
+    '.split-version-selector.open .split-version-menu'
   ].forEach((selector) => {
     assert.match(appSource, new RegExp(`'${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
   });
   assert.doesNotMatch(appSource, /'\.credits-overlay\.open'/);
   assert.doesNotMatch(appSource, /'\.video-loading-overlay\.active'/);
+  assert.match(appSource, /function doesRectOverlapMpvHost\(rect\) \{[\s\S]+elements\.videoWrapper\?\.getBoundingClientRect\(\)[\s\S]+rect\.right > hostRect\.left[\s\S]+rect\.left < hostRect\.right[\s\S]+rect\.bottom > hostRect\.top[\s\S]+rect\.top < hostRect\.bottom/);
+  assert.match(appSource, /function isElementVisiblyBlockingMpv\(element\) \{[\s\S]+const rect = element\.getBoundingClientRect\(\);[\s\S]+if \(!doesRectOverlapMpvHost\(rect\)\) return false;[\s\S]+return rect\.width > 0 && rect\.height > 0;/);
   assert.match(appSource, /function hasBlockingOverlayForMpv\(\) \{[\s\S]+document\.querySelectorAll\(MPV_BLOCKING_OVERLAY_SELECTOR\)[\s\S]+some\(isElementVisiblyBlockingMpv\);/);
   assert.match(appSource, /let mpvPilotHostPreparing = false;/);
   assert.match(appSource, /function didMpvHostVisibilityApply\(result, shouldShowMpvHost\) \{[\s\S]+if \(!result\?\.success\) return false;[\s\S]+if \(shouldShowMpvHost\) return true;[\s\S]+return result\.embed\?\.ready === true && result\.overlay\?\.ready === true;/);
@@ -348,6 +363,10 @@ test('mpv pilot mirrors DOM overlays into a click-through native overlay window'
   });
   assert.match(appSource, /function getMpvOverlayState\(\) \{[\s\S]+drawingDataUrl[\s\S]+onionDataUrl[\s\S]+markerHtml: serializeMpvOverlayMarkerHtml\(\)[\s\S]+tooltipHtml: serializeMpvOverlayTooltipHtml\(\)[\s\S]+htmlOverlayHtml: serializeMpvOverlayHtml\(\)/);
   assert.match(appSource, /function scheduleMpvOverlayStateSync\(options = \{\}\) \{[\s\S]+syncMpvOverlayState\(\);/);
+  assert.match(appSource, /const MPV_MIRRORED_OVERLAY_SELECTOR = \[[\s\S]+'.comment-markers-container'[\s\S]+'.comment-marker-tooltip'[\s\S]+'.video-comment-range-overlay'[\s\S]+\]\.join\(','\);/);
+  assert.match(appSource, /function isMpvMirroredOverlayMutation\(mutation\) \{[\s\S]+target\.matches\?\.\(MPV_MIRRORED_OVERLAY_SELECTOR\)[\s\S]+target\.closest\?\.\(MPV_MIRRORED_OVERLAY_SELECTOR\)[\s\S]+node\.querySelector\?\.\(MPV_MIRRORED_OVERLAY_SELECTOR\)/);
+  assert.match(appSource, /function installMpvMirroredOverlayObserver\(\) \{[\s\S]+new MutationObserver\(\(mutations\) => \{[\s\S]+if \(!document\.body\.classList\.contains\('mpv-pilot-mode'\)\) return;[\s\S]+mutations\.some\(isMpvMirroredOverlayMutation\)[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);/);
+  assert.match(appSource, /installMpvMirroredOverlayObserver\(\);/);
   assert.match(appSource, /const MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS = 350;/);
   assert.match(appSource, /function showZoomIndicator\(zoom\) \{[\s\S]+elements\.zoomIndicatorOverlay\.classList\.remove\('visible'\);[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+setTimeout\(\(\) => \{[\s\S]+if \(!elements\.zoomIndicatorOverlay\?\.classList\.contains\('visible'\)\) \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);[\s\S]+\}[\s\S]+\}, MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS\);/);
   assert.match(appSource, /function hideFullscreenScrubOverlay\(\) \{[\s\S]+fullscreenScrubOverlay\?\.classList\.remove\('visible'\);[\s\S]+scheduleMpvOverlayStateSync\(\);[\s\S]+setTimeout\(\(\) => \{[\s\S]+if \(!fullscreenScrubOverlay\?\.classList\.contains\('visible'\)\) \{[\s\S]+scheduleMpvOverlayStateSync\(\{ force: true \}\);[\s\S]+\}[\s\S]+\}, MPV_OVERLAY_FADE_OUT_SYNC_DELAY_MS\);/);


### PR DESCRIPTION
## 📋 업데이트 요약

- 🎬 mpv 직접 재생 중 댓글 입력창, 댓글 관련 표시, 도구 팝업이 영상 뒤로 가려질 수 있던 문제를 보완했습니다.
- 💬 영상 위에서 댓글을 찍고 입력할 때, 입력창이 보이지 않거나 조작하기 어려운 상황을 줄였습니다.
- 🧰 드로잉 도구, 마커/하이라이트/레이어 팝업, 멘션/필터/설정 드롭다운처럼 영상 위에 걸칠 수 있는 화면 요소도 같이 점검했습니다.
- 🪟 영상과 실제로 겹치는 경우에만 mpv 화면을 잠깐 뒤로 보내도록 해서, 옆 패널 메뉴를 열었다고 영상이 불필요하게 사라지는 일을 줄였습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - `MPV_BLOCKING_OVERLAY_SELECTOR`에 `.comment-marker-input-wrapper`, `.drawing-tools.visible`, `.marker-popup`, `.layer-settings-popup`, `.highlight-popup`, `.mention-dropdown` 등 mpv native host 위에서 가려질 수 있는 interactive overlay 후보를 추가했습니다.
  - `doesRectOverlapMpvHost(rect)`를 추가해 blocking 후보가 실제 `elements.videoWrapper` 영역과 겹칠 때만 `mpvSetHostVisible(false)`가 호출되도록 했습니다.
  - `MPV_MIRRORED_OVERLAY_SELECTOR`와 `installMpvMirroredOverlayObserver()`를 추가해 댓글 마커, 댓글 툴팁, 영상 하단 댓글 범위, 줌/전체화면/토스트/합성 레이어 오버레이의 DOM 변화가 mpv 투명 오버레이에 자동 반영되도록 했습니다.
  - 기존의 수동 `scheduleMpvOverlayStateSync()` 호출은 유지하고, 누락 가능성이 있는 DOM 변화는 observer로 보강했습니다.
- `scripts/tests/mpv-runtime-source.test.js`
  - mpv blocking selector가 댓글/도구/팝업 계열까지 포함하는지 검증을 추가했습니다.
  - blocking 여부가 단순 표시 상태가 아니라 영상 영역 overlap 기준으로 판단되는지 검증했습니다.
  - mpv mirrored overlay observer가 댓글/툴팁/범위 오버레이 변화에 반응하는지 검증했습니다.
- `DEVLOG/2026-06-29-mpv-overlay-visibility.md`
  - 원인, 구현, 리스크, 테스트 방법을 기록했습니다.

## 🚧 개발 난항

- mpv는 일반 웹 화면처럼 한 화면 안에서 z-index만 올려 해결되는 구조가 아니었습니다. 실제 영상이 별도 네이티브 창으로 올라오기 때문에, 화면 요소별로 “복제해서 보여줄 것”과 “mpv 창을 잠깐 숨길 것”을 나눠야 했습니다.
- 처음부터 모든 드롭다운을 blocking 처리하면 옆 패널 메뉴를 열 때도 영상이 사라질 수 있어, 실제 영상 영역과 겹치는지 확인하는 overlap 조건을 추가했습니다.
- 댓글 범위/툴팁처럼 계속 보이거나 자주 바뀌는 요소는 매번 mpv host를 숨기면 재생 경험이 나빠지므로, 투명 overlay 복제 갱신으로 처리했습니다.

## ✅ 테스트 가이드

실사용자용

1. mpv 직접 재생을 켠 상태에서 영상을 엽니다.
2. 영상 위를 클릭해 댓글 입력창을 띄우고, 입력창이 영상 뒤로 사라지지 않는지 확인합니다.
3. 댓글 범위 표시, 드로잉 도구, 마커/하이라이트/레이어 팝업, 멘션/필터/설정 드롭다운을 열어 화면에 정상 표시되는지 확인합니다.
4. 옆 패널 안의 메뉴만 열었을 때 영상이 불필요하게 깜빡이거나 사라지지 않는지 확인합니다.

개발자용

- `node --test scripts/tests/mpv-runtime-source.test.js`
- `npm run test:mpv`
- `node --test scripts/tests/comment-input-focus-source.test.js`
- `npm run test:playlist`
- `npm run build`
