### PR TITLE
[v1.4.1-beta] 드로잉 잠금 보호 및 펜 Ctrl 지우개 보정

### DIFF
--- a/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
+++ b/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
@@ -1,0 +1,1165 @@
+# 윤성원 피드백 UI/UX 개선 및 버그 수정 구현계획
+
+> **작성일**: 2026-07-03
+> **피드백 출처**: 윤성원(애니메이션팀) Slack DM, 2026-07-03 19:19 ~ 22:17 (텍스트 9건 + 스크린샷 10장)
+> **분석 기준 코드**: `main` @ `0b41163` (v1.4.0-beta)
+> **분석 방법**: 영역별 코드 심층 분석 에이전트 8개 + 독립 검증 에이전트 8개 교차검증 완료. 아래 모든 파일 경로/함수명/줄번호는 실제 코드를 열어 확인한 실측치이며, 검증 단계에서 발견된 정정사항이 모두 반영되어 있다.
+
+---
+
+## 0. 이 문서를 읽는 구현자(Codex/Opus 등 AI 모델)에게
+
+이 문서 하나만 보고 구현할 수 있도록 작성했다. 반드시 지킬 것:
+
+1. **경로**: 모든 파일 경로는 리포 루트(`BAEFRAME/`) 기준. 줄번호는 `main @ 0b41163` 기준 실측치(±2줄 오차 허용). 구현 시점에 코드가 밀렸을 수 있으니 **줄번호가 아니라 함수명/코드 조각으로 위치를 재확인**한 후 수정할 것.
+2. **코드 스타일**: 2스페이스 들여쓰기, 싱글쿼트, 세미콜론 필수, 주석은 한글. 커밋 메시지/PR도 한글 (CLAUDE.md 참조).
+3. **변경 금지**: `.bframe` 파일 포맷(하위 호환성), `mpv/` 폴더. 이 계획의 모든 Phase는 `.bframe` 스키마를 변경하지 않는다 (검증 완료).
+4. **설정 저장 패턴 주의**: 이 프로젝트의 사용자 설정은 electron-store **모듈이 아니라** `renderer/scripts/modules/user-settings.js`의 **localStorage(`baeframe_user_settings`) + IPC 파일 저장(`window.electronAPI.saveSettings`) 이중화 패턴**이다. 새 설정 키는 반드시 이 패턴(기본값 블록 추가 → getter/setter → `_save()` + `_emit()` + `log.info` 3종 세트)을 따를 것. 기존 설정 파일에 키가 없으면 스프레드 병합(user-settings.js:242, 281)으로 기본값이 적용되므로 마이그레이션 코드는 불필요하다.
+5. **각 Phase는 독립적**이며 문서 하단의 "권장 PR 분할" 순서로 진행한다. Phase 완료 시 요약 테이블의 상태를 갱신할 것.
+6. 검증 명령: 드로잉 관련은 `npm run test:drawing`, 프레임 그리드는 `npm run test:frame-grid`, 클러스터는 `npm run test:cluster`. 빌드는 `npm run build`.
+
+---
+
+## 요약
+
+| Phase | 내용 | 분류 | 수정 파일 | 우선순위 | 상태 |
+|-------|------|------|----------|---------|------|
+| 1 | 잠긴/숨긴 레이어 그리기·지우기 입력 차단 (픽셀 지우개 잠금 무시 버그) | 버그 | drawing-canvas.js, drawing-manager.js, app.js | **최상** (데이터 파괴) | ✅ |
+| 2 | 활성 레이어 분리 렌더링 — 3-캔버스 스택 (레이어 나누기 드로잉 귀속 버그) | 버그 | drawing-manager.js, app.js, index.html, main.css | **최상** (데이터 오염) | ⬜ |
+| 3 | 펜(태블릿) 입력 시 Ctrl+드로잉 지우개 토글 미인식 | 버그 | drawing-canvas.js, drawing-runtime-source.test.js | 높음 | ✅ |
+| 4 | 댓글 구간 ON 시 좌/우 타임라인 행 어긋남 + 상시 2px 어긋남 | 버그 | timeline.js, main.css | 높음 | ⬜ |
+| 5 | 키프레임 드래그 오버레이를 정확히 1프레임 칸으로 | 버그 | timeline.js, main.css | 높음 | ⬜ |
+| 6 | 프레임 1칸 셀 표시 모드 (ON/OFF/AUTO 토글) — Animate 스타일 | 기능 | timeline.js, frame-grid-tiers.js, user-settings.js, app.js, index.html, main.css | 높음 | ⬜ |
+| 7 | 브러시 설정 영속화 + Alt 드래그 크기 조절 + [ / ] 단축키 | 기능 | user-settings.js, app.js, drawing-canvas.js, index.html, main.css | 높음 | ⬜ |
+| 8 | 레이어 눈/잠금 토글 버튼 확대(14px→24px) 및 on/off 상태 시각화 | 기능 | timeline.js, main.css, index.html | 중간 | ⬜ |
+| 9 | 미명시 UX 개선 (도구 커서, 키프레임 히트영역, 재렌더 병합 등) | 개선 | 다수 (소형 3건 포함 + 별도 이슈 3건) | 중간~낮음 | ⬜ |
+
+---
+
+## 1. 피드백 원문 및 증거 정리
+
+윤성원님이 2026-07-03 저녁에 DM으로 보낸 피드백 전체를 시간순으로 정리했다. 각 항목의 "이미지 증거"는 첨부 스크린샷을 직접 판독한 결과다.
+
+### 1.1 프레임 표기 관련 (19:19) → Phase 5, 6
+
+원문 요지:
+- 현재 프레임 바(플레이헤드)는 정확히 1프레임씩 스냅되며 이동됨 — **현행 만족**.
+- **드로잉 키프레임도 1칸이 정확히 명시되면 직관적일 것. like Adobe Animate.**
+- **키프레임을 드래그해서 이동할 때 보이는 오버레이 디자인이 정확히 1칸이 아님.** 이동 시에도 명확히 드래그가 가능하면 좋겠음.
+- 프레임 칸 전체 표시가 긴 영상에서 문제가 되거나 렉을 유발할 수 있으니 **유저가 토글할 수 있는 옵션**으로:
+  - **ON**: Animate/Moho처럼 프레임 한 칸 너비 최소값을 고정하여 보여주는 모드
+  - **OFF**: 지금처럼 작동
+  - **AUTO**: 확대(줌)가 일정 % 이상이면 자동 ON
+
+이미지 증거 (4장):
+1. 현행 BAEFRAME 타임라인 — 드로잉 키프레임이 트랙 위 **작은 주황색 점**으로만 표시되고 프레임 칸 구분 없음.
+2. Adobe Animate 타임라인 (참고 목표) — 프레임이 1칸씩 셀로 구분(5프레임마다 숫자 눈금), 키프레임은 셀 안의 점.
+3. 현행 키프레임 드래그 — `F1` 배지 + 주황 오버레이가 표시되는데 **오버레이 폭이 1프레임 칸과 불일치**.
+4. Animate에서 키프레임 셀을 칸 단위로 드래그 이동하는 모습 (원하는 UX, 빨간 화살표 표시).
+
+### 1.2 브러시 크기 조절 관련 (19:22) → Phase 7
+
+원문 요지:
+- 브러시 크기 조절 단축키가 있는지? **Alt 드래그 등으로 브러시 크기 변경**이 가능하면 편리하겠음.
+- **이전 브러시 설정을 기억하는 설정** — 지금은 앱을 껐다 켤 때마다 리셋됨.
+
+이미지 증거 (1장): 드로잉 도구 패널 — 도구 2줄(펜/브러시(선택)/지우개/직선/화살표/사각형/원), 크기 13px 슬라이더 + 빨간 원형 프리뷰, 불투명도 100%, 외곽선 OFF, 색상 스와치(빨강 선택), 그리기 어니언 ON, 이전 [2]장.
+
+### 1.3 갤탭 신티크 펜 Ctrl 지우개 미인식 (19:22 제보 → 22:03~22:05 확정) → Phase 3
+
+원문 요지:
+- 브러시 모드에서 **Ctrl 누르고 드로잉하면 지우개 모드로 토글**되는 기능이, 갤럭시탭을 신티크(펜 디스플레이)로 활용해 **펜으로 드로잉하면 인식이 안 됨**. **마우스 Ctrl 드래그만 인식**.
+- 처음엔 "다른 PC도 이런지 비교 검증 후 말씀드리겠다"고 했다가, 22:03~22:05에 직접 재테스트 후 "펜 인식이 안 되는 버그"로 **확정 제보**.
+
+### 1.4 픽셀 지우개가 잠긴 레이어를 지움 (20:26) → Phase 1
+
+원문 요지:
+- **픽셀 단위 지우개가 잠긴 레이어의 이미지까지 지워버리는 오류.**
+- **획 단위(지우개)는 레이어 잠금이 잘 작동됨.**
+
+이미지 증거 (1장): 지우개 설정 패널에서 "지우개 방식: **픽셀**" 선택(크기 27px). 캔버스의 캐릭터 이미지와 드로잉이 픽셀 단위로 함께 파먹힌 흔적. 타임라인에서 "레이어 1"(100%)에 **노란 잠금 아이콘이 켜져 있고** 키프레임 다수, "드로잉 2"(100%)가 선택 상태.
+
+### 1.5 레이어 나누기 시 드로잉 귀속 오류 (20:28) → Phase 2
+
+원문 요지:
+- 레이어 나누기 작업 시, **기존 레이어 이미지가 새로운 레이어에 귀속되어버리는 오류**:
+  - 레이어 1에 드로잉 A, B, C를 작업함
+  - 레이어 2에 드로잉 D를 작업함
+  - 이때 **드로잉 A가 레이어 2에 귀속됨**
+  - 그래서 드로잉 B가 보이는 타이밍인데도 A가 함께 중첩되어 보임
+  - 재밌는 건, **레이어 2의 드로잉 D를 삭제하면 다시 정상**으로 보임
+
+이미지 증거 (1장): 뷰어에 서로 다른 시점의 빨간 프리핸드 드로잉 여러 개가 캐릭터 두 명 위에 어지럽게 **중첩 표시**된 상태. 타임라인은 "레이어 1" 트랙에 키프레임(주황 점+루프 아이콘) 3~4세트, 선택된 "드로잉 2" 트랙에 노란 점 1개(=드로잉 D). 플레이헤드는 Frame 1694/3841.
+
+### 1.6 댓글 구간 두 줄 + 좌/우 행 어긋남 (22:12) → Phase 4
+
+원문 요지:
+- **댓글 구간을 켜면 댓글 라인이 두 줄이 되며, 레이어 탭과 타임라인 탭 가로 줄이 어긋나는 버그**도 있음.
+
+이미지 증거 (2장, 빨간 손그림 주석 포함):
+- 타임라인 헤더 우측의 "**댓글 구간**" 체크박스에 빨간 원 — 버그 유발 조건 지목.
+- 댓글 마커 라인이 **2단으로 스택**되고(겹치는 구간 댓글들이 위아래 레인으로 분리), 그 늘어난 높이가 **우측 트랙 영역에만 반영**됨.
+- 픽셀 측정 결과: 좌측 "레이어 1" 라벨 행(y216–259)과 우측 레인(y210–259) 어긋남, **좌측 패널은 y304에서 끝나는데 우측 트랙 영역에는 y304–360에 라벨 없는 레인이 한 줄 더 존재** — 우측이 한 행 분량 밀린 상태. 빨간 화살표 3개가 레이어 라벨과 실제 트랙의 세로 불일치를 지목.
+
+### 1.7 레이어 눈 토글 버튼이 너무 작음 (22:17) → Phase 8
+
+원문 요지:
+- **레이어의 눈 토글 버튼이 너무 작아서 직관적으로 확인이 불가능.** 크기가 더 커지고 클릭도 쉬워지면 좋겠음.
+
+이미지 증거 (1장): 레이어 패널 — "Video" 행(눈+잠금 아이콘), "레이어 1"(100% 배지, 잠금), "드로잉 2"(100% 배지, 선택 상태). 행 좌측의 아주 작은 눈 토글 영역을 빨간 표시로 강조. 눈 아이콘의 켜짐/꺼짐 상태 구분도 안 보임.
+
+---
+
+## 2. 구현자가 알아야 할 현행 아키텍처 (필수 컨텍스트)
+
+이번 버그 다수가 아래 구조에서 파생된다. 수정 전에 반드시 이해할 것.
+
+### 2.1 드로잉 시스템 — "단일 합성 캔버스" 구조 (Phase 1, 2의 뿌리)
+
+- 비디오 위 오버레이 캔버스는 `renderer/index.html:494-501`에 **2장뿐**: `#onionSkinCanvas`(어니언 스킨 전용, z-index:2)와 `#drawingCanvas`(z-index:3).
+- 데이터 모델은 레이어별로 분리되어 있다: `drawing-layer.js`의 `DrawingLayer`(레이어 메타 + `keyframes[]`)와 `Keyframe`(`{frame, canvasData(PNG dataURL), isEmpty, baseCanvasData, strokeRecords}`). `getKeyframeAtFrame(frame)`(drawing-layer.js:155-167)은 "해당 프레임 이하의 가장 가까운 키프레임"을 반환하는 **홀드 방식** — 키프레임은 다음 키프레임 전까지(없으면 영상 끝까지) 유지된다.
+- 그러나 **화면은** `drawing-manager.js`의 `renderFrame()`(802-880)이 **모든 visible 레이어의 키프레임 이미지를 단 하나의 `#drawingCanvas`에 순서대로 합성**한다(845-876). 재생 중 경로 `_renderFrameSync()`(887-926)도 동일.
+- 그리기 종료 시 `_saveCurrentFrameData()`(195-225)가 `drawingCanvas.toDataURL()`(210줄) — 즉 **모든 레이어가 합성된 캔버스 전체** — 를 활성 레이어의 키프레임 `canvasData`에 저장한다. **이것이 Phase 2 버그의 직접 원인**이며, 픽셀 지우개(destination-out)가 타 레이어 픽셀까지 지우는 구조적 원인이기도 하다.
+- 그리기 중(`isDrawing`)에는 `renderFrame()`이 스킵된다(803-807).
+
+### 2.2 입력 계층 — mouse/touch 이벤트만 사용 (Phase 1, 3, 7의 무대)
+
+- `drawing-canvas.js`의 `_setupEventListeners()`(78-91)는 canvas에 `mousedown/mousemove/mouseup/mouseleave` + `touchstart/touchmove/touchend`만 등록. **Pointer Events 미사용** (renderer 전체에서 pointer 이벤트는 app.js/timeline.js/composition-layer-manager.js에만 존재).
+- 펜 입력은 Chromium이 합성하는 호환(compatibility) mouse 이벤트로 들어오거나, 미러링 앱 구성에 따라 touch 이벤트로 들어온다.
+- 터치 경로 `_onTouchStart`(251-255)는 `{clientX, clientY}`만 담은 합성 객체를 `_onMouseDown`에 넘긴다 — **ctrlKey가 원천 소실**된다 (Phase 3의 확정 원인 중 하나).
+- 리스너는 `AbortController`(67줄, signal 79줄)로 일괄 해제된다. 새 window 리스너를 추가할 때 같은 signal을 쓰면 `destroy()`에서 자동 정리된다.
+- Ctrl 임시 지우개: `_onMouseDown`(129-169)의 137줄에서 `_resolveEffectiveTool(e)`(296-301)로 **스트로크 시작 시 1회** 유효 도구를 확정. `PEN/BRUSH + e?.ctrlKey → ERASER`.
+
+### 2.3 타임라인 좌/우 정렬 규약 (Phase 4의 무대)
+
+- 좌측 레이어 패널(`.layer-headers`, index.html:929-960)과 우측 트랙 영역(`.timeline-tracks > .tracks-container`, index.html:963-981)은 **완전히 독립된 두 세로 컬럼**이며, 행 정렬은 오직 "**행별 고정 px 높이가 좌우 동일하다**"는 암묵적 규약으로만 유지된다 (스크롤은 timeline.js:190-229에서 scrollTop 상호 복사).
+- 행 높이 대응: 룰러 32px ↔ 32px, 하이라이트 24px+margin-bottom 2px ↔ 동일, **댓글 헤더 24px(margin 없음!) ↔ 댓글 트랙 24px+margin-bottom 2px(JS로 동적 height 변경, transition 0.28s)**, 이하 video/드로잉 행은 CSS 변수(`--timeline-video-track-height: 48px`, `--timeline-drawing-track-height: 44px`) 공유. 전역 `box-sizing: border-box`.
+- **한쪽 행 높이만 바꾸면 그 아래 모든 행이 어긋난다** — 이것이 Phase 4 버그의 본질.
+
+### 2.4 설정 저장 패턴 (Phase 6, 7의 기반)
+
+- `user-settings.js`: 기본값 블록(162-201), `_loadFromStorage()`(237-259, localStorage 동기 로드 + 스프레드 병합 242), `_loadFromFile()`(276-288, IPC 파일 **비동기** 병합), `_save()`(311-314, localStorage+파일 동시 저장).
+- getter/setter 선례: `getEraserMode`/`setEraserMode`(615-624) — `_save()` + `_emit('xxxChanged')` + `log.info(한글)` 3종 세트.
+- 메인 프로세스는 `main/ipc-handlers.js:1077-1084`에서 settings 객체 전체를 JSON 파일로 저장하므로 **새 키 추가에 메인 프로세스 수정 불필요**.
+- 주의: initApp 시점의 getter는 localStorage 값만 반영한다(파일 로드는 비동기). 기존 `eraserMode` 복원(app.js:2810)도 동일한 한계이므로 이 패턴을 그대로 따르면 일관적이다.
+
+### 2.5 협업(Liveblocks) / .bframe 주의사항
+
+- 드로잉 실시간 동기화: `drawing-sync.js`가 **drawingCanvas의** `drawstart/drawmove`(57-58줄)와 **drawingManager의** `drawend`(60줄)를 구독해 브로드캐스트한다. detail의 `tool`은 Ctrl 토글이 반영된 유효 도구다.
+- 원격 스트로크는 별도 `_remoteOverlay` 캔버스(z-index:25)에 그려져 로컬 `#drawingCanvas`를 오염시키지 않는다.
+- 이 계획의 모든 Phase는 Liveblocks 프로토콜과 `.bframe` 스키마를 변경하지 않는다. `DrawingLayer.locked/visible`은 이미 `toJSON/fromJSON`(drawing-layer.js:334-360)으로 직렬화되고 있다.
+
+---
+
+## Phase 1: 잠긴/숨긴 레이어 그리기·지우기 입력 차단
+
+### 목표
+픽셀 지우개(및 펜/브러시/도형)가 잠긴 레이어의 데이터를 파괴하지 못하게 입력 단계에서 차단하고, 사용자에게 토스트로 알린다. 숨긴 레이어에 그려서 "그림이 증발"하는 문제(감사 발견)도 함께 차단한다.
+
+### 근본 원인 (검증: CONFIRMED)
+- 지우개 파이프라인에서 `layer.locked`를 검사하는 코드는 **획 지우개 전용인 `drawing-manager.js:317`** (`_eraseStrokeRecords`의 `if (!layer || layer.locked) return false;`) **단 한 곳뿐**이다. grep 전수조사 결과 locked 체크는 317/540/559/578/623/677/695/725줄(키프레임 조작 계열)에만 존재.
+- 픽셀 지우개는 완전히 다른 경로를 탄다: `drawing-canvas.js` `_onMouseDown`(129) → `_setupContext`(415-430)의 `globalCompositeOperation = 'destination-out'`(421-424)으로 **표시 캔버스(=전 레이어 합성본)의 픽셀을 직접 삭제** → `drawing-manager.js` `_onDrawEnd`(176-179) → `_saveCurrentFrameData`(195-225)가 지워진 캔버스를 활성 레이어 키프레임에 저장. **이 경로 어디에도 잠금 체크가 없다.**
+- `toggleLayerLock()`(438-444)은 locked만 반전하고 `activeLayerId`를 바꾸지 않으며 레이어 선택(`setActiveLayer`, 414-421)에도 잠금 필터가 없다 → 잠긴 레이어가 활성 레이어로 남은 채 지우개를 쓰면 그 키프레임 데이터가 파괴된다. 획 지우개만 317줄에서 차단되는 비대칭이 "획 단위는 잘 작동"이라는 제보와 정확히 부합한다.
+- 같은 이유로 펜/브러시/도형도 잠긴 활성 레이어에 그려진다(피드백에는 지우개만 보고됐지만 함께 막아야 함). `_onDrawStart`(103-140)에는 visible 체크도 없어 숨긴 레이어에 그리면 저장은 되는데 화면에서 사라진다(renderFrame 845-846이 `!layer.visible` 스킵).
+
+### 수정 파일
+`renderer/scripts/modules/drawing-canvas.js`, `renderer/scripts/modules/drawing-manager.js`, `renderer/scripts/app.js`, (선택) `renderer/styles/main.css`
+
+### 구현 내용
+
+**(a) drawing-canvas.js — 입력 게이트 훅**
+
+constructor(약 67줄 `_abortController` 근처)에 추가:
+```js
+  // 그리기 가능 여부 판정 훅 (DrawingManager가 잠긴/숨긴 레이어 차단용으로 주입)
+  this.canDraw = null;
+```
+
+`_onMouseDown`(129) 최상단, `if (!this.canvas.classList.contains('active')) return;` (130줄) 직후에 추가:
+```js
+  // 잠긴/숨긴 레이어 등 그리기 불가 상태면 입력 자체를 차단
+  if (typeof this.canDraw === 'function' && !this.canDraw()) {
+    this._emit('drawblocked', { tool: this._resolveEffectiveTool(e) });
+    return;
+  }
+```
+
+**왜 mousedown에서 차단하는가 (핵심)**: 여기서 차단하면 `isDrawing`이 켜지지 않아 `drawstart/drawmove/drawend`가 전혀 발행되지 않고, destination-out 첫 점(166-168줄)도 찍히지 않으며, **drawing-sync의 `STROKE_START` 브로드캐스트(drawing-sync.js:105)도 발생하지 않는다** (drawing-sync는 drawingCanvas의 drawstart를 직접 구독하므로, 이보다 늦은 단계에서 차단하면 원격에 유령 스트로크 시작 신호가 유출되고 STROKE_END가 영영 오지 않아 원격 상태가 매달린다 — 검증 단계에서 확인된 함정). Ctrl+펜 임시 지우개와 터치 입력(`_onTouchStart`→`_onMouseDown` 경유)도 같은 가드를 탄다.
+
+**(b) drawing-manager.js — 훅 주입 + 이벤트 중계 + 방어선**
+
+constructor의 `this.drawingCanvas = new DrawingCanvas(this.canvas);`(28줄) 직후:
+```js
+  // 잠긴/숨긴 레이어에는 그리기 입력 차단 (픽셀 지우개 포함)
+  this.drawingCanvas.canDraw = () => {
+    const layer = this.getActiveLayer();
+    return !layer || (layer.locked !== true && layer.visible !== false);
+  };
+```
+
+`_setupEvents()`(83-98)에 중계 추가 (차단 사유를 여기서 판정해 detail에 실음):
+```js
+  // 잠긴/숨긴 레이어 입력 차단 알림 중계
+  this.drawingCanvas.addEventListener('drawblocked', (e) => {
+    const layer = this.getActiveLayer();
+    const reason = layer?.locked ? 'locked' : 'hidden';
+    this._emit('drawblocked', { ...e.detail, reason });
+  });
+```
+
+방어선(defense-in-depth):
+- `_onDrawStart`(109줄 `if (!layer) return;`)를 `if (!layer || layer.locked || !layer.visible) return;`으로 변경. (`_saveToHistory` 호출 113-115줄보다 앞이므로 undo 스택 오염도 방지된다.)
+- `_saveCurrentFrameData`(197-200줄) 가드 강화:
+```js
+  if (!layer || layer.locked) {
+    log.warn('저장 실패: 활성 레이어 없음 또는 잠김');
+    if (layer?.locked) this.renderFrame(this.currentFrame); // 화면 원상 복구
+    return null;
+  }
+```
+(drawend 시점에는 drawing-canvas.js:222에서 이미 `isDrawing=false`이므로 renderFrame의 803-807줄 스킵 가드에 걸리지 않는다. 또한 `setCurrentFrame`(786-797)의 그리기 중 프레임 이동 저장 경로(791-793줄)도 이 방어선이 커버한다.)
+
+**(c) app.js — 토스트 + 전체 지우기 가드**
+
+drawstart 리스너(1268-1270줄) 근처에 추가:
+```js
+  // 잠긴/숨긴 레이어 그리기 시도 알림
+  drawingManager.addEventListener('drawblocked', (e) => {
+    showToast(e.detail?.reason === 'hidden'
+      ? '숨겨진 레이어입니다. 레이어를 표시하고 그려주세요.'
+      : '잠긴 레이어에는 그릴 수 없습니다', 'warn');
+  });
+```
+(`showToast`의 'warn' 타입은 app.js:9101 등에서 이미 사용 중.)
+
+전체 지우기 버튼(`btnClearDrawing`, 2966-2980줄)에도 활성 레이어 잠금 가드 추가:
+```js
+  if (layer?.locked) {
+    showToast('잠긴 레이어는 지울 수 없습니다', 'warn');
+    return;
+  }
+```
+
+**(d) (선택) 커서 피드백**: 잠긴 레이어가 활성일 때 `not-allowed` 커서 — main.css에 `.video-wrapper.drawing-mode.layer-locked #drawingCanvas.active { cursor: not-allowed; }` 추가하고, app.js의 `activeLayerChanged`/`layersChanged` 리스너에서 `elements.videoWrapper.classList.toggle('layer-locked', !!drawingManager.getActiveLayer()?.locked)` 갱신.
+
+**(e) (선택, 저비용 권장) drawing-sync 아웃바운드 스킵**: `drawing-sync.js` `_onDrawStart`(105-130)는 110줄에서 이미 활성 레이어를 조회하므로, 그 자리에서 `if (layer?.locked || layer?.visible === false) return;` 스킵을 추가하면 이중 방어가 된다.
+
+### 예상 리스크
+- 동작 변경: "잠가도 그려지던" 기존 동작이 차단으로 바뀐다 — 릴리즈 노트에 명시 (요청된 방향).
+- 협업/스키마: 영향 없음 (mousedown 차단 → 이벤트 미발행; `canDraw`/`drawblocked` 식별자는 리포 전체에서 미사용 확인 완료).
+- 참고: 협업 세션에서 원격 피어의 키프레임 갱신(`_applyRemoteKeyframe`, drawing-sync.js:295-339)은 locked를 검사하지 않는다(잠금 상태 자체가 브로드캐스트되지 않음) — 별도 이슈로 분리 (하단 "기존 갭" 참조).
+
+### 테스트
+- `scripts/tests/drawing-runtime-source.test.js`에 소스 정규식 스타일로 추가:
+```js
+test('pixel eraser and pen respect drawing layer lock', () => {
+  assert.match(drawingCanvasSource, /this\.canDraw = null;/);
+  assert.match(drawingCanvasSource, /typeof this\.canDraw === 'function' && !this\.canDraw\(\)/);
+  assert.match(drawingCanvasSource, /_emit\('drawblocked'/);
+  assert.match(drawingManagerSource, /this\.drawingCanvas\.canDraw = \(\) =>/);
+  assert.match(drawingManagerSource, /저장 실패: 활성 레이어 없음 또는 잠김/);
+  assert.match(appSource, /drawblocked/);
+  assert.match(appSource, /잠긴 레이어에는 그릴 수 없습니다/);
+});
+```
+- 수동: ① 레이어 1개에 그림 → 🔒 잠금 → 픽셀 지우개 드래그: 아무것도 지워지지 않고 토스트 표시, 프레임 이동 후 복귀해도 그림 유지 ② 획 지우개/펜/브러시/도형/Ctrl+펜 지우개 모두 차단 ③ 잠금 해제 후 정상 동작(특히 픽셀 지우개 연속 두 번째 스트로크) ④ 전체 지우기 차단 ⑤ 협업 2클라이언트: 잠긴 상태의 입력이 상대 화면에 안 나타남 ⑥ `npm run test:drawing` 통과.
+
+---
+
+## Phase 2: 활성 레이어 분리 렌더링 (3-캔버스 스택)
+
+### 목표
+"레이어 나누기 시 기존 레이어의 드로잉이 새 레이어에 귀속"되는 데이터 오염을 원천 차단한다. 그리기 대상 `#drawingCanvas`에는 **활성 레이어 내용만** 올리고, 비활성 레이어는 아래/위 2장의 정적 캔버스에 분리 합성한다.
+
+### 근본 원인 (검증: CONFIRMED — 렌더링 버그가 아니라 데이터 귀속 버그)
+피드백 시나리오를 코드로 재구성하면:
+1. 레이어 1에 A(프레임 fA), B(프레임 fB), C 키프레임 존재.
+2. 레이어 추가(app.js:2982-2987 → `createLayer`, drawing-manager.js:359-374) → 새 레이어가 **즉시 활성화**되지만 **캔버스 재렌더링은 없다** (합성 방식이라 화면이 그대로이므로) — 캔버스에는 레이어 1의 A가 남아 있다.
+3. 재생헤드가 A의 홀드 구간(fA ≤ 현재 < fB)에 있는 상태에서 D를 그림 → `_onDrawStart` 117줄이 **A가 포함된 합성 화면 전체**를 `_activeStrokeBaseData`로 스냅샷 → `_onDrawEnd` → `_saveCurrentFrameData` 210-211줄에서 **A+D 합성본이 레이어 2 키프레임의 canvasData로 저장**. **A가 레이어 2에 귀속되는 시점이 바로 여기다.**
+4. fB로 이동 → renderFrame이 레이어 1의 B + 레이어 2의 (A+D) 키프레임(홀드 방식이라 끝까지 유지)을 합성 → **B 위에 A+D가 겹쳐 보인다.**
+5. "D를 삭제하면 정상 복귀"의 성립: D 삭제 = 레이어 2의 유일한 키프레임 제거 → `getKeyframeAtFrame`이 null → renderFrame 850줄 `if (!keyframe ...) continue;`로 레이어 2 전체(구워진 A 포함)가 렌더링에서 제외 → B만 보임. **증상과 코드 경로가 정확히 일치.**
+
+파생 버그(같은 원인): (a) 픽셀 지우개가 타 레이어의 화면 픽셀을 함께 지움 (b) `drawingCanvas.isEmpty()`(210줄) 판정이 타 레이어 내용 때문에 항상 false (c) 획 지우개의 `_redrawKeyframeFromRecords`(338-354)도 drawingCanvas를 스크래치 버퍼로 써서 합성 스냅샷 기반 재저장 — 동일 오염 계열 (d) 협업이 오염된 canvasData를 그대로 전파.
+
+### 수정 파일
+`renderer/index.html`, `renderer/styles/main.css`, `renderer/scripts/modules/drawing-manager.js`, `renderer/scripts/app.js`
+
+### 구현 내용
+
+**(1) index.html (494-501줄)** — `#drawingCanvas` 앞뒤에 캔버스 2장 추가:
+```html
+<!-- 비활성 레이어 합성 캔버스 (활성 레이어 아래) -->
+<canvas id="layersBelowCanvas" class="drawing-overlay layers-below-layer"></canvas>
+<!-- Drawing Overlay Canvas (활성 레이어 전용) -->
+<canvas id="drawingCanvas" class="drawing-overlay"></canvas>
+<!-- 비활성 레이어 합성 캔버스 (활성 레이어 위) -->
+<canvas id="layersAboveCanvas" class="drawing-overlay layers-above-layer"></canvas>
+```
+**DOM 배치가 필수 조건**: `compositionLayerOverlay`(div, z-index:2)가 onionSkin과 drawingCanvas 사이에 있으므로, `layersBelowCanvas`(z:2)를 `#drawingCanvas` 직전에 두어야 DOM 순서에 의해 합성 프리뷰 위에 페인트되어 현행 시각 순서가 유지된다.
+
+**(2) main.css (1825-1831줄 부근)**:
+```css
+.layers-below-layer { z-index: 2; }
+.layers-above-layer { z-index: 4; }
+```
+`.drawing-overlay` 공통 규칙(1097줄, pointer-events:none)을 상속하므로 클릭 방해 없음 — **두 캔버스에 `.active` 클래스를 절대 주지 말 것**. z-index:4는 video-wrapper 내 댓글 범위/컨트롤(z:5~7), 마커(z:50), remoteStrokeOverlay(z:25)보다 낮아 기존 시각 순서 유지 (검증 완료).
+
+**(3) drawing-manager.js (핵심)**:
+- 생성자(23-78줄): 어니언 스킨 패턴(31-32줄)과 동형으로 `this.layersBelowCanvasElement = options.layersBelowCanvas;` + `getContext('2d')`, above도 동일.
+- `setCanvasSize`(769-781): 두 캔버스 width/height 동기화 추가.
+- 헬퍼 추가 (순수 함수로 분리해 export하면 테스트 용이):
+```js
+// 활성 레이어 기준으로 레이어를 아래/활성/위 3그룹으로 분할
+_partitionLayersByActive() {
+  const activeIndex = this.layers.findIndex((l) => l.id === this.activeLayerId);
+  return {
+    below: activeIndex === -1 ? [...this.layers] : this.layers.slice(0, activeIndex),
+    active: activeIndex === -1 ? null : this.layers[activeIndex],
+    above: activeIndex === -1 ? [] : this.layers.slice(activeIndex + 1)
+  };
+}
+_clearStaticLayerCanvases() { /* below/above ctx clearRect */ }
+```
+- `renderFrame`(802-880) 수정: 821줄 `clear()` 뒤에 `_clearStaticLayerCanvases()` 호출. 845-876줄 합성 루프를 분기 — below 그룹은 `layersBelowCtx`, 활성 레이어는 기존 `drawingCanvas.ctx`, above 그룹은 `layersAboveCtx`에 `globalAlpha = layer.opacity`로 drawImage. (visible/keyframe/isEmpty 필터는 기존 로직 그대로.)
+- **`_renderFrameSync`(887-926)도 동일하게 3분할** — 재생 중 경로 누락 금지 (검증 단계 지적사항). `_playbackCanvasCleared` 플래그는 3캔버스 모두 비웠을 때만 true.
+- `setActiveLayer`(414-421): activeLayerId 변경 후 `this.renderFrame(this.currentFrame);` 추가 — 활성 전환 시 내용이 캔버스 간 이동해야 하므로 **필수**.
+- `createLayer`(359-374): `this.activeLayerId = layer.id;` 다음에 `this.renderFrame(this.currentFrame);` 추가 — **이번 버그의 트리거 경로 방어**. 단 그리기 중(isDrawing)이면 renderFrame이 스킵되는데, 레이어 0개에서 첫 그리기의 자동 생성 경로(105-107줄)는 화면이 비어 있어 문제 없음.
+- **원격 레이어 생성의 활성 탈취 방지 (검증 단계 발견)**: `drawing-sync.js`의 `_applyRemoteLayerCreated`(341-359)가 `createLayer`를 호출하면 무조건 내 활성 레이어가 바뀐다(367줄). `createLayer(options, saveHistory)`에 `options.skipActivate` 지원을 추가하고 원격 경유 호출에서 `skipActivate: true`를 넘겨, 협업 중 상대가 레이어를 추가해도 내 활성 레이어와 캔버스가 소리 없이 바뀌지 않게 한다.
+- `clearAll()`(1002-1009)과 `reset()`(1014~): `drawingCanvas.clear()`만 호출하므로 **`_clearStaticLayerCanvases()`를 함께 호출** — 파일 전환 시 비활성 레이어 잔상 방지 (검증 단계 지적사항).
+- `deleteLayer`/`toggleLayerVisibility`/`importData`/`_restoreSnapshot`은 이미 renderFrame을 호출하므로 자동 반영.
+- `_onDrawStart` 117줄의 `_activeStrokeBaseData` 스냅샷과 `_saveCurrentFrameData`의 `isEmpty()` 판정은 이제 활성 레이어만 담으므로 **코드 변경 없이 자동 치유**된다. 획 지우개의 `_redrawKeyframeFromRecords`(338-354)도 동일하게 자동 치유.
+
+**(4) app.js**:
+- 114-115줄: `layersBelowCanvas`/`layersAboveCanvas` DOM 등록.
+- 806-807줄: DrawingManager 생성 옵션에 두 캔버스 전달.
+- `syncCanvasOverlay`(4923-4951): onionCanvas 블록(4943-4951)과 동일한 위치/크기 동기화를 두 캔버스에 추가 (4회 반복이 되므로 `applyOverlayCanvasRect(canvasEl, renderArea)` 헬퍼로 묶기 권장).
+- 4670-4676줄 줌 transform 적용부에도 두 캔버스 추가.
+- `getMpvOverlayState`(5985-6010): mpv 오버레이가 `drawingDataUrl` 하나만 보내므로, 임시 캔버스에 below→drawing→above 순으로 합성한 dataURL을 반환하는 `getCompositedDrawingDataUrl()` 헬퍼를 추가해 사용 (mpv 프로토콜 변경 회피). `getCanvasOverlayDataUrl`(5834-5837)의 호출부는 5991-5992 두 곳뿐임을 grep으로 확정 — 이 경로만 바꾸면 된다. (참고: `splitDrawingCanvasLeft/Right`는 index.html에만 존재하는 미사용 요소로 파급 대상 아님 — 검증 완료.)
+
+**(5) 데이터/협업 — 변경 없음**: `.bframe` `drawings.layers[].keyframes[].canvasData` 스키마 그대로. drawing-sync 송수신 필드도 그대로 — 앞으로는 깨끗한 레이어별 데이터가 전송된다. **이미 오염된 기존 파일의 키프레임 PNG는 자동 분리 불가**(픽셀이 구워짐) — 릴리즈 노트에 "문제 키프레임을 삭제 후 다시 그려주세요" 안내 필요.
+
+### 예상 리스크
+| 리스크 | 심각도 | 완화 방안 |
+|--------|--------|----------|
+| 레이어 시각 순서 깨짐 | 높음 | 반드시 below/above 2장 분리 (1장에 몰면 활성 레이어가 항상 최상단/최하단이 됨) |
+| 재생 중 렌더 경로 누락 | 높음 | `_renderFrameSync`도 반드시 3분할. 재생 스모크 테스트 필수 |
+| mpv 오버레이/캡처에서 비활성 레이어 누락 | 중간 | `getCompositedDrawingDataUrl()` 합성 헬퍼로 해결 |
+| 활성 전환 시 재렌더 비용 | 낮음 | 키프레임 이미지는 `_cachedImage` 캐시 사용, 체감 낮음 |
+| 구버전 클라이언트 혼용 시 오염 데이터 재유입 | 낮음 | 혼용 기간 한정, 허용 |
+
+### 테스트
+- 신규 `scripts/tests/drawing-layer-partition.test.js`: `partitionLayersByActive` 순수 함수 단위 테스트 (활성이 중간/없음/1개일 때 분할·순서 보존).
+- `drawing-runtime-source.test.js`에 소스 assertion: `layersBelowCtx`/`layersAboveCtx` 분기 존재, `setActiveLayer`/`createLayer` 본문에 renderFrame 호출 존재, index.html에 두 캔버스 존재.
+- 수동 (피드백 재현 시나리오 — 반드시 수행):
+  1. 레이어 1에서 프레임 10에 A, 프레임 50에 B를 그림.
+  2. 레이어 추가 → 재생헤드를 프레임 20(A 홀드 구간)에 두고 레이어 2에 D를 그림.
+  3. 프레임 50 이동: **B와 D만 보이고 A가 겹치지 않아야 함. 레이어 2를 숨기면 A 흔적이 전혀 없어야 함 (핵심 판정).**
+  4. .bframe 저장 후 재로드해 3번 동일 확인. 레이어 2 키프레임 canvasData PNG에 A 픽셀이 없는지 확인.
+  5. 픽셀 지우개로 레이어 2에서 문지를 때 레이어 1 그림이 지워지지 않는지 + **획 지우개(stroke 모드)도 동일 확인**.
+  6. 활성 레이어 1↔2 전환 시 화면 합성 결과(순서 포함) 불변 확인.
+  7. 재생 중 드로잉 정상 합성, 어니언 스킨 온/오프, 줌/리사이즈 시 3캔버스 정렬 확인.
+  8. 협업 2클라이언트에서 레이어 2에 그렸을 때 원격도 레이어 2에만 반영 + 원격이 레이어를 추가해도 내 활성 레이어가 바뀌지 않는지 확인.
+  9. mpv 오버레이 모드/댓글 캡처에서 비활성 레이어 드로잉이 누락되지 않는지 확인.
+  10. 파일 전환(clearAll/reset) 시 비활성 캔버스 잔상 없음 확인.
+
+---
+
+## Phase 3: 펜 입력 시 Ctrl+드로잉 지우개 토글 미인식 수정
+
+### 목표
+갤럭시탭 신티크(펜 디스플레이) 등 펜/터치 유래 입력에서도 Ctrl 임시 지우개 토글이 동작하게 한다.
+
+### 근본 원인 (검증: 가설 A는 코드로 확정, 가설 B는 유력 — 수정안은 동일)
+- 현행은 `_resolveEffectiveTool(e)`(drawing-canvas.js:296-301)가 **이벤트 객체의 `e.ctrlKey`만** 읽는다. 파일 내 ctrlKey 참조는 grep 결과 정확히 **132/157/184/242/297줄 5곳**.
+- **가설 A (확실)**: 미러링 앱이 펜 접촉을 터치로 주입하면 `_onTouchStart`(251-255)가 `{clientX, clientY}`만 담은 합성 객체를 `_onMouseDown`에 전달 → ctrlKey가 존재하지 않아 `e?.ctrlKey`가 항상 undefined → **구조적으로 토글 불가**.
+- **가설 B (유력)**: 펜이 Windows Ink 포인터(WM_POINTER)로 주입되는 경우, Chromium은 펜 유래 이벤트의 모디파이어를 키보드 전역 상태가 아니라 `POINTER_INFO.dwKeyStates`에서 가져오는데, 서드파티 입력 주입 드라이버는 이를 채우지 않는 경우가 흔함 → 물리적으로 Ctrl을 눌러도 `e.ctrlKey === false`. 실제 마우스는 키보드 상태를 정상 반영하므로 "마우스만 인식"이라는 증상과 정확히 일치.
+- 어느 쪽이든 **PC 키보드의 Ctrl keydown 자체는 렌더러에 정상 전달**되므로, 전역 keydown 추적으로 해결된다. app.js:4429-4443에 이미 동일 문제를 우회한 선례가 있다(`ctrlCommentResizeKeyDown` 플래그: document keydown/keyup('Control') + window blur 리셋, 4025줄에서 이벤트 프로퍼티와 OR 병용).
+
+### 수정 파일
+`renderer/scripts/modules/drawing-canvas.js`, `scripts/tests/drawing-runtime-source.test.js`
+
+### 구현 내용
+
+1. 생성자(50줄대 상태 초기화 블록)에 추가:
+```js
+  // Ctrl 모디파이어 전역 추적 상태 (펜/터치 입력은 이벤트에 ctrlKey가 실리지 않을 수 있음)
+  this._modifierCtrlDown = false;
+```
+
+2. `_setupEventListeners()`(78줄) 끝에 **기존 signal 재사용**으로 전역 리스너 추가 (destroy()의 abort로 자동 해제):
+```js
+  // Ctrl 전역 추적: 펜/터치 유래 이벤트는 ctrlKey가 비어 오는 환경(펜 디스플레이 등)이 있어
+  // 키보드에서 직접 상태를 추적한다
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Control') this._modifierCtrlDown = true;
+  }, { signal });
+  window.addEventListener('keyup', (e) => {
+    if (e.key === 'Control') this._modifierCtrlDown = false;
+  }, { signal });
+  window.addEventListener('blur', () => {
+    this._modifierCtrlDown = false;
+  }, { signal });
+```
+
+3. 헬퍼 추가 (`_resolveEffectiveTool` 296줄 근처):
+```js
+  /**
+   * Ctrl 활성 여부 판정 (이벤트 프로퍼티 + 전역 키 상태 병용)
+   */
+  _isCtrlActive(e) {
+    return e?.ctrlKey === true || this._modifierCtrlDown === true;
+  }
+```
+
+4. `e.ctrlKey` 참조 **5곳** 교체:
+- 132줄: `if (e.ctrlKey) {` → `if (this._isCtrlActive(e)) {` (터치 합성 객체에서도 `e.preventDefault?.()`는 옵셔널 체이닝이라 무해)
+- 157줄(drawstart) / 184줄(drawmove) / 242줄(drawend): `ctrlKey: e.ctrlKey === true` → `ctrlKey: this._isCtrlActive(e)`
+- 297줄: `e?.ctrlKey` → `this._isCtrlActive(e)` ← **기능적으로 결정적인 지점** (157/184/242의 detail 필드는 현재 소비처가 없는 데이터 정합성 정리 수준 — 검증 확인)
+
+5. 동작 유지: 유효 도구는 지금처럼 스트로크 시작 시 1회만 확정(activeTool 고정 244-245줄 유지). 미드스트로크 토글은 도입하지 않는다. `setTool`(682-688)/`setEraserMode`(693-699)의 `!this.isDrawing` 가드가 이와 자연스럽게 정합함을 확인했다.
+
+6. **⚠ 기존 테스트 갱신 필수 (검증 단계 발견 — 누락 시 CI 깨짐)**: `scripts/tests/drawing-runtime-source.test.js` 45줄의 `assert.match(drawingCanvasSource, /e\.ctrlKey/)`는 5곳 교체 후 파일에 리터럴 `e.ctrlKey`가 남지 않아 **실패한다** (`e?.ctrlKey`는 `?` 때문에 매칭 안 됨). 해당 단언을 `/e\?\.ctrlKey/` 또는 `/_isCtrlActive/`로 갱신할 것.
+
+7. 신규 테스트 (같은 파일에 추가):
+```js
+test('ctrl eraser toggle tracks modifier state globally for pen and touch input', () => {
+  assert.match(drawingCanvasSource, /this\._modifierCtrlDown = false;/);
+  assert.match(drawingCanvasSource, /_isCtrlActive\(e\)/);
+  assert.match(drawingCanvasSource, /e\?\.ctrlKey === true \|\| this\._modifierCtrlDown === true/);
+  assert.match(drawingCanvasSource, /window\.addEventListener\('keydown'/);
+  assert.match(drawingCanvasSource, /e\.key === 'Control'/);
+  assert.match(drawingCanvasSource, /window\.addEventListener\('blur'/);
+});
+```
+
+### 예상 리스크
+- 전역 keydown 리스너는 플래그만 갱신하고 preventDefault를 하지 않으므로 기존 단축키와 무충돌.
+- keyup 유실(Ctrl 누른 채 포커스 이탈)은 window blur 리셋으로 커버 — app.js 선례와 동일 전략.
+- 원격 데스크톱 구성에서 Ctrl keydown조차 PC로 안 오는 경우(태블릿 화면 키보드만 사용)는 여전히 불가 — 피드백 시나리오(PC 키보드 Ctrl + 탭 펜)는 확실히 해결됨.
+- Liveblocks/스키마: 영향 없음 (detail.tool에 이미 토글 결과가 반영되는 구조, ctrlKey는 와이어에 실리지 않음 — 검증 완료).
+
+### 테스트 (수동)
+① 갤탭 펜 디스플레이 환경: 브러시 선택 → PC 키보드 Ctrl 홀드 → 펜 드로잉 시 지우개로 동작 ② 마우스 Ctrl 드래그 회귀 ③ Ctrl 뗀 후 다음 스트로크 브러시 복귀 ④ Ctrl 누른 채 Alt+Tab 후 복귀 시 지우개 고착 없음 ⑤ 협업에서 Ctrl 지우개 스트로크 정상 반영 ⑥ 획 지우개 모드(eraserMode='stroke')에서도 Ctrl 토글 동작 ⑦ `npm run test:drawing` 통과.
+
+---
+
+## Phase 4: 댓글 구간 좌/우 행 어긋남 수정
+
+### 목표
+"댓글 구간" 토글 ON 시 (1) 댓글 라인이 다중 레인으로 커질 때 좌측 '댓글' 헤더도 같은 높이로 동기화되고 (2) 상시 2px 어긋남이 사라지게 한다. **레인 스태킹(두 줄) 자체는 의도된 UX**(겹치는 구간 댓글이 서로 덮이지 않게 쌓기, DEVLOG/2026-04-20-코멘트-클러스터-UX-재작업.md)이므로 유지 — 좌측 헤더가 함께 커지면 정상 동작으로 보인다.
+
+> 참고: 이 문제는 DEVLOG/2026-04-17-사용자리뷰-UIUX개선-설계.md:292에 "commentLayerHeader 높이 동기화 — 낮음"으로 이미 기록되어 있던 알려진 이슈가 표면화된 것이다.
+
+### 근본 원인 (검증: 코드로 확정)
+1. **다중 레인 시 30px 어긋남**: `renderCommentRanges()`(timeline.js:2509-2624)가 레인 수에 따라 `this.commentTrack.style.height = targetHeight`(정확히 **2596줄**, 2레인=24×2+6=54px)를 설정하는데, **좌측 `#commentLayerHeader`의 높이를 설정하는 코드는 리포 전체에 0건**(grep 확정). 좌측은 CSS 고정 24px(main.css:3985) → 그 아래 모든 행이 (targetHeight−24)px 어긋남.
+2. **상시 2px 어긋남**: `.comment-track`은 `margin-bottom: 2px`(main.css:3976)인데 `.comment-layer-header`(main.css:3981-3988)는 margin-bottom이 없음. (하이라이트 쌍은 둘 다 2px로 일치하는 대조 사례 — main.css:3036.)
+3. **부수 버그**: `renderPlaylistCommentRanges()`(2444-2503)는 height를 리셋하지 않아 다중 레인 높이(54px)가 플레이리스트 모드에 잔존.
+4. '두 줄'의 발생 메커니즘: 프레임 구간이 겹치는 댓글들이 `findRangeClusters`(comment-cluster.js:12-32)로 묶인 뒤 `splitClustersByPixelGap`(200-230, 임계 20px)으로 쪼개지고, 조각끼리 여전히 프레임이 겹치면 `assignRenderLanes`(73-113)가 위 레인으로 스택 → `maxLanes=2` → 54px.
+
+### 수정 파일
+`renderer/scripts/modules/timeline.js`, `renderer/styles/main.css`
+
+### 구현 내용
+
+**(1) timeline.js — 높이 동기화 헬퍼** (renderCommentRanges 근처, 2505줄 앞):
+```js
+/**
+ * 댓글 트랙과 좌측 댓글 레이어 헤더의 높이를 함께 갱신
+ * 좌/우 컬럼은 행별 고정 높이 규약으로 정렬되므로 반드시 쌍으로 변경해야 한다.
+ * (인라인 style이 CSS height보다 우선하므로 이후 높이 조정은 반드시 이 헬퍼를 경유할 것)
+ * @param {number} heightPx
+ */
+_syncCommentTrackHeight(heightPx) {
+  if (!this.commentTrack) return;
+  this.commentTrack.style.height = `${heightPx}px`;
+  if (this.commentLayerHeader) {
+    this.commentLayerHeader.style.height = `${heightPx}px`;
+    this.commentLayerHeader.style.minHeight = `${heightPx}px`;
+  }
+}
+```
+적용 지점 4곳:
+- 2596줄 `this.commentTrack.style.height = ...` → `this._syncCommentTrackHeight(targetHeight);`
+- `renderPlaylistCommentRanges`: 아이템 생성 루프(2470) 직전 또는 hasRanges 분기(2491-2496) 안에 `this._syncCommentTrackHeight(24);` — 다중 레인 잔존 높이 리셋.
+- `renderCommentRanges`의 빈 데이터/비표시 early-return(2520-2537)과 `clearPlaylistCommentRanges`(2275-2292)에도 `this._syncCommentTrackHeight(24);` — 다음 표시 시 transition 점프 방지.
+- (`commentLayerHeader`는 `setCommentTrack`(app.js:3722)에서 실제로 전달되어 존재함을 검증 완료. `_syncCommentTrackHeight` 이름 충돌 없음.)
+
+**(2) main.css — `.comment-layer-header`(3981-3988) 수정**:
+```css
+.comment-layer-header {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  height: 24px;
+  min-height: 24px;              /* flex 수축 방지 — 레이어 많을 때 comment 헤더만 줄어드는 벡터 차단 */
+  margin-bottom: 2px;            /* .comment-track의 margin-bottom과 짝 맞춤 */
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-subtle);
+  transition: height 0.28s ease, min-height 0.28s ease; /* .comment-track의 transition과 동기 */
+}
+```
+`.comment-track`(3973-3978)은 그대로. **transition 타이밍(0.28s ease)이 좌우 동일해야 애니메이션 중에도 어긋나지 않는다.** `min-height`는 부모 `.layer-headers`(flex column + overflow-y:auto)에서 comment 헤더만 flex-shrink로 줄어드는 추가 어긋남 벡터를 차단하므로 반드시 유지 (검증 단계 발견).
+
+**(3) 선택 사항 (별도 논의)**: '두 줄 자체'를 원치 않으면 split 조각 중 프레임이 겹치는 것들을 다시 배지로 합치는 후처리로 1레인을 보장할 수 있으나, 이는 2026-04-20 재작업의 '줌 반응형 분리' UX를 부분 롤백하는 것이므로 기본안은 (1)+(2)이고 윤성원님 확인 후 결정.
+
+### 예상 리스크
+- .bframe/협업: 영향 없음 (순수 렌더링/CSS. 원격 댓글 변경 재렌더는 app.js:4589-4610 `refreshCommentRangesForCurrentMode` 경유로 renderCommentRanges가 재호출되므로 헬퍼가 자동 커버).
+- 좌측 헤더가 인라인 style로 제어되므로 이후 CSS만 고쳐서는 높이가 안 바뀜 — 주석으로 명시했음.
+- **주의 (검증 단계 발견)**: 줌 변경만으로는 댓글 구간이 재클러스터되지 않는다 — `zoomChanged` 핸들러(app.js:1674-1677)가 `renderCommentRanges`를 호출하지 않기 때문. "줌으로 배지↔분리 전환" 수동 테스트는 현재 코드에서 기대대로 동작하지 않으니, 줌 후 다른 렌더 트리거(댓글 추가 등)를 거쳐 확인할 것. zoomChanged 배선 추가는 별도 이슈 (하단 "기존 갭").
+
+### 테스트
+- 기존: `npm run test:cluster` (comment-cluster.test.js 40건) — 클러스터 함수 무변경이므로 그대로 통과해야 함.
+- 신규 `scripts/tests/comment-track-header-sync-source.test.js` (소스 문자열 검증 관례):
+  1. timeline.js에 `_syncCommentTrackHeight(` 정의 존재 + 내부에서 `commentLayerHeader.style.height`/`minHeight` 설정.
+  2. renderCommentRanges 본문에 `this.commentTrack.style.height =` 직접 대입 **부재**(assert.doesNotMatch) + `_syncCommentTrackHeight(targetHeight)` 호출 존재.
+  3. renderPlaylistCommentRanges 본문에 `_syncCommentTrackHeight(` 호출 존재.
+  4. main.css `.comment-layer-header` 블록에 `margin-bottom: 2px`와 `transition: height` 포함.
+- 수동: ① 구간이 겹치는 댓글 2개(예: 0-100, 30-90프레임) 생성 → 토글 ON → 2레인으로 쌓일 때 좌측 '댓글' 헤더도 같은 높이로 커지고 그 아래 Video/드로잉 행이 픽셀 단위로 정렬(제보 스크린샷과 대조) ② 단일 댓글에서 토글 ON/OFF 반복 — 2px 어긋남 없음, transition 중 좌우 동기 ③ **클러스터 배지 펼침(expandedClusterId) 케이스**에서도 동기화 확인 (같은 targetHeight 경로, 2578-2586줄) ④ 다중 레인 상태에서 플레이리스트 열기 → 24px 리셋 ⑤ 협업 상대의 댓글 추가/이동 시 정렬 유지 ⑥ 레이어 다수 + 휠 스크롤 시 좌우 정렬 유지.
+
+---
+
+## Phase 5: 키프레임 드래그 오버레이 1프레임 칸 정합
+
+### 목표
+키프레임 드래그 시 표시되는 고스트 오버레이가 줌 레벨과 무관하게 **정확히 1프레임 칸**을 차지하고, 드롭 프레임이 "마우스가 올라간 칸"과 일치하게 한다. Phase 6과 독립적으로, 점 표시 모드에서도 항상 적용된다.
+
+### 근본 원인 (검증: 3건 모두 반박 실패로 성립)
+1. **[확실] 폭 고정 24px**: `_createDragGhost()`(timeline.js:1554-1582)가 10px 점 마커를 `cloneNode`한 뒤 className을 `'drawing-clip keyframe-drag-ghost-clip'`으로 교체(1558-1559줄). `.drawing-clip` CSS(main.css:4416-4427)는 `min-width: 24px`에 width 미지정 → **오버레이 폭이 줌과 무관하게 항상 약 24px**. pxPerFrame이 24px가 아닌 한 1칸과 일치 불가.
+2. **[확실] 반 칸 오프셋**: 원본 마커는 left가 프레임 중앙(`(frame+0.5)/totalFrames`, 1297줄) + 클래스 규칙의 `translate(-50%,-50%)`(main.css:4334)로 정렬되는데, 고스트는 `style.cssText` 복사(1565줄)로 인라인 left만 가져오고 **클래스 교체로 transform을 잃는다** → 고스트의 왼쪽 끝이 칸 중앙에 놓여 +0.5프레임 어긋남. 이후 `_updateKeyframeDrag()`(1495줄)는 칸 시작 기준으로 갱신하므로 첫 mousemove에서 기준 자체가 바뀌며 튀는 것처럼 보인다.
+3. **[유력] 드롭 매핑 불일치**: 1492줄 `Math.round(percent * (totalFrames - 1))`은 "마우스가 어느 칸 위에 있는가"(`floor(percent * totalFrames)`)와 경계가 반 칸 어긋난다 (수치 검산: totalFrames=100, percent=0.006 → round=1, floor=0).
+
+### 수정 파일
+`renderer/scripts/modules/timeline.js`, `renderer/styles/main.css`
+
+### 구현 내용
+
+**(1) `_createDragGhost()`(1554-1582) 전면 교체** — cloneNode를 버리고 전용 셀 고스트:
+```js
+_createDragGhost(e, frame) {
+  const { element: clipElement } = this.draggedKeyframe;
+  const container = clipElement.closest('.keyframe-container') || clipElement.parentElement;
+
+  // 정확히 1프레임 칸 크기의 고스트 셀 생성
+  this.dragGhost = document.createElement('div');
+  this.dragGhost.className = 'keyframe-drag-ghost-cell';
+  this.dragGhost.style.left = `${(frame / this.totalFrames) * 100}%`;
+  this.dragGhost.style.width = `${(1 / this.totalFrames) * 100}%`;
+  this.dragGhost.dataset.targetFrame = frame;
+
+  // 원본 마커 반투명 처리 (기존 유지)
+  clipElement.style.opacity = '0.3';
+
+  // 프레임 표시 툴팁 (기존 유지)
+  this.dragTooltip = document.createElement('div');
+  this.dragTooltip.className = 'keyframe-drag-ghost';
+  this.dragTooltip.textContent = `F${frame}`;
+  this.dragTooltip.style.left = `${((frame + 0.5) / this.totalFrames) * 100}%`;
+
+  container.appendChild(this.dragGhost);
+  this.tracksContainer.appendChild(this.dragTooltip);
+}
+```
+(기존 코드의 고스트/툴팁 변수명·정리(cleanup) 경로를 확인해 위 두 참조(`dragGhost`/`dragTooltip`)가 `_finishKeyframeDrag`(1511-1549)의 제거 로직과 일치하도록 맞출 것. `_finishKeyframeDrag`는 `dragGhost.dataset.targetFrame`을 읽으므로 무변경.)
+
+**(2) `_updateKeyframeDrag()`(1482-1506)** — 1492줄 매핑을 칸 단위 floor로:
+```js
+const newFrame = Math.min(this.totalFrames - 1, Math.floor(percent * this.totalFrames));
+```
+툴팁 left는 칸 중앙 `((newFrame + 0.5) / this.totalFrames) * 100%`로 갱신(1500줄 부근). 고스트 left 갱신(1495-1496줄)은 칸 시작 기준 그대로 (이제 폭과 정합).
+
+**(3) main.css 신규 클래스** (4490줄 부근, 기존 `.keyframe-drag-ghost-clip` 아래):
+```css
+/* 키프레임 드래그 고스트 — 정확히 1프레임 칸 */
+.keyframe-drag-ghost-cell {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  min-width: 2px;              /* 극단적 줌아웃에서도 보이도록 */
+  box-sizing: border-box;
+  background: rgba(255, 208, 0, 0.3);
+  outline: 2px dashed var(--accent-primary);
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 100;
+}
+```
+
+**(4) 정리(선택)**: 미사용이 되는 `.keyframe-drag-ghost-clip` CSS(main.css:4466-4490 중 해당 블록)와 레거시 `_createKeyframeClip()`(1394-1451, 호출부 전무 확인됨) 제거.
+
+### 예상 리스크
+- round→floor는 반 칸 경계의 미세한 동작 변화 — 피드백이 요구한 방향이므로 릴리즈 노트에 의도된 변화로 명시.
+- 다중 선택 드래그, 대상 칸에 기존 키프레임 존재 시 이동 거부(`moveKeyframes`의 충돌 검증, drawing-manager.js:712-755) 경로는 무변경 — 회귀 테스트로 확인.
+- 참고(기존 갭, 이번 범위 밖): 키프레임 이동(`moveKeyframes` → `layersChanged`)은 Liveblocks 브로드캐스트도, .bframe 자동저장 트리거도 아니다 — 하단 "기존 갭" 참조.
+
+### 테스트
+- 신규 `scripts/tests/keyframe-drag-ghost-source.test.js` (소스 정규식 관례): `keyframe-drag-ghost-cell` 클래스 생성 코드 존재, `Math.floor(percent * this.totalFrames)` 존재 + `Math.round(percent * (this.totalFrames - 1))` 부재, `_createDragGhost` 내 `cloneNode` 부재.
+- 기존 `scripts/tests/keyframe-multi-select-source.test.js` 통과 유지 (셀렉터 무변경).
+- 수동: 여러 줌 레벨에서 드래그 시 오버레이가 격자 1칸과 정확히 일치·칸 경계 스냅, `F숫자` 툴팁이 드롭 결과와 일치, 다중 선택 드래그/충돌 거부(toast) 정상.
+
+---
+
+## Phase 6: 프레임 1칸 셀 표시 모드 (ON/OFF/AUTO)
+
+### 목표
+Animate 스타일로 (1) 드로잉 키프레임을 정확히 1프레임 폭 셀로 표시하고 (2) ON: 프레임 1칸 최소 폭을 고정(줌아웃 제한), OFF: 현행 유지, AUTO: 프레임 격자선이 보이는 줌(pxPerFrame ≥ 4px)에서 자동 활성 — 3상태 토글을 제공한다. 기본값 AUTO.
+
+### 현행 구조 요약 (자세한 근거는 §2 참조)
+- 프레임 격자: `_updateFrameGrid()`(timeline.js:832-863)가 `pxPerFrame = tracksContainer.offsetWidth / totalFrames`를 계산하고 `resolveFrameGridTier()`(frame-grid-tiers.js, 임계 0.5/1/2/4px + ±3% 히스테리시스)로 5단계 티어 결정 → `_renderFrameGridTiered()`(883-930)가 **CSS repeating-linear-gradient 단일 요소**로 렌더 (프레임 수와 무관한 O(1) — "칸 표기 시 렉" 우려에 대한 답. DOM은 키프레임 수만큼만 생성된다).
+- 줌: `zoom`=100(최소)~동적 maxZoom(프레임당 15px 기준, 상한 50000%), `_applyZoom()`(725-741)이 `tracksContainer.style.width = scale*100%` 방식. minZoom은 100 고정(58줄) — ON 모드가 없던 이유.
+- 키프레임 표시: `_renderLayerTrack()`(1253-1328)이 `.keyframe-marker-dot`(고정 10px 원형 점, left=칸 중앙, translate(-50%,-50%)) 렌더. 2026-01-14 DEVLOG에서 "프레임 셀 방식"이 설계됐으나 점 방식으로 축소 구현됐고 CSS 잔재(`.frame-cell*`, main.css:4377-4411)와 미호출 함수(`_applyGridBackground` 1333-1389)만 남음.
+- 격자 토글: 2상태 불리언 `showFrameGrid`(user-settings.js:194, 566-576), UI `#btnGridToggle`(index.html:893-902), 배선 app.js:10619-10638.
+
+### 수정 파일
+`renderer/scripts/modules/frame-grid-tiers.js`, `renderer/scripts/modules/timeline.js`, `renderer/scripts/modules/user-settings.js`, `renderer/scripts/app.js`, `renderer/index.html`, `renderer/styles/main.css`
+
+### 구현 내용
+
+**(A) 설정: `frameCellMode`** — user-settings.js 기본값 블록(194줄 `showFrameGrid: true` 아래):
+```js
+      // 타임라인 프레임 1칸 셀 표시 모드 (on: 최소 폭 고정, off: 현행 유지, auto: 줌 임계 이상에서 표시)
+      frameCellMode: 'auto',
+```
+getter/setter를 `setShowFrameGrid` 패턴(566-576) 그대로 578줄 부근에 추가:
+```js
+  getFrameCellMode() {
+    const mode = this.settings.frameCellMode;
+    return ['on', 'off', 'auto'].includes(mode) ? mode : 'auto';
+  }
+
+  setFrameCellMode(mode) {
+    if (!['on', 'off', 'auto'].includes(mode)) return;
+    this.settings.frameCellMode = mode;
+    this._save();
+    this._emit('frameCellModeChanged', { mode });
+    log.info('프레임 셀 모드 변경됨', { mode });
+  }
+```
+
+**(B) frame-grid-tiers.js — 순수 함수 2개 추가** (테스트 용이):
+```js
+// 셀 모드 활성 여부 (auto는 EVERY_FRAME 티어와 동일 임계·히스테리시스 공유)
+export function resolveFrameCellActive(mode, tierResult) {
+  if (mode === 'off') return false;
+  if (mode === 'on') return true;
+  return !!tierResult.showFrame; // auto: 프레임 격자선이 보일 때 = pxPerFrame >= 4px
+}
+
+// ON 모드: 프레임 1칸 최소 폭을 보장하는 최소 줌 계산
+export function computeMinZoomForCellMode(totalFrames, viewportWidth, minFramePx) {
+  if (!totalFrames || !viewportWidth) return 100;
+  return Math.max(100, Math.ceil((minFramePx * totalFrames * 100) / viewportWidth));
+}
+```
+
+**(C) timeline.js — 모드 로직 + 셀 렌더링**
+
+constructor(67줄 부근) 상태 추가:
+```js
+  this.frameCellMode = 'auto';       // 'on' | 'off' | 'auto'
+  this._frameCellActive = false;     // 현재 셀 렌더링 활성 여부
+  this.minFrameCellPx = 8;           // ON 모드에서 보장할 프레임 1칸 최소 px
+  this._lastDrawingLayers = null;    // 셀 모드 전환 시 재렌더용 캐시
+  this._lastDrawingActiveLayerId = null;
+```
+
+공개 메서드 (setGridVisible 868-871 아래):
+```js
+  setFrameCellMode(mode) {
+    this.frameCellMode = mode;
+    this._applyCellModeMinZoom();
+    this._applyZoom(); // 격자·셀 활성 재평가 + zoomChanged 전파
+  }
+
+  _applyCellModeMinZoom() {
+    const viewportWidth = this.timelineTracks?.clientWidth || 0;
+    this.minZoom = this.frameCellMode === 'on'
+      ? computeMinZoomForCellMode(this.totalFrames, viewportWidth, this.minFrameCellPx)
+      : 100;
+    if (this.zoom < this.minZoom) this.zoom = this.minZoom;
+    this._updateZoomDisplay();
+  }
+```
+ON 모드의 "최소 프레임 폭 고정"은 **minZoom 상향만으로** 구현한다 — `_applyZoom`의 width=% 방식, 룰러, 휠 앵커 줌, % 기반 마커가 전부 기존 경로를 그대로 타므로 부작용이 최소다. `setZoom`(684)/휠 줌(208)/리셋 버튼(setZoom(100), 2064줄)이 minZoom을 클램프하므로 정합 (검증 완료).
+
+**⚠ 검증 단계에서 발견된 보완 3건 — 반드시 반영할 것**:
+1. **셀 활성 판정 위치**: `_updateFrameGrid()`는 `gridVisible=false`일 때 836-842줄에서 **tierResult 계산 전에 조기 반환**하고 `_lastFrameGridTier`를 null로 리셋한다. 셀 활성 판정을 tierResult 산출 직후(859-862)에만 두면 격자 토글 OFF 상태에서 셀 모드가 영원히 재평가되지 않아 동결된다. **판정 로직을 조기 반환 이전으로 호이스팅**하거나 별도 경로에서 평가할 것:
+```js
+  // (조기 반환보다 앞에서) 셀 활성 판정 — 격자 표시 여부와 독립적으로 평가
+  const frameWidth = this._computePxPerFrame(); // offsetWidth/totalFrames 계산을 헬퍼로 분리
+  const tierResult = resolveFrameGridTier(frameWidth, this._lastFrameGridTier);
+  const cellActive = resolveFrameCellActive(this.frameCellMode, tierResult);
+  if (cellActive !== this._frameCellActive) {
+    this._frameCellActive = cellActive;
+    this._refreshDrawingLayerRender();
+  }
+  if (!this.gridVisible) { /* 기존 조기 반환 (격자만 숨김) */ }
+```
+2. **영상 로드 경로**: `setVideoInfo()`(463-477)는 `_applyZoom()`을 호출하지 않으므로, ON 모드에서 영상 로드 시 `_applyCellModeMinZoom()`이 zoom을 올려도 컨테이너 폭이 갱신되지 않는다. `setVideoInfo` 안에서 `_calculateDynamicMaxZoom()` 다음에 `this._applyCellModeMinZoom();`을 호출하고 **`_applyZoom()`도 함께 호출**할 것.
+3. **셀 분기의 인라인 배경 제외**: 기존 마커 생성부의 `marker.style.background = layer.color`(1299줄) 인라인 지정을 셀 분기에서 유지하면 계획된 CSS 반투명 배경을 덮어써 셀이 불투명 단색이 된다 — **셀 분기에서는 이 줄을 제외**할 것.
+
+셀 렌더 분기 — `_renderLayerTrack()`(1290-1323) 마커 생성부:
+```js
+const marker = document.createElement('div');
+if (this._frameCellActive) {
+  // Animate 스타일: 정확히 1프레임 폭 셀 + 내부 점
+  marker.className = `keyframe-cell keyframe-marker-dot${range.keyframe.isEmpty ? ' empty' : ''}`;
+  marker.style.left = `${(range.start / this.totalFrames) * 100}%`;
+  marker.style.width = `${(1 / this.totalFrames) * 100}%`;
+  marker.style.setProperty('--kf-color', layer.color);
+  marker.innerHTML = '<span class="keyframe-cell-dot" aria-hidden="true"></span>';
+} else {
+  // 기존 점 방식 (1291~1299줄 그대로 — style.background 인라인 포함)
+}
+// dataset.frame / dataset.layerId / title / mousedown·click 리스너는 두 분기 공통 (기존 1293~1321줄 유지, 단 셀 분기는 background 인라인 제외)
+```
+**`.keyframe-marker-dot` 클래스를 셀에도 유지하는 것이 핵심** — 라쏘 선택(1657-1658), 박스 선택(1740), 선택 UI(1622, 1634-1635), 기존 소스 테스트(keyframe-multi-select-source.test.js의 regex)가 전부 무수정으로 동작한다.
+
+재렌더 캐시: `renderDrawingLayers()`(1179) 첫머리에 `this._lastDrawingLayers = layers; this._lastDrawingActiveLayerId = activeLayerId;` 추가, `_refreshDrawingLayerRender()`는 캐시 존재 시 재호출. (참고: app.js의 keyframesMove 핸들러(1437)가 renderDrawingLayers를 직접 호출하고 layersChanged 리스너(1263-1266)도 호출해 **현재도 이동 1회당 2회 재렌더**되는 기존 중복이 있다 — Phase 9.3의 rAF 병합이 이를 함께 완화한다.)
+
+**(D) main.css** — 점 스타일을 셀 스타일로 오버라이드. **`.keyframe-marker-dot` 규칙(4331줄)보다 반드시 뒤에 선언** (동일 특이도라 선언 순서 의존):
+```css
+/* 프레임 1칸 키프레임 셀 (Animate 스타일) */
+.keyframe-container .keyframe-cell {
+  top: 0;
+  height: 100%;
+  transform: none;            /* 점 방식의 translate(-50%,-50%) 해제 */
+  border-radius: 0;
+  border: 1px solid var(--kf-color, #4a9eff);
+  background: color-mix(in srgb, var(--kf-color, #4a9eff) 30%, transparent);
+  box-sizing: border-box;
+  min-width: 3px;
+  box-shadow: none;
+}
+.keyframe-container .keyframe-cell:hover { transform: none; filter: brightness(1.3); }
+.keyframe-cell .keyframe-cell-dot {
+  position: absolute;
+  left: 50%;
+  bottom: 3px;
+  transform: translateX(-50%);
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fff;
+  pointer-events: none;
+}
+.keyframe-cell.empty { background: transparent; border-style: dashed; }
+.keyframe-cell.empty .keyframe-cell-dot { background: transparent; border: 1px solid #fff; }
+.keyframe-container .keyframe-cell.selected {
+  border-color: var(--accent-primary);
+  box-shadow: inset 0 0 0 1px var(--accent-primary);
+}
+```
+(`color-mix`는 Chromium 111+ — Electron 28이므로 사용 가능, 검증 완료. web-viewer는 이 CSS를 공유하지 않음.)
+
+**(E) UI 배선** — index.html 902줄 `#btnGridToggle` 뒤에 3상태 순환 버튼:
+```html
+<button class="timeline-toolbar-btn" id="btnFrameCellMode" type="button"
+        data-mode="auto" aria-label="프레임 1칸 표시 모드"
+        title="프레임 1칸 표시: AUTO (클릭으로 ON/OFF/AUTO 전환)">
+  <span class="frame-cell-mode-label">1F</span>
+  <span class="frame-cell-mode-badge" id="frameCellModeBadge">A</span>
+</button>
+```
+app.js 10638줄(격자 토글 배선 아래): `elements`에 `btnFrameCellMode` 등록 후
+```js
+  // ===== 프레임 1칸 셀 표시 모드 (on/off/auto) =====
+  const FRAME_CELL_MODE_ORDER = ['auto', 'on', 'off'];
+  const FRAME_CELL_MODE_LABEL = { auto: 'A', on: 'ON', off: 'OFF' };
+  function _syncFrameCellModeUI(mode) {
+    if (!elements.btnFrameCellMode) return;
+    elements.btnFrameCellMode.dataset.mode = mode;
+    elements.btnFrameCellMode.classList.toggle('active', mode !== 'off');
+    elements.btnFrameCellMode.title = `프레임 1칸 표시: ${mode.toUpperCase()} (클릭으로 전환)`;
+    const badge = document.getElementById('frameCellModeBadge');
+    if (badge) badge.textContent = FRAME_CELL_MODE_LABEL[mode];
+  }
+  const initFrameCellMode = userSettings.getFrameCellMode();
+  timeline.setFrameCellMode(initFrameCellMode);
+  _syncFrameCellModeUI(initFrameCellMode);
+  elements.btnFrameCellMode?.addEventListener('click', () => {
+    const cur = userSettings.getFrameCellMode();
+    const next = FRAME_CELL_MODE_ORDER[(FRAME_CELL_MODE_ORDER.indexOf(cur) + 1) % 3];
+    userSettings.setFrameCellMode(next);
+    timeline.setFrameCellMode(next);
+    _syncFrameCellModeUI(next);
+    showToast(`프레임 1칸 표시: ${next.toUpperCase()}`, 'info');
+  });
+```
+
+**(F) 성능 보강**: `_updateRuler()`(795-826)는 `ceil(6*scale)`개 span을 전량 재생성하므로 ON 모드 장편에서 수천 개 가능 — `const numMarks = Math.min(Math.ceil(6 * scale), 600);` 캡 추가. (본격 가상화는 후속 과제.) ON 모드 최대 폭 검산: 30분@24fps=43,200프레임 × 8px ≈ 345,600px — Chromium 요소 폭 한계 내이며 기존 maxZoom 50000% 경로에서 이미 도달 가능한 크기라 신규 리스크 아님. AUTO 전환은 티어 히스테리시스(±3%)를 공유해 경계 줌 깜빡임 없음.
+
+**(G) 잔재 정리(선택)**: `.frame-cell*` CSS(4377-4411), `_applyGridBackground()`(1333-1389), `_createKeyframeClip()`(1394-1451) 삭제.
+
+### 예상 리스크
+- ON 모드에서 줌 표시가 "2880%"처럼 보일 수 있음 — OFF/AUTO 복귀 시 minZoom=100으로 복원되고 현재 zoom은 유지되므로 화면 점프 없음.
+- `_applyCellModeMinZoom`은 `clientWidth`가 0인 시점(초기 로드/탭 비활성)에 100으로 폴백 — setVideoInfo 이후 재호출 경로가 반드시 있어야 함 (위 보완 2번이 충족).
+- AUTO 경계 전환 시 renderDrawingLayers 1회 재렌더 비용 — 히스테리시스로 반복 방지, 허용 범위.
+- .bframe/협업: 영향 없음 (표시 전용, 설정은 로컬 저장).
+
+### 테스트
+- `frame-grid-tiers.test.js`에 추가: `resolveFrameCellActive('off'|'on'|'auto', ...)` 각 분기 (auto는 pxPerFrame 3.9/4.0/4.2 경계 + 히스테리시스 공유), `computeMinZoomForCellMode(43200, 1200, 8) === 28800`, `(120, 1200, 8) === 100`(하한), 0 입력 → 100. 실행: `npm run test:frame-grid`.
+- 신규 `keyframe-drag-ghost-source.test.js`(Phase 5와 공유)에 `getFrameCellMode`/`setFrameCellMode`/`btnFrameCellMode` 존재 확인 추가.
+- 기존 `keyframe-multi-select-source.test.js` 통과 유지 (클래스 유지 설계 덕분).
+- 수동: ① 짧은 영상 AUTO — 줌인으로 pxPerFrame≥4 도달 시 점→셀 전환, 경계 줌 깜빡임 없음 ② ON — 즉시 가로 스크롤 상태 + 모든 칸 최소 8px, 스크롤/휠줌/플레이헤드 스냅 정상 ③ OFF — 현행과 완전 동일 ④ **격자 토글(#btnGridToggle) OFF 상태에서도 셀 모드 전환이 동작**하는지 (보완 1번 검증) ⑤ 재시작 후 설정 유지, 기존 사용자 설정 파일(키 없음) → 'auto' 기본값 ⑥ 30분@24fps에서 ON 전환 시간/줌 드래그 60fps 유지 ⑦ 드래그 오버레이(Phase 5)가 셀/점 두 모드 모두에서 1칸 정합.
+
+---
+
+## Phase 7: 브러시 설정 영속화 + Alt 드래그 크기 조절 + [ / ] 단축키
+
+### 목표
+(1) 브러시/지우개 설정(도구, 색상, 크기, 불투명도, 외곽선)을 앱 재시작 후에도 복원. (2) 캔버스 위 Alt+드래그로 브러시 크기를 즉석 조절(원형 HUD 표시). (3) 선택: `[`/`]` 키 단축키.
+
+### 근본 원인/갭 (검증: CONFIRMED — 기능 부재)
+- 브러시 상태는 (a) `DrawingCanvas` 생성자 하드코딩(drawing-canvas.js:36-47 — tool=PEN, color='#ff4757', lineWidth=3, opacity=1, 외곽선 off)과 (b) app.js initApp 클로저의 인메모리 변수(`toolSettings` 2778-2781, `currentToolType` 2782, `currentColor` 2885)에만 존재. **유일한 영속화 선례는 지우개 방식뿐**(`applyEraserMode` 2796-2808 + `getEraserMode` 복원 2810; user-settings.js:200, 615-624). 렌더러 전체 grep에서 brushSettings 0건.
+- 크기 조절 단축키 부재: `DEFAULT_SHORTCUTS`(user-settings.js:16-61)와 `handleKeydown`(app.js:10027-10381)에 크기 액션 없음. 크기 변경 수단은 `#brushSizeSlider`(index.html:622, min=1 max=50)뿐.
+- Alt+드래그 충돌성 검증: **그리기 캔버스 위에서는 Alt 미사용** (타임라인 트랙에는 Alt+드래그 선택박스가 있으나(timeline.js:252-260) DOM이 분리되어 무충돌 — 검증 정정 반영). 그리기 모드에서 비디오 팬(canPanVideo, app.js:4630-4632가 `!state.isDrawMode` 요구)과 휠 줌(4765-4772) 모두 비활성 → 충돌 없음. 터치 경로는 합성 객체에 altKey가 없어 오작동 여지 없음.
+
+### 수정 파일
+`renderer/scripts/modules/user-settings.js`, `renderer/scripts/app.js`, `renderer/scripts/modules/drawing-canvas.js`, `renderer/index.html`, `renderer/styles/main.css`
+
+### 구현 내용
+
+**◆ 파트 A: 영속화**
+
+[1] user-settings.js 기본값(200줄 `eraserMode` 아래):
+```js
+      // 이 PC에서 마지막으로 사용한 브러시 설정
+      brushSettings: {
+        tool: 'brush',        // 마지막 도구 (pen/brush/eraser/line/arrow/rect/circle)
+        color: '#ff4757',     // 브러시 색상 (hex)
+        brushSize: 3,         // 브러시/펜 크기 (1~50)
+        eraserSize: 20,       // 지우개 크기 (1~50)
+        opacity: 100,         // 불투명도 (10~100)
+        strokeEnabled: false, // 외곽선 활성화
+        strokeWidth: 3,       // 외곽선 두께 (1~10)
+        strokeColor: '#ffffff' // 외곽선 색상
+      },
+```
+
+[2] getter/setter (setEraserMode 615-624 아래, 동일 패턴):
+```js
+  getBrushSettings() {
+    const defaults = { tool: 'brush', color: '#ff4757', brushSize: 3, eraserSize: 20, opacity: 100, strokeEnabled: false, strokeWidth: 3, strokeColor: '#ffffff' };
+    const merged = { ...defaults, ...(this.settings.brushSettings || {}) };
+    // 값 범위 방어 (설정 파일 손상 대비)
+    merged.brushSize = Math.min(50, Math.max(1, parseInt(merged.brushSize) || 3));
+    merged.eraserSize = Math.min(50, Math.max(1, parseInt(merged.eraserSize) || 20));
+    merged.opacity = Math.min(100, Math.max(10, parseInt(merged.opacity) || 100));
+    merged.strokeWidth = Math.min(10, Math.max(1, parseInt(merged.strokeWidth) || 3));
+    return merged;
+  }
+
+  setBrushSettings(partial) {
+    this.settings.brushSettings = { ...this.getBrushSettings(), ...partial };
+    this._save();
+    this._emit('brushSettingsChanged', { brushSettings: this.settings.brushSettings });
+    log.info('브러시 설정 변경됨', partial);
+  }
+```
+
+[3] app.js — 초기화 교체 및 복원. `colorMap`(2874-2883)을 `toolSettings` 선언보다 위로 이동한 뒤:
+```js
+  // 도구별 설정 저장 (크기, 불투명도) — 저장된 브러시 설정에서 복원
+  const savedBrush = userSettings.getBrushSettings();
+  const toolSettings = {
+    eraser: { size: savedBrush.eraserSize },
+    brush: { size: savedBrush.brushSize, opacity: savedBrush.opacity }
+  };
+  let currentToolType = 'brush';
+  let currentColor = savedBrush.color;
+```
+초기 UI/캔버스 반영(updateSizePreview 정의 이후, 2924 부근):
+- `brushSizeSlider.value`/`brushOpacitySlider.value`/`brushOpacityValue.textContent` 복원.
+- 색상 버튼 active 복원: `const colorNameByHex = Object.fromEntries(Object.entries(colorMap).map(([k, v]) => [v, k]));` → `.color-btn[data-color="${colorNameByHex[savedBrush.color]}"]`에 active 이관. **colorMap에 없는 hex(손상)면 red 폴백**.
+- 외곽선: strokeToggle 상태/텍스트, strokeControls 표시, strokeWidthSlider/`.stroke-color-btn` active 복원.
+- 캔버스 반영: `drawingManager.setColor / setLineWidth / setOpacity(opacity/100) / setStrokeEnabled / setStrokeWidth / setStrokeColor` 호출 (setter 위임: drawing-manager.js:1033-1121).
+- (선택) 마지막 도구 복원: drawMode 진입 훅(app.js:10300-10302)의 `.tool-btn[data-tool="brush"]` 강제 클릭을 `.tool-btn[data-tool="${saved.tool}"] || brush`로 변경. **이때 index.html:594의 초기 `tool-btn active`(pen)와 훅의 brush 강제 클릭 양쪽을 함께 정리**해야 이중 동작이 없다 (검증 지적).
+
+[4] 저장 훅 — **파일 IO가 있으므로 슬라이더는 `input`이 아니라 `change` 이벤트에서 저장** (드래그 중 수십 회 파일 쓰기 방지):
+- brushSizeSlider 'change': `userSettings.setBrushSettings(currentToolType === 'eraser' ? { eraserSize: size } : { brushSize: size });`
+- brushOpacitySlider 'change': `{ opacity }` / 색상 클릭(2892 뒤): `{ color: currentColor }` / 도구 클릭(2868 뒤): `{ tool, brushSize, eraserSize }` / 외곽선 토글·두께('change')·색상: 각각 해당 키.
+
+**◆ 파트 B: Alt+드래그 크기 조절 (drawing-canvas.js)**
+
+생성자(50줄 부근) 상태:
+```js
+    // Alt+드래그 브러시 크기 조절 상태
+    this.isSizeAdjusting = false;
+    this._sizeAdjustStartX = 0;
+    this._sizeAdjustStartWidth = 0;
+    this._sizeAdjustAbort = null;
+```
+`_onMouseDown`(129) — `.active` 체크 직후, **Ctrl 처리(132)와 Phase 1의 canDraw 게이트보다 먼저** (Alt 우선 — Photoshop 관례; 크기 조절은 잠긴 레이어에서도 허용되는 게 자연스러움):
+```js
+    if (e.altKey && (e.button === 0 || e.button === 2)) {
+      e.preventDefault?.();
+      this._beginSizeAdjust(e);
+      return;
+    }
+```
+`_setupEventListeners`(78)에 컨텍스트 메뉴 억제 (Alt+우클릭드래그 지원, 일반 우클릭 보존):
+```js
+    this.canvas.addEventListener('contextmenu', (e) => {
+      if (e.altKey || this.isSizeAdjusting) e.preventDefault();
+    }, { signal });
+```
+새 메서드 (setLineWidth 712 근처) — **캔버스 밖으로 나가도 이어지도록 window 임시 리스너**(canvas mouseleave가 _onMouseUp을 부르는 구조라 canvas 리스너로는 끊긴다):
+```js
+  _beginSizeAdjust(e) {
+    this.isSizeAdjusting = true;
+    this._sizeAdjustStartX = e.clientX;
+    this._sizeAdjustStartWidth = this.lineWidth;
+    this._sizeAdjustAbort = new AbortController();
+    const signal = this._sizeAdjustAbort.signal;
+    window.addEventListener('mousemove', (ev) => this._updateSizeAdjust(ev), { signal });
+    window.addEventListener('mouseup', () => this._endSizeAdjust(), { signal });
+    this._emit('sizeadjuststart', { clientX: e.clientX, clientY: e.clientY, lineWidth: this.lineWidth });
+  }
+
+  _updateSizeAdjust(e) {
+    if (!this.isSizeAdjusting) return;
+    // 좌우 드래그 감도: 4px 이동당 1px 크기 변화 (슬라이더와 동일 범위 1~50)
+    const delta = (e.clientX - this._sizeAdjustStartX) / 4;
+    const newWidth = Math.min(50, Math.max(1, Math.round(this._sizeAdjustStartWidth + delta)));
+    if (newWidth !== this.lineWidth) {
+      this.setLineWidth(newWidth);
+      this._emit('sizeadjust', { lineWidth: newWidth });
+    }
+  }
+
+  _endSizeAdjust() {
+    if (!this.isSizeAdjusting) return;
+    this.isSizeAdjusting = false;
+    this._sizeAdjustAbort?.abort();
+    this._sizeAdjustAbort = null;
+    this._emit('sizeadjustend', { lineWidth: this.lineWidth });
+  }
+```
+`destroy()`에 `this._sizeAdjustAbort?.abort();` 추가. **early return 덕분에 drawstart/drawmove가 emit되지 않아** undo 히스토리(`_saveToHistory`, drawing-manager.js:113-115)와 Liveblocks 스트리밍에 노이즈가 없다 — 코드리뷰 핵심 확인 포인트.
+
+**HUD**: index.html(drawingCanvas 아래, 502 부근) `<div id="brushSizeHud" class="brush-size-hud" hidden></div>` + main.css(.size-preview 근처 2160 부근):
+```css
+/* Alt+드래그 브러시 크기 조절 미리보기 */
+.brush-size-hud {
+  position: fixed;
+  pointer-events: none;
+  z-index: 100;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.6);
+  transform: translate(-50%, -50%);
+}
+```
+app.js 배선: `sizeadjuststart`에서 HUD 표시(드래그 시작점 고정, 화면 px 크기 = lineWidth × (rect.width / canvas.width)), `sizeadjust`에서 `toolSettings[currentToolType].size`/슬라이더/`updateSizePreview()`/HUD 동기화, `sizeadjustend`에서 HUD 숨김 + `setBrushSettings` 1회 저장. (지우개 도구일 때 HUD 배경 투명, 브러시일 때 `${currentColor}80`.)
+
+**◆ 파트 C (선택 권장): [ / ] 단축키**
+
+- user-settings.js DEFAULT_SHORTCUTS '그리기 보조' 블록(57-60)에:
+```js
+  brushSizeDown: { key: 'BracketLeft', ctrl: false, shift: false, alt: false, label: '브러시 크기 줄이기' },
+  brushSizeUp: { key: 'BracketRight', ctrl: false, shift: false, alt: false, label: '브러시 크기 키우기' }
+```
+- app.js handleKeydown 그리기 모드 블록(10306 인근)에서 matchShortcut으로 ±1 조절 후 슬라이더에 input+change 디스패치. 단축키 설정 모달 카테고리(SHORTCUT_CATEGORIES, 10906-10914)에 '그리기'로 등록.
+- **주의 (검증 발견)**: `[`/`]`는 스플릿 뷰(split-view-manager.js:227-244)에서 오버레이 불투명도/와이프 조절에 이미 사용 중. handleKeydown이 스플릿 뷰 오픈 시 조기 리턴(app.js:10044)하므로 **기능 충돌은 없지만**, 같은 키가 컨텍스트별로 다른 동작을 함을 단축키 목록 문서/설정 UI에 명시할 것. RESERVED_SHORTCUTS(10940-10949)에는 bracket 없음 — 예약 충돌 없음.
+
+### 예상 리스크
+- .bframe/Liveblocks: 영향 없음 (스트로크 레코드에는 이미 스트로크별 lineWidth/color/opacity가 기록됨 — drawing-canvas.js:307-322; 설정은 로컬 저장 전용).
+- 저장 IO: 반드시 'change'/'sizeadjustend'에서만 저장 (thumbnailScaleSlider가 input마다 저장하는 기존 선례는 답습하지 않음).
+- 설정 로드 타이밍: initApp 시점 getter는 localStorage 값만 반영 (파일 로드는 비동기) — 기존 eraserMode와 동일한 한계로 일관 유지. 개선하려면 `waitForReady()` 대기 (후속).
+- Windows Alt 메뉴 포커스: 마우스 버튼과 함께 쓰는 제스처라 실영향 낮음. 문제 시 renderer keyup에서 `e.key === 'Alt' && state.isDrawMode`일 때 preventDefault로 대응.
+
+### 테스트
+- 신규 `scripts/tests/brush-settings-source.test.js` (소스 정규식 관례): user-settings에 `brushSettings:`/`getBrushSettings()`/`setBrushSettings(partial)` 존재, app.js에 `userSettings.getBrushSettings()` 복원 참조, drawing-canvas에 `e.altKey`/`_beginSizeAdjust(e)`/`isSizeAdjusting`/`sizeadjustend` 존재 + **Alt 분기가 Ctrl 분기보다 앞서는지 indexOf 비교**, index.html에 `id="brushSizeHud"`, main.css에 `.brush-size-hud`.
+- 수동: ① 크기 27px·노랑·불투명도 60%·외곽선 ON(5px 검정)·지우개 35로 변경 → 앱 완전 재시작 → 전 값+UI active 상태 복원, %APPDATA% 설정 파일/localStorage에 brushSettings 기록 ② Alt+좌드래그(좌→우 증가), Alt+우클릭드래그 동일 + 컨텍스트 메뉴 미표시, HUD 원 크기·슬라이더·px 라벨 실시간 동기화, 드래그 중 선이 그려지지 않음 ③ Ctrl 임시 지우개/비디오 팬 회귀 없음 ④ 협업: Alt 드래그 중 상대 화면에 유령 스트로크 없음, 변경된 굵기로 그린 스트로크가 상대에게 정상 렌더 ⑤ Alt 드래그만 한 뒤 Ctrl+Z 시 이전 그리기가 취소되지 않음(히스토리 미오염) ⑥ [/] 단축키: 그리기 모드에서만 동작, 스플릿 뷰에서는 기존 동작 유지.
+
+---
+
+## Phase 8: 레이어 눈/잠금 토글 버튼 확대 및 상태 시각화
+
+### 목표
+타임라인 좌측 레이어 헤더의 눈 토글을 24×24px 버튼 + SVG 아이콘(꺼짐 시 슬래시)으로 교체하고, 잠금 버튼도 함께 확대한다. WCAG 2.5.8 최소 타겟(24×24)과 앱 내 기존 기준(우측 합성 레이어 패널이 이미 24×24)에 맞춘다.
+
+### 근본 원인/갭 (검증: 원인 자체는 CONFIRMED)
+- 그리기 레이어 헤더의 눈 토글은 `_renderLayerHeader()`(timeline.js:1199-1247)의 1207-1209줄에서 **`<span>` + 이모지 텍스트**(`👁`/`👁‍🗨`)로 생성. CSS `.layer-visibility`(main.css:3115-3128)가 **14×14px, font-size 9px** — 9px에서 두 이모지는 사실상 동일하게 보이고 ZWJ 시퀀스는 환경에 따라 깨진다. 켜짐/꺼짐 시각 구분 없음.
+- 잠금은 한 술 더 떠 `${layer.locked ? '🔒' : ''}`(1213줄) — **해제 상태에서 완전히 투명한 14×14 클릭 영역만 존재**해 기능의 발견 자체가 불가.
+- 클릭 리스너(1235-1238)는 span 자체에 붙으므로 시각 박스 = 히트 박스 — CSS 확대가 곧 히트영역 확대다 (release-deploy 스킬의 "실제 입력 영역" 경고 검증 완료).
+- 합성 레이어 타임라인 헤더의 눈 버튼(1000-1002줄)은 SVG지만 18×18(main.css:3420-3428)로 역시 미달. 우측 플로팅 합성 패널(main.css:1417-1424)만 24×24 — 이것이 기준 패턴.
+- Video 행의 눈(index.html:947-959)은 **핸들러 없는 순수 장식** (grep 확정).
+
+### 수정 파일
+`renderer/scripts/modules/timeline.js`, `renderer/styles/main.css`, `renderer/index.html`
+
+### 구현 내용
+
+**(1) SVG 아이콘 생성기 일반화** — `_getCompositionLayerVisibilityIcon(enabled)`(1089-1100)에 size 파라미터를 추가해 `_getLayerVisibilityIcon(enabled, size = 16)`으로 일반화 (눈 path + 중심 circle + 꺼짐 시 슬래시 line). 기존 소스 테스트는 함수명/크기를 검사하지 않아 rename 안전 (검증 완료).
+
+**(2) `_renderLayerHeader()`(1205-1215) — span+이모지 → button+SVG**:
+```js
+const visibilityLabel = layer.visible ? '레이어 숨기기' : '레이어 보이기';
+header.classList.toggle('layer-hidden', !layer.visible);
+header.innerHTML = `
+  <div class="layer-color" style="background: ${layer.color}"></div>
+  <button class="layer-visibility" type="button" data-action="visibility" title="${visibilityLabel}" aria-label="${visibilityLabel}" aria-pressed="${layer.visible}">
+    ${this._getLayerVisibilityIcon(layer.visible)}
+  </button>
+  <span class="layer-name" title="${this._escapeHtml(layer.name)}">${this._escapeHtml(layer.name)}</span>
+  <span class="layer-opacity-badge" title="불투명도 ${opacityPercent}%">${opacityPercent}%</span>
+  <button class="layer-lock${layer.locked ? ' locked' : ''}" type="button" data-action="lock" title="${layer.locked ? '잠금 해제' : '레이어 잠금'}" aria-label="${layer.locked ? '잠금 해제' : '레이어 잠금'}">
+    ${layer.locked ? '🔒' : '🔓'}
+  </button>
+`;
+```
+- **`_escapeHtml(layer.name)` 필수** — 현행은 이스케이프 없이 innerHTML 삽입(기존 XSS/마크업 깨짐 결함, 검증 발견). 합성 레이어 쪽 `this._escapeHtml()`(1165-1172) 재사용.
+- **잠금 해제 상태에 흐린 🔓 표시** — "보이지 않는 24×24 클릭 영역"이 눈 버튼 옆에 생기는 오클릭 함정 방지 (검증 발견). CSS로 `.layer-lock:not(.locked) { opacity: 0.35; }` + `:hover { opacity: 1; }`.
+- 기존 클릭 리스너(1235-1244)는 `querySelector('[data-action="visibility"]')` 방식이라 span→button 변경에 무수정 동작. 헤더 클릭 가드(1218-1221, `closest('[data-action]')`)도 SVG 자식 클릭을 커버 (검증 완료).
+
+**(3) 합성 레이어 타임라인 헤더**(1001줄): `${this._getLayerVisibilityIcon(layer.enabled, 16)}`으로 교체.
+
+**(4) main.css `.layer-visibility`(3115-3128) 교체**:
+```css
+.layer-visibility {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;         /* flex 수축 방지 */
+  border: 0;
+  padding: 0;
+  border-radius: 4px;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.layer-visibility:hover { background: var(--bg-hover); color: var(--accent-primary); }
+.layer-visibility:focus-visible { outline: 1px solid var(--accent-primary); outline-offset: -1px; }
+
+/* 숨김 상태: 눈 아이콘 흐리게 + 행 전체 텍스트 감쇠 */
+.layer-header.layer-hidden .layer-visibility { opacity: 0.45; }
+.layer-header.layer-hidden .layer-name,
+.layer-header.layer-hidden .layer-opacity-badge { opacity: 0.5; }
+```
+- `.composition-layer-header-visibility`(3420-3428): 18px → 24px 통일. **주의: `.layer-visibility` 전역 확대는 이 클래스(특이도 우선)와 Video 장식 span에도 적용되므로 (5)/(6)을 빠뜨리면 크기 불일치가 남는 순서 의존성이 있다** (검증 지적).
+- `.drawing-layer-header .layer-visibility`(4285-4293)의 opacity 0.7 규칙 삭제 (새 상태 스타일과 충돌).
+- `.layer-lock`(3145-3154): 14px → 24px, font-size 9px → 12px, `cursor: pointer` 추가(현재 누락).
+
+**(5) index.html Video 헤더(947-959)**: 눈 SVG 14→16 통일 + `.layer-header[data-layer="video"] .layer-visibility { cursor: default; }` (클릭 가능해 보이는 오해 제거).
+
+**(6) 공간 검토**: 드로잉 헤더 행 높이는 44px(`--timeline-drawing-track-height`)라 24px 버튼 수용 여유 충분. 160px 헤더 폭에서 이름 영역이 약 20px 줄지만 `.layer-name`은 ellipsis 처리(3134-3143)라 기능 문제 없음. 답답하면 `--layer-header-width`(main.css:81) 160→176px 옵션.
+
+### 예상 리스크
+- 협업: **레이어 visibility 토글은 원격에 전파되지 않는 로컬 전용 동작**이다 (drawing-sync는 레이어 생성 시 1회만 visible을 전송, 토글 브로드캐스트 없음 — 검증 확정). 이번 UI 수정은 이 동작을 바꾸지 않으며, 수동 테스트에서 "상대 화면에 반영 안 됨(로컬 전용)"을 정상으로 판정할 것.
+- 합성 레이어 헤더는 draggable이라 버튼 확대로 드래그 시작 가능 영역이 줄어듦 — 전용 드래그 핸들(⋮⋮, 999줄)이 있어 허용.
+- .bframe: 영향 없음 (visible/locked는 기존 직렬화 유지).
+
+### 테스트
+- 신규 `scripts/tests/layer-visibility-hit-area.test.js` (audio-waveform-hit-area.test.js 형식): main.css `.layer-visibility`에 24px 매치, timeline.js에 `👁` 부재(`assert.doesNotMatch`) + `<button class="layer-visibility"` + `aria-pressed=` 존재, `.layer-header.layer-hidden` CSS와 `classList.toggle('layer-hidden'` 존재, 꺼짐 분기의 슬래시 라인 존재.
+- 수동: ① 눈 버튼 시각 크기/hover 배경 ② **기존 14px 밖 영역(버튼 모서리) 클릭으로 토글되는지** — 실제 입력 영역 확인 ③ 꺼짐 상태에서 슬래시+행 흐림이 한눈에 구분 ④ 헤더 빈 영역 클릭 시 레이어 선택만 됨 ⑤ 잠금 토글(해제 상태 🔓 표시)·우클릭 메뉴 회귀 ⑥ 라이트 모드에서 hover 대비 ⑦ `node --test scripts/tests/` 전체 통과.
+
+---
+
+## Phase 9: 미명시 UX 개선 (코드 감사 결과)
+
+피드백에 직접 언급되지 않았지만 인접 영역 감사에서 확인된 문제들. **9.1~9.3은 소형이라 이번 사이클에 포함 권장**, 9.4~9.6은 별도 이슈로 분리.
+
+### 9.1 도구별 커서 피드백 (포함 권장)
+- 현행: `.drawing-overlay.active { cursor: crosshair; }`(main.css:1107-1110) 하나뿐 — 펜/브러시/지우개 전부 동일, 브러시 크기를 화면에서 볼 수 없음.
+- 구현: app.js에 `updateDrawingCursor()` — 현재 도구/크기/색으로 SVG data URI 원형 커서 생성(`canvas.style.cursor = url(...) hotspot, crosshair`), 표시 크기 = lineWidth × (rect.width / canvas.width)로 줌 반영, 6~64px 클램프. 호출: 도구 클릭(2868 뒤)/크기 input(2913 뒤)/색상 클릭(2894 뒤)/그리기 모드 진입/Phase 7의 sizeadjust. 도형 도구는 crosshair 유지.
+
+### 9.2 키프레임 점 히트영역 + 드래그 임계값 (포함 권장)
+- 현행: `.keyframe-marker-dot` 10×10px(border 포함 14px, main.css:4345-4355) 정밀 클릭 요구. `_startKeyframeDrag()`(1458-1477)는 mousedown 즉시 드래그 모드 — 단순 클릭에도 고스트가 생겼다 사라짐.
+- 구현: (a) `.keyframe-marker-dot::before { content: ''; position: absolute; inset: -6px; }` 히트 확장 — **주의: 셀 모드(Phase 6)에서는 셀 폭이 곧 히트영역이므로 `::before` 확장은 점 모드 전용 셀렉터(`:not(.keyframe-cell)`)로 한정**하고, 고배율에서 인접 마커와 겹칠 수 있어 z-index로 가까운 마커 우선 처리. (b) 드래그 임계값: mousedown 시 `pendingKeyframeDrag`만 저장하고 document mousemove(293줄 분기)에서 `|dx| > 4px`일 때 비로소 고스트 생성 — 클릭이면 pending 해제만 (기존 click 리스너 1318줄과 중복 없게).
+
+### 9.3 타임라인 재렌더 rAF 병합 (포함 권장)
+- 현행: 매 획마다 `layersChanged`(drawing-manager.js:188, 획 지우개는 170) → app.js:1263-1266 → `renderDrawingLayers()`가 트랙/헤더 전량 재생성 + 마커마다 리스너 2개 재부착. keyframesMove 경로는 직접 호출(1437)과 이벤트 경로가 겹쳐 **이동 1회당 2회 재렌더**.
+- 구현: app.js 1263-1266을 rAF 병합으로 교체(플래그 + requestAnimationFrame). **직접 호출 지점 12곳(app.js 1028, 1291, 1437, 1451, 1461, 2985, 3001, 6779, 10338, 10351, 10358 등)은 그대로 두고 이벤트 경로만 병합** — 동기 DOM 읽기 타이밍 이슈 회피 (검증 정정 반영). 여유가 되면 마커 개별 리스너를 keyframeContainer 이벤트 위임으로 전환 (컨테이너는 pointer-events:none, 마커만 auto라 버블링 수신 구조 성립 — 검증 확인).
+
+### 9.4 Pointer Events 전환 + 필압 지원 (별도 이슈 — 중대형)
+- 현행: mouse/touch 이벤트만 사용 → (a) 캔버스 가장자리 이탈 시 획 강제 종료(mouseleave, 포인터 캡처 부재) (b) 포인트에 pressure 미기록 — **렌더 파이프라인은 이미 필압 지원**(freehand-stroke-renderer.js:17 `pressure ?? 0.5`, 87줄 `[x, y, pressure]`, 30줄 simulatePressure) — 입력 계층만 죽어 있음 (c) 펜 고주파 샘플 병합 손실.
+- 방향: pointerdown/move/up + `setPointerCapture` + `getCoalescedEvents` 전환, `touch-action: none` 필수, strokeRecord에 `hasPressure` 플래그를 함께 저장해 구/신 렌더 판정을 레코드 단위로 고정(하위 호환 안전). Phase 3의 Ctrl 문제도 근본적으로는 이것으로 해소되지만, 입력 경로 전면 교체라 회귀 위험이 커 **반드시 별도 PR** (Windows Ink 여부에 따른 동작 차이를 실기기로 검증해야 함).
+
+### 9.5 사용자 상태 영속화 확장 (별도 이슈 — 소~중형)
+재시작 시 리셋되는 것들 (user-settings 패턴 미적용): 타임라인 줌(timeline.js:57), 볼륨/음소거(app.js:1912-1946 지역 변수), 합성 레이어 패널 크기·위치·접힘(composition-layer-manager.js:1468-1529, 813-834 — inline style만 변경). Phase 7의 brushSettings와 동일 패턴으로 `timelineZoom`/`playerVolume`/`playerMuted`/`compositionPanelState` 키 추가. 줌은 영상마다 체감이 달라 전역 1개 값으로 시작(파일별 기억은 recent-files 확장으로 후속). 볼륨은 HTML video와 mpv(app.js:6276) 양쪽 복원 필요.
+
+### 9.6 그리기 레이어 워크플로 (별도 이슈 — 중형)
+- 이름 변경이 우클릭 팝업뿐(태블릿 펜은 우클릭 어려움) → `.layer-name` 더블클릭으로 기존 `layerContextMenu` 팝업(app.js:1306-1396) 재사용이 최소 구현.
+- 레이어 순서 변경 수단 전무 (합성 레이어에는 있음) → `DrawingManager.reorderLayer(layerId, targetIndex)` 추가(`layers.splice` + `_saveToHistory` + `layersChanged`; layers 배열 순서가 곧 렌더 순서라 스키마 무변경). 참고 구현은 **timeline.js 991줄(draggable), 1017-1020줄(dragstart/dragover/drop 등록), 1024-1087줄(핸들러)** — HTML5 Drag&Drop API 기반임에 유의 (검증 정정: 이전 분석의 1332-1400줄은 오기).
+- 레이어 병합(merge down) 부재 — 애니메이터 러프→클린업 워크플로에서 기대되는 기능.
+
+---
+
+## 발견된 기존 갭 (이번 범위 밖 — 별도 이슈 등록 권장)
+
+분석/검증 중 발견된, 이번 피드백과 별개인 기존 문제들. 각각 이슈로 등록해 추적할 것.
+
+| # | 내용 | 근거 |
+|---|------|------|
+| G1 | **키프레임 드래그 이동이 자동저장·원격 동기화에 반영되지 않음** — `moveKeyframes`는 `layersChanged`만 발행하는데, drawing-sync는 keyframeRemoved만 브로드캐스트(57-63줄)하고 review-data-manager도 layersChanged를 저장 트리거로 구독하지 않음(182-191줄). 다음 drawend 등에서 간접 반영될 뿐 | frame-grid 분석·검증 |
+| G2 | **원격 레이어 생성이 내 활성 레이어를 탈취** — `_applyRemoteLayerCreated` → `createLayer`가 무조건 activeLayerId 변경(367줄). 사용자가 모르는 사이 원격 레이어에 그리게 되는 트리거 (Phase 2에서 `skipActivate`로 함께 해결 권장) | layer-attribution 검증 |
+| G3 | **레이어 visibility/lock 토글이 협업에 전파되지 않음** — 생성 시 1회만 전송. 원격 키프레임 적용(`_applyRemoteKeyframe`)도 locked 미검사라 상대방 조작이 내 잠긴 레이어를 갱신 | eye-toggle·eraser 검증 |
+| G4 | **줌 변경 시 댓글 구간이 재클러스터되지 않음** — zoomChanged 핸들러(app.js:1674-1677)가 renderCommentRanges 미호출. 줌 반응형 split(20px 임계)이 다음 렌더 시점까지 반영 안 됨 | comment-lane 검증 |
+| G5 | **keyframesMove 이중 재렌더** — app.js 1437 직접 호출 + layersChanged 이벤트 경로 중복 (9.3이 완화) | frame-grid 검증 |
+| G6 | 미사용 코드 잔재 — `.frame-cell*` CSS, `_applyGridBackground()`, `_createKeyframeClip()`, `splitDrawingCanvasLeft/Right`(HTML만 존재) | frame-grid·eraser 검증 |
+
+---
+
+## 리스크 및 우려 사항 (총괄)
+
+| 리스크 | 심각도 | 완화 방안 |
+|--------|--------|----------|
+| Phase 2 캔버스 분리의 파급 (mpv 오버레이, 재생 경로, 캡처) | 높음 | 별도 PR + 수동 시나리오 10종 전수 수행. `_renderFrameSync`/`clearAll` 누락 금지 |
+| 이미 오염된 .bframe 데이터는 복구 불가 | 중간 | 릴리즈 노트에 "문제 키프레임 삭제 후 재작성" 안내 |
+| Phase 3 테스트 정규식 갱신 누락 시 CI 실패 | 중간 | drawing-runtime-source.test.js 45줄 단언 갱신을 같은 커밋에 포함 |
+| Phase 6 셀 모드와 격자 토글 OFF 조합의 판정 동결 | 중간 | 셀 활성 판정을 조기 반환 이전으로 호이스팅 (보완 1) |
+| CSS 선언 순서 의존 (셀 오버라이드, 눈 버튼 특이도) | 중간 | `.keyframe-cell`은 `.keyframe-marker-dot` 뒤에, Phase 8은 (4)(5)(6) 세트로 적용 |
+| 슬라이더 input마다 설정 파일 쓰기 | 낮음 | 'change'/'sizeadjustend'에서만 저장 |
+| 잠금 차단·드롭 매핑(round→floor) 등 체감 동작 변화 | 낮음 | 릴리즈 노트에 의도된 변경으로 명시 |
+
+---
+
+## 테스트 방법 (총괄)
+
+### 자동 테스트
+```bash
+npm run test:drawing      # Phase 1, 3, 7 (drawing-runtime-source, drawing-stroke-records, keyframe-multi-select-source)
+npm run test:frame-grid   # Phase 6 (frame-grid-tiers)
+npm run test:cluster      # Phase 4 회귀 (comment-cluster 40건)
+node --test scripts/tests/   # 전체
+npm run build             # 릴리즈 전 필수
+```
+신규 테스트 파일 (모두 리포 관례인 node:test + 소스 정규식 방식):
+- `drawing-layer-partition.test.js` (Phase 2)
+- `comment-track-header-sync-source.test.js` (Phase 4)
+- `keyframe-drag-ghost-source.test.js` (Phase 5, 6)
+- `brush-settings-source.test.js` (Phase 7)
+- `layer-visibility-hit-area.test.js` (Phase 8)
+
+### 수동 QA 핵심 시나리오 (윤성원님 제보 재현 기준)
+1. **[Phase 2]** 레이어1에 프레임 10/50 드로잉 → 레이어 추가 → 프레임 20에서 레이어2에 드로잉 → 프레임 50에서 겹침 없음 + 레이어2 숨김 시 레이어1 흔적 전무.
+2. **[Phase 1]** 레이어 잠금 → 픽셀 지우개: 차단 + 토스트. 획 지우개/펜/도형/전체 지우기도 차단.
+3. **[Phase 3]** 갤탭 신티크 + PC 키보드 Ctrl + 펜 드로잉 = 지우개 동작 (윤성원님 실환경 검증 요청 필수).
+4. **[Phase 4]** 겹치는 구간 댓글 2개 + "댓글 구간" ON → 좌측 '댓글' 헤더가 함께 커지고 이하 행 픽셀 정렬 (제보 스크린샷과 대조).
+5. **[Phase 5/6]** 여러 줌에서 키프레임 드래그 오버레이 1칸 정합, 1F 버튼 AUTO/ON/OFF 순환, 재시작 후 유지, 30분 영상 성능.
+6. **[Phase 7]** 설정 변경 → 재시작 → 복원. Alt 드래그 크기 조절 + HUD. 협업 유령 스트로크 없음.
+7. **[Phase 8]** 눈/잠금 버튼 확대·상태 구분, 기존 14px 밖 영역 클릭 동작.
+8. 공통 회귀: 협업 2클라이언트 스모크, .bframe 저장/재로드, 구버전 파일 열기, `npm run build` 후 dist 실행 확인.
+
+---
+
+## 권장 PR 분할 및 작업 순서
+
+| PR | 포함 Phase | 브랜치 예시 | 비고 |
+|----|-----------|------------|------|
+| 1 | Phase 1 + 3 | `fix/드로잉-잠금-펜Ctrl-입력버그` | 저위험·고가치. 같은 파일(drawing-canvas.js)이라 묶음. `npm run test:drawing` |
+| 2 | Phase 2 | `fix/레이어-분리-렌더링` | 파급 커서 단독 PR. 수동 시나리오 전수 |
+| 3 | Phase 4 | `fix/댓글구간-행높이-동기화` | 독립 |
+| 4 | Phase 5 + 6 | `feature/프레임-1칸-셀-표시` | Phase 5 먼저 커밋 → 6 순서로 |
+| 5 | Phase 7 | `feature/브러시-설정-기억-Alt드래그` | 독립 |
+| 6 | Phase 8 (+9.1~9.3 선택) | `feature/레이어-토글-버튼-개선` | 독립 |
+
+각 PR 완료 시: DEVLOG 상태 갱신 → 코덱스 리뷰(codex-review-loop) → main 머지 → 필요 시 `baeframe-release-deploy` 스킬로 빌드/배포.
+
+---
+
+*이 문서는 2026-07-03 윤성원님 DM 피드백(19:19~22:17)의 텍스트 9건과 스크린샷 10장(Slack 파일 ID: F0BF3BUCT0U, F0BEZLD4198, F0BEXL5Q7GW, F0BEZLRA8M8, F0BEJAR42G7, F0BEY2DHEDU, F0BEY30NV46, F0BEYMMNY6A, F0BEUEK8SHZ, F0BEKBWS08P)을 전수 판독하고, main @ 0b41163 기준 코드를 영역별 분석·교차검증하여 작성되었다.*

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1277,6 +1277,14 @@ async function initApp() {
     scheduleMpvOverlayStateSync({ force: true });
   });
 
