### PR TITLE
[v1.4.0] 레이어 토글 버튼 시인성 및 클릭 영역 개선

### DIFF
--- a/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
+++ b/DEVLOG/2026-07-03-윤성원-피드백-UIUX개선-구현계획.md
@@ -31,7 +31,7 @@
 | 5 | 키프레임 드래그 오버레이를 정확히 1프레임 칸으로 | 버그 | timeline.js, main.css | 높음 | ✅ |
 | 6 | 프레임 1칸 셀 표시 모드 (ON/OFF/AUTO 토글) — Animate 스타일 | 기능 | timeline.js, frame-grid-tiers.js, user-settings.js, app.js, index.html, main.css | 높음 | ✅ |
 | 7 | 브러시 설정 영속화 + Alt 드래그 크기 조절 + [ / ] 단축키 | 기능 | user-settings.js, app.js, drawing-canvas.js, index.html, main.css | 높음 | ✅ |
-| 8 | 레이어 눈/잠금 토글 버튼 확대(14px→24px) 및 on/off 상태 시각화 | 기능 | timeline.js, main.css, index.html | 중간 | ⬜ |
+| 8 | 레이어 눈/잠금 토글 버튼 확대(14px→24px) 및 on/off 상태 시각화 | 기능 | timeline.js, main.css, index.html | 중간 | ✅ |
 | 9 | 미명시 UX 개선 (도구 커서, 키프레임 히트영역, 재렌더 병합 등) | 개선 | 다수 (소형 3건 포함 + 별도 이슈 3건) | 중간~낮음 | ⬜ |
 
 ---

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "test:recent": "node --test scripts/tests/recent-files-store.test.js scripts/tests/recent-files-source.test.js",
-    "test:frame-grid": "node --test scripts/tests/frame-grid-tiers.test.js scripts/tests/keyframe-drag-ghost-source.test.js",
+    "test:frame-grid": "node --test scripts/tests/frame-grid-tiers.test.js scripts/tests/keyframe-drag-ghost-source.test.js scripts/tests/layer-visibility-hit-area.test.js",
     "test:cluster": "node --test scripts/tests/comment-cluster.test.js scripts/tests/comment-track-header-sync-source.test.js",
     "test:playlist-ordering": "node --test scripts/tests/playlist-ordering.test.js",
     "test:playlist-continuous": "node --test scripts/tests/playlist-continuous-core.test.js",

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -956,7 +956,7 @@
             <div class="layer-header" data-layer="video">
               <div class="layer-color" style="background: #3a3a3a"></div>
               <span class="layer-visibility">
