### PR TITLE
[v1.4.1-beta] 드로잉 레이어 분리 렌더링으로 레이어 오염 방지

### DIFF
--- a/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
+++ b/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
@@ -25,7 +25,7 @@
 | Phase | 내용 | 분류 | 수정 파일 | 우선순위 | 상태 |
 |-------|------|------|----------|---------|------|
 | 1 | 잠긴/숨긴 레이어 그리기·지우기 입력 차단 (픽셀 지우개 잠금 무시 버그) | 버그 | drawing-canvas.js, drawing-manager.js, app.js | **최상** (데이터 파괴) | ✅ |
-| 2 | 활성 레이어 분리 렌더링 — 3-캔버스 스택 (레이어 나누기 드로잉 귀속 버그) | 버그 | drawing-manager.js, app.js, index.html, main.css | **최상** (데이터 오염) | ⬜ |
+| 2 | 활성 레이어 분리 렌더링 — 3-캔버스 스택 (레이어 나누기 드로잉 귀속 버그) | 버그 | drawing-manager.js, app.js, index.html, main.css | **최상** (데이터 오염) | ✅ |
 | 3 | 펜(태블릿) 입력 시 Ctrl+드로잉 지우개 토글 미인식 | 버그 | drawing-canvas.js, drawing-runtime-source.test.js | 높음 | ✅ |
 | 4 | 댓글 구간 ON 시 좌/우 타임라인 행 어긋남 + 상시 2px 어긋남 | 버그 | timeline.js, main.css | 높음 | ⬜ |
 | 5 | 키프레임 드래그 오버레이를 정확히 1프레임 칸으로 | 버그 | timeline.js, main.css | 높음 | ⬜ |

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:playlist-comments": "node --test scripts/tests/playlist-comment-index.test.js",
     "test:playlist": "node --test scripts/tests/playlist-ordering.test.js scripts/tests/playlist-continuous-core.test.js scripts/tests/playlist-continuous-runtime.test.js scripts/tests/playlist-comment-index.test.js scripts/tests/playlist-autoplay-source.test.js scripts/tests/bplaylist-file-association-source.test.js scripts/tests/project-file-associations.test.js scripts/tests/instance-policy.test.js",
     "test:cutlist": "node --test scripts/tests/cutlist-manager.test.js scripts/tests/cutlist-schema.test.js scripts/tests/moho-scene-info-parser.test.js scripts/tests/cutlist-core.test.js scripts/tests/cutlist-runtime-source.test.js scripts/tests/cutlist-comment-index.test.js",
-    "test:drawing": "node --test scripts/tests/drawing-stroke-records.test.js scripts/tests/drawing-runtime-source.test.js scripts/tests/keyframe-multi-select-source.test.js",
+    "test:drawing": "node --test scripts/tests/drawing-stroke-records.test.js scripts/tests/drawing-layer-partition.test.js scripts/tests/drawing-runtime-source.test.js scripts/tests/keyframe-multi-select-source.test.js",
     "test:video-pan": "node --test scripts/tests/video-pan-controls.test.js scripts/tests/playhead-frame-step-source.test.js",
     "test:mpv": "node --test scripts/tests/mpv-manager.test.js scripts/tests/mpv-embed-host.test.js scripts/tests/mpv-overlay-host.test.js scripts/tests/mpv-runtime-source.test.js",
     "test:audio-waveform": "node --test scripts/tests/audio-waveform-hit-area.test.js",

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -497,8 +497,10 @@
           <!-- Composition Layer Overlay (이미지/영상 합성 프리뷰) -->
           <div id="compositionLayerOverlay" class="composition-layer-overlay"></div>
 
-          <!-- Drawing Overlay Canvas -->
+          <!-- Drawing Layer Canvases -->
+          <canvas id="layersBelowCanvas" class="drawing-overlay layers-below-layer"></canvas>
           <canvas id="drawingCanvas" class="drawing-overlay"></canvas>
