### PR TITLE
[v1.4.1] 드로잉 지우개 안정화 및 브러시 크기 표시 개선

### DIFF
--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1296,6 +1296,10 @@ async function initApp() {
     showToast(message, 'warning');
   });
 
+  drawingManager.addEventListener('strokeeraserunavailable', () => {
+    showToast('픽셀 지우개로 편집된 그림은 획 단위로 지울 수 없습니다. 픽셀 지우개로 지우거나 새로 그린 획을 지워주세요.', 'warning');
+  });
+
   // 프레임 렌더링 완료 시
   drawingManager.addEventListener('frameRendered', (e) => {
     log.debug('프레임 렌더링 완료', { frame: e.detail.frame });
@@ -2925,7 +2929,7 @@ async function initApp() {
     const scale = rect && elements.drawingCanvas?.width
       ? rect.width / elements.drawingCanvas.width
       : 1;
-    const displaySize = Math.min(96, Math.max(28, Math.round(size * scale)));
+    const displaySize = Math.max(2, Math.round(size * scale));
     const x = Number.isFinite(detail.clientX) ? detail.clientX : window.innerWidth / 2;
     const y = Number.isFinite(detail.clientY) ? detail.clientY : window.innerHeight / 2;
 
@@ -2935,7 +2939,8 @@ async function initApp() {
     brushSizeHud.style.height = `${displaySize}px`;
     brushSizeHud.style.background = currentToolType === 'eraser' ? 'transparent' : `${currentColor}80`;
     brushSizeHud.style.borderColor = currentToolType === 'eraser' ? 'rgba(255, 255, 255, 0.95)' : currentColor;
-    brushSizeHud.textContent = `${size}px`;
+    brushSizeHud.dataset.sizeLabel = `${size}px`;
+    brushSizeHud.textContent = '';
   }
 
   function showBrushSizeHud(detail = {}) {

--- a/renderer/scripts/modules/drawing-canvas.js
+++ b/renderer/scripts/modules/drawing-canvas.js
@@ -227,7 +227,16 @@ export class DrawingCanvas extends EventTarget {
     this._sizeAdjustUsesPointerEvents = typeof e.pointerId === 'number';
     this._activeSizeAdjustPointerId = this._sizeAdjustUsesPointerEvents ? e.pointerId : null;
     this._sizeAdjustMoveHandler = (event) => this._updateSizeAdjust(event);
-    this._sizeAdjustEndHandler = () => this._endSizeAdjust();
+    this._sizeAdjustEndHandler = (event) => {
+      if (
+        this._sizeAdjustUsesPointerEvents &&
+        typeof event?.pointerId === 'number' &&
+        event.pointerId !== this._activeSizeAdjustPointerId
+      ) {
+        return;
+      }
+      this._endSizeAdjust();
+    };
 
     if (this._sizeAdjustUsesPointerEvents) {
       this.canvas.setPointerCapture?.(e.pointerId);

--- a/renderer/scripts/modules/drawing-canvas.js
+++ b/renderer/scripts/modules/drawing-canvas.js
@@ -56,6 +56,8 @@ export class DrawingCanvas extends EventTarget {
     this._sizeAdjustStartSize = 3;
     this._sizeAdjustMoveHandler = null;
     this._sizeAdjustEndHandler = null;
+    this._sizeAdjustUsesPointerEvents = false;
+    this._activeSizeAdjustPointerId = null;
     this.lastX = 0;
     this.lastY = 0;
     this.startX = 0;
@@ -87,6 +89,7 @@ export class DrawingCanvas extends EventTarget {
     const signal = this._abortController.signal;
 
     // 마우스 이벤트
+    this.canvas.addEventListener('pointerdown', (e) => this._onPointerDown(e), { signal });
     this.canvas.addEventListener('mousedown', (e) => this._onMouseDown(e), { signal });
     this.canvas.addEventListener('mousemove', (e) => this._onMouseMove(e), { signal });
     this.canvas.addEventListener('mouseup', (e) => this._onMouseUp(e), { signal });
@@ -206,6 +209,14 @@ export class DrawingCanvas extends EventTarget {
     }
   }
 
+  _onPointerDown(e) {
+    if (!this.canvas.classList.contains('active')) return;
+    if (e.pointerType === 'pen' && e.altKey && (e.button === 0 || e.button === 2)) {
+      e.preventDefault?.();
+      this._beginSizeAdjust(e);
+    }
+  }
+
   _beginSizeAdjust(e) {
     if (this.isSizeAdjusting) return;
 
@@ -213,11 +224,20 @@ export class DrawingCanvas extends EventTarget {
     this._sizeAdjustStartX = e.clientX;
     this._sizeAdjustStartY = e.clientY;
     this._sizeAdjustStartSize = Math.min(50, Math.max(1, parseInt(this.lineWidth) || 3));
+    this._sizeAdjustUsesPointerEvents = typeof e.pointerId === 'number';
+    this._activeSizeAdjustPointerId = this._sizeAdjustUsesPointerEvents ? e.pointerId : null;
     this._sizeAdjustMoveHandler = (event) => this._updateSizeAdjust(event);
     this._sizeAdjustEndHandler = () => this._endSizeAdjust();
 
-    window.addEventListener('mousemove', this._sizeAdjustMoveHandler, { signal: this._abortController.signal });
-    window.addEventListener('mouseup', this._sizeAdjustEndHandler, { signal: this._abortController.signal });
+    if (this._sizeAdjustUsesPointerEvents) {
+      this.canvas.setPointerCapture?.(e.pointerId);
+      window.addEventListener('pointermove', this._sizeAdjustMoveHandler, { signal: this._abortController.signal });
+      window.addEventListener('pointerup', this._sizeAdjustEndHandler, { signal: this._abortController.signal });
+      window.addEventListener('pointercancel', this._sizeAdjustEndHandler, { signal: this._abortController.signal });
+    } else {
+      window.addEventListener('mousemove', this._sizeAdjustMoveHandler, { signal: this._abortController.signal });
+      window.addEventListener('mouseup', this._sizeAdjustEndHandler, { signal: this._abortController.signal });
+    }
 
     this._emit('sizeadjuststart', {
       size: this.lineWidth,
@@ -228,6 +248,13 @@ export class DrawingCanvas extends EventTarget {
 
   _updateSizeAdjust(e) {
     if (!this.isSizeAdjusting) return;
+    if (
+      this._sizeAdjustUsesPointerEvents &&
+      typeof e.pointerId === 'number' &&
+      e.pointerId !== this._activeSizeAdjustPointerId
+    ) {
+      return;
+    }
     e.preventDefault?.();
 
     const delta = e.clientX - this._sizeAdjustStartX;
@@ -255,12 +282,17 @@ export class DrawingCanvas extends EventTarget {
   _removeSizeAdjustListeners() {
     if (this._sizeAdjustMoveHandler) {
       window.removeEventListener('mousemove', this._sizeAdjustMoveHandler);
+      window.removeEventListener('pointermove', this._sizeAdjustMoveHandler);
       this._sizeAdjustMoveHandler = null;
     }
     if (this._sizeAdjustEndHandler) {
       window.removeEventListener('mouseup', this._sizeAdjustEndHandler);
+      window.removeEventListener('pointerup', this._sizeAdjustEndHandler);
+      window.removeEventListener('pointercancel', this._sizeAdjustEndHandler);
       this._sizeAdjustEndHandler = null;
     }
+    this._sizeAdjustUsesPointerEvents = false;
+    this._activeSizeAdjustPointerId = null;
   }
 
   /**

--- a/renderer/scripts/modules/drawing-manager.js
+++ b/renderer/scripts/modules/drawing-manager.js
@@ -91,6 +91,7 @@ export class DrawingManager extends EventTarget {
     this.eraserMode = ERASER_MODES.PIXEL;
     this._activeStrokeBaseData = null;
     this._strokeEraseQueue = Promise.resolve();
+    this._strokeEraseUnavailableNotified = false;
 
     // Undo/Redo — 외부 통합 스택과 연동
     this._onUndoPush = null; // 외부에서 설정하는 콜백: (action) => void
@@ -134,6 +135,8 @@ export class DrawingManager extends EventTarget {
    * 그리기 시작 처리
    */
   _onDrawStart(detail) {
+    this._strokeEraseUnavailableNotified = false;
+
     // 레이어가 없으면 새 레이어 생성
     if (this.layers.length === 0 || !this.activeLayerId) {
       this.createLayer();
@@ -155,6 +158,8 @@ export class DrawingManager extends EventTarget {
         preserveSourceRecords: true,
         fallbackBaseData: this._activeStrokeBaseData
       });
+      const keyframe = layer.getKeyframeAtFrame(this.currentFrame);
+      this._notifyStrokeEraseUnavailable(keyframe);
     } else {
       // 현재 프레임에 키프레임이 없으면 생성
       // (기존 키프레임 범위 내에서 그리는 경우는 덧그리기)
@@ -352,6 +357,8 @@ export class DrawingManager extends EventTarget {
     keyframe.strokeRecords = [];
     keyframe._cachedImage = null;
     keyframe._cachedSrc = null;
+    keyframe._cachedBaseImage = null;
+    keyframe._cachedBaseSrc = null;
   }
 
   async _eraseStrokeRecords(detail) {
@@ -363,7 +370,10 @@ export class DrawingManager extends EventTarget {
       preserveSourceRecords: true,
       fallbackBaseData: this._activeStrokeBaseData
     });
-    if (!keyframe?.strokeRecords?.length) return false;
+    if (!keyframe?.strokeRecords?.length) {
+      this._notifyStrokeEraseUnavailable(keyframe);
+      return false;
+    }
 
     const result = removeIntersectingStrokes(
       keyframe.strokeRecords,
@@ -380,9 +390,13 @@ export class DrawingManager extends EventTarget {
   async _redrawKeyframeFromRecords(keyframe) {
     if (!keyframe) return;
 
-    this.drawingCanvas.clear();
-    if (keyframe.baseCanvasData) {
-      await this.drawingCanvas.drawImageDataUrl(keyframe.baseCanvasData);
+    const baseImage = keyframe.baseCanvasData
+      ? await this._loadBaseCanvasImage(keyframe)
+      : null;
+
+    this.drawingCanvas.clear({ silent: true });
+    if (baseImage) {
+      this.drawingCanvas.ctx.drawImage(baseImage, 0, 0);
     }
 
     for (const record of keyframe.strokeRecords || []) {
@@ -393,6 +407,40 @@ export class DrawingManager extends EventTarget {
     keyframe.setCanvasData(imageData);
     keyframe._cachedImage = null;
     keyframe._cachedSrc = null;
+  }
+
+  _loadBaseCanvasImage(keyframe) {
+    const src = keyframe?.baseCanvasData;
+    if (!src) return Promise.resolve(null);
+    if (keyframe._cachedBaseImage && keyframe._cachedBaseSrc === src) {
+      return Promise.resolve(keyframe._cachedBaseImage);
+    }
+
+    return new Promise(resolve => {
+      const image = new Image();
+      image.onload = () => {
+        keyframe._cachedBaseImage = image;
+        keyframe._cachedBaseSrc = src;
+        resolve(image);
+      };
+      image.onerror = () => {
+        log.warn('획 지우기 기준 이미지 로드 실패');
+        resolve(null);
+      };
+      image.src = src;
+    });
+  }
+
+  _notifyStrokeEraseUnavailable(keyframe) {
+    if (this._strokeEraseUnavailableNotified) return;
+    if (!keyframe || keyframe.strokeRecords?.length > 0) return;
+    if (!keyframe.canvasData && keyframe.isEmpty !== false) return;
+
+    this._strokeEraseUnavailableNotified = true;
+    this._emit('strokeeraserunavailable', {
+      frame: keyframe.frame,
+      reason: 'bitmap-only'
+    });
   }
 
   /**

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -2193,21 +2193,32 @@ body.app-fullscreen .video-comment-overlay-controls {
   left: 0;
   top: 0;
   z-index: 10000;
-  display: grid;
-  place-items: center;
-  min-width: 28px;
-  min-height: 28px;
+  display: block;
+  box-sizing: border-box;
   border: 2px solid rgba(255, 255, 255, 0.9);
   border-radius: 50%;
   background: rgba(255, 71, 87, 0.5);
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+}
+
+.brush-size-hud::after {
+  content: attr(data-size-label);
+  position: absolute;
+  left: 50%;
+  top: -22px;
+  transform: translateX(-50%);
+  padding: 3px 6px;
+  border-radius: 6px;
+  background: rgba(9, 12, 18, 0.84);
   color: #fff;
   font-size: 11px;
   font-weight: 700;
   line-height: 1;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+  white-space: nowrap;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.75);
   pointer-events: none;
-  transform: translate(-50%, -50%);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
 }
 
 .brush-size-hud[hidden] {

--- a/scripts/tests/brush-settings-source.test.js
+++ b/scripts/tests/brush-settings-source.test.js
@@ -46,6 +46,8 @@ test('drawing toolbar restores persisted brush state and saves changes deliberat
 test('alt drag adjusts brush size before drawing or ctrl eraser handling', () => {
   const mouseDownBody = drawingCanvasSource.match(/_onMouseDown\(e\) \{[\s\S]*?\n  \}/)?.[0] || '';
   assert.match(drawingCanvasSource, /this\.isSizeAdjusting = false;/);
+  assert.match(drawingCanvasSource, /pointerdown/);
+  assert.match(drawingCanvasSource, /_onPointerDown\(e\)/);
   assert.match(drawingCanvasSource, /_beginSizeAdjust\(e\)/);
   assert.match(drawingCanvasSource, /_updateSizeAdjust\(e\)/);
   assert.match(drawingCanvasSource, /_endSizeAdjust\(\)/);
@@ -64,12 +66,27 @@ test('alt drag adjusts brush size before drawing or ctrl eraser handling', () =>
   assert.match(drawingCanvasSource, /this\.setLineWidth\(nextSize\)/);
 });
 
+test('alt drag size adjustment follows pen pointer events until pointer release', () => {
+  assert.match(drawingCanvasSource, /e\.pointerType === 'pen'/);
+  assert.match(drawingCanvasSource, /e\.altKey && \(e\.button === 0 \|\| e\.button === 2\)/);
+  assert.match(drawingCanvasSource, /this\.canvas\.setPointerCapture\?\.\(e\.pointerId\)/);
+  assert.match(drawingCanvasSource, /window\.addEventListener\('pointermove', this\._sizeAdjustMoveHandler/);
+  assert.match(drawingCanvasSource, /window\.addEventListener\('pointerup', this\._sizeAdjustEndHandler/);
+  assert.match(drawingCanvasSource, /window\.removeEventListener\('pointermove', this\._sizeAdjustMoveHandler\)/);
+  assert.match(drawingCanvasSource, /window\.removeEventListener\('pointerup', this\._sizeAdjustEndHandler\)/);
+});
+
 test('brush size HUD and bracket shortcuts are wired for drawing mode only', () => {
   assert.match(indexSource, /id="brushSizeHud"/);
   assert.match(mainCss, /\.brush-size-hud/);
+  assert.match(mainCss, /\.brush-size-hud::after/);
+  assert.match(mainCss, /content:\s*attr\(data-size-label\)/);
   assert.match(appSource, /brushSizeHud/);
   assert.match(appSource, /showBrushSizeHud/);
   assert.match(appSource, /hideBrushSizeHud/);
+  assert.match(appSource, /brushSizeHud\.dataset\.sizeLabel = `\$\{size\}px`;/);
+  assert.match(appSource, /brushSizeHud\.textContent = '';/);
+  assert.doesNotMatch(appSource, /Math\.min\(96, Math\.max\(28, Math\.round\(size \* scale\)\)\)/);
   assert.match(appSource, /sizeadjuststart/);
   assert.match(appSource, /sizeadjustend/);
   assert.match(userSettingsSource, /brushSizeDown:\s*\{ key: 'BracketLeft'/);

--- a/scripts/tests/brush-settings-source.test.js
+++ b/scripts/tests/brush-settings-source.test.js
@@ -72,6 +72,7 @@ test('alt drag size adjustment follows pen pointer events until pointer release'
   assert.match(drawingCanvasSource, /this\.canvas\.setPointerCapture\?\.\(e\.pointerId\)/);
   assert.match(drawingCanvasSource, /window\.addEventListener\('pointermove', this\._sizeAdjustMoveHandler/);
   assert.match(drawingCanvasSource, /window\.addEventListener\('pointerup', this\._sizeAdjustEndHandler/);
+  assert.match(drawingCanvasSource, /event\.pointerId !== this\._activeSizeAdjustPointerId/);
   assert.match(drawingCanvasSource, /window\.removeEventListener\('pointermove', this\._sizeAdjustMoveHandler\)/);
   assert.match(drawingCanvasSource, /window\.removeEventListener\('pointerup', this\._sizeAdjustEndHandler\)/);
 });

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -140,6 +140,26 @@ test('stroke eraser gestures do not stream as live pixel eraser strokes to colla
   assert.match(drawingSyncSource, /baseCanvasData: keyframe\.baseCanvasData/);
 });
 
+test('stroke eraser explains unavailable bitmap-only frames instead of silently doing nothing', () => {
+  assert.match(drawingManagerSource, /_strokeEraseUnavailableNotified = false;/);
+  assert.match(drawingManagerSource, /_notifyStrokeEraseUnavailable\(keyframe\)/);
+  assert.match(drawingManagerSource, /this\._emit\('strokeeraserunavailable'/);
+  assert.match(drawingManagerSource, /reason: 'bitmap-only'/);
+  assert.match(appSource, /drawingManager\.addEventListener\('strokeeraserunavailable'/);
+  assert.match(appSource, /픽셀 지우개로 편집된 그림은 획 단위로 지울 수 없습니다/);
+});
+
+test('stroke eraser redraw loads base image before clearing the visible canvas', () => {
+  const redrawBody = drawingManagerSource.match(/async _redrawKeyframeFromRecords\(keyframe\) \{[\s\S]*?\n  \}/)?.[0] || '';
+  assert.match(drawingManagerSource, /_loadBaseCanvasImage\(keyframe\)/);
+  assert.match(redrawBody, /const baseImage = keyframe\.baseCanvasData[\s\S]+await this\._loadBaseCanvasImage\(keyframe\)/);
+  assert.ok(
+    redrawBody.indexOf('await this._loadBaseCanvasImage(keyframe)') < redrawBody.indexOf('this.drawingCanvas.clear({ silent: true })'),
+    'base image must be decoded before visible canvas clear to avoid flicker'
+  );
+  assert.match(redrawBody, /this\.drawingCanvas\.ctx\.drawImage\(baseImage, 0, 0\);/);
+});
+
 test('drawing playback avoids noisy per-frame canvas clears and preload churn', () => {
   const renderFrameBody = drawingManagerSource.match(/async renderFrame\(frame\) \{[\s\S]*?\n  \}/)?.[0] || '';
   const syncRenderBody = drawingManagerSource.match(/_renderFrameSync\(frame\) \{[\s\S]*?\n  \}/)?.[0] || '';


### PR DESCRIPTION
## 📋 업데이트 요약

🖊️ 태블릿 펜으로 Alt를 누른 채 드래그해도 브러시 크기가 조절되도록 개선했습니다.

🎯 브러시 크기 조절 중 표시되는 원이 실제 크기와 더 가깝게 보이도록 바꿨습니다. 숫자는 원 안이 아니라 별도 라벨로 표시되어 작은/큰 브러시 크기를 더 정확히 확인할 수 있습니다.

🧽 픽셀 지우개로 편집된 그림에서 획 단위 지우개가 더 이상 조용히 무반응처럼 보이지 않습니다. 해당 상황에서는 왜 지울 수 없는지 안내 메시지를 보여줍니다.

✨ 획 단위 지우개로 선을 지울 때 그림 전체가 순간적으로 깜빡이는 현상을 줄였습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/drawing-canvas.js`
  - 태블릿 펜 입력을 위해 `pointerdown`, `pointermove`, `pointerup`, `pointercancel` 기반 브러시 크기 조절 경로를 추가했습니다.
  - 기존 마우스 입력 경로는 유지하고, 펜 입력일 때만 pointer capture를 사용해 캔버스 밖으로 조금 벗어나도 크기 조절이 이어지도록 했습니다.

- `renderer/scripts/app.js`, `renderer/styles/main.css`
  - 브러시 크기 HUD의 원 내부 텍스트를 제거하고 `data-size-label` + `::after` 라벨 방식으로 변경했습니다.
  - 기존 `28px~96px` 표시 제한을 제거하고, 화면 배율을 반영한 실제 표시 크기를 쓰도록 조정했습니다.

- `renderer/scripts/modules/drawing-manager.js`
  - 획 지우개가 지울 수 있는 `strokeRecords`가 없고 실제 그림 데이터만 있는 경우 `strokeeraserunavailable` 이벤트를 발생시킵니다.
  - 앱에서는 이 이벤트를 받아 픽셀 편집 그림은 획 단위로 지울 수 없다는 토스트를 표시합니다.
  - `_redrawKeyframeFromRecords()`에서 기준 이미지를 먼저 로드한 뒤 visible canvas를 지우고 다시 그리도록 순서를 바꿔, 비동기 이미지 로딩 중 빈 캔버스가 노출되는 시간을 줄였습니다.

- `scripts/tests/brush-settings-source.test.js`, `scripts/tests/drawing-runtime-source.test.js`
  - 펜 pointer 기반 Alt 드래그, 실제 크기 HUD, bitmap-only 획 지우개 안내, redraw 순서에 대한 회귀 테스트를 추가했습니다.

## 🚧 개발 난항

- 브러시 크기 조절은 기존에 마우스 이벤트 중심으로만 구현되어 있어 태블릿 펜 입력이 같은 흐름을 타지 못했습니다. 마우스 동작은 유지하면서 펜 입력에만 pointer 이벤트를 추가하는 방식으로 범위를 좁혔습니다.
- 획 지우개는 “획 기록이 있는 그림”과 “픽셀로 편집된 그림”의 데이터 구조가 다릅니다. 픽셀 편집 그림을 억지로 획처럼 지우는 대신, 지금 상태에서 가능한 동작과 불가능한 동작을 사용자에게 명확히 안내하는 쪽으로 처리했습니다.
- 획 지우개 깜빡임은 지우기 결과를 다시 그릴 때 기준 이미지 로딩보다 캔버스 초기화가 먼저 실행되는 순서 문제였습니다. 기준 이미지를 먼저 준비한 뒤 화면을 갱신하도록 바꿨습니다.

## ✅ 테스트 가이드

실사용자용:
- 태블릿 펜으로 드로잉 모드에서 Alt를 누른 채 좌우로 드래그해 브러시 크기가 바뀌는지 확인합니다.
- 브러시 크기 조절 중 원 안에는 숫자가 들어가지 않고, 원 주변 라벨에 px 값이 보이는지 확인합니다.
- 픽셀 지우개로 편집한 그림에서 획 지우개를 사용하면 안내 메시지가 뜨는지 확인합니다.
- 여러 획이 있는 그림에서 획 지우개로 선을 지울 때 화면 전체가 빈 화면처럼 깜빡이지 않는지 확인합니다.

개발자용:
- `npm run test:drawing`
- `git diff --check`