-                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
               </span>
               <span class="layer-name">
                 <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 4px"><rect x="2" y="2" width="20" height="20" rx="2.18"/><line x1="7" y1="2" x2="7" y2="22"/><line x1="17" y1="2" x2="17" y2="22"/><line x1="2" y1="12" x2="22" y2="12"/></svg>

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -1040,7 +1040,7 @@ export class Timeline extends EventTarget {
       <div class="layer-color" style="background: var(--composition-layer-color)"></div>
       <span class="composition-layer-header-drag" title="순서 변경" aria-hidden="true">⋮⋮</span>
       <button class="layer-visibility composition-layer-header-visibility" type="button" data-action="composition-visibility" title="${layer.enabled ? '레이어 숨기기' : '레이어 보이기'}" aria-label="${layer.enabled ? '레이어 숨기기' : '레이어 보이기'}">
-        ${this._getCompositionLayerVisibilityIcon(layer.enabled)}
+        ${this._getLayerVisibilityIcon(layer.enabled, 16)}
       </button>
       <span class="composition-layer-header-type" title="${typeLabel}" aria-label="${typeLabel}">${_getCompositionLayerTypeIcon(layer.type)}</span>
       <span class="layer-name" title="${this._escapeHtml(layer.name)}">${this._escapeHtml(layer.name)}</span>
@@ -1128,12 +1128,12 @@ export class Timeline extends EventTarget {
     this.compositionLayerReorderState = null;
   }
 
-  _getCompositionLayerVisibilityIcon(enabled) {
+  _getLayerVisibilityIcon(enabled, size = 16) {
     const slash = enabled
       ? ''
       : '<line x1="4" y1="20" x2="20" y2="4"></line>';
     return `
-      <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+      <svg viewBox="0 0 24 24" width="${size}" height="${size}" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
         <path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6-9.5-6-9.5-6z"></path>
         <circle cx="12" cy="12" r="2.4"></circle>
         ${slash}
@@ -1250,18 +1250,22 @@ export class Timeline extends EventTarget {
     const header = document.createElement('div');
     header.className = `layer-header drawing-layer-header${isActive ? ' selected' : ''}`;
     header.dataset.layerId = layer.id;
+    header.classList.toggle('layer-hidden', !layer.visible);
 
     const opacityPercent = Math.round((layer.opacity ?? 1) * 100);
+    const safeName = this._escapeHtml(layer.name);
+    const visibilityLabel = layer.visible ? '레이어 숨기기' : '레이어 보이기';
+    const lockLabel = layer.locked ? '잠금 해제' : '레이어 잠금';
     header.innerHTML = `
       <div class="layer-color" style="background: ${layer.color}"></div>
-      <span class="layer-visibility" data-action="visibility">
-        ${layer.visible ? '👁' : '👁‍🗨'}
-      </span>
-      <span class="layer-name" title="${layer.name}">${layer.name}</span>
+      <button class="layer-visibility" type="button" data-action="visibility" title="${visibilityLabel}" aria-label="${visibilityLabel}" aria-pressed="${layer.visible}">
+        ${this._getLayerVisibilityIcon(layer.visible)}
+      </button>
+      <span class="layer-name" title="${safeName}">${safeName}</span>
       <span class="layer-opacity-badge" title="불투명도 ${opacityPercent}%">${opacityPercent}%</span>
-      <span class="layer-lock" data-action="lock">
-        ${layer.locked ? '🔒' : ''}
-      </span>
+      <button class="layer-lock${layer.locked ? ' locked' : ''}" type="button" data-action="lock" title="${lockLabel}" aria-label="${lockLabel}" aria-pressed="${layer.locked}">
+        ${layer.locked ? '🔒' : '🔓'}
+      </button>
     `;
 
     // 레이어 선택 클릭

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -3173,22 +3173,56 @@ body.app-fullscreen .video-comment-overlay-controls {
 }
 
 .layer-visibility {
-  width: 14px;
-  height: 14px;
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
   border: 0;
   padding: 0;
+  border-radius: 4px;
   background: transparent;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 9px;
   color: var(--text-tertiary);
   cursor: pointer;
   flex-shrink: 0;
 }
 
 .layer-visibility:hover {
+  background: var(--bg-hover);
   color: var(--accent-primary);
+}
+
+.layer-visibility:focus-visible {
+  outline: 1px solid var(--accent-primary);
+  outline-offset: -1px;
+}
+
+.layer-header.layer-hidden .layer-visibility {
+  opacity: 0.45;
+}
+
+.layer-header.layer-hidden .layer-name,
+.layer-header.layer-hidden .layer-opacity-badge {
+  opacity: 0.5;
+}
+
+.layer-header[data-layer="video"] .layer-visibility {
+  cursor: default;
+}
+
+.layer-header[data-layer="video"] .layer-visibility:hover {
+  background: transparent;
+  color: var(--text-tertiary);
+}
+
+.layer-header[data-layer="video"] .layer-lock {
+  cursor: default;
+}
+
+.layer-header[data-layer="video"] .layer-lock:hover {
+  background: transparent;
+  color: var(--text-tertiary);
 }
 
 .layer-name {
@@ -3203,14 +3237,35 @@ body.app-fullscreen .video-comment-overlay-controls {
 }
 
 .layer-lock {
-  width: 14px;
-  height: 14px;
-  display: flex;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  padding: 0;
+  border-radius: 4px;
+  background: transparent;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 9px;
+  font-size: 12px;
   color: var(--text-tertiary);
+  cursor: pointer;
   flex-shrink: 0;
+}
+
+.layer-lock:not(.locked) {
+  opacity: 0.35;
+}
+
+.layer-lock:hover,
+.layer-lock:not(.locked):hover {
+  opacity: 1;
+  background: var(--bg-hover);
+  color: var(--accent-primary);
+}
+
+.layer-lock:focus-visible {
+  outline: 1px solid var(--accent-primary);
+  outline-offset: -1px;
 }
 
 /* 레이어 불투명도 배지 (헤더 인라인) */
@@ -3478,8 +3533,8 @@ body.app-fullscreen .video-comment-overlay-controls {
 }
 
 .composition-layer-header-visibility {
-  width: 18px;
-  height: 18px;
+  width: 24px;
+  height: 24px;
   border-radius: 4px;
 }
 
@@ -4343,16 +4398,6 @@ body.app-fullscreen .video-comment-overlay-controls {
 .drawing-layer-header.selected {
   background: var(--accent-glow);
   border-left: 3px solid var(--accent-primary);
-}
-
-.drawing-layer-header .layer-visibility {
-  cursor: pointer;
-  opacity: 0.7;
-  transition: opacity var(--transition-fast);
-}
-
-.drawing-layer-header .layer-visibility:hover {
-  opacity: 1;
 }
 
 /* ====== Adobe Animate 스타일 키프레임 격자 ====== */

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -3252,12 +3252,12 @@ body.app-fullscreen .video-comment-overlay-controls {
   flex-shrink: 0;
 }
 
-.layer-lock:not(.locked) {
+button.layer-lock:not(.locked) {
   opacity: 0.35;
 }
 
-.layer-lock:hover,
-.layer-lock:not(.locked):hover {
+button.layer-lock:hover,
+button.layer-lock:not(.locked):hover {
   opacity: 1;
   background: var(--bg-hover);
   color: var(--accent-primary);

--- a/scripts/tests/layer-visibility-hit-area.test.js
+++ b/scripts/tests/layer-visibility-hit-area.test.js
@@ -1,0 +1,67 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const timelineSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/timeline.js'), 'utf8'));
+const mainCss = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
+const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
+const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+
+function cssBlock(selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = mainCss.match(new RegExp(`(^|\\n)${escaped}\\s*\\{[\\s\\S]*?\\n\\}`));
+  return match?.[0] || '';
+}
+
+test('drawing layer visibility and lock controls are real 24px buttons', () => {
+  const visibilityBlock = cssBlock('.layer-visibility');
+  const lockBlock = cssBlock('.layer-lock');
+
+  assert.match(visibilityBlock, /width:\s*24px;/);
+  assert.match(visibilityBlock, /height:\s*24px;/);
+  assert.match(visibilityBlock, /min-width:\s*24px;/);
+  assert.match(visibilityBlock, /display:\s*inline-flex;/);
+  assert.match(visibilityBlock, /cursor:\s*pointer;/);
+
+  assert.match(lockBlock, /width:\s*24px;/);
+  assert.match(lockBlock, /height:\s*24px;/);
+  assert.match(lockBlock, /font-size:\s*12px;/);
+  assert.match(lockBlock, /cursor:\s*pointer;/);
+  assert.match(mainCss, /\.layer-lock:not\(\.locked\)\s*\{[\s\S]*?opacity:\s*0\.35;/);
+});
+
+test('drawing layer header renders accessible SVG visibility and visible lock states', () => {
+  assert.doesNotMatch(timelineSource, /👁/);
+  assert.match(timelineSource, /header\.classList\.toggle\('layer-hidden', !layer\.visible\);/);
+  assert.match(timelineSource, /<button class="layer-visibility" type="button" data-action="visibility"/);
+  assert.match(timelineSource, /aria-pressed="\$\{layer\.visible\}"/);
+  assert.match(timelineSource, /\$\{this\._getLayerVisibilityIcon\(layer\.visible\)\}/);
+  assert.match(timelineSource, /<button class="layer-lock\$\{layer\.locked \? ' locked' : ''\}" type="button" data-action="lock"/);
+  assert.match(timelineSource, /\$\{layer\.locked \? '🔒' : '🔓'\}/);
+  assert.match(timelineSource, /title="\$\{this\._escapeHtml\(layer\.name\)\}"/);
+  assert.match(timelineSource, />\$\{this\._escapeHtml\(layer\.name\)\}<\/span>/);
+});
+
+test('visibility icon helper is shared and renders a slash when disabled', () => {
+  assert.match(timelineSource, /_getLayerVisibilityIcon\(enabled, size = 16\)/);
+  assert.match(timelineSource, /width="\$\{size\}" height="\$\{size\}"/);
+  assert.match(timelineSource, /<line x1="4" y1="20" x2="20" y2="4"><\/line>/);
+  assert.match(timelineSource, /this\._getLayerVisibilityIcon\(layer\.enabled, 16\)/);
+  assert.doesNotMatch(timelineSource, /_getCompositionLayerVisibilityIcon/);
+});
+
+test('hidden rows are visually subdued without shrinking hit areas', () => {
+  assert.match(mainCss, /\.layer-header\.layer-hidden \.layer-visibility\s*\{[\s\S]*?opacity:\s*0\.45;/);
+  assert.match(mainCss, /\.layer-header\.layer-hidden \.layer-name,[\s\S]*?\.layer-header\.layer-hidden \.layer-opacity-badge\s*\{[\s\S]*?opacity:\s*0\.5;/);
+  assert.match(cssBlock('.composition-layer-header-visibility'), /width:\s*24px;[\s\S]*height:\s*24px;/);
+  assert.doesNotMatch(mainCss, /\.drawing-layer-header \.layer-visibility\s*\{[\s\S]*?opacity:\s*0\.7;/);
+});
+
+test('video layer decorative controls keep matching icon size but do not look clickable', () => {
+  assert.match(indexSource, /class="layer-header" data-layer="video"[\s\S]*<span class="layer-visibility">[\s\S]*width="16" height="16"/);
+  assert.match(mainCss, /\.layer-header\[data-layer="video"\] \.layer-visibility\s*\{[\s\S]*?cursor:\s*default;/);
+  assert.match(packageJson.scripts['test:frame-grid'], /layer-visibility-hit-area\.test\.js/);
+});

--- a/scripts/tests/layer-visibility-hit-area.test.js
+++ b/scripts/tests/layer-visibility-hit-area.test.js
@@ -30,7 +30,8 @@ test('drawing layer visibility and lock controls are real 24px buttons', () => {
   assert.match(lockBlock, /height:\s*24px;/);
   assert.match(lockBlock, /font-size:\s*12px;/);
   assert.match(lockBlock, /cursor:\s*pointer;/);
-  assert.match(mainCss, /\.layer-lock:not\(\.locked\)\s*\{[\s\S]*?opacity:\s*0\.35;/);
+  assert.match(mainCss, /button\.layer-lock:not\(\.locked\)\s*\{[\s\S]*?opacity:\s*0\.35;/);
+  assert.doesNotMatch(mainCss, /(?<!button)\.layer-lock:not\(\.locked\)\s*\{/);
 });
 
 test('drawing layer header renders accessible SVG visibility and visible lock states', () => {


### PR DESCRIPTION
## 📋 업데이트 요약

- 👁️ 레이어 눈 버튼이 더 커지고, 꺼진 상태는 슬래시 아이콘과 흐린 행으로 바로 구분됩니다.
- 🔒 잠금 버튼도 24px 크기로 커지고, 잠금 해제 상태도 흐리게 표시되어 버튼 위치를 찾기 쉬워졌습니다.
- 🎬 비디오 행의 눈/잠금 아이콘은 장식용임을 더 분명히 해서 실제 버튼과 혼동을 줄였습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/timeline.js`에서 그리기 레이어 헤더의 이모지 기반 `span`을 접근성 속성이 있는 `button`으로 교체했습니다. `aria-label`, `aria-pressed`, `title`을 추가하고, 레이어명은 `_escapeHtml()`로 안전하게 렌더링합니다.
- 기존 `_getCompositionLayerVisibilityIcon()`을 `_getLayerVisibilityIcon(enabled, size = 16)`으로 일반화해 그리기 레이어와 합성 레이어가 같은 SVG 눈 아이콘을 사용하도록 정리했습니다.
- `renderer/styles/main.css`에서 `.layer-visibility`, `.layer-lock`, `.composition-layer-header-visibility`를 24×24px 히트영역으로 통일하고, 숨김 상태 `.layer-header.layer-hidden` 스타일을 추가했습니다.
- `renderer/index.html`의 비디오 행 눈 SVG 크기를 16px로 맞추고, CSS에서 비디오 행 장식 아이콘 hover/cursor를 비활성화했습니다.
- `scripts/tests/layer-visibility-hit-area.test.js`를 추가하고 `npm run test:frame-grid`에 포함해 24px 히트영역, SVG 아이콘, 숨김 상태 표시, 비디오 행 장식 처리를 회귀 테스트로 고정했습니다.

## 🚧 개발 난항

- 기존 눈 버튼은 이모지 텍스트라 운영체제/폰트에 따라 켜짐과 꺼짐이 거의 구분되지 않았습니다. 그래서 텍스트 크기를 키우는 방식 대신 SVG 아이콘으로 바꿔 상태 표현을 안정화했습니다.
- 잠금 해제 상태는 기존에 빈 14px 영역이라 기능을 찾기 어려웠습니다. 완전히 숨기지 않고 흐린 열린 자물쇠로 표시해 발견성과 오클릭 방지를 같이 맞췄습니다.
- 같은 `.layer-visibility` 클래스가 그리기 레이어, 합성 레이어, 비디오 행에 함께 쓰이고 있어 공통 크기를 키운 뒤 비디오 행만 장식용 스타일로 따로 정리했습니다.

## ✅ 테스트 가이드

실사용자용:
- 타임라인 왼쪽 레이어의 눈 버튼 모서리 쪽을 눌러도 표시/숨김이 토글되는지 확인합니다.
- 숨김 상태에서 눈 아이콘 슬래시와 레이어명 흐림이 보이는지 확인합니다.
- 잠금/잠금 해제 버튼이 모두 보이고 클릭 가능한지 확인합니다.

개발자용:
- `npm run test:frame-grid`
- `npm run build`