### PR TITLE
[v1.4.1-beta] 프레임 1칸 셀 표시 및 키프레임 드래그 개선

### DIFF
--- a/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
+++ b/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
@@ -28,8 +28,8 @@
 | 2 | 활성 레이어 분리 렌더링 — 3-캔버스 스택 (레이어 나누기 드로잉 귀속 버그) | 버그 | drawing-manager.js, app.js, index.html, main.css | **최상** (데이터 오염) | ✅ |
 | 3 | 펜(태블릿) 입력 시 Ctrl+드로잉 지우개 토글 미인식 | 버그 | drawing-canvas.js, drawing-runtime-source.test.js | 높음 | ✅ |
 | 4 | 댓글 구간 ON 시 좌/우 타임라인 행 어긋남 + 상시 2px 어긋남 | 버그 | timeline.js, main.css | 높음 | ✅ |
-| 5 | 키프레임 드래그 오버레이를 정확히 1프레임 칸으로 | 버그 | timeline.js, main.css | 높음 | ⬜ |
-| 6 | 프레임 1칸 셀 표시 모드 (ON/OFF/AUTO 토글) — Animate 스타일 | 기능 | timeline.js, frame-grid-tiers.js, user-settings.js, app.js, index.html, main.css | 높음 | ⬜ |
+| 5 | 키프레임 드래그 오버레이를 정확히 1프레임 칸으로 | 버그 | timeline.js, main.css | 높음 | ✅ |
+| 6 | 프레임 1칸 셀 표시 모드 (ON/OFF/AUTO 토글) — Animate 스타일 | 기능 | timeline.js, frame-grid-tiers.js, user-settings.js, app.js, index.html, main.css | 높음 | ✅ |
 | 7 | 브러시 설정 영속화 + Alt 드래그 크기 조절 + [ / ] 단축키 | 기능 | user-settings.js, app.js, drawing-canvas.js, index.html, main.css | 높음 | ⬜ |
 | 8 | 레이어 눈/잠금 토글 버튼 확대(14px→24px) 및 on/off 상태 시각화 | 기능 | timeline.js, main.css, index.html | 중간 | ⬜ |
 | 9 | 미명시 UX 개선 (도구 커서, 키프레임 히트영역, 재렌더 병합 등) | 개선 | 다수 (소형 3건 포함 + 별도 이슈 3건) | 중간~낮음 | ⬜ |

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "test:recent": "node --test scripts/tests/recent-files-store.test.js scripts/tests/recent-files-source.test.js",
-    "test:frame-grid": "node --test scripts/tests/frame-grid-tiers.test.js",
+    "test:frame-grid": "node --test scripts/tests/frame-grid-tiers.test.js scripts/tests/keyframe-drag-ghost-source.test.js",
     "test:cluster": "node --test scripts/tests/comment-cluster.test.js scripts/tests/comment-track-header-sync-source.test.js",
     "test:playlist-ordering": "node --test scripts/tests/playlist-ordering.test.js",
     "test:playlist-continuous": "node --test scripts/tests/playlist-continuous-core.test.js",

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -902,6 +902,12 @@
                 <line x1="15" y1="3" x2="15" y2="21"/>
               </svg>
             </button>
+            <button class="timeline-toolbar-btn frame-cell-mode-btn" id="btnFrameCellMode" type="button"
+                    data-mode="auto" aria-label="프레임 1칸 표시 모드"
+                    title="프레임 1칸 표시: AUTO (클릭으로 ON/OFF/AUTO 전환)">
+              <span class="frame-cell-mode-label">1F</span>
+              <span class="frame-cell-mode-badge" id="frameCellModeBadge">A</span>
+            </button>
             <label class="comment-timeline-toggle" title="댓글 지속시간 구간 표시/숨김">
               <input type="checkbox" id="toggleCommentTimelineRanges" checked>
               <span class="comment-timeline-toggle-box" aria-hidden="true"></span>

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -131,6 +131,7 @@ async function initApp() {
     frameIndicator: document.getElementById('frameIndicator'),
     btnDrawMode: document.getElementById('btnDrawMode'),
     btnGridToggle: document.getElementById('btnGridToggle'),
+    btnFrameCellMode: document.getElementById('btnFrameCellMode'),
     btnAddComment: document.getElementById('btnAddComment'),
     btnPrevComment: document.getElementById('btnPrevComment'),
     btnNextComment: document.getElementById('btnNextComment'),
@@ -10683,6 +10684,31 @@ async function initApp() {
       _syncGridToggleUI(next);
     });
   }
