### PR TITLE
[v1.5.0-beta] 버전 간 피드백 이식 기능 추가

### DIFF
--- a/docs/superpowers/plans/2026-07-04-feedback-import.md
+++ b/docs/superpowers/plans/2026-07-04-feedback-import.md
@@ -1,0 +1,239 @@
+# Feedback Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a version-dropdown action that imports comments, replies, and attached images from another video version into the currently open version.
+
+**Architecture:** Put copy rules in a small pure module so behavior is tested without Electron. Keep the version dropdown responsible only for rendering the import button and emitting the selected source version. Keep `renderer/scripts/app.js` responsible for reading the source `.bframe`, applying the import to the current `CommentManager`, saving through `ReviewDataManager`, and refreshing the visible UI.
+
+**Tech Stack:** Electron renderer JavaScript modules, existing `.bframe` persistence, Node built-in `node:test`, source-level tests.
+
+---
+
+### Task 1: Add Failing Tests For Feedback Import Core
+
+**Files:**
+- Create: `scripts/tests/feedback-import.test.js`
+- Create: `renderer/scripts/modules/feedback-import.js`
+
+- [ ] **Step 1: Write the failing behavior tests**
+
+Add tests that import from `renderer/scripts/modules/feedback-import.js` and call:
+
+```js
+import {
+  cloneFeedbackMarkers,
+  countImportableFeedbackMarkers,
+  importFeedbackIntoTargetComments
+} from '../../renderer/scripts/modules/feedback-import.js';
+```
+
+The tests must cover:
+
+```js
+test('imports source markers into target comments without removing target markers', () => {});
+test('copies replies and attached images while assigning new IDs', () => {});
+test('returns zero importable markers for empty or missing comment layers', () => {});
+```
+
+- [ ] **Step 2: Run the new test and verify red**
+
+Run:
+
+```bash
+node --test scripts/tests/feedback-import.test.js
+```
+
+Expected: FAIL because `renderer/scripts/modules/feedback-import.js` does not exist yet.
+
+### Task 2: Implement The Pure Import Module
+
+**Files:**
+- Create: `renderer/scripts/modules/feedback-import.js`
+- Modify: `scripts/tests/feedback-import.test.js`
+
+- [ ] **Step 1: Implement `countImportableFeedbackMarkers(sourceComments)`**
+
+Count non-deleted markers from `sourceComments.layers`.
+
+- [ ] **Step 2: Implement `cloneFeedbackMarkers(sourceComments, options)`**
+
+Return cloned marker records with:
+
+```js
+id: options.createId('marker')
+layerId: options.targetLayerId
+replies: source replies with options.createId('reply')
+```
+
+Copy marker position, frame range, text, author, image fields, color, resolved metadata, and timestamps.
+
+- [ ] **Step 3: Implement `importFeedbackIntoTargetComments(targetComments, sourceComments, options)`**
+
+Return:
+
+```js
+{
+  comments,
+  importedCount,
+  importedMarkers
+}
+```
+
+Append cloned markers to the target layer. Preserve all existing target layers and markers.
+
+- [ ] **Step 4: Run the new unit test and verify green**
+
+Run:
+
+```bash
+node --test scripts/tests/feedback-import.test.js
+```
+
+Expected: PASS.
+
+### Task 3: Wire The Version Dropdown Import Action
+
+**Files:**
+- Modify: `renderer/scripts/modules/version-dropdown.js`
+- Modify: `renderer/styles/main.css`
+- Modify: `renderer/index.html`
+
+- [ ] **Step 1: Add an import callback API**
+
+Add:
+
+```js
+onFeedbackImport(callback) {
+  this._onFeedbackImport = callback;
+}
+```
+
+- [ ] **Step 2: Render the import button for non-current version rows**
+
+Add an icon-only row action with title:
+
+```text
+이 버전의 피드백 가져오기
+```
+
+The click handler must call `this._onFeedbackImport(versionInfo)` and stop propagation.
+
+- [ ] **Step 3: Add focused CSS**
+
+Add `.version-item-import-feedback` styles next to existing version row action button styles.
+
+### Task 4: Apply Imported Feedback In The App
+
+**Files:**
+- Modify: `renderer/scripts/app.js`
+
+- [ ] **Step 1: Import helpers**
+
+Add:
+
+```js
+import { countImportableFeedbackMarkers, importFeedbackIntoTargetComments } from './modules/feedback-import.js';
+import { getBframePath } from './modules/review-data-manager.js';
+```
+
+Use the existing `ReviewDataManager` import if `getBframePath` is already imported from the same module.
+
+- [ ] **Step 2: Add `handleImportFeedbackFromVersion(versionInfo)`**
+
+The handler must:
+
+```js
+const sourceBframePath = getBframePath(versionInfo.path);
+const sourceData = await window.electronAPI.loadReview(sourceBframePath);
+const sourceCount = countImportableFeedbackMarkers(sourceData?.comments);
+```
+
+Warn if source count is zero. Confirm before import. Apply the import to `commentManager.toJSON()`, call `commentManager.fromJSON(result.comments)`, save with `reviewDataManager.save()`, then refresh comment list, timeline markers, video markers, and comment ranges.
+
+- [ ] **Step 3: Register the dropdown callback**
+
+After `versionDropdown.setReviewDataManager(reviewDataManager)`, call:
+
+```js
+versionDropdown.onFeedbackImport(handleImportFeedbackFromVersion);
+```
+
+### Task 5: Add Source Tests For UI Wiring
+
+**Files:**
+- Create: `scripts/tests/feedback-import-source.test.js`
+
+- [ ] **Step 1: Assert source wiring**
+
+Check that:
+
+```js
+renderer/scripts/modules/version-dropdown.js
+```
+
+contains `onFeedbackImport`, `version-item-import-feedback`, and the Korean tooltip.
+
+Check that:
+
+```js
+renderer/scripts/app.js
+```
+
+imports `feedback-import.js`, defines `handleImportFeedbackFromVersion`, calls `window.electronAPI.loadReview(sourceBframePath)`, calls `reviewDataManager.save()`, and registers `versionDropdown.onFeedbackImport(handleImportFeedbackFromVersion)`.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+node --test scripts/tests/feedback-import.test.js scripts/tests/feedback-import-source.test.js
+```
+
+Expected: PASS.
+
+### Task 6: Verify, Review, And Release
+
+**Files:**
+- All touched files
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+node --test scripts/tests/feedback-import.test.js scripts/tests/feedback-import-source.test.js
+```
+
+- [ ] **Step 2: Run related comment and playlist tests**
+
+```bash
+npm run test:comment-input
+npm run test:playlist-comments
+```
+
+- [ ] **Step 3: Run build**
+
+```bash
+npm run build
+```
+
+- [ ] **Step 4: Self-review the diff**
+
+Review for duplicate import bugs, self-import bugs, accidental drawing/highlight copy, save failures, and UI event propagation mistakes.
+
+- [ ] **Step 5: Re-run focused tests after review fixes**
+
+```bash
+node --test scripts/tests/feedback-import.test.js scripts/tests/feedback-import-source.test.js
+```
+
+- [ ] **Step 6: Commit, push, prepare PR, run review loop, merge, rebuild, and deploy**
+
+Follow the BAEFRAME release deploy workflow:
+
+```bash
+git add docs/superpowers/specs/2026-07-04-feedback-import-design.md docs/superpowers/plans/2026-07-04-feedback-import.md renderer/scripts/modules/feedback-import.js renderer/scripts/modules/version-dropdown.js renderer/scripts/app.js renderer/styles/main.css scripts/tests/feedback-import.test.js scripts/tests/feedback-import-source.test.js
+git commit -m "피드백 버전 이식 기능 추가"
+git push -u origin codex/baeframe-feedback-import
+```
+
+Then create PR, run Codex review loop, merge, build, copy `dist\win-unpacked` to the shared-drive beta folder, and verify hashes.

