### PR TITLE
[v1.4.1-beta] 댓글 구간 행 높이 동기화

### DIFF
--- a/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
+++ b/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
@@ -27,7 +27,7 @@
 | 1 | 잠긴/숨긴 레이어 그리기·지우기 입력 차단 (픽셀 지우개 잠금 무시 버그) | 버그 | drawing-canvas.js, drawing-manager.js, app.js | **최상** (데이터 파괴) | ✅ |
 | 2 | 활성 레이어 분리 렌더링 — 3-캔버스 스택 (레이어 나누기 드로잉 귀속 버그) | 버그 | drawing-manager.js, app.js, index.html, main.css | **최상** (데이터 오염) | ✅ |
 | 3 | 펜(태블릿) 입력 시 Ctrl+드로잉 지우개 토글 미인식 | 버그 | drawing-canvas.js, drawing-runtime-source.test.js | 높음 | ✅ |
-| 4 | 댓글 구간 ON 시 좌/우 타임라인 행 어긋남 + 상시 2px 어긋남 | 버그 | timeline.js, main.css | 높음 | ⬜ |
+| 4 | 댓글 구간 ON 시 좌/우 타임라인 행 어긋남 + 상시 2px 어긋남 | 버그 | timeline.js, main.css | 높음 | ✅ |
 | 5 | 키프레임 드래그 오버레이를 정확히 1프레임 칸으로 | 버그 | timeline.js, main.css | 높음 | ⬜ |
 | 6 | 프레임 1칸 셀 표시 모드 (ON/OFF/AUTO 토글) — Animate 스타일 | 기능 | timeline.js, frame-grid-tiers.js, user-settings.js, app.js, index.html, main.css | 높음 | ⬜ |
 | 7 | 브러시 설정 영속화 + Alt 드래그 크기 조절 + [ / ] 단축키 | 기능 | user-settings.js, app.js, drawing-canvas.js, index.html, main.css | 높음 | ⬜ |

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write .",
     "test:recent": "node --test scripts/tests/recent-files-store.test.js scripts/tests/recent-files-source.test.js",
     "test:frame-grid": "node --test scripts/tests/frame-grid-tiers.test.js",
