### PR TITLE
[v1.4.0] 브러시 설정 저장 및 크기 조절 개선

### DIFF
--- a/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
+++ b/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
@@ -30,7 +30,7 @@
 | 4 | 댓글 구간 ON 시 좌/우 타임라인 행 어긋남 + 상시 2px 어긋남 | 버그 | timeline.js, main.css | 높음 | ✅ |
 | 5 | 키프레임 드래그 오버레이를 정확히 1프레임 칸으로 | 버그 | timeline.js, main.css | 높음 | ✅ |
 | 6 | 프레임 1칸 셀 표시 모드 (ON/OFF/AUTO 토글) — Animate 스타일 | 기능 | timeline.js, frame-grid-tiers.js, user-settings.js, app.js, index.html, main.css | 높음 | ✅ |
-| 7 | 브러시 설정 영속화 + Alt 드래그 크기 조절 + [ / ] 단축키 | 기능 | user-settings.js, app.js, drawing-canvas.js, index.html, main.css | 높음 | ⬜ |
+| 7 | 브러시 설정 영속화 + Alt 드래그 크기 조절 + [ / ] 단축키 | 기능 | user-settings.js, app.js, drawing-canvas.js, index.html, main.css | 높음 | ✅ |
 | 8 | 레이어 눈/잠금 토글 버튼 확대(14px→24px) 및 on/off 상태 시각화 | 기능 | timeline.js, main.css, index.html | 중간 | ⬜ |
 | 9 | 미명시 UX 개선 (도구 커서, 키프레임 히트영역, 재렌더 병합 등) | 개선 | 다수 (소형 3건 포함 + 별도 이슈 3건) | 중간~낮음 | ⬜ |
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:playlist-comments": "node --test scripts/tests/playlist-comment-index.test.js",
     "test:playlist": "node --test scripts/tests/playlist-ordering.test.js scripts/tests/playlist-continuous-core.test.js scripts/tests/playlist-continuous-runtime.test.js scripts/tests/playlist-comment-index.test.js scripts/tests/playlist-autoplay-source.test.js scripts/tests/bplaylist-file-association-source.test.js scripts/tests/project-file-associations.test.js scripts/tests/instance-policy.test.js",
     "test:cutlist": "node --test scripts/tests/cutlist-manager.test.js scripts/tests/cutlist-schema.test.js scripts/tests/moho-scene-info-parser.test.js scripts/tests/cutlist-core.test.js scripts/tests/cutlist-runtime-source.test.js scripts/tests/cutlist-comment-index.test.js",
-    "test:drawing": "node --test scripts/tests/drawing-stroke-records.test.js scripts/tests/drawing-layer-partition.test.js scripts/tests/drawing-runtime-source.test.js scripts/tests/keyframe-multi-select-source.test.js",
+    "test:drawing": "node --test scripts/tests/drawing-stroke-records.test.js scripts/tests/drawing-layer-partition.test.js scripts/tests/drawing-runtime-source.test.js scripts/tests/keyframe-multi-select-source.test.js scripts/tests/brush-settings-source.test.js",
     "test:video-pan": "node --test scripts/tests/video-pan-controls.test.js scripts/tests/playhead-frame-step-source.test.js",
     "test:mpv": "node --test scripts/tests/mpv-manager.test.js scripts/tests/mpv-embed-host.test.js scripts/tests/mpv-overlay-host.test.js scripts/tests/mpv-runtime-source.test.js",
     "test:audio-waveform": "node --test scripts/tests/audio-waveform-hit-area.test.js",

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -501,6 +501,7 @@
           <canvas id="layersBelowCanvas" class="drawing-overlay layers-below-layer"></canvas>
           <canvas id="drawingCanvas" class="drawing-overlay"></canvas>
           <canvas id="layersAboveCanvas" class="drawing-overlay layers-above-layer"></canvas>