+          <canvas id="layersAboveCanvas" class="drawing-overlay layers-above-layer"></canvas>
 
           <!-- Comment Range Overlay (비디오 하단 댓글 범위 표시) -->
           <div class="video-comment-range-overlay" id="videoCommentRangeOverlay">

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -111,7 +111,9 @@ async function initApp() {
     btnCompositionLayerUndo: document.getElementById('btnCompositionLayerUndo'),
     btnCompositionLayerRedo: document.getElementById('btnCompositionLayerRedo'),
     btnCompositionLayerPanelCollapse: document.getElementById('btnCompositionLayerPanelCollapse'),
+    layersBelowCanvas: document.getElementById('layersBelowCanvas'),
     drawingCanvas: document.getElementById('drawingCanvas'),
+    layersAboveCanvas: document.getElementById('layersAboveCanvas'),
     onionSkinCanvas: document.getElementById('onionSkinCanvas'),
     drawingTools: document.getElementById('drawingTools'),
     btnOpenFile: document.getElementById('btnOpenFile'),
@@ -804,6 +806,8 @@ async function initApp() {
   // 드로잉 매니저
   const drawingManager = new DrawingManager({
     canvas: elements.drawingCanvas,
+    layersBelowCanvas: elements.layersBelowCanvas,
+    layersAboveCanvas: elements.layersAboveCanvas,
     onionSkinCanvas: elements.onionSkinCanvas
   });
 
@@ -4683,10 +4687,11 @@ async function initApp() {
     const scale = state.videoZoom / 100;
     const transform = `scale(${scale}) translate(${state.videoPanX}px, ${state.videoPanY}px)`;
 
-    if (elements.drawingCanvas) {
-      elements.drawingCanvas.style.transform = transform;
-      elements.drawingCanvas.style.transformOrigin = 'center center';
-    }
+    [elements.layersBelowCanvas, elements.drawingCanvas, elements.layersAboveCanvas].forEach((canvas) => {
+      if (!canvas) return;
+      canvas.style.transform = transform;
+      canvas.style.transformOrigin = 'center center';
+    });
     if (elements.onionSkinCanvas) {
       elements.onionSkinCanvas.style.transform = transform;
       elements.onionSkinCanvas.style.transformOrigin = 'center center';
@@ -4939,6 +4944,7 @@ async function initApp() {
   function syncCanvasOverlay() {
     const renderArea = getVideoRenderArea();
     const canvas = elements.drawingCanvas;
+    const layerCanvases = [elements.layersBelowCanvas, elements.drawingCanvas, elements.layersAboveCanvas];
     const onionCanvas = elements.onionSkinCanvas;
     const compositionOverlay = elements.compositionLayerOverlay;
 
@@ -4947,13 +4953,16 @@ async function initApp() {
     }
 
     // 그리기 캔버스 위치와 크기를 비디오 실제 렌더 영역에 맞춤
-    canvas.style.position = 'absolute';
-    canvas.style.left = `${renderArea.left}px`;
-    canvas.style.top = `${renderArea.top}px`;
-    canvas.style.width = `${renderArea.width}px`;
-    canvas.style.height = `${renderArea.height}px`;
-    canvas.width = renderArea.videoWidth;
-    canvas.height = renderArea.videoHeight;
+    layerCanvases.forEach((layerCanvas) => {
+      if (!layerCanvas) return;
+      layerCanvas.style.position = 'absolute';
+      layerCanvas.style.left = `${renderArea.left}px`;
+      layerCanvas.style.top = `${renderArea.top}px`;
+      layerCanvas.style.width = `${renderArea.width}px`;
+      layerCanvas.style.height = `${renderArea.height}px`;
+      layerCanvas.width = renderArea.videoWidth;
+      layerCanvas.height = renderArea.videoHeight;
+    });
 
     // 어니언 스킨 캔버스도 동일하게 동기화
     if (onionCanvas) {
@@ -5857,6 +5866,28 @@ async function initApp() {
     }
   }
 
+  function getCompositedDrawingOverlayDataUrl() {
+    const baseCanvas = elements.drawingCanvas;
+    if (!baseCanvas || baseCanvas.width <= 0 || baseCanvas.height <= 0) return '';
+
+    const compositeCanvas = document.createElement('canvas');
+    compositeCanvas.width = baseCanvas.width;
+    compositeCanvas.height = baseCanvas.height;
+    const ctx = compositeCanvas.getContext('2d');
+
+    [elements.layersBelowCanvas, baseCanvas, elements.layersAboveCanvas].forEach((canvas) => {
+      if (!canvas || canvas.width <= 0 || canvas.height <= 0) return;
+      ctx.drawImage(canvas, 0, 0);
+    });
+
+    try {
+      return compositeCanvas.toDataURL('image/png');
+    } catch (error) {
+      log.debug('mpv 드로잉 합성 스냅샷 실패', { error: error.message });
+      return '';
+    }
+  }
+
   function isMpvMarkerOverlayVisible() {
     if (!markerContainer) return false;
     const style = window.getComputedStyle(markerContainer);
@@ -6004,7 +6035,7 @@ async function initApp() {
     if (!wrapperRect || !canvasRect) return null;
 
     return {
-      drawingDataUrl: getCanvasOverlayDataUrl(elements.drawingCanvas),
+      drawingDataUrl: getCompositedDrawingOverlayDataUrl(),
       onionDataUrl: getCanvasOverlayDataUrl(elements.onionSkinCanvas),
       markerHtml: serializeMpvOverlayMarkerHtml(),
       tooltipHtml: serializeMpvOverlayTooltipHtml(),

--- a/renderer/scripts/modules/drawing-manager.js
+++ b/renderer/scripts/modules/drawing-manager.js
@@ -16,6 +16,23 @@ import {
 
 const log = createLogger('DrawingManager');
 
+export function partitionDrawingLayersForActive(layers = [], activeLayerId) {
+  const activeIndex = layers.findIndex(layer => layer.id === activeLayerId);
+  if (activeIndex === -1) {
+    return {
+      below: [...layers],
+      active: null,
+      above: []
+    };
+  }
+
+  return {
+    below: layers.slice(0, activeIndex),
+    active: layers[activeIndex],
+    above: layers.slice(activeIndex + 1)
+  };
+}
+
 /**
  * 드로잉 매니저 클래스
  */
@@ -34,6 +51,10 @@ export class DrawingManager extends EventTarget {
     // 어니언 스킨 전용 캔버스 (별도 레이어)
     this.onionSkinCanvasElement = options.onionSkinCanvas;
     this.onionSkinCtx = this.onionSkinCanvasElement?.getContext('2d');
+    this.layersBelowCanvas = options.layersBelowCanvas;
+    this.layersAboveCanvas = options.layersAboveCanvas;
+    this.layersBelowCtx = this.layersBelowCanvas?.getContext('2d');
+    this.layersAboveCtx = this.layersAboveCanvas?.getContext('2d');
 
     // 레이어 관리
     this.layers = [];
@@ -385,10 +406,13 @@ export class DrawingManager extends EventTarget {
 
     const layer = new DrawingLayer(options);
     this.layers.push(layer);
-    this.activeLayerId = layer.id;
+    if (options.skipActivate !== true) {
+      this.activeLayerId = layer.id;
+    }
 
     this._emit('layerCreated', { layer });
     this._emit('layersChanged');
+    this.renderFrame(this.currentFrame);
 
     log.info('새 레이어 생성됨', { id: layer.id, name: layer.name });
     return layer;
@@ -437,6 +461,7 @@ export class DrawingManager extends EventTarget {
     if (layer) {
       this.activeLayerId = layerId;
       this._emit('activeLayerChanged', { layer });
+      this.renderFrame(this.currentFrame);
       log.debug('활성 레이어 변경', { id: layerId });
     }
   }
@@ -791,6 +816,11 @@ export class DrawingManager extends EventTarget {
     this.canvasWidth = width;
     this.canvasHeight = height;
     this.drawingCanvas.syncSize(width, height);
+    [this.layersBelowCanvas, this.layersAboveCanvas].forEach((canvas) => {
+      if (!canvas) return;
+      canvas.width = width;
+      canvas.height = height;
+    });
 
     // 어니언 스킨 캔버스 크기도 동기화
     if (this.onionSkinCanvasElement) {
@@ -799,6 +829,7 @@ export class DrawingManager extends EventTarget {
     }
 
     log.debug('캔버스 크기 설정됨', { width, height });
+    this.renderFrame(this.currentFrame);
   }
 
   /**
@@ -815,6 +846,32 @@ export class DrawingManager extends EventTarget {
 
     this.currentFrame = frame;
     this.renderFrame(frame);
+  }
+
+  _clearCanvasElement(canvas, ctx) {
+    if (!canvas || !ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  _clearStaticLayerCanvases() {
+    this._clearCanvasElement(this.layersBelowCanvas, this.layersBelowCtx);
+    this._clearCanvasElement(this.layersAboveCanvas, this.layersAboveCtx);
+  }
+
+  _getLayerRenderBuckets() {
+    const { below, active, above } = partitionDrawingLayersForActive(this.layers, this.activeLayerId);
+    return [
+      { layers: below, ctx: this.layersBelowCtx },
+      { layers: active ? [active] : [], ctx: this.drawingCanvas.ctx },
+      { layers: above, ctx: this.layersAboveCtx }
+    ];
+  }
+
+  _drawImageToContext(ctx, img, opacity) {
+    if (!ctx || !img) return;
+    ctx.globalAlpha = opacity;
+    ctx.drawImage(img, 0, 0);
+    ctx.globalAlpha = 1;
   }
 
   /**
@@ -840,6 +897,7 @@ export class DrawingManager extends EventTarget {
     // 일시정지 상태에서만 캔버스 초기화
     this._playbackCanvasCleared = false;
     this.drawingCanvas.clear();
+    this._clearStaticLayerCanvases();
     this._clearOnionSkinCanvas();
 
     log.debug('renderFrame 시작', {
@@ -863,23 +921,25 @@ export class DrawingManager extends EventTarget {
     // 렌더링할 이미지들을 먼저 모두 로드
     const imagesToRender = [];
 
-    for (const layer of this.layers) {
-      if (!layer.visible) continue;
+    for (const bucket of this._getLayerRenderBuckets()) {
+      for (const layer of bucket.layers) {
+        if (!layer.visible) continue;
 
-      const keyframe = layer.getKeyframeAtFrame(frame);
+        const keyframe = layer.getKeyframeAtFrame(frame);
 
-      if (!keyframe || keyframe.isEmpty || !keyframe.canvasData) continue;
+        if (!keyframe || keyframe.isEmpty || !keyframe.canvasData) continue;
 
-      // 이미지 캐시 확인 또는 새로 로드
-      const img = await this._loadImage(keyframe.canvasData, keyframe);
-      if (img) {
-        imagesToRender.push({ img, layer });
-      }
+        // 이미지 캐시 확인 또는 새로 로드
+        const img = await this._loadImage(keyframe.canvasData, keyframe);
+        if (img) {
+          imagesToRender.push({ img, layer, ctx: bucket.ctx });
+        }
 
-      // 렌더링 취소 체크
-      if (this._renderingId !== currentRenderingId) {
-        log.debug('이미지 로드 중 렌더링 취소', { frame, currentRenderingId });
-        return;
+        // 렌더링 취소 체크
+        if (this._renderingId !== currentRenderingId) {
+          log.debug('이미지 로드 중 렌더링 취소', { frame, currentRenderingId });
+          return;
+        }
       }
     }
 
@@ -890,10 +950,8 @@ export class DrawingManager extends EventTarget {
     }
 
     // 모든 이미지를 순서대로 그리기
-    for (const { img, layer } of imagesToRender) {
-      this.drawingCanvas.ctx.globalAlpha = layer.opacity;
-      this.drawingCanvas.ctx.drawImage(img, 0, 0);
-      this.drawingCanvas.ctx.globalAlpha = 1;
+    for (const { img, layer, ctx } of imagesToRender) {
+      this._drawImageToContext(ctx, img, layer.opacity);
     }
 
     log.debug('renderFrame 완료', { frame, renderedCount: imagesToRender.length });
@@ -910,22 +968,25 @@ export class DrawingManager extends EventTarget {
     const images = [];
     let hasCacheMiss = false;
 
-    for (const layer of this.layers) {
-      if (!layer.visible) continue;
+    for (const bucket of this._getLayerRenderBuckets()) {
+      for (const layer of bucket.layers) {
+        if (!layer.visible) continue;
 
-      const keyframe = layer.getKeyframeAtFrame(frame);
-      if (!keyframe || keyframe.isEmpty || !keyframe.canvasData) continue;
+        const keyframe = layer.getKeyframeAtFrame(frame);
+        if (!keyframe || keyframe.isEmpty || !keyframe.canvasData) continue;
 
-      if (keyframe._cachedImage && keyframe._cachedSrc === keyframe.canvasData) {
-        images.push({ img: keyframe._cachedImage, opacity: layer.opacity });
-      } else {
-        hasCacheMiss = true;
+        if (keyframe._cachedImage && keyframe._cachedSrc === keyframe.canvasData) {
+          images.push({ img: keyframe._cachedImage, opacity: layer.opacity, ctx: bucket.ctx });
+        } else {
+          hasCacheMiss = true;
+        }
       }
     }
 
     if (images.length === 0 && !hasCacheMiss) {
       if (!this._playbackCanvasCleared) {
         this.drawingCanvas.clear({ silent: true });
+        this._clearStaticLayerCanvases();
         this._playbackCanvasCleared = true;
       }
       return;
@@ -933,11 +994,10 @@ export class DrawingManager extends EventTarget {
 
     // clear + draw를 원자적으로 수행 (깜빡임 방지)
     this.drawingCanvas.clear({ silent: true });
+    this._clearStaticLayerCanvases();
     this._playbackCanvasCleared = images.length === 0 && !hasCacheMiss;
-    for (const { img, opacity } of images) {
-      this.drawingCanvas.ctx.globalAlpha = opacity;
-      this.drawingCanvas.ctx.drawImage(img, 0, 0);
-      this.drawingCanvas.ctx.globalAlpha = 1;
+    for (const { img, opacity, ctx } of images) {
+      this._drawImageToContext(ctx, img, opacity);
     }
 
     // 캐시 미스가 있으면 백그라운드에서 로드 (다음 프레임에서 사용됨)
@@ -1024,6 +1084,7 @@ export class DrawingManager extends EventTarget {
     this.layers = [];
     this.activeLayerId = null;
     this.drawingCanvas.clear();
+    this._clearStaticLayerCanvases();
 
     this._emit('layersChanged');
     log.info('모든 레이어 초기화됨');
@@ -1036,6 +1097,7 @@ export class DrawingManager extends EventTarget {
     this.layers = [];
     this.activeLayerId = null;
     this.drawingCanvas.clear();
+    this._clearStaticLayerCanvases();
     this.clearHistory();
 
     // ID 충돌 방지: nextId를 1로 리셋

--- a/renderer/scripts/modules/drawing-sync.js
+++ b/renderer/scripts/modules/drawing-sync.js
@@ -350,7 +350,7 @@ export class DrawingSync {
 
       // DrawingManager에 레이어 추가
       if (this._dm.createLayer) {
-        this._dm.createLayer(layerData);
+        this._dm.createLayer({ ...layerData, skipActivate: true });
       }
       log.debug('원격 레이어 생성 적용', { id: layerData.id });
     } finally {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -1826,8 +1826,16 @@ body.mpv-pilot-mode .video-wrapper.mpv-pilot-mode > .remote-cursors-container {
   z-index: 2;
 }
 
+.layers-below-layer {
+  z-index: 2;
+}
+
 #drawingCanvas {
   z-index: 3;
+}
+
+.layers-above-layer {
+  z-index: 4;
 }
 
 /* ========================================

--- a/scripts/tests/drawing-layer-partition.test.js
+++ b/scripts/tests/drawing-layer-partition.test.js
@@ -1,0 +1,52 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+let partitionDrawingLayersForActive;
+
+test('drawing manager partition helper loads', async () => {
+  ({ partitionDrawingLayersForActive } = await import('../../renderer/scripts/modules/drawing-manager.js'));
+});
+
+function layer(id) {
+  return { id };
+}
+
+function ids(layers) {
+  return layers.map(item => item.id);
+}
+
+test('partition splits layers below active layer and above active layer', () => {
+  const layers = [layer('layer-1'), layer('layer-2'), layer('layer-3')];
+  const result = partitionDrawingLayersForActive(layers, 'layer-2');
+
+  assert.deepEqual(ids(result.below), ['layer-1']);
+  assert.equal(result.active.id, 'layer-2');
+  assert.deepEqual(ids(result.above), ['layer-3']);
+});
+
+test('partition keeps all higher layers above when active layer is first', () => {
+  const layers = [layer('layer-1'), layer('layer-2'), layer('layer-3')];
+  const result = partitionDrawingLayersForActive(layers, 'layer-1');
+
+  assert.deepEqual(ids(result.below), []);
+  assert.equal(result.active.id, 'layer-1');
+  assert.deepEqual(ids(result.above), ['layer-2', 'layer-3']);
+});
+
+test('partition keeps all lower layers below when active layer is last', () => {
+  const layers = [layer('layer-1'), layer('layer-2'), layer('layer-3')];
+  const result = partitionDrawingLayersForActive(layers, 'layer-3');
+
+  assert.deepEqual(ids(result.below), ['layer-1', 'layer-2']);
+  assert.equal(result.active.id, 'layer-3');
+  assert.deepEqual(ids(result.above), []);
+});
+
+test('partition treats every layer as static when active layer is missing', () => {
+  const layers = [layer('layer-1'), layer('layer-2')];
+  const result = partitionDrawingLayersForActive(layers, 'missing-layer');
+
+  assert.deepEqual(ids(result.below), ['layer-1', 'layer-2']);
+  assert.equal(result.active, null);
+  assert.deepEqual(ids(result.above), []);
+});

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -89,6 +89,32 @@ test('drawing manager skips stroke record persistence when a save is blocked', (
   );
 });
 
+test('drawing layer rendering uses static below and above canvases around the active layer', () => {
+  assert.match(indexSource, /id="layersBelowCanvas"/);
+  assert.match(indexSource, /id="layersAboveCanvas"/);
+  assert.match(mainCss, /\.layers-below-layer/);
+  assert.match(mainCss, /\.layers-above-layer/);
+
+  assert.match(appSource, /layersBelowCanvas: document\.getElementById\('layersBelowCanvas'\)/);
+  assert.match(appSource, /layersAboveCanvas: document\.getElementById\('layersAboveCanvas'\)/);
+  assert.match(appSource, /layersBelowCanvas: elements\.layersBelowCanvas/);
+  assert.match(appSource, /layersAboveCanvas: elements\.layersAboveCanvas/);
+  assert.match(appSource, /getCompositedDrawingOverlayDataUrl\(\)/);
+  assert.match(appSource, /drawingDataUrl: getCompositedDrawingOverlayDataUrl\(\)/);
+
+  assert.match(drawingManagerSource, /partitionDrawingLayersForActive\(layers = \[\], activeLayerId\)/);
+  assert.match(drawingManagerSource, /this\.layersBelowCanvas = options\.layersBelowCanvas/);
+  assert.match(drawingManagerSource, /this\.layersAboveCanvas = options\.layersAboveCanvas/);
+  assert.match(drawingManagerSource, /this\.layersBelowCtx = this\.layersBelowCanvas\?\.getContext\('2d'\)/);
+  assert.match(drawingManagerSource, /this\.layersAboveCtx = this\.layersAboveCanvas\?\.getContext\('2d'\)/);
+  assert.match(drawingManagerSource, /_clearStaticLayerCanvases\(\)/);
+  assert.match(drawingManagerSource, /_getLayerRenderBuckets\(\)/);
+  assert.match(drawingManagerSource, /_drawImageToContext\(ctx, img, opacity\)/);
+  assert.match(drawingManagerSource, /this\.renderFrame\(this\.currentFrame\);/);
+
+  assert.match(drawingSyncSource, /createLayer\(\{ \.\.\.layerData, skipActivate: true \}\)/);
+});
+
 test('drawing manager records freehand strokes and erases intersecting stroke records', () => {
   assert.match(drawingManagerSource, /createStrokeRecord/);
   assert.match(drawingManagerSource, /removeIntersectingStrokes/);


### PR DESCRIPTION
## 📋 업데이트 요약

- 🧱 드로잉 레이어를 화면에 그릴 때 활성 레이어와 그 아래/위 레이어를 분리해서 표시합니다.
- 🛡️ 새 레이어에 그림을 그릴 때 이전 레이어의 그림이 새 레이어 데이터에 섞여 들어가는 문제를 막았습니다.
- 🖥️ mpv 화면에서도 분리된 드로잉 레이어가 하나의 화면처럼 합쳐져 보이도록 맞췄습니다.
- 🗂️ DEVLOG에서 Phase 2 상태를 완료로 갱신했습니다.

## 🔧 상세 기술 설명

- `renderer/index.html`, `renderer/styles/main.css`
  - `layersBelowCanvas`, `drawingCanvas`, `layersAboveCanvas` 3장 구조를 추가했습니다.
  - 활성 입력 캔버스는 기존 `drawingCanvas`로 유지하고, 위/아래 레이어 캔버스는 `pointer-events: none` 계층으로 둡니다.
- `renderer/scripts/modules/drawing-manager.js`
  - `partitionDrawingLayersForActive()`를 추가해 레이어 배열을 `below / active / above`로 나눕니다.
  - `renderFrame()`과 `_renderFrameSync()` 모두 같은 분리 규칙을 사용해 pause/play 렌더 결과를 맞췄습니다.
  - `createLayer()`와 `setActiveLayer()` 직후 현재 프레임을 다시 렌더해 활성 캔버스가 이전 레이어 그림을 들고 있지 않게 했습니다.
  - `setCanvasSize()`, `clearAll()`, `reset()`에서 정적 레이어 캔버스도 함께 관리합니다.
- `renderer/scripts/app.js`
  - 새 캔버스 2장을 DOM 캐시에 연결하고 위치/크기/줌 동기화에 포함했습니다.
  - `getCompositedDrawingOverlayDataUrl()`를 추가해 mpv 오버레이에는 세 캔버스를 합성한 PNG를 전달합니다.
- `renderer/scripts/modules/drawing-sync.js`
  - 원격 레이어 생성이 내 활성 레이어를 뺏지 않도록 `skipActivate` 경로를 추가했습니다.
- `scripts/tests/drawing-layer-partition.test.js`, `scripts/tests/drawing-runtime-source.test.js`
  - 활성 레이어 기준 분리 규칙과 3캔버스 배선을 검증합니다.

## 🚧 개발 난항

- 기존에는 화면에 보이는 모든 레이어가 하나의 캔버스에 합쳐졌고, 저장도 그 캔버스 그대로 이뤄졌습니다. 그래서 저장 함수만 고쳐서는 부족했고, 표시 구조 자체를 나눠야 했습니다.
- 재생 중 렌더링 경로 `_renderFrameSync()`가 별도로 있어서 일시정지 화면만 고치면 재생 중 화면이 다르게 보일 위험이 있었습니다. 두 경로 모두 같은 분리 규칙을 쓰도록 맞췄습니다.
- mpv는 DOM 캔버스를 직접 보지 않기 때문에, 분리된 세 캔버스를 다시 하나로 합성해서 전달하는 별도 처리가 필요했습니다.

## ✅ 테스트 가이드

실사용자용
- 레이어 1에 그림 여러 개를 만든 뒤 레이어 2를 추가하고 새 그림을 그립니다.
- 프레임을 이동해도 레이어 2에 레이어 1 그림이 섞여 보이지 않는지 확인합니다.
- 레이어 2를 숨겼을 때 레이어 1 그림만 남는지 확인합니다.
- 가능하면 mpv 재생 모드에서도 드로잉 레이어가 동일하게 보이는지 확인합니다.

개발자용
- `npm run test:drawing`
- `npm run test:mpv`
- `npm run build`