### PR TITLE
fix: timeline _escapeHtml 중복 정의 제거 (레이어 이름 XSS 방어 복구)

### DIFF
--- a/DEVLOG/2026-07-04-윤성원-피드백-구현검증-리뷰.md
+++ b/DEVLOG/2026-07-04-윤성원-피드백-구현검증-리뷰.md
@@ -1,0 +1,209 @@
+# 윤성원 피드백 구현 검증 리뷰
+
+> **작성일**: 2026-07-04
+> **검증 대상**: [2026-07-03-윤성원-피드백-UIUX개선-구현계획.md](2026-07-03-윤성원-피드백-UIUX개선-구현계획.md) → PR #142~#147 구현
+> **기준 코드**: `main` @ `582c9db` (기준선 `0b41163`부터 17커밋)
+> **검증 방법**: PR별 계획 항목 전수 대조 에이전트 6개 + 문제 항목 적대적 재확인 에이전트 5개 + 핵심 발견 3건 직접 코드 실측. 아래 모든 file:line은 HEAD 582c9db 실측치.
+
+---
+
+## 0. 한눈에 보는 결론
+
+**계획 6개 PR이 전부 머지됐고, 윤성원님이 제보한 버그 4건과 요청 기능 3건은 모두 구현·적용되었습니다.** 필수 항목은 빠짐없이 반영됐고, 검증 단계에서 경고했던 함정들(레이어 분리 시 STROKE_START 유출 방지, `_renderFrameSync` 3분할, 셀 모드 판정 호이스팅, 테스트 정규식 갱신 등)도 정확히 처리됐습니다. 코덱스 리뷰 반영 커밋들이 계획보다 더 견고하게 만든 부분도 다수입니다.
+
+**다만 조치가 필요한 것이 딱 1건 있습니다**: Phase 8의 `_escapeHtml` 함수가 클래스 안에 **중복 정의**되어 있어, 이번에 넣은 레이어 이름 XSS 방어가 따옴표를 못 막습니다(아래 R1). 나머지는 전부 낮은 우선순위이거나 계획이 "선택/후속"으로 분류한 항목입니다.
+
+### Phase별 적용 현황
+
+| Phase | 내용 | 판정 | 조치 필요 |
+|-------|------|------|----------|
+| 1 | 잠긴/숨긴 레이어 입력 차단 (픽셀 지우개 버그) | ✅ 적용 | 선택 2건(커서·이중방어), 낮음 |
+| 2 | 활성 레이어 분리 렌더링 (레이어 귀속 버그) | ✅ **완전 적용** | 없음 |
+| 3 | 펜 Ctrl 지우개 토글 미인식 | ✅ 적용 | 테스트 단언 3줄 보강(낮음) |
+| 4 | 댓글 구간 행 어긋남 | ✅ 적용 | 테스트 네거티브 검증·주석(낮음) |
+| 5 | 키프레임 드래그 오버레이 1칸 | ✅ **완전 적용** | 없음 |
+| 6 | 프레임 1칸 셀 모드 (ON/OFF/AUTO) | ✅ **완전 적용** | 컷리스트 분모 통일(낮음) |
+| 7 | 브러시 설정 기억 + Alt 드래그 | ✅ **완전 적용** | 중복 emit·진입 파일쓰기(낮음) |
+| 8 | 레이어 눈/잠금 버튼 확대 | ✅ 적용 | **`_escapeHtml` 중복 정의(R1, 우선)** |
+
+### 테스트 결과
+- **전체 510건 중 508건 통과.** 실패 2건은 `cutlist-runtime-source.test.js`의 컷리스트 재생 테스트로, **기준 커밋 `0b41163`에서도 동일하게 실패**(워크트리 대조 확인)하는 기존 실패이며 이번 작업과 무관합니다.
+- 계획서가 명시한 신규 테스트 파일 5종이 모두 추가·통과: `brush-settings-source`, `comment-track-header-sync-source`, `drawing-layer-partition`, `keyframe-drag-ghost-source`, `layer-visibility-hit-area`.
+
+---
+
+## 1. 조치가 필요한 항목 (우선순위 순)
+
+### 🔴 R1. [Phase 8] `_escapeHtml` 중복 정의로 레이어 이름 XSS 방어가 불완전 — **우선 수정 권장**
+
+**증상**: PR #147은 레이어 이름을 `innerHTML`에 넣기 전 `_escapeHtml()`로 이스케이프하도록 고쳤는데(계획의 XSS 수정 항목), `Timeline` 클래스 안에 `_escapeHtml`이 **두 번 정의**되어 있습니다.
+
+- `timeline.js:1207` — 정규식 기반. `& < > " '` 전부 이스케이프 (제대로 된 버전)
+- `timeline.js:1905` — DOM 기반(`div.textContent → div.innerHTML`). **따옴표(`"` `'`)를 이스케이프하지 않음**
+
+JS 클래스 바디에서는 **나중 정의(1905)가 프로토타입을 덮어씁니다**. 실측 검증:
+```
+$ node -e "class U{ m(){return 'regex'} m(){return 'dom'} } console.log(new U().m())"
+later-wins: dom
+```
+즉 실제로 실행되는 것은 따옴표를 못 막는 1905 버전입니다. `timeline.js:1046`(합성 레이어 헤더)과 `1256/1264`(드로잉 레이어 헤더)의 `title="${safeName}"`에서 레이어 이름의 `"`가 속성을 탈출해 임의 속성 주입이 가능합니다.
+
+**심각도 — 낮음~중간**: `index.html:6`의 CSP가 `script-src 'self'`(인라인 미허용)라 주입된 `onclick` 등 **스크립트 실행은 차단**됩니다. 따라서 `alert()` 류 실행 XSS는 성립하지 않습니다. 다만 CSP는 심층 방어일 뿐이고, `style-src`에 `'unsafe-inline'`이 있어 **`style="..."` 속성 주입을 통한 UI 가림/스푸핑**과 마크업 무결성 훼손은 실재합니다. 레이어 이름은 우클릭 rename(`app.js`의 `layerNameInput`)이나 협업 원격 레이어 생성으로 임의 값이 들어올 수 있습니다.
+
+**수정** (1줄 삭제 수준):
+```js
+// timeline.js:1905-1911 의 DOM 기반 _escapeHtml 정의를 통째로 삭제
+// (1207의 정규식 기반 버전만 남긴다)
+```
+`1905` 버전을 지우면 1207 버전이 유효해집니다. 기존 다른 호출부(`1859`, `2044`의 텍스트 프리뷰)는 텍스트 컨텍스트라 정규식 버전으로 통일해도 렌더 결과가 동일해 안전합니다. **소스 테스트는 정규식 매칭만 해서 이 런타임 섀도잉을 못 잡으므로**, 수정과 함께 "`_escapeHtml` 정의가 1개뿐"임을 검증하는 단언을 추가하면 재발을 막습니다.
+
+> 참고: 이 중복 정의 자체는 기준 커밋 `4dd3041`(HEAD 기준 1901줄)에도 있던 **기존 결함**입니다. 다만 PR #147이 이 함수에 XSS 방어를 새로 의존하게 만들면서 위험이 표면화됐습니다.
+
+---
+
+### 🟡 R2. [Phase 3] 전역 Ctrl 추적 리스너에 대한 테스트 단언 누락 — 커버리지 공백
+
+**증상**: Phase 3의 펜 Ctrl 수정은 코드가 완벽히 적용됐지만(아래 §2.3), 계획이 요구한 **리스너 등록 자체를 검증하는 단언 3종**이 테스트에 빠졌습니다. `keydown('Control')`/`blur` 리스너를 실수로 지워도 CI가 못 잡습니다. `scripts/tests/`에서 `keydown|Control|blur` grep 0건.
+
+**심각도 — 낮음** (기능은 정상, 회귀 방지망만 약함).
+
+**수정**: `scripts/tests/drawing-runtime-source.test.js`의 Ctrl 추적 테스트(42줄 부근)에 3줄 추가. **구현이 `document`에 등록하므로 계획 초안의 `window` 정규식이 아니라 `document`로 써야 합니다**:
+```js
+assert.match(drawingCanvasSource, /document\.addEventListener\('keydown'/);
+assert.match(drawingCanvasSource, /e\.key === 'Control'/);
+assert.match(drawingCanvasSource, /window\.addEventListener\('blur'/);
+```
+
+---
+
+### 🟡 R3. [Phase 4] 댓글 높이 회귀 방지용 네거티브 단언 + 경고 주석 누락
+
+**증상**: 기능은 완전히 적용됐으나(아래 §2.4), 계획이 명시한 **"`renderCommentRanges` 본문에 `commentTrack.style.height` 직접 대입이 없어야 함"(`assert.doesNotMatch`)** 네거티브 검증이 테스트에 빠졌습니다. 누군가 헬퍼 호출을 유지한 채 그 뒤에 직접 대입을 재추가하면(좌우 어긋남 재발) 현행 테스트가 못 잡습니다. 또 헬퍼(`_setCommentTrackRowHeight`, `timeline.js:2299`)에 "인라인 style이 우선하니 반드시 이 헬퍼 경유" JSDoc 경고 주석도 빠졌습니다.
+
+**심각도 — 낮음**.
+
+**수정**: `comment-track-header-sync-source.test.js`에 `renderCommentRanges` 본문 슬라이스를 추출해 `assert.doesNotMatch(body, /this\.commentTrack\.style\.height =/)` 추가(리포에 본문 슬라이스+doesNotMatch 관례 다수 존재). 헬퍼 위에 경고 주석 1줄 추가.
+
+---
+
+### 🟡 R4. [Phase 6] 컷리스트 모드에서 셀 판정과 최소줌의 프레임 분모 불일치
+
+**증상**: PR #145가 신설한 `_computePxPerFrame`(`timeline.js:878`)은 `_getTimelineTotalFrames()`(컷리스트 모드 시 컷리스트 총 프레임)를 쓰는데, ON 모드 최소줌 `_applyCellModeMinZoom`(`908`)의 `computeMinZoomForCellMode(this.totalFrames, …)`는 여전히 현재 영상 프레임 수(`this.totalFrames`)를 씁니다. **컷리스트(연속 재생) 모드에서 1F=ON일 때** 격자 티어/auto 판정과 "1칸 최소 8px 보장"이 서로 다른 분모를 사용합니다.
+
+**심각도 — 낮음** (일반 단일 영상 모드에서는 두 값이 동일해 무영향. 컷리스트 재생 + ON 모드라는 조합에서만 최소줌 계산이 어긋남).
+
+**수정**: `_applyCellModeMinZoom`의 `computeMinZoomForCellMode` 첫 인자를 `this.totalFrames` → `this._getTimelineTotalFrames()`로 통일. (셀 마커 좌표는 트랙 전체가 `this.totalFrames` 기준으로 일관 렌더되므로 건드리지 말 것 — 바꾸면 같은 트랙의 range bar/점 마커와 정렬이 깨짐.)
+
+---
+
+### 🟢 R5. [Phase 7] Alt 드래그 크기 조절의 미세 비효율 2건
+
+둘 다 **낮음** (파일 IO 없음, 기능 정상):
+
+- **중복 emit**: `_updateSizeAdjust`(`drawing-canvas.js:229`)가 크기 미변경 mousemove에도 매번 `setLineWidth`+`sizeadjust` emit → 드래그 중 초당 수십 회 불필요한 DOM 갱신. 계획(문서)이 명시한 `nextSize !== this.lineWidth` 가드가 생략됨. 수정: `_updateSizeAdjust` 상단에 `if (nextSize === this.lineWidth) return;` 추가(단, `nextSize` 계산 뒤로).
+- **진입 시 무변경 파일 쓰기**: 그리기 모드 진입(D 키) 훅(`app.js:10525-10530`)이 `toolBtn.click()`을 호출 → `selectDrawingTool`이 `persist:true`로 실행 → 도구 미변경에도 매 진입마다 설정 파일 쓰기 1회. 수정: 진입 훅에서 `selectDrawingTool(savedTool, { persist: false })` 직접 호출.
+
+---
+
+### 🟢 R6. [Phase 1] 선택 항목 2건 미적용 + 무음 차단 UX 공백
+
+계획이 **"(선택)"**으로 표시했던 것들이라 계획 위반은 아니지만, 실사용 관점에서 남겨둔 메모:
+
+- **잠긴 레이어 커서 피드백 미적용**: `not-allowed` 커서(계획 P1-d) 미구현(`layer-locked` 클래스 grep 0건).
+- **무음 차단 가능성**: 잠긴/숨긴 레이어 차단 토스트가 `force=false`라, 사용자가 토스트 알림을 **끈 경우** 시각 신호 없이 입력만 막힙니다(`app.js:1291/3158`). 커서 피드백까지 없으면 "지우개가 안 먹는다"는 원래 제보와 유사한 혼란 소지. 수정: 차단 토스트를 `force=true`로 올리거나 위 커서 피드백을 적용.
+- **drawing-sync 아웃바운드 이중 방어 미적용**(계획 P1-e): mousedown 1차 차단으로 실동작 문제는 없음. 원하면 `drawing-sync.js:111` 직후 `if (layer.locked || layer.visible === false) return;` 1줄.
+
+---
+
+## 2. Phase별 상세 검증
+
+### 2.1 Phase 1 — 잠긴/숨긴 레이어 입력 차단 ✅
+
+핵심 함정이 정확히 처리됐습니다. `canDraw` 게이트가 `_onMouseDown`에서 `isDrawing=true`·`drawstart` emit·destination-out 첫 점보다 **앞**(drawing-canvas.js:166)에 있어 **Liveblocks STROKE_START 유출이 원천 차단**됩니다. `_onDrawStart`(143)·`_saveCurrentFrameData`(236) 방어선, 토스트(app.js:1286), 전체 지우기 가드(3151)까지 적용. 계획보다 넓게 **숨김(hidden) 레이어까지 차단**하도록 확장했고, 코덱스 리뷰로 "차단 저장 시 유령 스트로크 레코드 기록 방지"(drawing-manager.js:213, 커밋 d9b275f)가 추가됐습니다. → 조치: R6(선택).
+
+### 2.2 Phase 2 — 활성 레이어 분리 렌더링 ✅ 완전 적용
+
+**이번 작업에서 가장 깔끔하게 적용된 Phase.** 3-캔버스 스택(`layersBelowCanvas` z:2 / `drawingCanvas` z:3 / `layersAboveCanvas` z:4)이 DOM·CSS·매니저·app.js에 전부 반영됐고, 검증 단계의 **필수 지시가 모두 이행**됐습니다:
+- `_renderFrameSync`도 3분할(재생 경로) — drawing-manager.js:965
+- `createLayer`의 `skipActivate` 옵션 + `drawing-sync._applyRemoteLayerCreated`에서 사용(원격 활성 탈취 방지 G2) — drawing-manager.js:409, drawing-sync.js:352
+- `clearAll()`/`reset()`의 정적 캔버스 클리어(잔상 방지) — 1087/1100
+- mpv 오버레이 합성 헬퍼 `getCompositedDrawingOverlayDataUrl`(비활성 레이어 누락 방지) — app.js:6042
+
+diff가 122줄로 작아 보인 것은 분할 로직을 순수 함수 헬퍼 3개로 압축했기 때문이며 누락이 아닙니다. `.bframe` 스키마 무변경. → **조치 없음.** (레이어 귀속 버그와 픽셀 지우개 타 레이어 침범이 구조적으로 해소됨.)
+
+### 2.3 Phase 3 — 펜 Ctrl 지우개 ✅
+
+`_modifierCtrlDown` + 전역 keydown/keyup/blur 추적, `_isCtrlActive` 헬퍼, `e.ctrlKey` 5곳 전부 교체(drawing-canvas.js:162/195/279/337/396), 터치 합성 객체에도 전달. **계획이 경고한 함정 — 기존 테스트 45줄 `/e\.ctrlKey/` 정규식 갱신 — 도 정확히 처리**돼 CI가 깨지지 않습니다. 계획은 `window` 등록이었으나 `document` 등록으로 구현(키 이벤트는 document로 버블되므로 기능 동등, 동일 AbortController signal 재사용으로 누수 없음). → 조치: R2(테스트 보강).
+
+### 2.4 Phase 4 — 댓글 구간 행 동기화 ✅
+
+`_setCommentTrackRowHeight(height=24)` 헬퍼가 좌/우 높이를 쌍으로 설정하고, 적용 지점이 계획(4곳)보다 넓은 7곳(빈 데이터/비표시/플레이리스트/클리어 전부). CSS `.comment-layer-header`에 `min-height: 24px` + `margin-bottom: 2px` + `transition: height 0.28s ease`(트랙과 동일 타이밍) 적용. `commentTrack.style.height` 직접 대입은 헬퍼 내부 1곳뿐. → 조치: R3(테스트·주석).
+
+### 2.5 Phase 5 — 드래그 오버레이 1칸 ✅ 완전 적용
+
+`_createDragGhost`가 `cloneNode`를 버리고 1칸 셀 고스트 생성(left=`frame/totalFrames`, width=`1/totalFrames`), `_updateKeyframeDrag`가 `Math.floor(percent*totalFrames)` 매핑(round 부재), 툴팁 칸 중앙 배치, `.keyframe-drag-ghost-cell` CSS, `_finishKeyframeDrag` 정합까지 전부 적용. → **조치 없음.**
+
+### 2.6 Phase 6 — 프레임 셀 모드 ✅ 완전 적용
+
+`frameCellMode`(기본 auto) 설정, 순수 함수 2개, 1F 3상태 토글 버튼·배선·복원, 룰러 마크 캡(600) 모두 적용. **검증 단계 보완 3건이 정확히 반영**:
+- 보완1: 셀 활성 판정이 `gridVisible=false` 조기 반환보다 **앞**에서 평가(`_computePxPerFrame` 헬퍼 분리) — 격자 OFF+셀 모드 조합 정상
+- 보완2: `setVideoInfo`에서 `_applyCellModeMinZoom`+`_applyZoom` 호출
+- 보완3: 셀 분기에서 `marker.style.background` 인라인 제외(color-mix 반투명 배경 유효)
+
+코덱스 리뷰로 리사이즈 시 minZoom 재계산(커밋 6bb47a0), maxZoom 가드, 줌 슬라이더 0-나눗셈 가드까지 보강. `.keyframe-cell`이 `.keyframe-marker-dot` 뒤에 선언돼 특이도 정상. → 조치: R4(컷리스트 분모, 낮음).
+
+### 2.7 Phase 7 — 브러시 설정 기억 + Alt 드래그 ✅ 완전 적용
+
+`brushSettings` 저장/복원(범위 클램프 포함), Alt 분기가 Ctrl·canDraw보다 먼저(잠긴 레이어에서도 크기 조절 허용, early return으로 undo/Liveblocks 무오염), HUD, `[`/`]` 단축키(스플릿 뷰 충돌 처리), 슬라이더 `change` 전용 저장 전부 적용. 코덱스 리뷰로 `waitForReady` 후 파일값 재복원(b536070), 기존 단축키 우선 처리(394597f)까지. app.js +390줄은 도구/색상/외곽선 로직을 헬퍼로 추출한 리팩토링(초기 복원·change 저장·단축키·Alt HUD가 공유). → 조치: R5(미세 비효율, 낮음).
+
+### 2.8 Phase 8 — 레이어 눈/잠금 버튼 확대 ✅
+
+SVG 아이콘 일반화(꺼짐 슬래시), `<button>`+aria 교체, `layer-hidden` 토글, 24×24 CSS 세트, `.composition-layer-header-visibility` 18→24, opacity 0.7 규칙 제거, 이모지 완전 제거, **잠금 해제 시 🔓 흐림 표시**(보이지 않는 히트영역 방지) 적용. 코덱스 리뷰로 `button.layer-lock` 셀렉터를 분리해 Video 행 장식 span에 흐림이 안 먹도록 개선(bf82975). → 조치: **R1(escapeHtml, 우선).**
+
+---
+
+## 3. 계획이 "포함 권장/별도 이슈"로 분류한 미구현 항목
+
+이들은 **PR 범위 위반이 아닙니다** — 계획서가 처음부터 선택/후속으로 분류했습니다. 다만 아직 착수·이슈 등록이 안 됐으므로 추적용으로 남깁니다.
+
+**Phase 9 (포함 권장이었으나 미구현)**:
+- 9.1 도구별 커서 피드백(브러시 크기 원형 커서) — `updateDrawingCursor` grep 0건
+- 9.2 키프레임 히트영역 `::before` 확장 + 드래그 4px 임계값 — 미구현(현재 mousedown 즉시 드래그)
+- 9.3 `layersChanged` rAF 병합 — 미구현(동기 직접 호출 유지)
+
+**기존 갭 (별도 이슈 등록 권장이었으나 미등록 — `gh issue list` 확인, 열린 이슈 #72/#59/#52/#48 모두 무관)**:
+- G1 키프레임 드래그 이동이 자동저장·원격 동기화에 미반영
+- G3 레이어 visibility/lock 토글이 협업에 미전파
+- G4 줌 변경 시 댓글 구간 미재클러스터
+- G5 keyframesMove 이중 재렌더(9.3과 연동)
+- G6 미사용 코드 잔재(`.frame-cell*` CSS, `_applyGridBackground`, `_createKeyframeClip`, `splitDrawingCanvas*` HTML)
+- (G2 원격 레이어 활성 탈취는 Phase 2에서 `skipActivate`로 **해결 완료**)
+
+권장: 위 항목들을 GitHub 이슈로 등록해 백로그에 올려두면 추적이 쉽습니다.
+
+---
+
+## 4. 권장 조치 순서
+
+| 순위 | 항목 | 규모 | 비고 |
+|------|------|------|------|
+| 1 | **R1** `_escapeHtml` 중복 정의 삭제 (timeline.js:1905) | 1줄 삭제 + 테스트 1건 | 유일한 실질 결함 |
+| 2 | R2/R3 테스트 회귀 방지 단언 보강 | 각 3줄 | 함께 커밋 가능 |
+| 3 | R4 컷리스트 셀 최소줌 분모 통일 | 1줄 | 컷리스트+ON 조합만 영향 |
+| 4 | R5 Alt 드래그 미세 비효율 2건 | 각 1~2줄 | 성능 미미 |
+| 5 | R6 잠긴 레이어 커서/무음 차단 (선택) | 소형 | UX 개선 |
+| 6 | Phase 9.1~9.3 / 기존 갭 이슈 등록 | 이슈 등록 | 백로그화 |
+
+R1~R5는 파일 2~3개의 소규모 수정이라 **하나의 후속 PR(`fix/피드백-구현-후속보강`)로 묶어 처리 가능**합니다. R1만 해도 실질 결함은 정리됩니다.
+
+---
+
+## 5. 총평
+
+윤성원님 피드백의 **버그 4건·기능 3건이 모두 동작하도록 구현·머지됐고**, 계획서가 검증 단계에서 미리 경고했던 함정들(STROKE_START 유출, `_renderFrameSync` 3분할, skipActivate, 셀 판정 호이스팅, 테스트 정규식 갱신)이 빠짐없이 반영됐습니다. 코덱스 리뷰 루프가 계획보다 견고하게 다듬은 부분도 많습니다(범위 클램프, maxZoom 가드, 셀렉터 분리, waitForReady 재복원 등).
+
+발견된 문제 중 **실제로 손봐야 할 것은 `_escapeHtml` 중복 정의(R1) 하나**이며, 그마저 CSP 덕에 스크립트 실행은 막혀 심각도가 낮~중입니다. 나머지는 테스트 보강이나 계획이 선택/후속으로 남긴 항목입니다. **전반적으로 구현 품질이 계획 의도에 충실하며, 배포에 지장을 주는 결함은 없습니다.**
+
+---
+
+*검증: 계획 문서 대비 PR #142~#147 전수 대조(에이전트 6개) + 문제 항목 적대적 재확인(에이전트 5개, Phase 7 재확인은 직접 실측 대체) + 핵심 발견 3건(escapeHtml 섀도잉·Alt 중복 emit·진입 파일쓰기) 직접 코드 검증. 테스트 510건 실행(508 pass, cutlist 2건은 기준선부터 실패하는 기존 문제).*

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -1900,15 +1900,6 @@ export class Timeline extends EventTarget {
   }
 
   /**
-   * HTML 이스케이프
-   */
-  _escapeHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
-  }
-
-  /**
    * 타임코드 포맷 (HH:MM:SS:FF)
    * @param {number} time - 시간 (초)
    * @returns {string} 타임코드 문자열

--- a/scripts/tests/layer-visibility-hit-area.test.js
+++ b/scripts/tests/layer-visibility-hit-area.test.js
@@ -66,3 +66,14 @@ test('video layer decorative controls keep matching icon size but do not look cl
   assert.match(mainCss, /\.layer-header\[data-layer="video"\] \.layer-visibility\s*\{[\s\S]*?cursor:\s*default;/);
   assert.match(packageJson.scripts['test:frame-grid'], /layer-visibility-hit-area\.test\.js/);
 });
+
+test('_escapeHtml is defined exactly once and escapes quotes for attribute contexts', () => {
+  // 클래스 내 메서드가 중복 정의되면 나중 정의가 프로토타입을 덮어써
+  // 레이어 이름 title 속성의 따옴표 이스케이프가 무력화된다(속성 주입 방지).
+  const defs = timelineSource.match(/^  _escapeHtml\(/gm) || [];
+  assert.equal(defs.length, 1, '_escapeHtml는 정확히 1회만 정의되어야 함');
+  // 남은 정의는 따옴표까지 이스케이프하는 정규식 버전이어야 함
+  assert.match(timelineSource, /_escapeHtml\(value\)\s*\{[\s\S]*?replace\(\/"\/g, '&quot;'\)[\s\S]*?replace\(\/'\/g, '&#39;'\)/);
+  // DOM(textContent) 기반 버전은 따옴표를 이스케이프하지 못하므로 존재해선 안 됨
+  assert.doesNotMatch(timelineSource, /_escapeHtml\(text\)\s*\{[\s\S]*?div\.textContent/);
+});


### PR DESCRIPTION
## 업데이트 로그 (사용자 관점)
- 레이어 이름에 따옴표 등 특수문자를 넣어도 UI가 깨지거나 악용될 여지가 사라집니다. (겉보기 동작 변화는 없는 보안/안정성 수정입니다.)

## 무엇을 / 왜 / 어떻게

**배경**: 윤성원님 피드백 구현(PR #142~#147) 검증 리뷰에서 발견된 유일한 실질 결함입니다.

**문제**: `renderer/scripts/modules/timeline.js`의 `Timeline` 클래스에 `_escapeHtml`이 **두 번 정의**되어 있었습니다.
- `1207`: 정규식 기반 — `& < > " '` 전부 이스케이프 (올바른 버전)
- `1905`: DOM(`div.textContent → innerHTML`) 기반 — **따옴표를 이스케이프하지 않음**

JS 클래스 의미론상 **나중 정의(1905)가 프로토타입을 덮어써**, 실제로는 따옴표를 못 막는 버전이 실행됐습니다. 이 때문에 PR #147이 넣은 레이어 이름 이스케이프가 `title="${name}"` 속성 컨텍스트에서 무력화되어, 레이어 이름의 `"`로 속성 주입이 가능했습니다. (CSP `script-src 'self'`가 스크립트 실행은 차단하므로 실행 XSS는 아니지만, `style` 속성 주입을 통한 UI 스푸핑/마크업 훼손은 가능 — 심각도 낮~중.)

**수정**:
1. DOM 기반 중복 정의(1905~1909)를 삭제하고, 따옴표까지 이스케이프하는 정규식 버전만 남김.
2. 회귀 방지: `layer-visibility-hit-area` 테스트에 `_escapeHtml` **단일 정의** + 따옴표 이스케이프 + DOM 버전 부재 검증 추가. (소스 정규식 검증은 런타임 섀도잉을 못 잡으므로 정의 개수 자체를 단언.)
3. 구현검증 리뷰 문서(`DEVLOG/2026-07-04-...구현검증-리뷰.md`) 추가.

## 테스트
- `node --test scripts/tests/layer-visibility-hit-area.test.js` → 6/6 통과 (신규 1건 포함)
- 전체 `scripts/tests/*.test.js` → 509 pass / 2 fail. 실패 2건은 `cutlist-runtime-source`로 **기준 커밋에서도 실패하는 기존 문제**(이번 변경과 무관, 워크트리 대조 확인).
- `npm run build` (electron-builder --dir) 성공.

## 개발 난항
- 겉보기에는 이스케이프가 되어 있어 정상처럼 보이지만, `<`/`>`만 막히고 `"`는 통과하는 미묘한 케이스였습니다. `node`로 "동일 클래스 내 나중 메서드 정의가 이긴다"를 실증해 실효 함수를 특정했습니다.
- 소스 문자열 매칭 테스트로는 런타임 섀도잉을 못 잡으므로, 정의 **개수**를 세는 단언으로 재발을 방지했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)