+          <div id="brushSizeHud" class="brush-size-hud" hidden></div>
 
           <!-- Comment Range Overlay (비디오 하단 댓글 범위 표시) -->
           <div class="video-comment-range-overlay" id="videoCommentRangeOverlay">

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -3058,7 +3058,7 @@ async function initApp() {
 
   function applyStrokeSettings(settings = {}, options = {}) {
     const strokeEnabled = settings.strokeEnabled === true;
-    const strokeWidth = clampStrokeWidth(settings.strokeWidth, savedBrush.strokeWidth);
+    const strokeWidth = clampStrokeWidth(settings.strokeWidth, 3);
     const strokeColor = settings.strokeColor || '#ffffff';
 
     strokeToggle?.classList.toggle('active', strokeEnabled);
@@ -3126,10 +3126,19 @@ async function initApp() {
     hideBrushSizeHud();
   });
 
-  setCurrentColor(savedBrush.color, { persist: false });
-  applyBrushOpacityValue(savedBrush.opacity);
-  applyStrokeSettings(savedBrush);
-  selectDrawingTool(savedBrush.tool, { persist: false });
+  function applySavedBrushSettings(settings = userSettings.getBrushSettings()) {
+    toolSettings.eraser.size = clampBrushSize(settings.eraserSize, 20);
+    toolSettings.brush.size = clampBrushSize(settings.brushSize, 3);
+    toolSettings.brush.opacity = clampBrushOpacity(settings.opacity, 100);
+    currentStrokeColor = settings.strokeColor || '#ffffff';
+
+    setCurrentColor(settings.color, { persist: false });
+    applyBrushOpacityValue(toolSettings.brush.opacity);
+    applyStrokeSettings(settings);
+    selectDrawingTool(settings.tool, { persist: false });
+  }
+
+  applySavedBrushSettings(savedBrush);
 
   // Undo 버튼
   elements.btnUndo?.addEventListener('click', async () => {
@@ -10744,6 +10753,7 @@ async function initApp() {
   // ====== 사용자 이름 초기화 ======
   // 설정 파일 로드 완료 대기 (파일에서 hasSetNameOnce 등 로드)
   await userSettings.waitForReady();
+  applySavedBrushSettings(userSettings.getBrushSettings());
 
   // AuthManager 초기화
   const authManager = getAuthManager();

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -10415,9 +10415,10 @@ async function initApp() {
       return;
     }
 
-    if (state.isDrawMode && (userSettings.matchShortcut('brushSizeDown', e) || userSettings.matchShortcut('brushSizeUp', e))) {
+    const matchedBrushSizeAction = userSettings.findActionByEvent(e);
+    if (state.isDrawMode && (matchedBrushSizeAction === 'brushSizeDown' || matchedBrushSizeAction === 'brushSizeUp')) {
       e.preventDefault();
-      const delta = userSettings.matchShortcut('brushSizeDown', e) ? -1 : 1;
+      const delta = matchedBrushSizeAction === 'brushSizeDown' ? -1 : 1;
       adjustBrushSizeBy(delta, { persist: true });
       return;
     }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -114,6 +114,7 @@ async function initApp() {
     layersBelowCanvas: document.getElementById('layersBelowCanvas'),
     drawingCanvas: document.getElementById('drawingCanvas'),
     layersAboveCanvas: document.getElementById('layersAboveCanvas'),
+    brushSizeHud: document.getElementById('brushSizeHud'),
     onionSkinCanvas: document.getElementById('onionSkinCanvas'),
     drawingTools: document.getElementById('drawingTools'),
     btnOpenFile: document.getElementById('btnOpenFile'),
@@ -2787,12 +2788,7 @@ async function initApp() {
     userSettings.setShowRemoteCursors(!userSettings.getShowRemoteCursors());
   });
 
-  // 도구별 설정 저장 (크기, 불투명도)
-  const toolSettings = {
-    eraser: { size: 20 },      // 지우개는 기본 크기 더 크게
-    brush: { size: 3, opacity: 100 }  // 브러시/펜 등 다른 도구들
-  };
-  let currentToolType = 'brush';  // 'eraser' 또는 'brush'
+  const savedBrush = userSettings.getBrushSettings();
 
   // 그리기 도구 선택
   const opacitySection = document.getElementById('opacitySection');
@@ -2805,6 +2801,148 @@ async function initApp() {
   const colorSection = document.getElementById('colorSection');
   const strokeSection = document.getElementById('strokeSection');
   const eraserModeButtons = document.querySelectorAll('.eraser-mode-btn[data-eraser-mode]');
+  const brushSizeHud = elements.brushSizeHud;
+
+  // 도구 매핑
+  const toolMap = {
+    pen: DrawingTool.PEN,
+    brush: DrawingTool.BRUSH,
+    eraser: DrawingTool.ERASER,
+    line: DrawingTool.LINE,
+    arrow: DrawingTool.ARROW,
+    rect: DrawingTool.RECT,
+    circle: DrawingTool.CIRCLE
+  };
+
+  // 색상 선택 (8색 팔레트)
+  const colorMap = {
+    red: '#ff4757',
+    yellow: '#ffd000',
+    green: '#26de81',
+    blue: '#4a9eff',
+    white: '#ffffff',
+    black: '#000000',
+    mint: '#1abc9c',
+    pink: '#ff6b9d'
+  };
+
+  // 도구별 설정 저장 (크기, 불투명도)
+  const toolSettings = {
+    eraser: { size: savedBrush.eraserSize },
+    brush: { size: savedBrush.brushSize, opacity: savedBrush.opacity }
+  };
+  let currentToolType = savedBrush.tool === 'eraser' ? 'eraser' : 'brush';
+  let currentToolName = toolMap[savedBrush.tool] ? savedBrush.tool : 'brush';
+  let currentColor = savedBrush.color;
+
+  function clampBrushSize(size, fallback = 3) {
+    const parsed = parseInt(size);
+    return Math.min(50, Math.max(1, Number.isFinite(parsed) ? parsed : fallback));
+  }
+
+  function clampBrushOpacity(opacity, fallback = 100) {
+    const parsed = parseInt(opacity);
+    return Math.min(100, Math.max(10, Number.isFinite(parsed) ? parsed : fallback));
+  }
+
+  function clampStrokeWidth(width, fallback = 3) {
+    const parsed = parseInt(width);
+    return Math.min(10, Math.max(1, Number.isFinite(parsed) ? parsed : fallback));
+  }
+
+  function getColorNameByHex(hex) {
+    const normalized = String(hex || '').toLowerCase();
+    return Object.entries(colorMap).find(([, value]) => value.toLowerCase() === normalized)?.[0] || 'red';
+  }
+
+  function getCurrentSizeSettingPatch(size = toolSettings[currentToolType].size) {
+    return currentToolType === 'eraser'
+      ? { eraserSize: size }
+      : { brushSize: size };
+  }
+
+  function updateSizePreview() {
+    const size = brushSizeSlider.value;
+    brushSizeValue.textContent = `${size}px`;
+    sizePreview.classList.toggle('eraser-preview', currentToolType === 'eraser');
+    sizePreview.style.setProperty('--preview-size', `${Math.min(size, 20)}px`);
+    sizePreview.style.setProperty('--preview-color', currentColor);
+  }
+
+  function applyBrushSizeValue(size, options = {}) {
+    const nextSize = clampBrushSize(size, toolSettings[currentToolType].size);
+    toolSettings[currentToolType].size = nextSize;
+    brushSizeSlider.value = String(nextSize);
+    drawingManager.setLineWidth(nextSize);
+    updateSizePreview();
+
+    if (options.persist) {
+      userSettings.setBrushSettings(getCurrentSizeSettingPatch(nextSize));
+    }
+    return nextSize;
+  }
+
+  function applyBrushOpacityValue(opacity, options = {}) {
+    const nextOpacity = clampBrushOpacity(opacity, toolSettings.brush.opacity);
+    toolSettings.brush.opacity = nextOpacity;
+    brushOpacitySlider.value = String(nextOpacity);
+    brushOpacityValue.textContent = `${nextOpacity}%`;
+    if (currentToolType !== 'eraser') {
+      drawingManager.setOpacity(nextOpacity / 100);
+    }
+    if (options.persist) {
+      userSettings.setBrushSettings({ opacity: nextOpacity });
+    }
+    return nextOpacity;
+  }
+
+  function setActiveColorButton(color) {
+    const activeColor = getColorNameByHex(color);
+    document.querySelectorAll('.color-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.color === activeColor);
+    });
+  }
+
+  function setCurrentColor(color, options = {}) {
+    currentColor = color || '#ff4757';
+    setActiveColorButton(currentColor);
+    drawingManager.setColor(currentColor);
+    updateSizePreview();
+    if (options.persist) {
+      userSettings.setBrushSettings({ color: currentColor });
+    }
+  }
+
+  function updateBrushSizeHud(detail = {}) {
+    if (!brushSizeHud) return;
+    const size = clampBrushSize(detail.size, toolSettings[currentToolType].size);
+    const rect = elements.drawingCanvas?.getBoundingClientRect();
+    const scale = rect && elements.drawingCanvas?.width
+      ? rect.width / elements.drawingCanvas.width
+      : 1;
+    const displaySize = Math.min(96, Math.max(28, Math.round(size * scale)));
+    const x = Number.isFinite(detail.clientX) ? detail.clientX : window.innerWidth / 2;
+    const y = Number.isFinite(detail.clientY) ? detail.clientY : window.innerHeight / 2;
+
+    brushSizeHud.style.left = `${x}px`;
+    brushSizeHud.style.top = `${y}px`;
+    brushSizeHud.style.width = `${displaySize}px`;
+    brushSizeHud.style.height = `${displaySize}px`;
+    brushSizeHud.style.background = currentToolType === 'eraser' ? 'transparent' : `${currentColor}80`;
+    brushSizeHud.style.borderColor = currentToolType === 'eraser' ? 'rgba(255, 255, 255, 0.95)' : currentColor;
+    brushSizeHud.textContent = `${size}px`;
+  }
+
+  function showBrushSizeHud(detail = {}) {
+    if (!brushSizeHud) return;
+    brushSizeHud.hidden = false;
+    updateBrushSizeHud(detail);
+  }
+
+  function hideBrushSizeHud() {
+    if (!brushSizeHud) return;
+    brushSizeHud.hidden = true;
+  }
 
   function applyEraserMode(mode, persist = false) {
     mode = normalizeEraserMode(mode);
@@ -2829,144 +2967,169 @@ async function initApp() {
     });
   });
 
+  function selectDrawingTool(toolName, options = {}) {
+    const persist = options.persist !== false;
+    toolName = toolMap[toolName] ? toolName : 'brush';
+    document.querySelectorAll('.tool-btn[data-tool]').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.tool === toolName);
+    });
+
+    if (persist) {
+      toolSettings[currentToolType].size = clampBrushSize(brushSizeSlider.value, toolSettings[currentToolType].size);
+      if (currentToolType === 'brush') {
+        toolSettings.brush.opacity = clampBrushOpacity(brushOpacitySlider.value, toolSettings.brush.opacity);
+      }
+    }
+
+    currentToolName = toolName;
+    currentToolType = toolName === 'eraser' ? 'eraser' : 'brush';
+    applyBrushSizeValue(toolSettings[currentToolType].size);
+
+    if (currentToolType === 'eraser') {
+      opacitySection.style.display = 'none';
+      if (colorSection) colorSection.style.display = 'none';
+      if (strokeSection) strokeSection.style.display = 'none';
+      if (eraserModeSection) eraserModeSection.hidden = false;
+      applyEraserMode(currentEraserMode);
+      drawingManager.setOpacity(1);
+    } else {
+      opacitySection.style.display = 'block';
+      if (colorSection) colorSection.style.display = 'block';
+      if (strokeSection) strokeSection.style.display = 'block';
+      if (eraserModeSection) eraserModeSection.hidden = true;
+      applyBrushOpacityValue(toolSettings.brush.opacity);
+    }
+
+    drawingManager.setTool(toolMap[toolName]);
+
+    if (persist) {
+      userSettings.setBrushSettings({ tool: toolName, brushSize: toolSettings.brush.size, eraserSize: toolSettings.eraser.size });
+    }
+    log.debug('도구 선택', { tool: toolName, size: toolSettings[currentToolType].size });
+  }
+
   document.querySelectorAll('.tool-btn[data-tool]').forEach(btn => {
     btn.addEventListener('click', function() {
-      document.querySelectorAll('.tool-btn[data-tool]').forEach(b => b.classList.remove('active'));
-      this.classList.add('active');
-
-      // 도구 매핑
-      const toolMap = {
-        'pen': DrawingTool.PEN,
-        'brush': DrawingTool.BRUSH,
-        'eraser': DrawingTool.ERASER,
-        'line': DrawingTool.LINE,
-        'arrow': DrawingTool.ARROW,
-        'rect': DrawingTool.RECT,
-        'circle': DrawingTool.CIRCLE
-      };
-      const toolName = this.dataset.tool;
-      const tool = toolMap[toolName] || DrawingTool.PEN;
-      const newToolType = toolName === 'eraser' ? 'eraser' : 'brush';
-
-      // 이전 도구 설정 저장
-      toolSettings[currentToolType].size = parseInt(brushSizeSlider.value);
-      if (currentToolType === 'brush') {
-        toolSettings.brush.opacity = parseInt(brushOpacitySlider.value);
-      }
-
-      // 새 도구 설정 적용
-      currentToolType = newToolType;
-      brushSizeSlider.value = toolSettings[currentToolType].size;
-      drawingManager.setLineWidth(toolSettings[currentToolType].size);
-      updateSizePreview();
-
-      // 지우개일 때 불투명도 섹션 숨기기, 아니면 보이기
-      if (newToolType === 'eraser') {
-        opacitySection.style.display = 'none';
-        if (colorSection) colorSection.style.display = 'none';
-        if (strokeSection) strokeSection.style.display = 'none';
-        if (eraserModeSection) eraserModeSection.hidden = false;
-        applyEraserMode(currentEraserMode);
-        drawingManager.setOpacity(1);  // 지우개는 항상 100%
-      } else {
-        opacitySection.style.display = 'block';
-        if (colorSection) colorSection.style.display = 'block';
-        if (strokeSection) strokeSection.style.display = 'block';
-        if (eraserModeSection) eraserModeSection.hidden = true;
-        brushOpacitySlider.value = toolSettings.brush.opacity;
-        brushOpacityValue.textContent = `${toolSettings.brush.opacity}%`;
-        drawingManager.setOpacity(toolSettings.brush.opacity / 100);
-      }
-
-      drawingManager.setTool(tool);
-      log.debug('도구 선택', { tool: toolName, size: toolSettings[currentToolType].size });
+      selectDrawingTool(this.dataset.tool);
     });
   });
 