+  drawingManager.addEventListener('drawblocked', (e) => {
+    const reason = e.detail?.reason;
+    const message = reason === 'hidden'
+      ? '숨긴 레이어에는 그릴 수 없습니다. 레이어를 보이게 켠 뒤 다시 시도하세요.'
+      : '잠긴 레이어에는 그릴 수 없습니다. 잠금을 해제한 뒤 다시 시도하세요.';
+    showToast(message, 'warning');
+  });
+
   // 프레임 렌더링 완료 시
   drawingManager.addEventListener('frameRendered', (e) => {
     log.debug('프레임 렌더링 완료', { frame: e.detail.frame });
@@ -2966,6 +2974,14 @@ async function initApp() {
   elements.btnClearDrawing?.addEventListener('click', () => {
     const layer = drawingManager.getActiveLayer();
     if (layer) {
+      if (layer.locked || layer.visible === false) {
+        const message = layer.visible === false
+          ? '숨긴 레이어는 지울 수 없습니다. 레이어를 보이게 켠 뒤 다시 시도하세요.'
+          : '잠긴 레이어는 지울 수 없습니다. 잠금을 해제한 뒤 다시 시도하세요.';
+        showToast(message, 'warning');
+        return;
+      }
+
       // 현재 키프레임의 데이터를 지움
       const keyframe = layer.getKeyframeAtFrame(drawingManager.currentFrame);
       if (keyframe && !keyframe.isEmpty) {

--- a/renderer/scripts/modules/drawing-canvas.js
+++ b/renderer/scripts/modules/drawing-canvas.js
@@ -48,6 +48,8 @@ export class DrawingCanvas extends EventTarget {
 
     // 상태
     this.isDrawing = false;
+    this.canDraw = null;
+    this._modifierCtrlDown = false;
     this.lastX = 0;
     this.lastY = 0;
     this.startX = 0;
@@ -88,6 +90,17 @@ export class DrawingCanvas extends EventTarget {
     this.canvas.addEventListener('touchstart', (e) => this._onTouchStart(e), { signal });
     this.canvas.addEventListener('touchmove', (e) => this._onTouchMove(e), { signal });
     this.canvas.addEventListener('touchend', (e) => this._onTouchEnd(e), { signal });
+
+    // 펜/터치 유래 이벤트는 ctrlKey가 비어 오는 환경이 있어 전역 Ctrl 상태를 함께 본다.
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Control') this._modifierCtrlDown = true;
+    }, { signal });
+    document.addEventListener('keyup', (e) => {
+      if (e.key === 'Control') this._modifierCtrlDown = false;
+    }, { signal });
+    window.addEventListener('blur', () => {
+      this._modifierCtrlDown = false;
+    }, { signal });
   }
 
   /**
@@ -129,8 +142,16 @@ export class DrawingCanvas extends EventTarget {
   _onMouseDown(e) {
     if (!this.canvas.classList.contains('active')) return;
 
-    if (e.ctrlKey) {
+    if (this._isCtrlActive(e)) {
       e.preventDefault?.();
+    }
+
+    if (typeof this.canDraw === 'function' && !this.canDraw()) {
+      this._emit('drawblocked', {
+        tool: this._resolveEffectiveTool(e),
+        ctrlKey: this._isCtrlActive(e)
+      });
+      return;
     }
 
     const coords = this._getCanvasCoords(e);
@@ -154,7 +175,7 @@ export class DrawingCanvas extends EventTarget {
     this._emit('drawstart', this._createDrawEventDetail({
       x: coords.x,
       y: coords.y,
-      ctrlKey: e.ctrlKey === true
+      ctrlKey: this._isCtrlActive(e)
     }));
 
     // 펜/브러시는 점 찍기
@@ -181,7 +202,7 @@ export class DrawingCanvas extends EventTarget {
     this._emit('drawmove', this._createDrawEventDetail({
       x: coords.x,
       y: coords.y,
-      ctrlKey: e.ctrlKey === true
+      ctrlKey: this._isCtrlActive(e)
     }));
 
     if (this._isStrokeEraserActive()) {
@@ -239,7 +260,7 @@ export class DrawingCanvas extends EventTarget {
 
     // 그리기 완료 이벤트 발생
     this._emit('drawend', this._createDrawEventDetail({
-      ctrlKey: e.ctrlKey === true
+      ctrlKey: this._isCtrlActive(e)
     }));
     this.activeTool = this.tool;
     this.activeEraserMode = this.eraserMode;
@@ -251,7 +272,7 @@ export class DrawingCanvas extends EventTarget {
   _onTouchStart(e) {
     e.preventDefault();
     const touch = e.touches[0];
-    this._onMouseDown({ clientX: touch.clientX, clientY: touch.clientY });
+    this._onMouseDown({ clientX: touch.clientX, clientY: touch.clientY, ctrlKey: this._isCtrlActive(e) });
   }
 
   /**
@@ -260,7 +281,7 @@ export class DrawingCanvas extends EventTarget {
   _onTouchMove(e) {
     e.preventDefault();
     const touch = e.touches[0];
-    this._onMouseMove({ clientX: touch.clientX, clientY: touch.clientY });
+    this._onMouseMove({ clientX: touch.clientX, clientY: touch.clientY, ctrlKey: this._isCtrlActive(e) });
   }
 
   /**
@@ -268,7 +289,7 @@ export class DrawingCanvas extends EventTarget {
    */
   _onTouchEnd(e) {
     e.preventDefault();
-    this._onMouseUp({ type: 'touchend' });
+    this._onMouseUp({ type: 'touchend', ctrlKey: this._isCtrlActive(e) });
   }
 
   /**
@@ -293,8 +314,12 @@ export class DrawingCanvas extends EventTarget {
     return this.activeTool || this.tool;
   }
 
+  _isCtrlActive(e) {
+    return e?.ctrlKey === true || this._modifierCtrlDown === true;
+  }
+
   _resolveEffectiveTool(e) {
-    if ((this.tool === DrawingTool.PEN || this.tool === DrawingTool.BRUSH) && e?.ctrlKey) {
+    if ((this.tool === DrawingTool.PEN || this.tool === DrawingTool.BRUSH) && this._isCtrlActive(e)) {
       return DrawingTool.ERASER;
     }
     return this.tool;

--- a/renderer/scripts/modules/drawing-manager.js
+++ b/renderer/scripts/modules/drawing-manager.js
@@ -189,6 +189,12 @@ export class DrawingManager extends EventTarget {
       editHeldSourceKeyframe: (detail?.effectiveTool || detail?.tool) === DrawingTool.ERASER,
       preserveStrokeRecords: isRecordableStrokeTool(detail?.effectiveTool)
     });
+    if (!keyframe) {
+      this._emit('drawend', { frame: this.currentFrame });
+      this._emit('layersChanged');
+      this._activeStrokeBaseData = null;
+      return;
+    }
 
     if (isRecordableStrokeTool(detail?.effectiveTool)) {
       this._saveRecordableStroke(detail);

--- a/renderer/scripts/modules/drawing-manager.js
+++ b/renderer/scripts/modules/drawing-manager.js
@@ -26,6 +26,10 @@ export class DrawingManager extends EventTarget {
     // 캔버스 요소
     this.canvas = options.canvas;
     this.drawingCanvas = new DrawingCanvas(this.canvas);
+    this.drawingCanvas.canDraw = () => {
+      const layer = this.getActiveLayer();
+      return !layer || (layer.locked !== true && layer.visible !== false);
+    };
 
     // 어니언 스킨 전용 캔버스 (별도 레이어)
     this.onionSkinCanvasElement = options.onionSkinCanvas;
@@ -95,6 +99,14 @@ export class DrawingManager extends EventTarget {
     this.drawingCanvas.addEventListener('drawend', (e) => {
       void this._onDrawEnd(e.detail);
     });
+
+    this.drawingCanvas.addEventListener('drawblocked', (e) => {
+      const layer = this.getActiveLayer();
+      this._emit('drawblocked', {
+        ...e.detail,
+        reason: layer?.locked ? 'locked' : 'hidden'
+      });
+    });
   }
 
   /**
@@ -107,7 +119,7 @@ export class DrawingManager extends EventTarget {
     }
 
     const layer = this.getActiveLayer();
-    if (!layer) return;
+    if (!layer || layer.locked || layer.visible === false) return;
 
     // Undo를 위해 현재 상태 저장 (그리기 시작 전)
     if (!this._isUndoingOrRedoing) {
@@ -194,8 +206,11 @@ export class DrawingManager extends EventTarget {
    */
   _saveCurrentFrameData(options = {}) {
     const layer = this.getActiveLayer();
-    if (!layer) {
-      log.warn('저장 실패: 활성 레이어 없음');
+    if (!layer || layer.locked || layer.visible === false) {
+      log.warn('저장 실패: 활성 레이어 없음 또는 그리기 차단 상태');
+      if (layer?.locked || layer?.visible === false) {
+        this.renderFrame(this.currentFrame);
+      }
       return null;
     }
 
@@ -314,7 +329,7 @@ export class DrawingManager extends EventTarget {
 
   async _eraseStrokeRecords(detail) {
     const layer = this.getActiveLayer();
-    if (!layer || layer.locked) return false;
+    if (!layer || layer.locked || layer.visible === false) return false;
 
     const keyframe = this._getEditableKeyframeForCurrentFrame({
       editHeldSourceKeyframe: true,

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -79,6 +79,16 @@ test('clearing the current drawing frame respects locked and hidden layers', () 
   assert.match(appSource, /숨긴 레이어는 지울 수 없습니다/);
 });
 
+test('drawing manager skips stroke record persistence when a save is blocked', () => {
+  const drawEndBody = drawingManagerSource.match(/async _onDrawEnd\(detail\) \{[\s\S]*?\n  \}/)?.[0] || '';
+  assert.match(drawEndBody, /const keyframe = this\._saveCurrentFrameData\(/);
+  assert.match(drawEndBody, /if \(!keyframe\) \{/);
+  assert.ok(
+    drawEndBody.indexOf('if (!keyframe) {') < drawEndBody.indexOf('this._saveRecordableStroke(detail);'),
+    'blocked saves must return before strokeRecords can be appended'
+  );
+});
+
 test('drawing manager records freehand strokes and erases intersecting stroke records', () => {
   assert.match(drawingManagerSource, /createStrokeRecord/);
   assert.match(drawingManagerSource, /removeIntersectingStrokes/);

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -42,10 +42,41 @@ test('eraser tool hides color-only controls and uses a neutral size preview', ()
 test('drawing canvas resolves Ctrl pen and brush strokes as eraser at stroke start', () => {
   assert.match(drawingCanvasSource, /setEraserMode\(mode\)/);
   assert.match(drawingCanvasSource, /_resolveEffectiveTool\(e\)/);
-  assert.match(drawingCanvasSource, /e\.ctrlKey/);
+  assert.match(drawingCanvasSource, /this\._modifierCtrlDown = false;/);
+  assert.match(drawingCanvasSource, /_isCtrlActive\(e\)/);
+  assert.match(drawingCanvasSource, /e\?\.ctrlKey === true \|\| this\._modifierCtrlDown === true/);
   assert.match(drawingCanvasSource, /this\.activeTool = this\._resolveEffectiveTool\(e\);/);
   assert.match(drawingCanvasSource, /effectiveTool: this\.activeTool/);
   assert.match(drawingCanvasSource, /eraserMode: this\.activeEraserMode/);
+});
+
+test('drawing input is blocked before stroke events when the active layer is locked or hidden', () => {
+  const mouseDownBody = drawingCanvasSource.match(/_onMouseDown\(e\) \{[\s\S]*?\n  \}/)?.[0] || '';
+  assert.match(drawingCanvasSource, /this\.canDraw = null;/);
+  assert.match(mouseDownBody, /typeof this\.canDraw === 'function' && !this\.canDraw\(\)/);
+  assert.match(mouseDownBody, /this\._emit\('drawblocked'/);
+  assert.ok(
+    mouseDownBody.indexOf("this._emit('drawblocked'") < mouseDownBody.indexOf('this.isDrawing = true'),
+    'blocked input must return before isDrawing enables drawstart/drawmove/drawend'
+  );
+
+  assert.match(drawingManagerSource, /this\.drawingCanvas\.canDraw = \(\) => \{/);
+  assert.match(drawingManagerSource, /layer\.locked !== true && layer\.visible !== false/);
+  assert.match(drawingManagerSource, /this\.drawingCanvas\.addEventListener\('drawblocked'/);
+  assert.match(drawingManagerSource, /reason: layer\?\.locked \? 'locked' : 'hidden'/);
+  assert.match(drawingManagerSource, /if \(!layer \|\| layer\.locked \|\| layer\.visible === false\) return;/);
+  assert.match(drawingManagerSource, /if \(!layer \|\| layer\.locked \|\| layer\.visible === false\) \{/);
+
+  assert.match(appSource, /drawingManager\.addEventListener\('drawblocked'/);
+  assert.match(appSource, /잠긴 레이어에는 그릴 수 없습니다/);
+  assert.match(appSource, /숨긴 레이어에는 그릴 수 없습니다/);
+});
+
+test('clearing the current drawing frame respects locked and hidden layers', () => {
+  assert.match(appSource, /elements\.btnClearDrawing\?\.addEventListener\('click'/);
+  assert.match(appSource, /if \(layer\.locked \|\| layer\.visible === false\) \{/);
+  assert.match(appSource, /잠긴 레이어는 지울 수 없습니다/);
+  assert.match(appSource, /숨긴 레이어는 지울 수 없습니다/);
 });
 
 test('drawing manager records freehand strokes and erases intersecting stroke records', () => {


### PR DESCRIPTION
## 📋 업데이트 요약

- 🛡️ 잠긴 레이어나 숨긴 레이어에는 이제 그리기와 지우기가 시작되지 않습니다.
- ✏️ 펜 디스플레이/태블릿 입력에서도 Ctrl을 누른 상태의 임시 지우개 전환이 더 안정적으로 동작합니다.
- 🧽 “현재 프레임 지우기” 버튼도 잠긴/숨긴 레이어를 건드리지 않도록 막았습니다.
- 🗂️ 윤성원님 피드백 UI/UX 개선 계획서를 DEVLOG에 추가하고, 이번 PR에서 처리한 Phase 1/3 상태를 완료로 표시했습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/drawing-canvas.js`
  - `canDraw` 훅을 추가해 `_onMouseDown()`에서 `drawstart`/`drawmove`/`drawend` 발생 전 입력을 차단합니다.
  - `document` keydown/keyup과 `window` blur로 Ctrl 상태를 추적하는 `_modifierCtrlDown` 및 `_isCtrlActive()`를 추가했습니다.
  - mouse/touch 경로 모두 `_isCtrlActive()`를 사용하도록 바꿔 펜/터치 유래 이벤트의 `ctrlKey` 누락을 보완했습니다.
- `renderer/scripts/modules/drawing-manager.js`
  - 활성 레이어가 잠금 또는 숨김 상태면 DrawingCanvas 입력을 시작하지 않도록 `canDraw`를 주입했습니다.
  - `_onDrawStart()`, `_saveCurrentFrameData()`, `_eraseStrokeRecords()`에 방어선을 추가해 뒤늦은 저장/획 지우기 경로도 차단했습니다.
  - `drawblocked` 이벤트에 `locked`/`hidden` 사유를 실어 앱 레벨로 전달합니다.
- `renderer/scripts/app.js`
  - `drawblocked` 토스트를 추가했습니다.
  - 전체 지우기 버튼도 잠긴/숨긴 레이어에서는 바로 중단하도록 했습니다.
- `scripts/tests/drawing-runtime-source.test.js`
  - Ctrl 전역 추적, 입력 시작 전 차단, 전체 지우기 차단을 검증하는 소스 테스트를 추가했습니다.

## 🚧 개발 난항

- 기존 구조에서는 픽셀 지우개가 화면에 합쳐져 보이는 캔버스를 직접 지우기 때문에, 저장 단계에서 막으면 협업 이벤트나 첫 픽셀이 이미 새어 나갈 수 있었습니다.
- 그래서 저장 직전이 아니라 입력 시작 시점에서 차단하고, 매니저 저장 경로에는 보조 방어선을 두는 방식으로 정리했습니다.
- `npm ci` 후 postinstall이 번들 파일을 다시 만들면서 작업트리에 잡음이 생겼고, PR 범위와 무관한 생성물은 제외했습니다.

## ✅ 테스트 가이드

실사용자용
- 잠긴 레이어에서 픽셀 지우개/펜/브러시/도형을 써도 그림이 바뀌지 않고 안내가 뜨는지 확인합니다.
- 숨긴 레이어에서 그리기 또는 현재 프레임 지우기를 눌렀을 때 안내가 뜨는지 확인합니다.
- 갤럭시탭/펜 디스플레이 환경에서 PC 키보드 Ctrl을 누른 채 펜으로 그리면 임시 지우개처럼 동작하는지 확인합니다.

개발자용
- `npm run test:drawing`
- `npm run build`