--- a/docs/superpowers/specs/2026-07-04-feedback-import-design.md
+++ b/docs/superpowers/specs/2026-07-04-feedback-import-design.md
@@ -1,0 +1,74 @@
+# Feedback Import Design
+
+## Summary
+
+BAEFRAME will let a user open one version, usually the newer video, and import comment feedback from another version in the same version list. The import copies comments, replies, and attached images from the source version into the currently open version.
+
+The current version's existing comments are kept. Imported comments become new comments with new IDs so the source version and target version stay independent.
+
+## Goals
+
+- Import feedback from another detected or manually added video version.
+- Copy comment markers, text, time ranges, positions, authors, colors, resolved state, replies, and attached images.
+- Preserve existing comments in the currently open version.
+- Save the imported comments into the current version's `.bframe`.
+- Refresh the comment sidebar, video markers, and timeline comment ranges immediately after import.
+- Keep the flow inside the existing version dropdown.
+
+## Non-Goals
+
+- Do not copy drawings.
+- Do not copy highlights.
+- Do not copy composition layers.
+- Do not overwrite or delete existing target comments.
+- Do not auto-import feedback during version switching.
+- Do not create a new project-level feedback database.
+
+## User Flow
+
+1. User opens `v2`.
+2. User opens the version dropdown.
+3. User clicks the feedback import action on `v1`.
+4. BAEFRAME confirms the number of comments that will be added.
+5. BAEFRAME copies the feedback into `v2`, saves `v2.bframe`, and refreshes the UI.
+
+The current version item does not show an import action because importing from itself would be confusing and useless.
+
+## Data Behavior
+
+Feedback is read from the source version's `.bframe` file. Source and target `.bframe` paths are derived with the same `getBframePath(videoPath)` logic already used by `ReviewDataManager`.
+
+The import only reads `comments.layers[].markers[]`. Each copied marker receives:
+
+- a new marker ID
+- the target layer ID
+- copied marker fields such as frame range, position, text, author, color, resolved state, timestamps, and image data
+- copied replies with new reply IDs
+
+Target comments remain unchanged. Imported comments are added to the active target comment layer. If no active layer exists, the default comment layer is used.
+
+## Error Handling
+
+- If no current video is open, show a warning.
+- If the selected version has no file path, show a warning.
+- If the source `.bframe` does not exist or has no comments, show a warning.
+- If the user cancels the confirmation dialog, do nothing.
+- If saving the target `.bframe` fails, keep the imported data in memory but show an error so the user knows save failed.
+
+## UI
+
+Each non-current version row in the version dropdown gets a small import button with tooltip text:
+
+`이 버전의 피드백 가져오기`
+
+The button is icon-only and sits next to the existing edit/delete controls. It stops row-click propagation so clicking it does not switch versions.
+
+After a successful import, a toast reports the number of copied comments.
+
+## Tests
+
+- Unit tests cover cloning comments into target comments.
+- Unit tests verify replies and attached images are preserved.
+- Unit tests verify target comments are not removed.
+- Unit tests verify copied marker and reply IDs are new.
+- Source tests verify the version dropdown has an import action callback and the app wires it to source `.bframe` loading, target save, and UI refresh.

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -22,6 +22,10 @@ import { getImageFromClipboard, hasImageInClipboard, selectImageFile, isValidIma
 import { parseVersion, toVersionInfo } from './modules/version-parser.js';
 import { getVersionManager } from './modules/version-manager.js';
 import { getVersionDropdown } from './modules/version-dropdown.js';
+import {
+  countImportableFeedbackMarkers,
+  importFeedbackIntoTargetComments
+} from './modules/feedback-import.js';
 import { getSplitViewManager } from './modules/split-view-manager.js';
 import { getPlaylistManager } from './modules/playlist-manager.js';
 import { resizeClusterMembersByEdge } from './modules/comment-cluster.js';
@@ -7046,6 +7050,76 @@ async function initApp() {
     }
   }
 