-  // 색상 선택 (8색 팔레트)
-  const colorMap = {
-    'red': '#ff4757',
-    'yellow': '#ffd000',
-    'green': '#26de81',
-    'blue': '#4a9eff',
-    'white': '#ffffff',
-    'black': '#000000',
-    'mint': '#1abc9c',
-    'pink': '#ff6b9d'
-  };
-
-  let currentColor = '#ff4757';
-
   document.querySelectorAll('.color-btn').forEach(btn => {
     btn.addEventListener('click', function() {
-      document.querySelectorAll('.color-btn').forEach(b => b.classList.remove('active'));
-      this.classList.add('active');
-
-      currentColor = colorMap[this.dataset.color] || '#ff4757';
-      drawingManager.setColor(currentColor);
-      updateSizePreview();
+      setCurrentColor(colorMap[this.dataset.color] || '#ff4757', { persist: true });
       log.debug('색상 선택', { color: this.dataset.color });
     });
   });
 
-  // 브러쉬 사이즈 슬라이더 (변수는 위에서 이미 선언됨)
-  function updateSizePreview() {
-    const size = brushSizeSlider.value;
-    brushSizeValue.textContent = `${size}px`;
-    sizePreview.classList.toggle('eraser-preview', currentToolType === 'eraser');
-    sizePreview.style.setProperty('--preview-size', `${Math.min(size, 20)}px`);
-    sizePreview.style.setProperty('--preview-color', currentColor);
-  }
-
   brushSizeSlider.addEventListener('input', function() {
-    const size = parseInt(this.value);
-    toolSettings[currentToolType].size = size;  // 현재 도구 설정에 저장
-    drawingManager.setLineWidth(size);
-    updateSizePreview();
+    applyBrushSizeValue(this.value);
+  });
+
+  brushSizeSlider.addEventListener('change', function() {
+    applyBrushSizeValue(this.value, { persist: true });
   });
 
   // 불투명도 슬라이더
   brushOpacitySlider.addEventListener('input', function() {
-    const opacity = parseInt(this.value);
-    toolSettings.brush.opacity = opacity;  // 브러시 설정에 저장
-    brushOpacityValue.textContent = `${opacity}%`;
-    drawingManager.setOpacity(opacity / 100);
+    applyBrushOpacityValue(this.value);
   });
 