-    "test:cluster": "node --test scripts/tests/comment-cluster.test.js",
+    "test:cluster": "node --test scripts/tests/comment-cluster.test.js scripts/tests/comment-track-header-sync-source.test.js",
     "test:playlist-ordering": "node --test scripts/tests/playlist-ordering.test.js",
     "test:playlist-continuous": "node --test scripts/tests/playlist-continuous-core.test.js",
     "test:playlist-comments": "node --test scripts/tests/playlist-comment-index.test.js",

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -2232,8 +2232,23 @@ export class Timeline extends EventTarget {
   setCommentTrack(trackElement, layerHeaderElement = null) {
     this.commentTrack = trackElement;
     this.commentLayerHeader = layerHeaderElement;
+    this.clearCommentTrackRowHeight();
     // 트랙 배경 클릭으로 펼친 클러스터 접기 / 배지 펼치기 등은 app.js의
     // setupCommentRangeInteractions()에서 드래그 가드와 함께 위임 처리한다.
+  }
+
+  _setCommentTrackRowHeight(height = 24) {
+    if (this.commentTrack) {
+      this.commentTrack.style.height = `${height}px`;
+    }
+    if (this.commentLayerHeader) {
+      this.commentLayerHeader.style.height = `${height}px`;
+      this.commentLayerHeader.style.minHeight = `${height}px`;
+    }
+  }
+
+  clearCommentTrackRowHeight() {
+    this._setCommentTrackRowHeight();
   }
 
   setCommentRangesVisible(visible) {
@@ -2241,6 +2256,7 @@ export class Timeline extends EventTarget {
     if (!this.commentTrack) return;
 
     if (!this.commentRangesVisible) {
+      this.clearCommentTrackRowHeight();
       this.commentTrack.style.display = 'none';
       if (this.commentLayerHeader) {
         this.commentLayerHeader.style.display = 'none';
@@ -2284,6 +2300,7 @@ export class Timeline extends EventTarget {
       '.comment-range-item, .comment-cluster-badge, .comment-cluster-close-badge'
     );
     if (!hasCommentContent) {
+      this.clearCommentTrackRowHeight();
       this.commentTrack.style.display = 'none';
       if (this.commentLayerHeader) {
         this.commentLayerHeader.style.display = 'none';
@@ -2445,12 +2462,14 @@ export class Timeline extends EventTarget {
     if (!this.commentTrack) return;
     this._lastPlaylistCommentRanges = ranges || [];
     this._lastPlaylistCommentDuration = totalDuration || this.playlistDuration || this.duration || 0;
+    this._setCommentTrackRowHeight();
     this.commentTrack.querySelectorAll(
       '.playlist-comment-range, .comment-range-item, .comment-cluster-badge, .comment-cluster-close-badge'
     ).forEach(el => el.remove());
     this._lastComments = null;
     this.expandedClusterId = null;
     if (!this.commentRangesVisible) {
+      this.clearCommentTrackRowHeight();
       this.commentTrack.style.display = 'none';
       if (this.commentLayerHeader) {
         this.commentLayerHeader.style.display = 'none';
@@ -2460,6 +2479,7 @@ export class Timeline extends EventTarget {
 
     const duration = this._lastPlaylistCommentDuration;
     if (!duration) {
+      this.clearCommentTrackRowHeight();
       this.commentTrack.style.display = 'none';
       if (this.commentLayerHeader) {
         this.commentLayerHeader.style.display = 'none';
@@ -2495,6 +2515,7 @@ export class Timeline extends EventTarget {
         this.commentLayerHeader.style.display = 'flex';
       }
     } else {
+      this.clearCommentTrackRowHeight();
       this.commentTrack.style.display = 'none';
       if (this.commentLayerHeader) {
         this.commentLayerHeader.style.display = 'none';
@@ -2518,6 +2539,7 @@ export class Timeline extends EventTarget {
     this.commentTrack.innerHTML = '';
 
     if (!this.commentRangesVisible) {
+      this.clearCommentTrackRowHeight();
       this.commentTrack.style.display = 'none';
       if (this.commentLayerHeader) {
         this.commentLayerHeader.style.display = 'none';
@@ -2527,6 +2549,7 @@ export class Timeline extends EventTarget {
 
     // 댓글이 없으면 트랙 및 레이어 헤더 숨김 (기존 로직 유지)
     if (!comments || comments.length === 0) {
+      this.clearCommentTrackRowHeight();
       this.commentTrack.style.display = 'none';
       if (this.commentLayerHeader) {
         this.commentLayerHeader.style.display = 'none';
@@ -2593,7 +2616,7 @@ export class Timeline extends EventTarget {
     const targetHeight = maxLanes > 1
       ? laneHeight * maxLanes + lanePadding
       : baseHeight;
-    this.commentTrack.style.height = `${targetHeight}px`;
+    this._setCommentTrackRowHeight(targetHeight);
 
     // 5) 각 클러스터 렌더
     renderItems.forEach(item => {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -3991,8 +3991,11 @@ body.app-fullscreen .video-comment-overlay-controls {
   align-items: center;
   padding: 0 12px;
   height: 24px;
+  min-height: 24px;
+  margin-bottom: 2px;
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border-subtle);
+  transition: height 0.28s ease, min-height 0.28s ease;
 }
 
 .comment-layer-header .comment-label {

--- a/scripts/tests/comment-track-header-sync-source.test.js
+++ b/scripts/tests/comment-track-header-sync-source.test.js
@@ -1,0 +1,29 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const timelineSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/timeline.js'), 'utf8'));
+const mainCss = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
+
+test('comment range track synchronizes the left header height with dynamic lanes', () => {
+  assert.match(timelineSource, /_setCommentTrackRowHeight\(height = 24\)/);
+  assert.match(timelineSource, /this\.commentTrack\.style\.height = `\$\{height\}px`;/);
+  assert.match(timelineSource, /this\.commentLayerHeader\.style\.height = `\$\{height\}px`;/);
+  assert.match(timelineSource, /this\.commentLayerHeader\.style\.minHeight = `\$\{height\}px`;/);
+  assert.match(timelineSource, /this\._setCommentTrackRowHeight\(targetHeight\);/);
+});
+
+test('comment row spacing matches between the layer header column and track column', () => {
+  assert.match(mainCss, /\.comment-track\s*\{[\s\S]*?height: 24px;[\s\S]*?margin-bottom: 2px;/);
+  assert.match(mainCss, /\.comment-layer-header\s*\{[\s\S]*?height: 24px;[\s\S]*?min-height: 24px;[\s\S]*?margin-bottom: 2px;/);
+  assert.match(mainCss, /\.comment-layer-header\s*\{[\s\S]*?transition: height 0\.28s ease, min-height 0\.28s ease;/);
+});
+
+test('playlist and empty comment states reset the shared comment row height', () => {
+  assert.match(timelineSource, /clearCommentTrackRowHeight\(\)/);
+  assert.match(timelineSource, /this\._setCommentTrackRowHeight\(\);/);
+  assert.match(timelineSource, /renderPlaylistCommentRanges\(ranges, totalDuration\) \{[\s\S]*?this\._setCommentTrackRowHeight\(\);/);
+});


### PR DESCRIPTION
## 📋 업데이트 요약
- 💬 댓글 구간을 켰을 때 댓글 줄이 2줄 이상으로 커져도, 왼쪽 레이어 목록과 오른쪽 타임라인 줄이 같이 맞춰지도록 고쳤습니다.
- 📏 기존에 항상 살짝 어긋나 보이던 2px 줄 간격도 좌우가 동일하게 보이도록 정리했습니다.
- ✅ 댓글 구간이 없거나 꺼져 있을 때는 기본 높이로 돌아가도록 해, 다른 타임라인 행에 영향이 남지 않게 했습니다.

## 🔧 상세 기술 설명
- `renderer/scripts/modules/timeline.js`
  - `_setCommentTrackRowHeight(height = 24)`와 `clearCommentTrackRowHeight()`를 추가해 `commentTrack`과 `commentLayerHeader`의 `height`/`minHeight`를 한 번에 동기화합니다.
  - `renderCommentRanges()`에서 댓글 클러스터 레인 수로 계산한 `targetHeight`를 오른쪽 트랙에만 넣던 기존 경로를 공용 높이 함수 호출로 교체했습니다.
  - 댓글 구간 숨김, 빈 댓글, 플레이리스트 댓글 렌더링 경로에서는 기본 24px 높이로 재설정해 이전 다중 레인 높이가 남지 않도록 했습니다.
- `renderer/styles/main.css`
  - `.comment-layer-header`에 `min-height: 24px`, `margin-bottom: 2px`, 높이 transition을 추가해 오른쪽 `.comment-track`과 같은 행 규칙을 따르게 했습니다.
- `scripts/tests/comment-track-header-sync-source.test.js`
  - 좌우 댓글 행 높이 동기화, 2px 간격 동기화, 플레이리스트/빈 상태 초기화 경로를 소스 테스트로 고정했습니다.
- `package.json`
  - `npm run test:cluster`가 새 댓글 행 동기화 테스트까지 함께 실행하도록 확장했습니다.

## 🚧 개발 난항
- 이 버그는 댓글 구간 자체의 배치 문제라기보다, 좌측 레이어 헤더와 우측 타임라인 트랙이 서로 독립된 DOM 컬럼이라는 구조 때문에 발생했습니다.
- 오른쪽 댓글 트랙은 댓글이 겹칠 때 동적으로 높이가 커졌지만, 왼쪽 `commentLayerHeader`는 계속 24px에 머물러 아래 행 전체가 어긋났습니다.
- 추가로 오른쪽에는 `margin-bottom: 2px`가 있고 왼쪽에는 없어서, 댓글이 한 줄이어도 미세한 상시 어긋남이 남아 있었습니다.

## ✅ 테스트 가이드
실사용자용:
- 댓글 구간 표시를 켠 상태에서 겹치는 댓글을 2개 이상 만든 뒤, 왼쪽 “댓글/레이어” 줄과 오른쪽 타임라인 줄이 같은 높이로 맞는지 확인합니다.
- 댓글 구간을 끄거나 댓글이 없는 상태로 돌아갔을 때, 아래 Video/드로잉 레이어 줄이 다시 기본 위치로 돌아오는지 확인합니다.

개발자용:
- `npm run test:cluster`
- `npm run build`