+  async function handleImportFeedbackFromVersion(versionInfo) {
+    if (!state.currentFile) {
+      showToast('먼저 피드백을 받을 버전을 열어주세요.', 'warning');
+      return false;
+    }
+
+    if (!versionInfo?.path) {
+      showToast('피드백을 가져올 버전 파일을 찾을 수 없습니다.', 'warning');
+      return false;
+    }
+
+    if (isSameFilePath(versionInfo.path, state.currentFile)) {
+      showToast('현재 열려 있는 버전에서는 피드백을 가져올 수 없습니다.', 'info');
+      return false;
+    }
+
+    const sourceBframePath = getBframePath(versionInfo.path);
+    let sourceData = null;
+
+    try {
+      sourceData = await window.electronAPI.loadReview(sourceBframePath);
+    } catch (error) {
+      log.warn('피드백 가져오기 소스 로드 실패', {
+        sourceBframePath,
+        error: error.message
+      });
+      showToast('선택한 버전의 피드백 파일을 열 수 없습니다.', 'warning');
+      return false;
+    }
+
+    const sourceCount = countImportableFeedbackMarkers(sourceData?.comments);
+    if (sourceCount <= 0) {
+      showToast('선택한 버전에 가져올 피드백이 없습니다.', 'info');
+      return false;
+    }
+
+    const sourceLabel = versionInfo.displayLabel || (versionInfo.version ? `v${versionInfo.version}` : versionInfo.fileName || '선택한 버전');
+    const confirmed = confirm(`${sourceLabel}에서 피드백 ${sourceCount}개를 현재 버전으로 가져올까요?`);
+    if (!confirmed) return false;
+
+    const targetLayerId = commentManager.activeLayerId || commentManager.getActiveLayer()?.id || 'comment-layer-1';
+    const result = importFeedbackIntoTargetComments(
+      commentManager.toJSON(),
+      sourceData?.comments,
+      { targetLayerId }
+    );
+
+    if (result.importedCount <= 0) {
+      showToast('가져올 수 있는 피드백이 없습니다.', 'info');
+      return false;
+    }
+
+    commentManager.fromJSON(result.comments);
+    commentManager.setActiveLayer(targetLayerId);
+    const saved = await reviewDataManager.save();
+
+    updateCommentList();
+    updateTimelineMarkers();
+    renderVideoMarkers();
+    await refreshCommentRangesForCurrentMode();
+
+    if (!saved) {
+      showToast('피드백은 화면에 추가됐지만 저장에 실패했습니다.', 'error');
+      return false;
+    }
+
+    showToast(`피드백 ${result.importedCount}개를 가져왔습니다.`, 'success');
+    return true;
+  }
+
   // 썸네일 리스너 참조 저장 (파일 전환 시 정리용)
   const thumbnailListeners = {
     progress: null,
@@ -12833,6 +12907,7 @@ async function initApp() {
   const versionDropdown = getVersionDropdown();
   versionDropdown.init();
   versionDropdown.setReviewDataManager(reviewDataManager);
+  versionDropdown.onFeedbackImport(handleImportFeedbackFromVersion);
 
   // 스플릿 뷰 매니저 초기화
   const splitViewManager = getSplitViewManager();

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1553,15 +1553,15 @@ async function initApp() {
 
   // 마커 추가됨
   commentManager.addEventListener('markerAdded', async (e) => {
-    const { marker, remote, restored } = e.detail;
+    const { marker, remote, restored, imported } = e.detail;
     removePendingMarkerUI();
     renderVideoMarkers();
     updateTimelineMarkers();
     updateCommentList();
     log.info('마커 추가됨', { id: marker.id, text: marker.text, remote: !!remote });
 
-    // 원격 변경 또는 Redo 복원은 알림/Undo 스킵
-    if (remote || restored) return;
+    // 원격 변경, Redo 복원, 가져온 피드백은 알림/Undo 스킵
+    if (remote || restored || imported) return;
 
     // Slack 알림: @멘션 대상에게 웹훅 전송 (딥링크 전에 저장하여 최신 상태 보장)
     if (reviewDataManager.getBframePath()) {
@@ -7104,8 +7104,13 @@ async function initApp() {
       return false;
     }
 
-    commentManager.fromJSON(result.comments);
-    commentManager.setActiveLayer(targetLayerId);
+    const importedMarkers = commentManager.addImportedMarkers(result.importedMarkers, targetLayerId);
+    if (importedMarkers.length <= 0) {
+      showToast('가져올 수 있는 피드백이 없습니다.', 'info');
+      return false;
+    }
+
+    commentManager.setActiveLayer(importedMarkers[0].layerId || targetLayerId);
     const saved = await reviewDataManager.save();
 
     updateCommentList();
@@ -7118,7 +7123,7 @@ async function initApp() {
       return false;
     }
 
-    showToast(`피드백 ${result.importedCount}개를 가져왔습니다.`, 'success');
+    showToast(`피드백 ${importedMarkers.length}개를 가져왔습니다.`, 'success');
     return true;
   }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -24,7 +24,8 @@ import { getVersionManager } from './modules/version-manager.js';
 import { getVersionDropdown } from './modules/version-dropdown.js';
 import {
   countImportableFeedbackMarkers,
-  importFeedbackIntoTargetComments
+  importFeedbackIntoTargetComments,
+  normalizeFeedbackSourceComments
 } from './modules/feedback-import.js';
 import { getSplitViewManager } from './modules/split-view-manager.js';
 import { getPlaylistManager } from './modules/playlist-manager.js';
@@ -7080,7 +7081,8 @@ async function initApp() {
       return false;
     }
 
-    const sourceCount = countImportableFeedbackMarkers(sourceData?.comments);
+    const sourceComments = normalizeFeedbackSourceComments(sourceData);
+    const sourceCount = countImportableFeedbackMarkers(sourceComments);
     if (sourceCount <= 0) {
       showToast('선택한 버전에 가져올 피드백이 없습니다.', 'info');
       return false;
@@ -7093,7 +7095,7 @@ async function initApp() {
     const targetLayerId = commentManager.activeLayerId || commentManager.getActiveLayer()?.id || 'comment-layer-1';
     const result = importFeedbackIntoTargetComments(
       commentManager.toJSON(),
-      sourceData?.comments,
+      sourceComments,
       { targetLayerId }
     );
 

--- a/renderer/scripts/modules/comment-manager.js
+++ b/renderer/scripts/modules/comment-manager.js
@@ -28,7 +28,7 @@ export const AUTHOR_COLORS = [
   { color: '#c084fc', bgColor: 'rgba(192, 132, 252, 0.3)' },  // 보라
   { color: '#f97316', bgColor: 'rgba(249, 115, 22, 0.3)' },   // 주황
   { color: '#38bdf8', bgColor: 'rgba(56, 189, 248, 0.3)' },   // 하늘
-  { color: '#fb7185', bgColor: 'rgba(251, 113, 133, 0.3)' },  // 장미
+  { color: '#fb7185', bgColor: 'rgba(251, 113, 133, 0.3)' }  // 장미
 ];
 
 // authorId → 고정 색상 매핑 (해시 기반)
@@ -607,6 +607,43 @@ export class CommentManager extends EventTarget {
       return marker;
     }
     return null;
+  }
+
+  /**
+   * 가져온 피드백 마커를 현재 댓글 레이어에 추가한다.
+   * markerAdded 이벤트를 내보내 Liveblocks 협업 방송 경로도 동일하게 탄다.
+   */
+  addImportedMarkers(markerDataList, targetLayerId = this.activeLayerId) {
+    if (!Array.isArray(markerDataList) || markerDataList.length === 0) return [];
+
+    const layer = this.layers.find(l => l.id === targetLayerId) || this.getActiveLayer();
+    if (!layer) return [];
+
+    const importedMarkers = [];
+    for (const markerData of markerDataList) {
+      if (!markerData?.id || this.getMarker(markerData.id)) continue;
+
+      const marker = markerData instanceof CommentMarker
+        ? markerData
+        : CommentMarker.fromJSON({
+          ...markerData,
+          layerId: layer.id
+        });
+
+      layer.addMarker(marker);
+      importedMarkers.push(marker);
+      this._emit('markerAdded', { marker, layerId: layer.id, imported: true });
+    }
+
+    if (importedMarkers.length > 0) {
+      this._emit('markersChanged', {
+        imported: true,
+        markers: importedMarkers,
+        layerId: layer.id
+      });
+    }
+
+    return importedMarkers;
   }
 
   /**

--- a/renderer/scripts/modules/feedback-import.js
+++ b/renderer/scripts/modules/feedback-import.js
@@ -1,0 +1,145 @@
+/**
+ * Feedback import helpers.
+ *
+ * Copies comment feedback from one version into another without mutating either
+ * source object. Drawing, highlight, and composition data are intentionally out
+ * of scope for this module.
+ */
+
+function defaultCreateId(prefix = 'feedback') {
+  if (globalThis.crypto?.randomUUID) {
+    return `${prefix}-${globalThis.crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function clonePlainRecord(record) {
+  if (!record || typeof record !== 'object') return {};
+  return JSON.parse(JSON.stringify(record));
+}
+
+function getCommentLayers(comments) {
+  return Array.isArray(comments?.layers) ? comments.layers : [];
+}
+
+function getMarkers(layer) {
+  return Array.isArray(layer?.markers) ? layer.markers : [];
+}
+
+function getImportableMarkers(sourceComments) {
+  return getCommentLayers(sourceComments)
+    .flatMap(layer => getMarkers(layer))
+    .filter(marker => marker && marker.deleted !== true);
+}
+
+function createDefaultTargetLayer(targetLayerId = 'comment-layer-1') {
+  return {
+    id: targetLayerId,
+    name: '댓글 1',
+    color: '#ff6b6b',
+    visible: true,
+    locked: false,
+    markers: []
+  };
+}
+
+function normalizeTargetComments(targetComments, targetLayerId) {
+  const base = {
+    ...clonePlainRecord(targetComments),
+    layers: getCommentLayers(targetComments).map(layer => ({
+      ...clonePlainRecord(layer),
+      markers: getMarkers(layer).map(marker => clonePlainRecord(marker))
+    }))
+  };
+
+  if (base.layers.length === 0) {
+    base.layers.push(createDefaultTargetLayer(targetLayerId));
+  }
+
+  return base;
+}
+
+function resolveTargetLayer(comments, preferredLayerId) {
+  if (!comments.layers.length) {
+    comments.layers.push(createDefaultTargetLayer(preferredLayerId));
+  }
+
+  const preferred = preferredLayerId
+    ? comments.layers.find(layer => layer.id === preferredLayerId)
+    : null;
+
+  return preferred || comments.layers[0];
+}
+
+/**
+ * Count source comment markers that can be imported.
+ *
+ * @param {object|null} sourceComments
+ * @returns {number}
+ */
+export function countImportableFeedbackMarkers(sourceComments) {
+  return getImportableMarkers(sourceComments).length;
+}
+
+/**
+ * Clone source feedback markers for insertion into a target comment layer.
+ *
+ * @param {object|null} sourceComments
+ * @param {object} options
+ * @param {(prefix: string) => string} options.createId
+ * @param {string} options.targetLayerId
+ * @returns {Array<object>}
+ */
+export function cloneFeedbackMarkers(sourceComments, options = {}) {
+  const createId = options.createId || defaultCreateId;
+  const targetLayerId = options.targetLayerId || 'comment-layer-1';
+
+  return getImportableMarkers(sourceComments).map(sourceMarker => {
+    const cloned = {
+      ...clonePlainRecord(sourceMarker),
+      id: createId('marker'),
+      layerId: targetLayerId,
+      replies: Array.isArray(sourceMarker.replies)
+        ? sourceMarker.replies.map(reply => ({
+          ...clonePlainRecord(reply),
+          id: createId('reply')
+        }))
+        : []
+    };
+
+    delete cloned.element;
+    delete cloned.tooltipElement;
+
+    return cloned;
+  });
+}
+
+/**
+ * Import source feedback markers into a target comments object.
+ *
+ * @param {object|null} targetComments
+ * @param {object|null} sourceComments
+ * @param {object} options
+ * @param {(prefix: string) => string} options.createId
+ * @param {string} options.targetLayerId
+ * @returns {{ comments: object, importedCount: number, importedMarkers: Array<object> }}
+ */
+export function importFeedbackIntoTargetComments(targetComments, sourceComments, options = {}) {
+  const comments = normalizeTargetComments(targetComments, options.targetLayerId || 'comment-layer-1');
+  const targetLayer = resolveTargetLayer(comments, options.targetLayerId);
+  const importedMarkers = cloneFeedbackMarkers(sourceComments, {
+    ...options,
+    targetLayerId: targetLayer.id
+  });
+
+  targetLayer.markers = [
+    ...getMarkers(targetLayer),
+    ...importedMarkers
+  ];
+
+  return {
+    comments,
+    importedCount: importedMarkers.length,
+    importedMarkers
+  };
+}

--- a/renderer/scripts/modules/feedback-import.js
+++ b/renderer/scripts/modules/feedback-import.js
@@ -6,6 +6,8 @@
  * of scope for this module.
  */
 
+import { migrateToV2 } from '../../../shared/schema.js';
+
 function defaultCreateId(prefix = 'feedback') {
   if (globalThis.crypto?.randomUUID) {
     return `${prefix}-${globalThis.crypto.randomUUID()}`;
@@ -19,7 +21,8 @@ function clonePlainRecord(record) {
 }
 
 function getCommentLayers(comments) {
-  return Array.isArray(comments?.layers) ? comments.layers : [];
+  const normalized = normalizeFeedbackComments(comments);
+  return Array.isArray(normalized?.layers) ? normalized.layers : [];
 }
 
 function getMarkers(layer) {
@@ -41,6 +44,57 @@ function createDefaultTargetLayer(targetLayerId = 'comment-layer-1') {
     locked: false,
     markers: []
   };
+}
+
+function normalizeLegacyCommentArray(comments) {
+  return {
+    layers: [
+      {
+        id: 'layer_default',
+        name: '기본 레이어',
+        visible: true,
+        markers: comments.map(comment => ({
+          ...clonePlainRecord(comment),
+          replies: Array.isArray(comment?.replies) ? comment.replies.map(reply => clonePlainRecord(reply)) : []
+        }))
+      }
+    ]
+  };
+}
+
+function normalizeFeedbackComments(comments) {
+  if (comments && typeof comments === 'object' && Array.isArray(comments.layers)) {
+    return comments;
+  }
+
+  if (Array.isArray(comments)) {
+    return normalizeLegacyCommentArray(comments);
+  }
+
+  return { layers: [] };
+}
+
+/**
+ * Normalize full source review data into importable v2 comment data.
+ *
+ * @param {object|Array|null} sourceData
+ * @returns {object}
+ */
+export function normalizeFeedbackSourceComments(sourceData) {
+  if (!sourceData || typeof sourceData !== 'object') {
+    return { layers: [] };
+  }
+
+  if (Array.isArray(sourceData) || Array.isArray(sourceData.layers)) {
+    return normalizeFeedbackComments(sourceData);
+  }
+
+  try {
+    const migrated = migrateToV2(sourceData);
+    return normalizeFeedbackComments(migrated?.comments);
+  } catch (_error) {
+    return normalizeFeedbackComments(sourceData.comments);
+  }
 }
 
 function normalizeTargetComments(targetComments, targetLayerId) {

--- a/renderer/scripts/modules/feedback-import.js
+++ b/renderer/scripts/modules/feedback-import.js
@@ -56,8 +56,9 @@ function createDefaultTargetLayer(targetLayerId = 'comment-layer-1') {
   };
 }
 
-function normalizeLegacyCommentArray(comments) {
+function normalizeLegacyCommentArray(comments, fps = null) {
   return {
+    ...(fps ? { fps } : {}),
     layers: [
       {
         id: 'layer_default',
@@ -72,16 +73,16 @@ function normalizeLegacyCommentArray(comments) {
   };
 }
 
-function normalizeFeedbackComments(comments) {
+function normalizeFeedbackComments(comments, fps = null) {
   if (comments && typeof comments === 'object' && Array.isArray(comments.layers)) {
-    return comments;
+    return fps && !comments.fps ? { ...comments, fps } : comments;
   }
 
   if (Array.isArray(comments)) {
-    return normalizeLegacyCommentArray(comments);
+    return normalizeLegacyCommentArray(comments, fps);
   }
 
-  return { layers: [] };
+  return fps ? { fps, layers: [] } : { layers: [] };
 }
 
 /**
@@ -99,11 +100,12 @@ export function normalizeFeedbackSourceComments(sourceData) {
     return normalizeFeedbackComments(sourceData);
   }
 
+  const sourceFps = toPositiveNumber(sourceData.fps);
   try {
     const migrated = migrateToV2(sourceData);
-    return normalizeFeedbackComments(migrated?.comments);
+    return normalizeFeedbackComments(migrated?.comments, toPositiveNumber(migrated?.fps) || sourceFps);
   } catch (_error) {
-    return normalizeFeedbackComments(sourceData.comments);
+    return normalizeFeedbackComments(sourceData.comments, sourceFps);
   }
 }
 
@@ -172,10 +174,11 @@ export function countImportableFeedbackMarkers(sourceComments) {
 export function cloneFeedbackMarkers(sourceComments, options = {}) {
   const createId = options.createId || defaultCreateId;
   const targetLayerId = options.targetLayerId || 'comment-layer-1';
+  const defaultFps = toPositiveNumber(sourceComments?.fps) || options.fps;
 
   return getImportableMarkers(sourceComments).map(sourceMarker => {
     const now = new Date().toISOString();
-    const { fps, startFrame, endFrame } = resolveMarkerFrames(sourceMarker, options.fps);
+    const { fps, startFrame, endFrame } = resolveMarkerFrames(sourceMarker, defaultFps);
     const cloned = {
       ...clonePlainRecord(sourceMarker),
       id: createId('marker'),

--- a/renderer/scripts/modules/feedback-import.js
+++ b/renderer/scripts/modules/feedback-import.js
@@ -183,12 +183,14 @@ export function cloneFeedbackMarkers(sourceComments, options = {}) {
       fps,
       startFrame,
       endFrame,
+      text: sourceMarker.text ?? sourceMarker.content ?? '',
       createdAt: sourceMarker.createdAt || now,
       updatedAt: sourceMarker.updatedAt || sourceMarker.createdAt || now,
       replies: Array.isArray(sourceMarker.replies)
         ? sourceMarker.replies.map(reply => ({
           ...clonePlainRecord(reply),
           id: createId('reply'),
+          text: reply.text ?? reply.content ?? '',
           createdAt: reply.createdAt || now,
           updatedAt: reply.updatedAt || reply.createdAt || now
         }))

--- a/renderer/scripts/modules/feedback-import.js
+++ b/renderer/scripts/modules/feedback-import.js
@@ -149,14 +149,19 @@ export function cloneFeedbackMarkers(sourceComments, options = {}) {
   const targetLayerId = options.targetLayerId || 'comment-layer-1';
 
   return getImportableMarkers(sourceComments).map(sourceMarker => {
+    const now = new Date().toISOString();
     const cloned = {
       ...clonePlainRecord(sourceMarker),
       id: createId('marker'),
       layerId: targetLayerId,
+      createdAt: sourceMarker.createdAt || now,
+      updatedAt: sourceMarker.updatedAt || sourceMarker.createdAt || now,
       replies: Array.isArray(sourceMarker.replies)
         ? sourceMarker.replies.map(reply => ({
           ...clonePlainRecord(reply),
-          id: createId('reply')
+          id: createId('reply'),
+          createdAt: reply.createdAt || now,
+          updatedAt: reply.updatedAt || reply.createdAt || now
         }))
         : []
     };

--- a/renderer/scripts/modules/feedback-import.js
+++ b/renderer/scripts/modules/feedback-import.js
@@ -20,6 +20,16 @@ function clonePlainRecord(record) {
   return JSON.parse(JSON.stringify(record));
 }
 
+function toFiniteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function toPositiveNumber(value) {
+  const number = toFiniteNumber(value);
+  return number && number > 0 ? number : null;
+}
+
 function getCommentLayers(comments) {
   const normalized = normalizeFeedbackComments(comments);
   return Array.isArray(normalized?.layers) ? normalized.layers : [];
@@ -125,6 +135,21 @@ function resolveTargetLayer(comments, preferredLayerId) {
   return preferred || comments.layers[0];
 }
 
+function resolveMarkerFrames(sourceMarker, defaultFps = 24) {
+  const fps = toPositiveNumber(sourceMarker.fps) || toPositiveNumber(defaultFps) || 24;
+  const startFrame = toFiniteNumber(sourceMarker.startFrame)
+    ?? toFiniteNumber(sourceMarker.frame)
+    ?? 0;
+  const endFrame = toFiniteNumber(sourceMarker.endFrame)
+    ?? (startFrame + Math.round(fps * 4));
+
+  return {
+    fps,
+    startFrame,
+    endFrame: Math.max(startFrame, endFrame)
+  };
+}
+
 /**
  * Count source comment markers that can be imported.
  *
@@ -150,10 +175,14 @@ export function cloneFeedbackMarkers(sourceComments, options = {}) {
 
   return getImportableMarkers(sourceComments).map(sourceMarker => {
     const now = new Date().toISOString();
+    const { fps, startFrame, endFrame } = resolveMarkerFrames(sourceMarker, options.fps);
     const cloned = {
       ...clonePlainRecord(sourceMarker),
       id: createId('marker'),
       layerId: targetLayerId,
+      fps,
+      startFrame,
+      endFrame,
       createdAt: sourceMarker.createdAt || now,
       updatedAt: sourceMarker.updatedAt || sourceMarker.createdAt || now,
       replies: Array.isArray(sourceMarker.replies)

--- a/renderer/scripts/modules/version-dropdown.js
+++ b/renderer/scripts/modules/version-dropdown.js
@@ -121,6 +121,7 @@ export class VersionDropdown {
 
     // Callbacks
     this._onVersionSelect = null;
+    this._onFeedbackImport = null;
 
     // VersionManager 참조
     this._versionManager = getVersionManager();
@@ -308,6 +309,14 @@ export class VersionDropdown {
   }
 
   /**
+   * 피드백 가져오기 콜백 설정
+   * @param {Function} callback - (versionInfo) => void
+   */
+  onFeedbackImport(callback) {
+    this._onFeedbackImport = callback;
+  }
+
+  /**
    * 목록 렌더링
    */
   _render() {
@@ -400,6 +409,22 @@ export class VersionDropdown {
     // 버튼 컨테이너
     const btnContainer = document.createElement('div');
     btnContainer.className = 'version-item-actions';
+
+    if (!isCurrent && versionInfo.path) {
+      const importFeedbackBtn = document.createElement('button');
+      importFeedbackBtn.className = 'version-item-import-feedback';
+      importFeedbackBtn.title = '이 버전의 피드백 가져오기';
+      importFeedbackBtn.innerHTML =
+        '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>';
+      importFeedbackBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        if (this._onFeedbackImport) {
+          this._onFeedbackImport(versionInfo);
+        }
+      });
+      btnContainer.appendChild(importFeedbackBtn);
+    }
 
     // 편집 버튼 (모든 버전)
     const editBtn = document.createElement('button');

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -10165,8 +10165,9 @@ body.app-fullscreen .video-wrapper.comment-mode::after {
   margin-left: 4px;
 }
 
-/* Version Item Edit Button */
-.version-item-edit {
+/* Version Item Row Action Buttons */
+.version-item-edit,
+.version-item-import-feedback {
   padding: 4px 6px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-subtle);
@@ -10179,10 +10180,15 @@ body.app-fullscreen .video-wrapper.comment-mode::after {
   justify-content: center;
 }
 
-.version-item-edit:hover {
+.version-item-edit:hover,
+.version-item-import-feedback:hover {
   color: var(--accent-primary);
   background: var(--accent-glow);
   border-color: var(--accent-secondary);
+}
+
+.version-item-import-feedback {
+  color: var(--text-tertiary);
 }
 
 /* Version Item Delete (Manual Only) */

--- a/scripts/tests/comment-realtime-sync.test.js
+++ b/scripts/tests/comment-realtime-sync.test.js
@@ -67,6 +67,47 @@ test('remote reply add and delete emit the same refresh signals as local changes
   assert.equal(new Date(marker.updatedAt).toISOString(), deleteRevision);
 });
 
+test('imported feedback markers emit markerAdded events for live collaboration broadcast', async () => {
+  const { CommentManager } = await import('../../renderer/scripts/modules/comment-manager.js');
+  const { CommentSync } = await import('../../renderer/scripts/modules/comment-sync.js');
+  const manager = new CommentManager({ author: '테스터' });
+  const broadcasts = [];
+  const liveblocksManager = new EventTarget();
+  liveblocksManager.broadcastEvent = event => broadcasts.push(event);
+
+  const sync = new CommentSync({ liveblocksManager, commentManager: manager });
+  await sync.start();
+
+  const imported = manager.addImportedMarkers([{
+    id: 'imported-marker-1',
+    x: 0.2,
+    y: 0.3,
+    startFrame: 12,
+    endFrame: 48,
+    fps: 24,
+    text: '가져온 피드백',
+    author: '리뷰어',
+    createdAt: '2026-07-04T00:00:00.000Z',
+    updatedAt: '2026-07-04T00:00:00.000Z',
+    replies: [{
+      id: 'imported-reply-1',
+      text: '가져온 답글',
+      author: '답글러',
+      createdAt: '2026-07-04T00:01:00.000Z',
+      updatedAt: '2026-07-04T00:01:00.000Z'
+    }]
+  }], manager.activeLayerId);
+
+  sync.stop();
+
+  assert.equal(imported.length, 1);
+  assert.equal(broadcasts.length, 1);
+  assert.equal(broadcasts[0].type, 'COMMENT_MARKER_ADDED');
+  assert.equal(broadcasts[0].layerId, manager.activeLayerId);
+  assert.equal(broadcasts[0].marker.id, 'imported-marker-1');
+  assert.equal(broadcasts[0].marker.replies[0].id, 'imported-reply-1');
+});
+
 test('file reload merge accepts newer remote replies even when marker updatedAt is unchanged', async () => {
   const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
   const localMarker = {

--- a/scripts/tests/feedback-import-source.test.js
+++ b/scripts/tests/feedback-import-source.test.js
@@ -24,9 +24,11 @@ test('feedback import is wired to load source bframe, save current bframe, and r
   assert.match(appSource, /async function handleImportFeedbackFromVersion\(versionInfo\) \{/);
   assert.match(appSource, /const sourceBframePath = getBframePath\(versionInfo\.path\);/);
   assert.match(appSource, /sourceData = await window\.electronAPI\.loadReview\(sourceBframePath\);/);
-  assert.match(appSource, /countImportableFeedbackMarkers\(sourceData\?\.comments\)/);
+  assert.match(appSource, /normalizeFeedbackSourceComments\(sourceData\)/);
+  assert.match(appSource, /countImportableFeedbackMarkers\(sourceComments\)/);
   assert.match(appSource, /confirm\(`[\s\S]+피드백[\s\S]+가져올까요\?`\)/);
   assert.match(appSource, /importFeedbackIntoTargetComments\(/);
+  assert.match(appSource, /commentManager\.toJSON\(\),[\s\S]+sourceComments,[\s\S]+\{ targetLayerId \}/);
   assert.match(appSource, /commentManager\.fromJSON\(result\.comments\);/);
   assert.match(appSource, /commentManager\.setActiveLayer\(targetLayerId\);/);
   assert.match(appSource, /const saved = await reviewDataManager\.save\(\);/);

--- a/scripts/tests/feedback-import-source.test.js
+++ b/scripts/tests/feedback-import-source.test.js
@@ -29,9 +29,14 @@ test('feedback import is wired to load source bframe, save current bframe, and r
   assert.match(appSource, /confirm\(`[\s\S]+피드백[\s\S]+가져올까요\?`\)/);
   assert.match(appSource, /importFeedbackIntoTargetComments\(/);
   assert.match(appSource, /commentManager\.toJSON\(\),[\s\S]+sourceComments,[\s\S]+\{ targetLayerId \}/);
-  assert.match(appSource, /commentManager\.fromJSON\(result\.comments\);/);
-  assert.match(appSource, /commentManager\.setActiveLayer\(targetLayerId\);/);
+  assert.match(appSource, /commentManager\.addImportedMarkers\(result\.importedMarkers, targetLayerId\)/);
+  assert.match(appSource, /commentManager\.setActiveLayer\(importedMarkers\[0\]\.layerId \|\| targetLayerId\);/);
   assert.match(appSource, /const saved = await reviewDataManager\.save\(\);/);
   assert.match(appSource, /updateCommentList\(\);[\s\S]+updateTimelineMarkers\(\);[\s\S]+renderVideoMarkers\(\);[\s\S]+refreshCommentRangesForCurrentMode\(\);/);
   assert.match(appSource, /versionDropdown\.onFeedbackImport\(handleImportFeedbackFromVersion\);/);
+});
+
+test('imported feedback skips local Slack and undo side effects while still using markerAdded', () => {
+  assert.match(appSource, /const \{ marker, remote, restored, imported \} = e\.detail;/);
+  assert.match(appSource, /if \(remote \|\| restored \|\| imported\) return;/);
 });

--- a/scripts/tests/feedback-import-source.test.js
+++ b/scripts/tests/feedback-import-source.test.js
@@ -1,0 +1,35 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
+const dropdownSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/version-dropdown.js'), 'utf8'));
+const cssSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
+
+test('version dropdown exposes a per-version feedback import action', () => {
+  assert.match(dropdownSource, /this\._onFeedbackImport = null;/);
+  assert.match(dropdownSource, /onFeedbackImport\(callback\) \{/);
+  assert.match(dropdownSource, /version-item-import-feedback/);
+  assert.match(dropdownSource, /이 버전의 피드백 가져오기/);
+  assert.match(dropdownSource, /this\._onFeedbackImport\(versionInfo\)/);
+  assert.match(dropdownSource, /e\.stopPropagation\(\);[\s\S]+this\._onFeedbackImport\(versionInfo\)/);
+  assert.match(cssSource, /\.version-item-import-feedback/);
+});
+
+test('feedback import is wired to load source bframe, save current bframe, and refresh visible UI', () => {
+  assert.match(appSource, /from '\.\/modules\/feedback-import\.js';/);
+  assert.match(appSource, /async function handleImportFeedbackFromVersion\(versionInfo\) \{/);
+  assert.match(appSource, /const sourceBframePath = getBframePath\(versionInfo\.path\);/);
+  assert.match(appSource, /sourceData = await window\.electronAPI\.loadReview\(sourceBframePath\);/);
+  assert.match(appSource, /countImportableFeedbackMarkers\(sourceData\?\.comments\)/);
+  assert.match(appSource, /confirm\(`[\s\S]+피드백[\s\S]+가져올까요\?`\)/);
+  assert.match(appSource, /importFeedbackIntoTargetComments\(/);
+  assert.match(appSource, /commentManager\.fromJSON\(result\.comments\);/);
+  assert.match(appSource, /commentManager\.setActiveLayer\(targetLayerId\);/);
+  assert.match(appSource, /const saved = await reviewDataManager\.save\(\);/);
+  assert.match(appSource, /updateCommentList\(\);[\s\S]+updateTimelineMarkers\(\);[\s\S]+renderVideoMarkers\(\);[\s\S]+refreshCommentRangesForCurrentMode\(\);/);
+  assert.match(appSource, /versionDropdown\.onFeedbackImport\(handleImportFeedbackFromVersion\);/);
+});

--- a/scripts/tests/feedback-import.test.js
+++ b/scripts/tests/feedback-import.test.js
@@ -179,8 +179,7 @@ test('normalizes legacy source review comments before import', async () => {
         id: 'legacy-marker',
         x: 0.25,
         y: 0.75,
-        startFrame: 10,
-        endFrame: 20,
+        frame: 240,
         fps: 24,
         text: 'legacy feedback',
         author: '예전 리뷰어',
@@ -215,6 +214,8 @@ test('normalizes legacy source review comments before import', async () => {
     ['v2 existing feedback', 'legacy feedback']
   );
   assert.equal(result.importedMarkers[0].image, 'data:image/png;base64,legacy-marker-image');
+  assert.equal(result.importedMarkers[0].startFrame, 240);
+  assert.equal(result.importedMarkers[0].endFrame, 336);
   assert.match(result.importedMarkers[0].createdAt, /^\d{4}-\d{2}-\d{2}T/);
   assert.match(result.importedMarkers[0].updatedAt, /^\d{4}-\d{2}-\d{2}T/);
   assert.equal(result.importedMarkers[0].replies[0].image, 'data:image/png;base64,legacy-reply-image');

--- a/scripts/tests/feedback-import.test.js
+++ b/scripts/tests/feedback-import.test.js
@@ -174,13 +174,13 @@ test('normalizes legacy source review comments before import', async () => {
   const legacySourceReview = {
     version: '1.0',
     videoPath: 'C:/videos/version-1.mp4',
+    fps: 60,
     comments: [
       {
         id: 'legacy-marker',
         x: 0.25,
         y: 0.75,
         frame: 240,
-        fps: 24,
         content: 'legacy feedback',
         author: '예전 리뷰어',
         image: 'data:image/png;base64,legacy-marker-image',
@@ -197,6 +197,7 @@ test('normalizes legacy source review comments before import', async () => {
   };
 
   const sourceComments = normalizeFeedbackSourceComments(legacySourceReview);
+  assert.equal(sourceComments.fps, 60);
   assert.equal(countImportableFeedbackMarkers(sourceComments), 1);
 
   const result = importFeedbackIntoTargetComments(
@@ -215,7 +216,8 @@ test('normalizes legacy source review comments before import', async () => {
   );
   assert.equal(result.importedMarkers[0].image, 'data:image/png;base64,legacy-marker-image');
   assert.equal(result.importedMarkers[0].startFrame, 240);
-  assert.equal(result.importedMarkers[0].endFrame, 336);
+  assert.equal(result.importedMarkers[0].endFrame, 480);
+  assert.equal(result.importedMarkers[0].fps, 60);
   assert.equal(result.importedMarkers[0].text, 'legacy feedback');
   assert.match(result.importedMarkers[0].createdAt, /^\d{4}-\d{2}-\d{2}T/);
   assert.match(result.importedMarkers[0].updatedAt, /^\d{4}-\d{2}-\d{2}T/);

--- a/scripts/tests/feedback-import.test.js
+++ b/scripts/tests/feedback-import.test.js
@@ -164,3 +164,56 @@ test('returns zero importable markers for empty or missing comment layers', asyn
     ['target-marker']
   );
 });
+
+test('normalizes legacy source review comments before import', async () => {
+  const {
+    countImportableFeedbackMarkers,
+    importFeedbackIntoTargetComments,
+    normalizeFeedbackSourceComments
+  } = await loadModule();
+  const legacySourceReview = {
+    version: '1.0',
+    videoPath: 'C:/videos/version-1.mp4',
+    comments: [
+      {
+        id: 'legacy-marker',
+        x: 0.25,
+        y: 0.75,
+        startFrame: 10,
+        endFrame: 20,
+        fps: 24,
+        text: 'legacy feedback',
+        author: '예전 리뷰어',
+        image: 'data:image/png;base64,legacy-marker-image',
+        replies: [
+          {
+            id: 'legacy-reply',
+            text: 'legacy reply',
+            author: '답글러',
+            image: 'data:image/png;base64,legacy-reply-image'
+          }
+        ]
+      }
+    ]
+  };
+
+  const sourceComments = normalizeFeedbackSourceComments(legacySourceReview);
+  assert.equal(countImportableFeedbackMarkers(sourceComments), 1);
+
+  const result = importFeedbackIntoTargetComments(
+    createTargetComments(),
+    sourceComments,
+    {
+      createId: createIdFactory(),
+      targetLayerId: 'target-layer'
+    }
+  );
+
+  assert.equal(result.importedCount, 1);
+  assert.deepEqual(
+    result.comments.layers[0].markers.map(marker => marker.text),
+    ['v2 existing feedback', 'legacy feedback']
+  );
+  assert.equal(result.importedMarkers[0].image, 'data:image/png;base64,legacy-marker-image');
+  assert.equal(result.importedMarkers[0].replies[0].image, 'data:image/png;base64,legacy-reply-image');
+});

--- a/scripts/tests/feedback-import.test.js
+++ b/scripts/tests/feedback-import.test.js
@@ -181,13 +181,13 @@ test('normalizes legacy source review comments before import', async () => {
         y: 0.75,
         frame: 240,
         fps: 24,
-        text: 'legacy feedback',
+        content: 'legacy feedback',
         author: '예전 리뷰어',
         image: 'data:image/png;base64,legacy-marker-image',
         replies: [
           {
             id: 'legacy-reply',
-            text: 'legacy reply',
+            content: 'legacy reply',
             author: '답글러',
             image: 'data:image/png;base64,legacy-reply-image'
           }
@@ -216,8 +216,10 @@ test('normalizes legacy source review comments before import', async () => {
   assert.equal(result.importedMarkers[0].image, 'data:image/png;base64,legacy-marker-image');
   assert.equal(result.importedMarkers[0].startFrame, 240);
   assert.equal(result.importedMarkers[0].endFrame, 336);
+  assert.equal(result.importedMarkers[0].text, 'legacy feedback');
   assert.match(result.importedMarkers[0].createdAt, /^\d{4}-\d{2}-\d{2}T/);
   assert.match(result.importedMarkers[0].updatedAt, /^\d{4}-\d{2}-\d{2}T/);
   assert.equal(result.importedMarkers[0].replies[0].image, 'data:image/png;base64,legacy-reply-image');
+  assert.equal(result.importedMarkers[0].replies[0].text, 'legacy reply');
   assert.match(result.importedMarkers[0].replies[0].createdAt, /^\d{4}-\d{2}-\d{2}T/);
 });

--- a/scripts/tests/feedback-import.test.js
+++ b/scripts/tests/feedback-import.test.js
@@ -215,5 +215,8 @@ test('normalizes legacy source review comments before import', async () => {
     ['v2 existing feedback', 'legacy feedback']
   );
   assert.equal(result.importedMarkers[0].image, 'data:image/png;base64,legacy-marker-image');
+  assert.match(result.importedMarkers[0].createdAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.match(result.importedMarkers[0].updatedAt, /^\d{4}-\d{2}-\d{2}T/);
   assert.equal(result.importedMarkers[0].replies[0].image, 'data:image/png;base64,legacy-reply-image');
+  assert.match(result.importedMarkers[0].replies[0].createdAt, /^\d{4}-\d{2}-\d{2}T/);
 });

--- a/scripts/tests/feedback-import.test.js
+++ b/scripts/tests/feedback-import.test.js
@@ -1,0 +1,166 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+async function loadModule() {
+  const moduleUrl = pathToFileURL(
+    path.join(__dirname, '../../renderer/scripts/modules/feedback-import.js')
+  );
+  return import(moduleUrl.href);
+}
+
+function createIdFactory() {
+  let next = 1;
+  return (prefix) => `${prefix}-copy-${next++}`;
+}
+
+function createTargetComments() {
+  return {
+    fps: 24,
+    layers: [
+      {
+        id: 'target-layer',
+        name: '댓글 1',
+        color: '#ff6b6b',
+        visible: true,
+        locked: false,
+        markers: [
+          {
+            id: 'target-marker',
+            layerId: 'target-layer',
+            x: 0.1,
+            y: 0.2,
+            startFrame: 12,
+            endFrame: 36,
+            fps: 24,
+            text: 'v2 existing feedback',
+            author: '배한솔',
+            createdAt: '2026-07-04T00:00:00.000Z',
+            updatedAt: '2026-07-04T00:00:00.000Z',
+            resolved: false,
+            colorKey: 'default',
+            replies: []
+          }
+        ]
+      }
+    ]
+  };
+}
+
+function createSourceComments() {
+  return {
+    fps: 24,
+    layers: [
+      {
+        id: 'source-layer',
+        name: '댓글 1',
+        color: '#4a9eff',
+        visible: true,
+        locked: false,
+        markers: [
+          {
+            id: 'source-marker',
+            layerId: 'source-layer',
+            x: 0.5,
+            y: 0.6,
+            startFrame: 48,
+            endFrame: 96,
+            fps: 24,
+            text: 'v1 feedback to import',
+            author: '리뷰어',
+            createdAt: '2026-07-03T10:00:00.000Z',
+            updatedAt: '2026-07-03T11:00:00.000Z',
+            resolved: true,
+            resolvedBy: '배한솔',
+            resolvedAt: '2026-07-03T12:00:00.000Z',
+            colorKey: 'yellow',
+            image: 'data:image/png;base64,source-marker-image',
+            imageWidth: 640,
+            imageHeight: 360,
+            replies: [
+              {
+                id: 'source-reply',
+                text: 'reply with image',
+                author: '답글러',
+                createdAt: '2026-07-03T10:30:00.000Z',
+                updatedAt: '2026-07-03T10:40:00.000Z',
+                image: 'data:image/png;base64,source-reply-image',
+                imageWidth: 320,
+                imageHeight: 180
+              }
+            ]
+          },
+          {
+            id: 'deleted-source-marker',
+            layerId: 'source-layer',
+            text: 'deleted feedback should not import',
+            deleted: true,
+            replies: []
+          }
+        ]
+      }
+    ]
+  };
+}
+
+test('imports source markers into target comments without removing target markers', async () => {
+  const { importFeedbackIntoTargetComments } = await loadModule();
+  const result = importFeedbackIntoTargetComments(
+    createTargetComments(),
+    createSourceComments(),
+    {
+      createId: createIdFactory(),
+      targetLayerId: 'target-layer'
+    }
+  );
+
+  assert.equal(result.importedCount, 1);
+  assert.equal(result.comments.layers.length, 1);
+  assert.deepEqual(
+    result.comments.layers[0].markers.map(marker => marker.text),
+    ['v2 existing feedback', 'v1 feedback to import']
+  );
+});
+
+test('copies replies and attached images while assigning new IDs', async () => {
+  const { cloneFeedbackMarkers } = await loadModule();
+  const [cloned] = cloneFeedbackMarkers(createSourceComments(), {
+    createId: createIdFactory(),
+    targetLayerId: 'target-layer'
+  });
+
+  assert.notEqual(cloned.id, 'source-marker');
+  assert.equal(cloned.id, 'marker-copy-1');
+  assert.equal(cloned.layerId, 'target-layer');
+  assert.equal(cloned.image, 'data:image/png;base64,source-marker-image');
+  assert.equal(cloned.imageWidth, 640);
+  assert.equal(cloned.imageHeight, 360);
+  assert.equal(cloned.resolved, true);
+  assert.equal(cloned.resolvedBy, '배한솔');
+  assert.equal(cloned.replies.length, 1);
+  assert.notEqual(cloned.replies[0].id, 'source-reply');
+  assert.equal(cloned.replies[0].id, 'reply-copy-2');
+  assert.equal(cloned.replies[0].image, 'data:image/png;base64,source-reply-image');
+  assert.equal(cloned.replies[0].imageWidth, 320);
+  assert.equal(cloned.replies[0].imageHeight, 180);
+});
+
+test('returns zero importable markers for empty or missing comment layers', async () => {
+  const { countImportableFeedbackMarkers, importFeedbackIntoTargetComments } = await loadModule();
+
+  assert.equal(countImportableFeedbackMarkers(null), 0);
+  assert.equal(countImportableFeedbackMarkers({ layers: [] }), 0);
+  assert.equal(countImportableFeedbackMarkers({ layers: [{ markers: [{ deleted: true }] }] }), 0);
+
+  const result = importFeedbackIntoTargetComments(createTargetComments(), { layers: [] }, {
+    createId: createIdFactory(),
+    targetLayerId: 'target-layer'
+  });
+
+  assert.equal(result.importedCount, 0);
+  assert.deepEqual(
+    result.comments.layers[0].markers.map(marker => marker.id),
+    ['target-marker']
+  );
+});


### PR DESCRIPTION
## 📋 업데이트 요약

🔁 이제 새 버전을 열어둔 상태에서 이전 버전의 피드백을 그대로 가져올 수 있습니다.

💬 가져오는 내용은 댓글, 답글, 첨부 이미지입니다.

🛡️ 현재 버전에 이미 적어둔 피드백은 지우지 않고, 가져온 피드백을 뒤에 추가합니다.

🎯 드로잉/하이라이트/합성 레이어는 이번 범위에서 제외해 원치 않는 화면 표시까지 복사되지 않게 했습니다.

제안 버전은 새 기능 추가 기준 `v1.5.0-beta`입니다. 현재 앱 패키지 값은 `1.4.0-beta`입니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/feedback-import.js`
  - `countImportableFeedbackMarkers()`, `cloneFeedbackMarkers()`, `importFeedbackIntoTargetComments()`를 추가했습니다.
  - 소스 `.bframe`의 `comments.layers[].markers[]`만 읽고, 삭제된 댓글은 제외합니다.
  - 복사되는 댓글과 답글에는 새 ID를 부여해 원본 버전과 현재 버전의 피드백이 서로 독립적으로 저장되게 했습니다.

- `renderer/scripts/modules/version-dropdown.js`
  - `onFeedbackImport(callback)` 콜백을 추가했습니다.
  - 현재 버전이 아닌 버전 항목에 `이 버전의 피드백 가져오기` 버튼을 표시합니다.

- `renderer/scripts/app.js`
  - `handleImportFeedbackFromVersion(versionInfo)`를 추가했습니다.
  - 선택한 버전의 `.bframe`을 읽고 현재 열린 버전의 댓글 데이터에 복제한 뒤 저장합니다.
  - 저장 후 댓글 목록, 타임라인, 영상 위 마커, 댓글 구간 표시를 즉시 갱신합니다.

- `renderer/styles/main.css`
  - 버전 항목 안의 피드백 가져오기 버튼 스타일을 기존 버튼 계열과 맞췄습니다.

- `scripts/tests/feedback-import.test.js`, `scripts/tests/feedback-import-source.test.js`
  - 복제 로직과 화면 연결 검증 테스트를 추가했습니다.

## 🚧 개발 난항

- 자체 리뷰 중 댓글 데이터를 다시 넣는 과정에서 활성 댓글 레이어가 첫 번째 레이어로 돌아갈 수 있는 점을 발견했습니다. 가져오기 대상 레이어를 다시 활성화하도록 수정했습니다.
- 처음 source 테스트가 구현 모양에 너무 강하게 묶여 있어, 실제 요구인 “소스 `.bframe` 로드 여부” 중심으로 조정했습니다.
- `npm run lint`는 저장소 전반의 기존 줄끝 오류 때문에 전체 신호로 쓰기 어려웠습니다. 대신 변경 파일은 줄끝 규칙만 제외하고 검사해 실제 JS 오류가 없는지 확인했습니다.

## ✅ 테스트 가이드

실사용자용:

1. v2 영상을 엽니다.
2. 상단 버전 드롭다운을 엽니다.
3. v1 행의 `이 버전의 피드백 가져오기` 버튼을 누릅니다.
4. 확인창에서 가져올 피드백 개수를 확인하고 진행합니다.
5. v2 댓글 목록, 영상 위 마커, 타임라인 댓글 구간에 v1 피드백이 추가됐는지 확인합니다.
6. 기존 v2 댓글이 사라지지 않았는지 확인합니다.

개발자용:

- `node --test scripts/tests/feedback-import.test.js scripts/tests/feedback-import-source.test.js`
- `npm run test:comment-input`
- `npm run test:playlist-comments`
- `npm run test:playlist`
- `npm run build`
- `git diff --check`

참고: `npm run lint`는 기존 CRLF linebreak-style 오류로 실패합니다. 줄끝 규칙 제외 검사에서는 변경 파일 JS 오류 0건, 기존 경고만 확인했습니다.