-  // 초기 사이즈 프리뷰 설정
-  updateSizePreview();
+  brushOpacitySlider.addEventListener('change', function() {
+    applyBrushOpacityValue(this.value, { persist: true });
+  });
+
+  function adjustBrushSizeBy(delta, options = {}) {
+    const nextSize = toolSettings[currentToolType].size + delta;
+    return applyBrushSizeValue(nextSize, options);
+  }
 
   // ====== 브러시 외곽선 ======
   const strokeToggle = document.getElementById('strokeToggle');
   const strokeControls = document.getElementById('strokeControls');
   const strokeWidthSlider = document.getElementById('strokeWidthSlider');
   const strokeWidthValue = document.getElementById('strokeWidthValue');
+  let currentStrokeColor = savedBrush.strokeColor;
+
+  function setActiveStrokeColorButton(color) {
+    document.querySelectorAll('.stroke-color-btn[data-stroke-color]').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.strokeColor === color);
+    });
+  }
+
+  function applyStrokeSettings(settings = {}, options = {}) {
+    const strokeEnabled = settings.strokeEnabled === true;
+    const strokeWidth = clampStrokeWidth(settings.strokeWidth, savedBrush.strokeWidth);
+    const strokeColor = settings.strokeColor || '#ffffff';
+
+    strokeToggle?.classList.toggle('active', strokeEnabled);
+    if (strokeToggle) strokeToggle.textContent = strokeEnabled ? 'ON' : 'OFF';
+    strokeControls?.classList.toggle('visible', strokeEnabled);
+    if (strokeWidthSlider) strokeWidthSlider.value = String(strokeWidth);
+    if (strokeWidthValue) strokeWidthValue.textContent = `${strokeWidth}px`;
+    currentStrokeColor = strokeColor;
+    setActiveStrokeColorButton(currentStrokeColor);
+
+    drawingManager.setStrokeEnabled(strokeEnabled);
+    drawingManager.setStrokeWidth(strokeWidth);
+    drawingManager.setStrokeColor(currentStrokeColor);
+
+    if (options.persist) {
+      userSettings.setBrushSettings({
+        strokeEnabled,
+        strokeWidth,
+        strokeColor: currentStrokeColor
+      });
+    }
+  }
 
   // 외곽선 토글
   strokeToggle?.addEventListener('click', () => {
     const isActive = !strokeToggle.classList.contains('active');
-    strokeToggle.classList.toggle('active', isActive);
-    strokeToggle.textContent = isActive ? 'ON' : 'OFF';
-    strokeControls?.classList.toggle('visible', isActive);
-    drawingManager.setStrokeEnabled(isActive);
+    applyStrokeSettings({
+      strokeEnabled: isActive,
+      strokeWidth: strokeWidthSlider?.value,
+      strokeColor: currentStrokeColor
+    }, { persist: true });
   });
 
   // 외곽선 두께
   strokeWidthSlider?.addEventListener('input', function() {
-    const width = parseInt(this.value);
+    const width = clampStrokeWidth(this.value);
     strokeWidthValue.textContent = `${width}px`;
     drawingManager.setStrokeWidth(width);
   });
+  strokeWidthSlider?.addEventListener('change', function() {
+    userSettings.setBrushSettings({ strokeWidth: clampStrokeWidth(this.value) });
+  });
 
   // 외곽선 색상