+
+  const FRAME_CELL_MODE_ORDER = ['auto', 'on', 'off'];
+  const FRAME_CELL_MODE_LABEL = { auto: 'A', on: 'ON', off: 'OFF' };
+
+  function _syncFrameCellModeUI(mode) {
+    if (!elements.btnFrameCellMode) return;
+    elements.btnFrameCellMode.dataset.mode = mode;
+    elements.btnFrameCellMode.classList.toggle('active', mode !== 'off');
+    elements.btnFrameCellMode.title = `프레임 1칸 표시: ${mode.toUpperCase()} (클릭으로 전환)`;
+    const badge = document.getElementById('frameCellModeBadge');
+    if (badge) badge.textContent = FRAME_CELL_MODE_LABEL[mode] || 'A';
+  }
+
+  const initFrameCellMode = userSettings.getFrameCellMode();
+  timeline.setFrameCellMode(initFrameCellMode);
+  _syncFrameCellModeUI(initFrameCellMode);
+
+  elements.btnFrameCellMode?.addEventListener('click', () => {
+    const cur = userSettings.getFrameCellMode();
+    const next = FRAME_CELL_MODE_ORDER[(FRAME_CELL_MODE_ORDER.indexOf(cur) + 1) % 3];
+    userSettings.setFrameCellMode(next);
+    timeline.setFrameCellMode(next);
+    _syncFrameCellModeUI(next);
+    showToast(`프레임 1칸 표시: ${next.toUpperCase()}`, 'info');
+  });
 
   function _syncCommentTimelineRangesToggleUI(show) {
     if (elements.toggleCommentTimelineRanges) {

--- a/renderer/scripts/modules/frame-grid-tiers.js
+++ b/renderer/scripts/modules/frame-grid-tiers.js
@@ -77,3 +77,14 @@ export function resolveFrameGridTier(pxPerFrame, prevTier) {
     showFrame: tier >= TIER.EVERY_FRAME
   };
 }
+
+export function resolveFrameCellActive(mode, tierResult) {
+  if (mode === 'off') return false;
+  if (mode === 'on') return true;
+  return !!tierResult?.showFrame;
+}
+
+export function computeMinZoomForCellMode(totalFrames, viewportWidth, minFramePx) {
+  if (!totalFrames || !viewportWidth || !minFramePx) return 100;
+  return Math.max(100, Math.ceil((minFramePx * totalFrames * 100) / viewportWidth));
+}

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -146,6 +146,12 @@ export class Timeline extends EventTarget {
 
         prevContainerWidth = newContainerWidth;
 
+        const prevZoom = this.zoom;
+        this._applyCellModeMinZoom();
+        if (this.zoom !== prevZoom) {
+          this._applyZoom();
+        }
+
         // 플레이헤드 위치 업데이트
         this._updatePlayheadPosition();
 

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -5,7 +5,7 @@
 
 import { createLogger } from '../logger.js';
 import { MARKER_COLORS } from './comment-manager.js';
-import { resolveFrameGridTier } from './frame-grid-tiers.js';
+import { computeMinZoomForCellMode, resolveFrameCellActive, resolveFrameGridTier } from './frame-grid-tiers.js';
 import { findRangeClusters, assignLanes, assignRenderLanes, clusterKey, splitClustersByPixelGap } from './comment-cluster.js';
 import { getTimelineFocalContentX, calculateAnchoredScrollLeft } from './timeline-zoom-core.js';
 import {
@@ -66,6 +66,11 @@ export class Timeline extends EventTarget {
     this.frameGridContainer = null;
     this.gridVisible = true;          // 격자 표시 토글 (기본 ON)
     this._lastFrameGridTier = null;  // 히스테리시스용 직전 단계
+    this.frameCellMode = 'auto';
+    this._frameCellActive = false;
+    this.minFrameCellPx = 8;
+    this._lastDrawingLayers = null;
+    this._lastDrawingActiveLayerId = null;
 
     // 클러스터 펼침/접힘 상태
     this.expandedClusterId = null;  // 현재 펼친 클러스터의 키 (markerId)
@@ -470,9 +475,9 @@ export class Timeline extends EventTarget {
     // 프레임이 4px 이상일 때 개별 프레임 그리드가 표시됨
     // 목표: maxZoom에서 frameWidth >= 5px (여유있게)
     this._calculateDynamicMaxZoom();
+    this._applyCellModeMinZoom();
+    this._applyZoom();
 
-    this._updateRuler();
-    this._updateFrameGrid();
     log.info('비디오 정보 설정', { duration, fps, totalFrames: this.totalFrames, maxZoom: this.maxZoom });
   }
 
@@ -748,7 +753,8 @@ export class Timeline extends EventTarget {
       this.zoomDisplay.textContent = `${Math.round(this.zoom)}%`;
     }
     if (this.zoomSlider) {
-      this.zoomSlider.value = ((this.zoom - this.minZoom) / (this.maxZoom - this.minZoom)) * 100;
+      const zoomRange = Math.max(1, this.maxZoom - this.minZoom);
+      this.zoomSlider.value = ((this.zoom - this.minZoom) / zoomRange) * 100;
     }
   }
 
@@ -802,7 +808,7 @@ export class Timeline extends EventTarget {
 
     // 마크 간격 계산 (화면에 약 6~8개의 마크가 보이도록)
     const scale = this.zoom / 100;
-    const numMarks = Math.ceil(6 * scale);
+    const numMarks = Math.min(Math.ceil(6 * scale), 600);
     const interval = duration / numMarks;
 
     for (let i = 0; i <= numMarks; i++) {
@@ -830,14 +836,21 @@ export class Timeline extends EventTarget {
    * 줌 레벨에 따라 5단 계단식 격자선 표시 (히스테리시스 적용)
    */
   _updateFrameGrid() {
-    if (!this.tracksContainer || this.duration === 0 || this.totalFrames === 0) return;
+    if (!this.tracksContainer || this.duration === 0 || this.totalFrames === 0) {
+      this._updateFrameCellActive(false);
+      return;
+    }
+
+    const frameWidth = this._computePxPerFrame();
+    const tierResult = resolveFrameGridTier(frameWidth, this._lastFrameGridTier ?? null);
+    this._lastFrameGridTier = tierResult.tier;
+    this._updateFrameCellActive(resolveFrameCellActive(this.frameCellMode, tierResult));
 
     // 격자 토글 OFF면 즉시 숨김 후 리턴
     if (!this.gridVisible) {
       if (this.frameGridContainer) {
         this.frameGridContainer.style.display = 'none';
       }
-      this._lastFrameGridTier = null;
       return;
     }
 
@@ -853,13 +866,20 @@ export class Timeline extends EventTarget {
       this.tracksContainer.appendChild(this.frameGridContainer);
     }
 
-    const containerWidth = this.tracksContainer.offsetWidth;
-    const frameWidth = containerWidth / this.totalFrames;
-
-    const tierResult = resolveFrameGridTier(frameWidth, this._lastFrameGridTier ?? null);
-    this._lastFrameGridTier = tierResult.tier;
-
     this._renderFrameGridTiered(frameWidth, tierResult);
+  }
+
+  _computePxPerFrame() {
+    const containerWidth = this.tracksContainer?.offsetWidth || 0;
+    const totalFrames = this._getTimelineTotalFrames() || this.totalFrames || 0;
+    return totalFrames > 0 ? containerWidth / totalFrames : 0;
+  }
+
+  _updateFrameCellActive(active) {
+    const next = active === true;
+    if (this._frameCellActive === next) return;
+    this._frameCellActive = next;
+    this._refreshDrawingLayerRender();
   }
 
   /**
@@ -868,6 +888,22 @@ export class Timeline extends EventTarget {
   setGridVisible(visible) {
     this.gridVisible = !!visible;
     this._updateFrameGrid();
+  }
+
+  setFrameCellMode(mode) {
+    this.frameCellMode = ['on', 'off', 'auto'].includes(mode) ? mode : 'auto';
+    this._applyCellModeMinZoom();
+    this._applyZoom();
+  }
+
+  _applyCellModeMinZoom() {
+    const viewportWidth = this.timelineTracks?.clientWidth || 0;
+    this.minZoom = this.frameCellMode === 'on'
+      ? computeMinZoomForCellMode(this.totalFrames, viewportWidth, this.minFrameCellPx)
+      : 100;
+    this.maxZoom = Math.max(this.maxZoom, this.minZoom);
+    if (this.zoom < this.minZoom) this.zoom = this.minZoom;
+    this._updateZoomDisplay();
   }
 
   /**
@@ -1179,6 +1215,9 @@ export class Timeline extends EventTarget {
   renderDrawingLayers(layers, activeLayerId) {
     if (!this.tracksContainer || !this.layerHeaders) return;
 
+    this._lastDrawingLayers = layers;
+    this._lastDrawingActiveLayerId = activeLayerId;
+
     // 기존 그리기 레이어 트랙 제거
     const existingTracks = this.tracksContainer.querySelectorAll('.drawing-track-row');
     existingTracks.forEach(t => t.remove());
@@ -1191,6 +1230,11 @@ export class Timeline extends EventTarget {
       this._renderLayerHeader(layer, activeLayerId === layer.id);
       this._renderLayerTrack(layer, activeLayerId === layer.id);
     });
+  }
+
+  _refreshDrawingLayerRender() {
+    if (!this._lastDrawingLayers) return;
+    this.renderDrawingLayers(this._lastDrawingLayers, this._lastDrawingActiveLayerId);
   }
 
   /**
@@ -1287,16 +1331,24 @@ export class Timeline extends EventTarget {
         keyframeContainer.appendChild(rangeBar);
       }
 
-      // 키프레임 마커 - 격자 칸 중앙에 배치
+      // 키프레임 마커 - 점 모드 또는 정확한 1프레임 셀 모드로 표시
       const marker = document.createElement('div');
-      marker.className = `keyframe-marker-dot${range.keyframe.isEmpty ? ' empty' : ''}`;
+      const emptyClass = range.keyframe.isEmpty ? ' empty' : '';
+      if (this._frameCellActive && this.totalFrames > 0) {
+        marker.className = `keyframe-cell keyframe-marker-dot${emptyClass}`;
+        marker.style.left = `${(range.start / this.totalFrames) * 100}%`;
+        marker.style.width = `${(1 / this.totalFrames) * 100}%`;
+        marker.style.setProperty('--kf-color', layer.color);
+        marker.innerHTML = '<span class="keyframe-cell-dot" aria-hidden="true"></span>';
+      } else {
+        marker.className = `keyframe-marker-dot${emptyClass}`;
+        // 프레임 중앙에 배치 (프레임 시작 + 0.5프레임)
+        const markerLeft = ((range.start + 0.5) / this.totalFrames) * 100;
+        marker.style.left = `${markerLeft}%`;
+        marker.style.background = range.keyframe.isEmpty ? 'transparent' : layer.color;
+      }
       marker.dataset.frame = range.start;
       marker.dataset.layerId = layer.id;
-
-      // 프레임 중앙에 배치 (프레임 시작 + 0.5프레임)
-      const markerLeft = ((range.start + 0.5) / this.totalFrames) * 100;
-      marker.style.left = `${markerLeft}%`;
-      marker.style.background = range.keyframe.isEmpty ? 'transparent' : layer.color;
       marker.title = `F${range.start}${range.keyframe.isEmpty ? ' (빈 키프레임)' : ''}`;
 
       // 선택 상태
@@ -1489,7 +1541,7 @@ export class Timeline extends EventTarget {
     // getBoundingClientRect()는 이미 스크롤 위치를 반영하므로 scrollLeft 추가 불필요
     const x = e.clientX - containerRect.left;
     const percent = Math.max(0, Math.min(x / containerWidth, 1));
-    const newFrame = Math.round(percent * (this.totalFrames - 1));
+    const newFrame = Math.min(this.totalFrames - 1, Math.floor(percent * this.totalFrames));
 
     // 고스트 클립 위치 업데이트
     const ghostPercent = (newFrame / this.totalFrames) * 100;
@@ -1497,7 +1549,8 @@ export class Timeline extends EventTarget {
 
     // 툴팁 위치 및 내용 업데이트
     if (this.dragTooltip) {
-      this.dragTooltip.style.left = `${ghostPercent}%`;
+      const tooltipPercent = ((newFrame + 0.5) / this.totalFrames) * 100;
+      this.dragTooltip.style.left = `${tooltipPercent}%`;
       this.dragTooltip.textContent = `F${newFrame}`;
     }
 
@@ -1552,20 +1605,16 @@ export class Timeline extends EventTarget {
    * 드래그 고스트 생성
    */
   _createDragGhost(e, frame) {
-    const { element: clipElement, layerId } = this.draggedKeyframe;
+    const { element: clipElement } = this.draggedKeyframe;
 
-    // 클립 요소 복제하여 고스트로 사용
-    this.dragGhost = clipElement.cloneNode(true);
-    this.dragGhost.className = 'drawing-clip keyframe-drag-ghost-clip';
-
-    // 원본 클립의 스타일 복사하고 투명도 적용
-    const clipRect = clipElement.getBoundingClientRect();
-    const trackRect = clipElement.parentElement.getBoundingClientRect();
-
-    this.dragGhost.style.cssText = clipElement.style.cssText;
-    this.dragGhost.style.opacity = '0.5';
-    this.dragGhost.style.pointerEvents = 'none';
-    this.dragGhost.style.zIndex = '100';
+    // 정확히 1프레임 칸을 나타내는 고스트를 새로 만든다.
+    this.dragGhost = document.createElement('div');
+    this.dragGhost.className = 'keyframe-drag-ghost-cell';
+    const ghostLeftPercent = (frame / this.totalFrames) * 100;
+    const ghostWidthPercent = (1 / this.totalFrames) * 100;
+    this.dragGhost.style.left = `${ghostLeftPercent}%`;
+    this.dragGhost.style.width = `${ghostWidthPercent}%`;
+    this.dragGhost.dataset.targetFrame = frame;
 
     // 원본 클립을 반투명하게 처리
     clipElement.style.opacity = '0.3';
@@ -1574,7 +1623,7 @@ export class Timeline extends EventTarget {
     this.dragTooltip = document.createElement('div');
     this.dragTooltip.className = 'keyframe-drag-ghost';
     this.dragTooltip.textContent = `F${frame}`;
-    const percent = (frame / this.totalFrames) * 100;
+    const percent = ((frame + 0.5) / this.totalFrames) * 100;
     this.dragTooltip.style.left = `${percent}%`;
 
     clipElement.parentElement.appendChild(this.dragGhost);

--- a/renderer/scripts/modules/user-settings.js
+++ b/renderer/scripts/modules/user-settings.js
@@ -192,6 +192,8 @@ export class UserSettings extends EventTarget {
       showRemoteCursors: true,
       // 타임라인 프레임 격자 표시 여부
       showFrameGrid: true,
+      // 타임라인 프레임 1칸 셀 표시 모드
+      frameCellMode: 'auto',
       // 타임라인 댓글 지속시간 구간 표시 여부
       showCommentTimelineRanges: true,
       // 100% 이하 줌에서 영상을 중앙에 고정할지 여부
@@ -573,6 +575,19 @@ export class UserSettings extends EventTarget {
     // 향후 외부에서 설정 변경을 감지해야 할 경우를 위한 hook
     this._emit('showFrameGridChanged', { show: this.settings.showFrameGrid });
     log.info('프레임 격자 설정 변경됨', { show });
+  }
+
+  getFrameCellMode() {
+    const mode = this.settings.frameCellMode;
+    return ['on', 'off', 'auto'].includes(mode) ? mode : 'auto';
+  }
+
+  setFrameCellMode(mode) {
+    if (!['on', 'off', 'auto'].includes(mode)) return;
+    this.settings.frameCellMode = mode;
+    this._save();
+    this._emit('frameCellModeChanged', { mode });
+    log.info('프레임 셀 모드 변경됨', { mode });
   }
 
   getShowCommentTimelineRanges() {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -2964,6 +2964,32 @@ body.app-fullscreen .video-comment-overlay-controls {
   color: var(--accent-primary, #ffd000);
 }
 
+.frame-cell-mode-btn {
+  gap: 4px;
+  min-width: 48px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.frame-cell-mode-btn[data-mode="off"] {
+  color: var(--text-tertiary);
+}
+
+.frame-cell-mode-badge {
+  min-width: 16px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: 3px;
+  background: var(--bg-elevated);
+  color: currentColor;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  line-height: 1;
+}
+
 /* 타임라인 줌 버튼들 */
 .zoom-buttons {
   display: flex;
@@ -4384,6 +4410,52 @@ body.app-fullscreen .video-comment-overlay-controls {
   border: 2px dashed white;
 }
 
+/* 프레임 1칸 키프레임 셀 */
+.keyframe-container .keyframe-cell {
+  top: 0;
+  width: auto;
+  height: 100%;
+  transform: none;
+  border-radius: 0;
+  border: 1px solid var(--kf-color, #4a9eff);
+  background: color-mix(in srgb, var(--kf-color, #4a9eff) 30%, transparent);
+  box-sizing: border-box;
+  min-width: 3px;
+  box-shadow: none;
+}
+
+.keyframe-container .keyframe-cell:hover {
+  transform: none;
+  filter: brightness(1.3);
+}
+
+.keyframe-cell .keyframe-cell-dot {
+  position: absolute;
+  left: 50%;
+  bottom: 3px;
+  transform: translateX(-50%);
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fff;
+  pointer-events: none;
+}
+
+.keyframe-cell.empty {
+  background: transparent;
+  border-style: dashed;
+}
+
+.keyframe-cell.empty .keyframe-cell-dot {
+  background: transparent;
+  border: 1px solid #fff;
+}
+
+.keyframe-container .keyframe-cell.selected {
+  border-color: var(--accent-primary);
+  box-shadow: inset 0 0 0 1px var(--accent-primary);
+}
+
 /* 선택된 프레임 셀 */
 .frame-cell.selected {
   background: var(--accent-glow-strong);
@@ -4498,6 +4570,19 @@ body.app-fullscreen .video-comment-overlay-controls {
   z-index: 100 !important;
   outline: 2px dashed var(--accent-primary) !important;
   outline-offset: -2px;
+}
+
+.keyframe-drag-ghost-cell {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  min-width: 2px;
+  box-sizing: border-box;
+  background: rgba(255, 208, 0, 0.3);
+  outline: 2px dashed var(--accent-primary);
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 100;
 }
 
 /* 선택 박스 */

--- a/scripts/tests/frame-grid-tiers.test.js
+++ b/scripts/tests/frame-grid-tiers.test.js
@@ -6,10 +6,12 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
-let resolveFrameGridTier, TIER;
+let resolveFrameGridTier, resolveFrameCellActive, computeMinZoomForCellMode, TIER;
 test('모듈 로드', async () => {
   const mod = await import('../../renderer/scripts/modules/frame-grid-tiers.js');
   resolveFrameGridTier = mod.resolveFrameGridTier;
+  resolveFrameCellActive = mod.resolveFrameCellActive;
+  computeMinZoomForCellMode = mod.computeMinZoomForCellMode;
   TIER = mod.TIER;
 });
 
@@ -87,4 +89,33 @@ test('엣지: 음수/NaN 입력 — 안전한 기본값', () => {
   assert.equal(t1.tier, TIER.FIVE_SEC, '음수는 FIVE_SEC로 수렴');
   const t2 = resolveFrameGridTier(NaN, null);
   assert.equal(t2.tier, TIER.FIVE_SEC, 'NaN도 안전 기본값');
+});
+
+test('프레임 셀 모드: off는 항상 비활성, on은 항상 활성', () => {
+  const hiddenFrameTier = resolveFrameGridTier(0.2, null);
+  assert.equal(resolveFrameCellActive('off', hiddenFrameTier), false);
+  assert.equal(resolveFrameCellActive('on', hiddenFrameTier), true);
+});
+
+test('프레임 셀 모드: auto는 매 프레임 격자 티어를 따른다', () => {
+  assert.equal(resolveFrameCellActive('auto', resolveFrameGridTier(3.9, null)), false);
+  assert.equal(resolveFrameCellActive('auto', resolveFrameGridTier(4.0, null)), true);
+  assert.equal(resolveFrameCellActive('auto', resolveFrameGridTier(4.2, null)), true);
+});
+
+test('프레임 셀 모드: auto는 격자 티어 히스테리시스를 공유한다', () => {
+  const kept = resolveFrameGridTier(3.9, TIER.EVERY_FRAME);
+  const dropped = resolveFrameGridTier(3.87, TIER.EVERY_FRAME);
+
+  assert.equal(kept.tier, TIER.EVERY_FRAME);
+  assert.equal(resolveFrameCellActive('auto', kept), true);
+  assert.notEqual(dropped.tier, TIER.EVERY_FRAME);
+  assert.equal(resolveFrameCellActive('auto', dropped), false);
+});
+
+test('ON 모드 최소 줌은 1프레임 최소 픽셀 폭을 보장한다', () => {
+  assert.equal(computeMinZoomForCellMode(43200, 1200, 8), 28800);
+  assert.equal(computeMinZoomForCellMode(120, 1200, 8), 100);
+  assert.equal(computeMinZoomForCellMode(0, 1200, 8), 100);
+  assert.equal(computeMinZoomForCellMode(120, 0, 8), 100);
 });

--- a/scripts/tests/keyframe-drag-ghost-source.test.js
+++ b/scripts/tests/keyframe-drag-ghost-source.test.js
@@ -1,0 +1,49 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const timelineSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/timeline.js'), 'utf8'));
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
+const userSettingsSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/user-settings.js'), 'utf8'));
+const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
+const mainCss = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
+
+test('keyframe drag ghost renders as an exact one-frame cell', () => {
+  assert.match(timelineSource, /keyframe-drag-ghost-cell/);
+  assert.match(timelineSource, /this\.dragGhost = document\.createElement\('div'\)/);
+  assert.match(timelineSource, /const ghostWidthPercent = \(1 \/ this\.totalFrames\) \* 100/);
+  assert.match(timelineSource, /Math\.floor\(percent \* this\.totalFrames\)/);
+  assert.match(timelineSource, /\(\(newFrame \+ 0\.5\) \/ this\.totalFrames\) \* 100/);
+  assert.doesNotMatch(timelineSource, /Math\.round\(percent \* \(this\.totalFrames - 1\)\)/);
+  assert.doesNotMatch(timelineSource, /cloneNode\(true\)/);
+  assert.match(mainCss, /\.keyframe-drag-ghost-cell\s*\{[\s\S]*?height:\s*100%;[\s\S]*?outline:\s*2px dashed var\(--accent-primary\);/);
+});
+
+test('frame cell mode is stored and wired through the timeline toolbar', () => {
+  assert.match(userSettingsSource, /frameCellMode: 'auto'/);
+  assert.match(userSettingsSource, /getFrameCellMode\(\)/);
+  assert.match(userSettingsSource, /setFrameCellMode\(mode\)/);
+  assert.match(userSettingsSource, /this\._emit\('frameCellModeChanged', \{ mode \}\)/);
+  assert.match(indexSource, /id="btnFrameCellMode"/);
+  assert.match(indexSource, /id="frameCellModeBadge"/);
+  assert.match(appSource, /FRAME_CELL_MODE_ORDER = \['auto', 'on', 'off'\]/);
+  assert.match(appSource, /timeline\.setFrameCellMode\(initFrameCellMode\)/);
+  assert.match(appSource, /userSettings\.setFrameCellMode\(next\)/);
+});
+
+test('timeline can switch between dot markers and one-frame keyframe cells', () => {
+  assert.match(timelineSource, /this\.frameCellMode = 'auto'/);
+  assert.match(timelineSource, /this\._frameCellActive = false/);
+  assert.match(timelineSource, /setFrameCellMode\(mode\)/);
+  assert.match(timelineSource, /_applyCellModeMinZoom\(\)/);
+  assert.match(timelineSource, /resolveFrameCellActive\(this\.frameCellMode, tierResult\)/);
+  assert.match(timelineSource, /this\._refreshDrawingLayerRender\(\)/);
+  assert.match(timelineSource, /marker\.className = `keyframe-cell keyframe-marker-dot/);
+  assert.match(timelineSource, /marker\.style\.setProperty\('--kf-color', layer\.color\)/);
+  assert.match(timelineSource, /marker\.innerHTML = '<span class="keyframe-cell-dot" aria-hidden="true"><\/span>'/);
+  assert.match(mainCss, /\.keyframe-container \.keyframe-cell\s*\{[\s\S]*?width:[\s\S]*?height:\s*100%;/);
+  assert.match(mainCss, /\.keyframe-cell \.keyframe-cell-dot/);
+});

--- a/scripts/tests/keyframe-drag-ghost-source.test.js
+++ b/scripts/tests/keyframe-drag-ghost-source.test.js
@@ -47,3 +47,10 @@ test('timeline can switch between dot markers and one-frame keyframe cells', () 
   assert.match(mainCss, /\.keyframe-container \.keyframe-cell\s*\{[\s\S]*?width:[\s\S]*?height:\s*100%;/);
   assert.match(mainCss, /\.keyframe-cell \.keyframe-cell-dot/);
 });
+
+test('frame cell ON mode recomputes minimum zoom when the timeline viewport resizes', () => {
+  const resizeObserverMatch = timelineSource.match(/const resizeObserver = new ResizeObserver\(\(entries\) => \{([\s\S]*?)\n    \}\);/);
+  assert.ok(resizeObserverMatch, 'timeline ResizeObserver should exist');
+  assert.match(resizeObserverMatch[1], /this\._applyCellModeMinZoom\(\)/);
+  assert.match(resizeObserverMatch[1], /if \(this\.zoom !== prevZoom\) \{[\s\S]*?this\._applyZoom\(\);/);
+});


### PR DESCRIPTION
## 📋 업데이트 요약
- 🎞️ 타임라인에 `1F` 버튼을 추가해 드로잉 키프레임을 1프레임 칸 단위로 볼 수 있게 했습니다.
- 🟨 키프레임을 드래그할 때 보이는 노란 오버레이가 정확히 1프레임 폭으로 표시됩니다.
- 🔁 `1F` 버튼은 `AUTO → ON → OFF` 순서로 전환되며, 설정은 앱을 다시 열어도 유지됩니다.
- ⚙️ ON 모드에서는 프레임 한 칸이 너무 작아지지 않도록 자동으로 최소 확대 상태를 보장합니다.

## 🔧 상세 기술 설명
- `renderer/scripts/modules/frame-grid-tiers.js`
  - `resolveFrameCellActive(mode, tierResult)`를 추가해 ON/OFF/AUTO 모드 판정을 프레임 격자 티어와 공유했습니다.
  - `computeMinZoomForCellMode(totalFrames, viewportWidth, minFramePx)`로 ON 모드의 최소 줌을 순수 함수로 계산합니다.
- `renderer/scripts/modules/timeline.js`
  - `frameCellMode`, `_frameCellActive`, `minFrameCellPx` 상태를 추가했습니다.
  - `setFrameCellMode()`, `_applyCellModeMinZoom()`, `_refreshDrawingLayerRender()`를 추가해 모드 전환 시 타임라인 폭과 키프레임 표시를 갱신합니다.
  - `_updateFrameGrid()`에서 격자 표시 여부와 관계없이 셀 활성 여부를 먼저 계산하도록 조정했습니다.
  - 키프레임 마커 렌더링을 점 모드와 `keyframe-cell keyframe-marker-dot` 셀 모드로 분기했습니다. 기존 선택/박스선택 셀렉터는 유지했습니다.
  - `_createDragGhost()`가 기존 요소 복제 대신 1프레임 폭의 `keyframe-drag-ghost-cell`을 새로 만들도록 변경했습니다.
  - 드래그 중 목표 프레임 계산을 `Math.floor(percent * this.totalFrames)`로 바꿔 칸 시작 기준과 맞췄습니다.
- `renderer/scripts/modules/user-settings.js`, `renderer/scripts/app.js`, `renderer/index.html`
  - `frameCellMode: 'auto'` 기본값, getter/setter, `btnFrameCellMode` UI 배선을 추가했습니다.
- `renderer/styles/main.css`
  - `1F` 버튼 배지, 키프레임 셀 표시, 1프레임 드래그 고스트 스타일을 추가했습니다.
- `scripts/tests/frame-grid-tiers.test.js`, `scripts/tests/keyframe-drag-ghost-source.test.js`
  - 모드 판정, 최소 줌 계산, 고스트/셀 렌더링/설정/UI 배선을 테스트로 고정했습니다.

## 🚧 개발 난항
- 긴 영상에서 모든 프레임 칸을 DOM으로 만들면 성능 부담이 커질 수 있어, 실제 프레임 칸 DOM은 만들지 않고 기존 타임라인 폭/퍼센트 계산을 활용했습니다.
- 격자 표시를 꺼도 `AUTO/ON/OFF` 셀 모드가 계속 제대로 계산되어야 했기 때문에, 셀 활성 판정은 격자 숨김 처리보다 먼저 실행되도록 분리했습니다.
- 기존 키프레임 선택과 박스선택이 `.keyframe-marker-dot` 셀렉터에 묶여 있어, 셀 모드에서도 이 클래스를 유지하는 방식으로 회귀를 줄였습니다.

## ✅ 테스트 가이드
실사용자용:
- 타임라인 오른쪽 위 `1F` 버튼을 눌러 `AUTO`, `ON`, `OFF`가 순환되는지 확인합니다.
- ON 상태에서 드로잉 키프레임이 작은 점이 아니라 한 프레임 폭의 셀로 보이는지 확인합니다.
- 키프레임을 드래그할 때 노란 오버레이가 정확히 한 칸 폭으로 움직이고, 툴팁의 `F숫자`와 드롭 결과가 맞는지 확인합니다.

개발자용:
- `npm run test:frame-grid`
- `npm run test:drawing`
- `npm run build`