-  document.querySelectorAll('.stroke-color-btn').forEach(btn => {
+  document.querySelectorAll('.stroke-color-btn[data-stroke-color]').forEach(btn => {
     btn.addEventListener('click', function() {
-      document.querySelectorAll('.stroke-color-btn').forEach(b => b.classList.remove('active'));
-      this.classList.add('active');
       const color = this.dataset.strokeColor;
+      currentStrokeColor = color;
+      setActiveStrokeColorButton(color);
       drawingManager.setStrokeColor(color);
+      userSettings.setBrushSettings({ strokeColor: color });
     });
   });
+
+  drawingManager.drawingCanvas?.addEventListener('sizeadjuststart', (event) => {
+    showBrushSizeHud(event.detail);
+  });
+  drawingManager.drawingCanvas?.addEventListener('sizeadjust', (event) => {
+    const size = applyBrushSizeValue(event.detail.size);
+    updateBrushSizeHud({ ...event.detail, size });
+  });
+  drawingManager.drawingCanvas?.addEventListener('sizeadjustend', (event) => {
+    const size = applyBrushSizeValue(event.detail.size, { persist: true });
+    updateBrushSizeHud({ ...event.detail, size });
+    hideBrushSizeHud();
+  });
+
+  setCurrentColor(savedBrush.color, { persist: false });
+  applyBrushOpacityValue(savedBrush.opacity);
+  applyStrokeSettings(savedBrush);
+  selectDrawingTool(savedBrush.tool, { persist: false });
 
   // Undo 버튼
   elements.btnUndo?.addEventListener('click', async () => {
@@ -10243,6 +10406,13 @@ async function initApp() {
       return;
     }
 
+    if (state.isDrawMode && (userSettings.matchShortcut('brushSizeDown', e) || userSettings.matchShortcut('brushSizeUp', e))) {
+      e.preventDefault();
+      const delta = userSettings.matchShortcut('brushSizeDown', e) ? -1 : 1;
+      adjustBrushSizeBy(delta, { persist: true });
+      return;
+    }
+
     // 키프레임 삭제 (그리기 모드에서만)
     if (userSettings.matchShortcut('keyframeDelete', e)) {
       if (state.isDrawMode) {
@@ -10345,9 +10515,10 @@ async function initApp() {
       const wasOff = !state.isDrawMode;
       toggleDrawMode();
       if (wasOff) {
-        // 진입 시에만 브러시 자동 선택
-        const brushBtn = document.querySelector('.tool-btn[data-tool="brush"]');
-        if (brushBtn) brushBtn.click();
+        // 진입 시에는 마지막으로 저장된 도구를 복원
+        const savedTool = userSettings.getBrushSettings().tool || currentToolName || 'brush';
+        const toolBtn = document.querySelector(`.tool-btn[data-tool="${savedTool}"]`) || document.querySelector('.tool-btn[data-tool="brush"]');
+        if (toolBtn) toolBtn.click();
       }
       return;
     }
@@ -10983,7 +11154,7 @@ async function initApp() {
     '실행취소': ['undo', 'redo'],
     '키프레임': ['keyframeAddWithCopy', 'keyframeAddBlank', 'keyframeAddBlank2', 'keyframeDelete', 'keyframeDeleteAlt', 'prevKeyframe', 'nextKeyframe'],
     '프레임 편집': ['insertFrame', 'deleteFrame'],
-    '그리기 보조': ['onionSkinToggle', 'prevFrameDraw', 'nextFrameDraw']
+    '그리기 보조': ['onionSkinToggle', 'prevFrameDraw', 'nextFrameDraw', 'brushSizeDown', 'brushSizeUp']
   };
 
   let capturingShortcutAction = null;

--- a/renderer/scripts/modules/drawing-canvas.js
+++ b/renderer/scripts/modules/drawing-canvas.js
@@ -50,6 +50,12 @@ export class DrawingCanvas extends EventTarget {
     this.isDrawing = false;
     this.canDraw = null;
     this._modifierCtrlDown = false;
+    this.isSizeAdjusting = false;
+    this._sizeAdjustStartX = 0;
+    this._sizeAdjustStartY = 0;
+    this._sizeAdjustStartSize = 3;
+    this._sizeAdjustMoveHandler = null;
+    this._sizeAdjustEndHandler = null;
     this.lastX = 0;
     this.lastY = 0;
     this.startX = 0;
@@ -85,6 +91,11 @@ export class DrawingCanvas extends EventTarget {
     this.canvas.addEventListener('mousemove', (e) => this._onMouseMove(e), { signal });
     this.canvas.addEventListener('mouseup', (e) => this._onMouseUp(e), { signal });
     this.canvas.addEventListener('mouseleave', (e) => this._onMouseUp(e), { signal });
+    this.canvas.addEventListener('contextmenu', (e) => {
+      if (e.altKey || this.isSizeAdjusting) {
+        e.preventDefault();
+      }
+    }, { signal });
 
     // 터치 이벤트 (태블릿 지원)
     this.canvas.addEventListener('touchstart', (e) => this._onTouchStart(e), { signal });
@@ -142,6 +153,12 @@ export class DrawingCanvas extends EventTarget {
   _onMouseDown(e) {
     if (!this.canvas.classList.contains('active')) return;
 
+    if (e.altKey && (e.button === 0 || e.button === 2)) {
+      e.preventDefault?.();
+      this._beginSizeAdjust(e);
+      return;
+    }
+
     if (this._isCtrlActive(e)) {
       e.preventDefault?.();
     }
@@ -186,6 +203,63 @@ export class DrawingCanvas extends EventTarget {
       });
     } else if (this._isFreeDrawTool(this.activeTool) && !this._isStrokeEraserActive()) {
       this._drawPoint(coords.x, coords.y, this.activeTool);
+    }
+  }
+
+  _beginSizeAdjust(e) {
+    if (this.isSizeAdjusting) return;
+
+    this.isSizeAdjusting = true;
+    this._sizeAdjustStartX = e.clientX;
+    this._sizeAdjustStartY = e.clientY;
+    this._sizeAdjustStartSize = Math.min(50, Math.max(1, parseInt(this.lineWidth) || 3));
+    this._sizeAdjustMoveHandler = (event) => this._updateSizeAdjust(event);
+    this._sizeAdjustEndHandler = () => this._endSizeAdjust();
+
+    window.addEventListener('mousemove', this._sizeAdjustMoveHandler, { signal: this._abortController.signal });
+    window.addEventListener('mouseup', this._sizeAdjustEndHandler, { signal: this._abortController.signal });
+
+    this._emit('sizeadjuststart', {
+      size: this.lineWidth,
+      clientX: e.clientX,
+      clientY: e.clientY
+    });
+  }
+
+  _updateSizeAdjust(e) {
+    if (!this.isSizeAdjusting) return;
+    e.preventDefault?.();
+
+    const delta = e.clientX - this._sizeAdjustStartX;
+    const nextSize = Math.min(50, Math.max(1, Math.round(this._sizeAdjustStartSize + (delta / 4))));
+    this.setLineWidth(nextSize);
+    this._emit('sizeadjust', {
+      size: nextSize,
+      clientX: this._sizeAdjustStartX,
+      clientY: this._sizeAdjustStartY
+    });
+  }
+
+  _endSizeAdjust() {
+    if (!this.isSizeAdjusting) return;
+    this.isSizeAdjusting = false;
+
+    this._removeSizeAdjustListeners();
+    this._emit('sizeadjustend', {
+      size: this.lineWidth,
+      clientX: this._sizeAdjustStartX,
+      clientY: this._sizeAdjustStartY
+    });
+  }
+
+  _removeSizeAdjustListeners() {
+    if (this._sizeAdjustMoveHandler) {
+      window.removeEventListener('mousemove', this._sizeAdjustMoveHandler);
+      this._sizeAdjustMoveHandler = null;
+    }
+    if (this._sizeAdjustEndHandler) {
+      window.removeEventListener('mouseup', this._sizeAdjustEndHandler);
+      this._sizeAdjustEndHandler = null;
     }
   }
 
@@ -735,8 +809,8 @@ export class DrawingCanvas extends EventTarget {
    * 선 두께 설정
    */
   setLineWidth(width) {
-    this.lineWidth = width;
-    log.debug('선 두께 변경', { width });
+    this.lineWidth = Math.min(50, Math.max(1, parseInt(width) || 3));
+    log.debug('선 두께 변경', { width: this.lineWidth });
   }
 
   /**
@@ -781,11 +855,13 @@ export class DrawingCanvas extends EventTarget {
    * 정리
    */
   destroy() {
+    this._endSizeAdjust();
     // AbortController를 통해 모든 이벤트 리스너 제거
     if (this._abortController) {
       this._abortController.abort();
       this._abortController = null;
     }
+    this._removeSizeAdjustListeners();
 
     // 임시 캔버스 정리
     this.tempCanvas = null;

--- a/renderer/scripts/modules/user-settings.js
+++ b/renderer/scripts/modules/user-settings.js
@@ -57,7 +57,9 @@ const DEFAULT_SHORTCUTS = {
   // 그리기 보조
   onionSkinToggle: { key: 'Digit1', ctrl: false, shift: false, alt: false, label: '어니언 스킨 토글' },
   prevFrameDraw: { key: 'KeyA', ctrl: false, shift: true, alt: false, label: '1프레임 이전 (Shift+A)' },
-  nextFrameDraw: { key: 'KeyD', ctrl: false, shift: true, alt: false, label: '1프레임 다음 (Shift+D)' }
+  nextFrameDraw: { key: 'KeyD', ctrl: false, shift: true, alt: false, label: '1프레임 다음 (Shift+D)' },
+  brushSizeDown: { key: 'BracketLeft', ctrl: false, shift: false, alt: false, label: '브러시 크기 줄이기' },
+  brushSizeUp: { key: 'BracketRight', ctrl: false, shift: false, alt: false, label: '브러시 크기 키우기' }
 };
 
 // 이름별 테마 매핑
@@ -199,7 +201,18 @@ export class UserSettings extends EventTarget {
       // 100% 이하 줌에서 영상을 중앙에 고정할지 여부
       videoCenterLocked: true,
       // 이 PC에서 마지막으로 사용한 지우개 방식
-      eraserMode: 'pixel'
+      eraserMode: 'pixel',
+      // 이 PC에서 마지막으로 사용한 브러시 설정
+      brushSettings: {
+        tool: 'brush',
+        color: '#ff4757',
+        brushSize: 3,
+        eraserSize: 20,
+        opacity: 100,
+        strokeEnabled: false,
+        strokeWidth: 3,
+        strokeColor: '#ffffff'
+      }
     };
 
     this._ready = false;
@@ -636,6 +649,40 @@ export class UserSettings extends EventTarget {
     this._save();
     this._emit('eraserModeChanged', { mode: this.settings.eraserMode });
     log.info('지우개 방식 설정 변경됨', { mode: this.settings.eraserMode });
+  }
+
+  getBrushSettings() {
+    const defaults = {
+      tool: 'brush',
+      color: '#ff4757',
+      brushSize: 3,
+      eraserSize: 20,
+      opacity: 100,
+      strokeEnabled: false,
+      strokeWidth: 3,
+      strokeColor: '#ffffff'
+    };
+    const merged = { ...defaults, ...(this.settings.brushSettings || {}) };
+    const validTools = ['pen', 'brush', 'eraser', 'line', 'arrow', 'rect', 'circle'];
+
+    merged.tool = validTools.includes(merged.tool) ? merged.tool : defaults.tool;
+    merged.color = typeof merged.color === 'string' ? merged.color : defaults.color;
+    merged.brushSize = Math.min(50, Math.max(1, parseInt(merged.brushSize) || 3));
+    merged.eraserSize = Math.min(50, Math.max(1, parseInt(merged.eraserSize) || 20));
+    merged.opacity = Math.min(100, Math.max(10, parseInt(merged.opacity) || 100));
+    merged.strokeEnabled = merged.strokeEnabled === true;
+    merged.strokeWidth = Math.min(10, Math.max(1, parseInt(merged.strokeWidth) || 3));
+    merged.strokeColor = typeof merged.strokeColor === 'string' ? merged.strokeColor : defaults.strokeColor;
+
+    return merged;
+  }
+
+  setBrushSettings(partial) {
+    this.settings.brushSettings = { ...this.getBrushSettings(), ...partial };
+    this.settings.brushSettings = this.getBrushSettings();
+    this._save();
+    this._emit('brushSettingsChanged', { brushSettings: this.settings.brushSettings });
+    log.info('브러시 설정 변경됨', partial);
   }
 
   getLightMode() {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -2188,6 +2188,32 @@ body.app-fullscreen .video-comment-overlay-controls {
   border: 2px solid var(--text-muted);
 }
 
+.brush-size-hud {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 10000;
+  display: grid;
+  place-items: center;
+  min-width: 28px;
+  min-height: 28px;
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  border-radius: 50%;
+  background: rgba(255, 71, 87, 0.5);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+}
+
+.brush-size-hud[hidden] {
+  display: none;
+}
+
 .eraser-mode-toggle {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/scripts/tests/brush-settings-source.test.js
+++ b/scripts/tests/brush-settings-source.test.js
@@ -74,9 +74,9 @@ test('brush size HUD and bracket shortcuts are wired for drawing mode only', () 
   assert.match(appSource, /sizeadjustend/);
   assert.match(userSettingsSource, /brushSizeDown:\s*\{ key: 'BracketLeft'/);
   assert.match(userSettingsSource, /brushSizeUp:\s*\{ key: 'BracketRight'/);
-  assert.match(appSource, /userSettings\.matchShortcut\('brushSizeDown', e\)/);
-  assert.match(appSource, /userSettings\.matchShortcut\('brushSizeUp', e\)/);
-  assert.match(appSource, /if \(state\.isDrawMode && \(userSettings\.matchShortcut\('brushSizeDown', e\) \|\| userSettings\.matchShortcut\('brushSizeUp', e\)\)\)/);
+  assert.match(appSource, /const matchedBrushSizeAction = userSettings\.findActionByEvent\(e\);/);
+  assert.match(appSource, /matchedBrushSizeAction === 'brushSizeDown'/);
+  assert.match(appSource, /matchedBrushSizeAction === 'brushSizeUp'/);
   assert.match(appSource, /'그리기 보조': \['onionSkinToggle', 'prevFrameDraw', 'nextFrameDraw', 'brushSizeDown', 'brushSizeUp'\]/);
 });
 

--- a/scripts/tests/brush-settings-source.test.js
+++ b/scripts/tests/brush-settings-source.test.js
@@ -1,0 +1,83 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
+const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
+const mainCss = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
+const drawingCanvasSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/drawing-canvas.js'), 'utf8'));
+const userSettingsSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/user-settings.js'), 'utf8'));
+const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+
+test('brush and eraser settings are persisted through user settings', () => {
+  assert.match(userSettingsSource, /brushSettings:\s*\{/);
+  assert.match(userSettingsSource, /tool:\s*'brush'/);
+  assert.match(userSettingsSource, /brushSize:\s*3/);
+  assert.match(userSettingsSource, /eraserSize:\s*20/);
+  assert.match(userSettingsSource, /opacity:\s*100/);
+  assert.match(userSettingsSource, /strokeEnabled:\s*false/);
+  assert.match(userSettingsSource, /getBrushSettings\(\)/);
+  assert.match(userSettingsSource, /setBrushSettings\(partial\)/);
+  assert.match(userSettingsSource, /this\._emit\('brushSettingsChanged', \{ brushSettings: this\.settings\.brushSettings \}\)/);
+  assert.match(userSettingsSource, /Math\.min\(50, Math\.max\(1, parseInt\(merged\.brushSize\) \|\| 3\)\)/);
+  assert.match(userSettingsSource, /Math\.min\(50, Math\.max\(1, parseInt\(merged\.eraserSize\) \|\| 20\)\)/);
+  assert.match(userSettingsSource, /Math\.min\(100, Math\.max\(10, parseInt\(merged\.opacity\) \|\| 100\)\)/);
+});
+
+test('drawing toolbar restores persisted brush state and saves changes deliberately', () => {
+  assert.match(appSource, /const savedBrush = userSettings\.getBrushSettings\(\);/);
+  assert.match(appSource, /eraser: \{ size: savedBrush\.eraserSize \}/);
+  assert.match(appSource, /brush: \{ size: savedBrush\.brushSize, opacity: savedBrush\.opacity \}/);
+  assert.match(appSource, /let currentColor = savedBrush\.color;/);
+  assert.match(appSource, /selectDrawingTool\(savedBrush\.tool, \{ persist: false \}\)/);
+  assert.match(appSource, /userSettings\.setBrushSettings\(\{ tool: toolName, brushSize: toolSettings\.brush\.size, eraserSize: toolSettings\.eraser\.size \}\)/);
+  assert.match(appSource, /brushSizeSlider\.addEventListener\('change'/);
+  assert.match(appSource, /brushOpacitySlider\.addEventListener\('change'/);
+  assert.match(appSource, /strokeToggle\?\.addEventListener\('click'/);
+  assert.match(appSource, /strokeWidthSlider\?\.addEventListener\('change'/);
+  assert.match(appSource, /data-stroke-color/);
+});
+
+test('alt drag adjusts brush size before drawing or ctrl eraser handling', () => {
+  const mouseDownBody = drawingCanvasSource.match(/_onMouseDown\(e\) \{[\s\S]*?\n  \}/)?.[0] || '';
+  assert.match(drawingCanvasSource, /this\.isSizeAdjusting = false;/);
+  assert.match(drawingCanvasSource, /_beginSizeAdjust\(e\)/);
+  assert.match(drawingCanvasSource, /_updateSizeAdjust\(e\)/);
+  assert.match(drawingCanvasSource, /_endSizeAdjust\(\)/);
+  assert.match(drawingCanvasSource, /sizeadjuststart/);
+  assert.match(drawingCanvasSource, /sizeadjustend/);
+  assert.match(mouseDownBody, /e\.altKey && \(e\.button === 0 \|\| e\.button === 2\)/);
+  assert.ok(
+    mouseDownBody.indexOf('e.altKey') < mouseDownBody.indexOf('this._isCtrlActive(e)'),
+    'Alt size adjustment must run before Ctrl eraser handling'
+  );
+  assert.ok(
+    mouseDownBody.indexOf('e.altKey') < mouseDownBody.indexOf('typeof this.canDraw'),
+    'Alt size adjustment must not be blocked by drawing-layer lock gates'
+  );
+  assert.match(drawingCanvasSource, /contextmenu/);
+  assert.match(drawingCanvasSource, /this\.setLineWidth\(nextSize\)/);
+});
+
+test('brush size HUD and bracket shortcuts are wired for drawing mode only', () => {
+  assert.match(indexSource, /id="brushSizeHud"/);
+  assert.match(mainCss, /\.brush-size-hud/);
+  assert.match(appSource, /brushSizeHud/);
+  assert.match(appSource, /showBrushSizeHud/);
+  assert.match(appSource, /hideBrushSizeHud/);
+  assert.match(appSource, /sizeadjuststart/);
+  assert.match(appSource, /sizeadjustend/);
+  assert.match(userSettingsSource, /brushSizeDown:\s*\{ key: 'BracketLeft'/);
+  assert.match(userSettingsSource, /brushSizeUp:\s*\{ key: 'BracketRight'/);
+  assert.match(appSource, /userSettings\.matchShortcut\('brushSizeDown', e\)/);
+  assert.match(appSource, /userSettings\.matchShortcut\('brushSizeUp', e\)/);
+  assert.match(appSource, /if \(state\.isDrawMode && \(userSettings\.matchShortcut\('brushSizeDown', e\) \|\| userSettings\.matchShortcut\('brushSizeUp', e\)\)\)/);
+  assert.match(appSource, /'그리기 보조': \['onionSkinToggle', 'prevFrameDraw', 'nextFrameDraw', 'brushSizeDown', 'brushSizeUp'\]/);
+});
+
+test('drawing test script includes the brush settings source coverage', () => {
+  assert.match(packageJson.scripts['test:drawing'], /brush-settings-source\.test\.js/);
+});

--- a/scripts/tests/brush-settings-source.test.js
+++ b/scripts/tests/brush-settings-source.test.js
@@ -32,7 +32,9 @@ test('drawing toolbar restores persisted brush state and saves changes deliberat
   assert.match(appSource, /eraser: \{ size: savedBrush\.eraserSize \}/);
   assert.match(appSource, /brush: \{ size: savedBrush\.brushSize, opacity: savedBrush\.opacity \}/);
   assert.match(appSource, /let currentColor = savedBrush\.color;/);
-  assert.match(appSource, /selectDrawingTool\(savedBrush\.tool, \{ persist: false \}\)/);
+  assert.match(appSource, /function applySavedBrushSettings\(settings = userSettings\.getBrushSettings\(\)\)/);
+  assert.match(appSource, /applySavedBrushSettings\(savedBrush\);/);
+  assert.match(appSource, /await userSettings\.waitForReady\(\);[\s\S]*applySavedBrushSettings\(userSettings\.getBrushSettings\(\)\);/);
   assert.match(appSource, /userSettings\.setBrushSettings\(\{ tool: toolName, brushSize: toolSettings\.brush\.size, eraserSize: toolSettings\.eraser\.size \}\)/);
   assert.match(appSource, /brushSizeSlider\.addEventListener\('change'/);
   assert.match(appSource, /brushOpacitySlider\.addEventListener\('change'/);


### PR DESCRIPTION
## 📋 업데이트 요약

- 🎨 브러시와 지우개 설정을 앱이 기억합니다. 마지막으로 쓴 도구, 색상, 크기, 불투명도, 외곽선 설정이 다음 실행 때도 복원됩니다.
- 🖱️ 그리기 화면에서 Alt를 누른 채 드래그하면 브러시/지우개 크기를 바로 조절할 수 있습니다. 조절 중에는 현재 크기가 원형 표시로 보입니다.
- ⌨️ 그리기 모드에서 `[` / `]` 키로 브러시 크기를 1px씩 줄이거나 키울 수 있습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/user-settings.js`에 `brushSettings` 기본값과 `getBrushSettings()`, `setBrushSettings(partial)`을 추가해 tool/color/brushSize/eraserSize/opacity/stroke 설정을 localStorage 및 설정 파일에 저장하도록 했습니다.
- `renderer/scripts/modules/drawing-canvas.js`에 Alt+좌클릭/우클릭 드래그 크기 조절 상태를 추가하고, `sizeadjuststart`, `sizeadjust`, `sizeadjustend` 이벤트를 발행하도록 했습니다. Alt 분기는 Ctrl 임시 지우개와 레이어 잠금 차단보다 먼저 처리되어 실제 선이 그려지지 않습니다.
- `renderer/scripts/app.js`의 드로잉 도구 초기화 흐름을 저장값 기반으로 정리했습니다. 슬라이더 입력 중에는 화면만 갱신하고, `change` 또는 Alt 드래그 종료 시점에 저장해 불필요한 설정 저장을 줄였습니다.
- `renderer/index.html`, `renderer/styles/main.css`에 `brushSizeHud`를 추가해 Alt 드래그 중 현재 크기와 원형 미리보기를 표시합니다.
- `scripts/tests/brush-settings-source.test.js`를 추가하고 `npm run test:drawing`에 포함해 설정 저장, Alt 우선 처리, HUD, 단축키 배선을 회귀 테스트로 고정했습니다.

## 🚧 개발 난항

- 기존 드로잉 도구 코드는 도구 선택, 색상, 크기, 외곽선 처리가 한 초기화 블록에 섞여 있었고, 그리기 모드 진입 시 브러시를 강제로 다시 선택하는 동작도 있었습니다. 저장된 마지막 도구를 자연스럽게 복원하려면 이 흐름을 `selectDrawingTool()`과 값 적용 헬퍼들로 정리해야 했습니다.
- 브러시 크기 조절은 마우스 이동마다 값이 바뀌므로 매번 설정 파일에 저장하면 부담이 커질 수 있습니다. 그래서 드래그 중에는 UI와 캔버스만 갱신하고, 드래그 종료 또는 슬라이더 변경 확정 시점에만 저장하도록 나눴습니다.

## ✅ 테스트 가이드

실사용자용:
- 그리기 도구에서 브러시 크기, 색상, 불투명도, 외곽선을 바꾼 뒤 앱을 다시 켰을 때 같은 값이 복원되는지 확인합니다.
- 그리기 모드에서 Alt+좌드래그 또는 Alt+우드래그로 크기가 바뀌고, 선이 그려지지 않으며 원형 크기 표시가 보이는지 확인합니다.
- 그리기 모드에서 `[` / `]` 키로 크기가 줄고 커지는지 확인합니다.

개발자용:
- `npm run test:drawing`
- `npm run build`