### PR TITLE
[v1.4.1] 다중 키프레임 이동 미리보기 개선

### DIFF
--- a/renderer/scripts/modules/drawing-manager.js
+++ b/renderer/scripts/modules/drawing-manager.js
@@ -811,8 +811,16 @@ export class DrawingManager extends EventTarget {
 
     let moved = false;
 
-    // 충돌 방지를 위해 뒤에서부터 처리 (프레임이 높은 것부터)
-    const sorted = [...keyframesToMove].sort((a, b) => b.fromFrame - a.fromFrame);
+    // 충돌 방지를 위해 이동 방향에 따라 빈칸을 먼저 만든다.
+    const sorted = [...keyframesToMove].sort((a, b) => {
+      const layerCompare = String(a.layerId).localeCompare(String(b.layerId));
+      if (layerCompare !== 0) return layerCompare;
+
+      const frameDelta = (a.toFrame - a.fromFrame) || (b.toFrame - b.fromFrame);
+      if (frameDelta < 0) return a.fromFrame - b.fromFrame;
+      if (frameDelta > 0) return b.fromFrame - a.fromFrame;
+      return 0;
+    });
 
     for (const { layerId, fromFrame, toFrame } of sorted) {
       const layer = this.layers.find(l => l.id === layerId);

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -1596,7 +1596,6 @@ export class Timeline extends EventTarget {
     // 고스트 및 툴팁 제거
     this.dragGhostItems.forEach(ghost => ghost.remove());
     this.dragGhostItems = [];
-    this.dragGhostKeyframes = [];
     if (this.dragGhost) {
       this.dragGhost.remove();
       this.dragGhost = null;
@@ -1612,16 +1611,19 @@ export class Timeline extends EventTarget {
     // 이동량이 있으면 이벤트 발생
     if (frameDelta !== 0) {
       // 선택된 모든 키프레임 이동
-      const keyframesToMove = this.selectedKeyframes.map(kf => ({
+      const keyframesToMove = this.dragGhostKeyframes.map(kf => ({
         layerId: kf.layerId,
         fromFrame: kf.frame,
         toFrame: kf.frame + frameDelta
       }));
 
-      this._emit('keyframesMove', { keyframes: keyframesToMove, frameDelta });
-      log.info('키프레임 이동', { keyframes: keyframesToMove, frameDelta });
+      if (keyframesToMove.length > 0) {
+        this._emit('keyframesMove', { keyframes: keyframesToMove, frameDelta });
+        log.info('키프레임 이동', { keyframes: keyframesToMove, frameDelta });
+      }
     }
 
+    this.dragGhostKeyframes = [];
     this.draggedKeyframe = null;
   }
 
@@ -1631,6 +1633,7 @@ export class Timeline extends EventTarget {
   _createDragGhost(e, frame) {
     const { layerId, element: clipElement } = this.draggedKeyframe;
     const ghostKeyframes = this._getDragGhostKeyframes(layerId, frame);
+    if (ghostKeyframes.length === 0) return;
 
     this.dragGhost = document.createElement('div');
     this.dragGhost.className = 'keyframe-drag-ghost-group';
@@ -1691,10 +1694,16 @@ export class Timeline extends EventTarget {
     const isDraggedKeyframeSelected = this.selectedKeyframes.some(
       keyframe => keyframe.layerId === layerId && keyframe.frame === frame
     );
-    if (isDraggedKeyframeSelected && this.selectedKeyframes.length > 0) {
-      return this.selectedKeyframes.map(keyframe => ({ ...keyframe }));
-    }
-    return [{ layerId, frame }];
+    const keyframes = isDraggedKeyframeSelected && this.selectedKeyframes.length > 0
+      ? this.selectedKeyframes.map(keyframe => ({ ...keyframe }))
+      : [{ layerId, frame }];
+    return keyframes.filter(keyframe => this._isKeyframeLayerMovable(keyframe.layerId));
+  }
+
+  _isKeyframeLayerMovable(layerId) {
+    if (!Array.isArray(this._lastDrawingLayers)) return true;
+    const layer = this._lastDrawingLayers.find(item => item.id === layerId);
+    return layer?.locked !== true;
   }
 
   _clampKeyframeDragDelta(frameDelta) {

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -102,6 +102,8 @@ export class Timeline extends EventTarget {
     this.dragStartX = 0;
     this.dragStartFrame = 0;
     this.dragGhost = null;  // 드래그 중 표시할 고스트 요소
+    this.dragGhostItems = [];
+    this.dragSourceElements = [];
 
     // 다중 선택 상태
     this.selectedKeyframes = [];  // [ { layerId, frame } ]
@@ -1554,8 +1556,13 @@ export class Timeline extends EventTarget {
     const newFrame = Math.min(this.totalFrames - 1, Math.floor(percent * this.totalFrames));
 
     // 고스트 클립 위치 업데이트
-    const ghostPercent = (newFrame / this.totalFrames) * 100;
-    this.dragGhost.style.left = `${ghostPercent}%`;
+    const frameDelta = newFrame - this.dragStartFrame;
+    this.dragGhostItems.forEach(ghostCell => {
+      const sourceFrame = parseInt(ghostCell.dataset.sourceFrame || '0', 10) + frameDelta;
+      const clampedFrame = Math.max(0, Math.min(this.totalFrames - 1, sourceFrame));
+      const ghostPercent = (clampedFrame / this.totalFrames) * 100;
+      ghostCell.style.left = `${ghostPercent}%`;
+    });
 
     // 툴팁 위치 및 내용 업데이트
     if (this.dragTooltip) {
@@ -1566,6 +1573,7 @@ export class Timeline extends EventTarget {
 
     // 프레임 이동량 저장
     this.dragGhost.dataset.targetFrame = newFrame;
+    this.dragGhost.dataset.frameDelta = frameDelta;
   }
 
   /**
@@ -1577,12 +1585,15 @@ export class Timeline extends EventTarget {
     const targetFrame = parseInt(this.dragGhost?.dataset.targetFrame || this.dragStartFrame);
     const frameDelta = targetFrame - this.dragStartFrame;
 
-    // 원본 클립 투명도 복원
-    if (this.draggedKeyframe.element) {
-      this.draggedKeyframe.element.style.opacity = '';
-    }
+    // 원본 키프레임 투명도 복원
+    this.dragSourceElements.forEach(element => {
+      element.style.opacity = '';
+    });
+    this.dragSourceElements = [];
 
     // 고스트 및 툴팁 제거
+    this.dragGhostItems.forEach(ghost => ghost.remove());
+    this.dragGhostItems = [];
     if (this.dragGhost) {
       this.dragGhost.remove();
       this.dragGhost = null;
@@ -1615,19 +1626,51 @@ export class Timeline extends EventTarget {
    * 드래그 고스트 생성
    */
   _createDragGhost(e, frame) {
-    const { element: clipElement } = this.draggedKeyframe;
+    const { layerId, element: clipElement } = this.draggedKeyframe;
+    const ghostKeyframes = this._getDragGhostKeyframes(layerId, frame);
 
-    // 정확히 1프레임 칸을 나타내는 고스트를 새로 만든다.
     this.dragGhost = document.createElement('div');
-    this.dragGhost.className = 'keyframe-drag-ghost-cell';
-    const ghostLeftPercent = (frame / this.totalFrames) * 100;
-    const ghostWidthPercent = (1 / this.totalFrames) * 100;
-    this.dragGhost.style.left = `${ghostLeftPercent}%`;
-    this.dragGhost.style.width = `${ghostWidthPercent}%`;
+    this.dragGhost.className = 'keyframe-drag-ghost-group';
     this.dragGhost.dataset.targetFrame = frame;
+    this.dragGhost.dataset.frameDelta = '0';
+    this.dragGhostItems = [];
+    this.dragSourceElements = [];
 
-    // 원본 클립을 반투명하게 처리
-    clipElement.style.opacity = '0.3';
+    // 선택된 키프레임 각각에 정확히 1프레임 칸을 나타내는 고스트를 만든다.
+    const ghostWidthPercent = (1 / this.totalFrames) * 100;
+    ghostKeyframes.forEach(keyframe => {
+      const sourceElement = this.tracksContainer?.querySelector(
+        `[data-layer-id="${keyframe.layerId}"][data-frame="${keyframe.frame}"]`
+      );
+      const ghostHost = sourceElement?.parentElement || clipElement.parentElement;
+      if (!ghostHost) return;
+
+      const ghostCell = document.createElement('div');
+      ghostCell.className = 'keyframe-drag-ghost-cell';
+      ghostCell.dataset.layerId = keyframe.layerId;
+      ghostCell.dataset.sourceFrame = keyframe.frame;
+      ghostCell.style.left = `${(keyframe.frame / this.totalFrames) * 100}%`;
+      ghostCell.style.width = `${ghostWidthPercent}%`;
+
+      ghostHost.appendChild(ghostCell);
+      this.dragGhostItems.push(ghostCell);
+
+      if (sourceElement) {
+        sourceElement.style.opacity = '0.3';
+        this.dragSourceElements.push(sourceElement);
+      }
+    });
+
+    if (this.dragGhostItems.length === 0) {
+      const fallbackGhost = document.createElement('div');
+      fallbackGhost.className = 'keyframe-drag-ghost-cell';
+      fallbackGhost.dataset.layerId = layerId;
+      fallbackGhost.dataset.sourceFrame = frame;
+      fallbackGhost.style.left = `${(frame / this.totalFrames) * 100}%`;
+      fallbackGhost.style.width = `${ghostWidthPercent}%`;
+      clipElement.parentElement?.appendChild(fallbackGhost);
+      this.dragGhostItems.push(fallbackGhost);
+    }
 
     // 프레임 표시 툴팁 추가
     this.dragTooltip = document.createElement('div');
@@ -1638,6 +1681,16 @@ export class Timeline extends EventTarget {
 
     clipElement.parentElement.appendChild(this.dragGhost);
     this.tracksContainer.appendChild(this.dragTooltip);
+  }
+
+  _getDragGhostKeyframes(layerId, frame) {
+    const isDraggedKeyframeSelected = this.selectedKeyframes.some(
+      keyframe => keyframe.layerId === layerId && keyframe.frame === frame
+    );
+    if (isDraggedKeyframeSelected && this.selectedKeyframes.length > 0) {
+      return this.selectedKeyframes.map(keyframe => ({ ...keyframe }));
+    }
+    return [{ layerId, frame }];
   }
 
   // ====== 키프레임 선택 ======

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -104,6 +104,7 @@ export class Timeline extends EventTarget {
     this.dragGhost = null;  // 드래그 중 표시할 고스트 요소
     this.dragGhostItems = [];
     this.dragSourceElements = [];
+    this.dragGhostKeyframes = [];
 
     // 다중 선택 상태
     this.selectedKeyframes = [];  // [ { layerId, frame } ]
@@ -1556,23 +1557,24 @@ export class Timeline extends EventTarget {
     const newFrame = Math.min(this.totalFrames - 1, Math.floor(percent * this.totalFrames));
 
     // 고스트 클립 위치 업데이트
-    const frameDelta = newFrame - this.dragStartFrame;
+    const rawFrameDelta = newFrame - this.dragStartFrame;
+    const frameDelta = this._clampKeyframeDragDelta(rawFrameDelta);
+    const targetFrame = this.dragStartFrame + frameDelta;
     this.dragGhostItems.forEach(ghostCell => {
       const sourceFrame = parseInt(ghostCell.dataset.sourceFrame || '0', 10) + frameDelta;
-      const clampedFrame = Math.max(0, Math.min(this.totalFrames - 1, sourceFrame));
-      const ghostPercent = (clampedFrame / this.totalFrames) * 100;
+      const ghostPercent = (sourceFrame / this.totalFrames) * 100;
       ghostCell.style.left = `${ghostPercent}%`;
     });
 
     // 툴팁 위치 및 내용 업데이트
     if (this.dragTooltip) {
-      const tooltipPercent = ((newFrame + 0.5) / this.totalFrames) * 100;
+      const tooltipPercent = ((targetFrame + 0.5) / this.totalFrames) * 100;
       this.dragTooltip.style.left = `${tooltipPercent}%`;
-      this.dragTooltip.textContent = `F${newFrame}`;
+      this.dragTooltip.textContent = `F${targetFrame}`;
     }
 
     // 프레임 이동량 저장
-    this.dragGhost.dataset.targetFrame = newFrame;
+    this.dragGhost.dataset.targetFrame = targetFrame;
     this.dragGhost.dataset.frameDelta = frameDelta;
   }
 
@@ -1594,6 +1596,7 @@ export class Timeline extends EventTarget {
     // 고스트 및 툴팁 제거
     this.dragGhostItems.forEach(ghost => ghost.remove());
     this.dragGhostItems = [];
+    this.dragGhostKeyframes = [];
     if (this.dragGhost) {
       this.dragGhost.remove();
       this.dragGhost = null;
@@ -1635,6 +1638,7 @@ export class Timeline extends EventTarget {
     this.dragGhost.dataset.frameDelta = '0';
     this.dragGhostItems = [];
     this.dragSourceElements = [];
+    this.dragGhostKeyframes = ghostKeyframes.map(keyframe => ({ ...keyframe }));
 
     // 선택된 키프레임 각각에 정확히 1프레임 칸을 나타내는 고스트를 만든다.
     const ghostWidthPercent = (1 / this.totalFrames) * 100;
@@ -1691,6 +1695,19 @@ export class Timeline extends EventTarget {
       return this.selectedKeyframes.map(keyframe => ({ ...keyframe }));
     }
     return [{ layerId, frame }];
+  }
+
+  _clampKeyframeDragDelta(frameDelta) {
+    const sourceFrames = this.dragGhostKeyframes
+      .map(keyframe => Number(keyframe.frame))
+      .filter(Number.isFinite);
+    if (sourceFrames.length === 0 || this.totalFrames <= 0) return frameDelta;
+
+    const minFrame = Math.min(...sourceFrames);
+    const maxFrame = Math.max(...sourceFrames);
+    const minDelta = -minFrame;
+    const maxDelta = (this.totalFrames - 1) - maxFrame;
+    return Math.max(minDelta, Math.min(maxDelta, frameDelta));
   }
 
   // ====== 키프레임 선택 ======

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -4654,6 +4654,10 @@ button.layer-lock:not(.locked):hover {
   outline-offset: -2px;
 }
 
+.keyframe-drag-ghost-group {
+  display: none;
+}
+
 .keyframe-drag-ghost-cell {
   position: absolute;
   top: 0;

--- a/scripts/tests/keyframe-drag-ghost-source.test.js
+++ b/scripts/tests/keyframe-drag-ghost-source.test.js
@@ -22,6 +22,21 @@ test('keyframe drag ghost renders as an exact one-frame cell', () => {
   assert.match(mainCss, /\.keyframe-drag-ghost-cell\s*\{[\s\S]*?height:\s*100%;[\s\S]*?outline:\s*2px dashed var\(--accent-primary\);/);
 });
 
+test('keyframe drag ghost previews every selected keyframe while dragging', () => {
+  assert.match(timelineSource, /this\.dragGhostItems = \[\]/);
+  assert.match(timelineSource, /this\.dragSourceElements = \[\]/);
+  assert.match(timelineSource, /_getDragGhostKeyframes\(layerId, frame\)/);
+  assert.match(timelineSource, /const ghostKeyframes = this\._getDragGhostKeyframes\(layerId, frame\);/);
+  assert.match(timelineSource, /ghostKeyframes\.forEach\(keyframe => \{/);
+  assert.match(timelineSource, /ghostCell\.dataset\.sourceFrame = keyframe\.frame;/);
+  assert.match(timelineSource, /this\.dragGhostItems\.push\(ghostCell\)/);
+  assert.match(timelineSource, /const frameDelta = newFrame - this\.dragStartFrame;/);
+  assert.match(timelineSource, /this\.dragGhostItems\.forEach\(ghostCell => \{/);
+  assert.match(timelineSource, /parseInt\(ghostCell\.dataset\.sourceFrame \|\| '0', 10\) \+ frameDelta/);
+  assert.match(timelineSource, /this\.dragSourceElements\.forEach\(element => \{/);
+  assert.match(timelineSource, /this\.dragGhostItems\.forEach\(ghost => ghost\.remove\(\)\)/);
+});
+
 test('frame cell mode is stored and wired through the timeline toolbar', () => {
   assert.match(userSettingsSource, /frameCellMode: 'auto'/);
   assert.match(userSettingsSource, /getFrameCellMode\(\)/);

--- a/scripts/tests/keyframe-drag-ghost-source.test.js
+++ b/scripts/tests/keyframe-drag-ghost-source.test.js
@@ -16,7 +16,7 @@ test('keyframe drag ghost renders as an exact one-frame cell', () => {
   assert.match(timelineSource, /this\.dragGhost = document\.createElement\('div'\)/);
   assert.match(timelineSource, /const ghostWidthPercent = \(1 \/ this\.totalFrames\) \* 100/);
   assert.match(timelineSource, /Math\.floor\(percent \* this\.totalFrames\)/);
-  assert.match(timelineSource, /\(\(newFrame \+ 0\.5\) \/ this\.totalFrames\) \* 100/);
+  assert.match(timelineSource, /\(\(targetFrame \+ 0\.5\) \/ this\.totalFrames\) \* 100/);
   assert.doesNotMatch(timelineSource, /Math\.round\(percent \* \(this\.totalFrames - 1\)\)/);
   assert.doesNotMatch(timelineSource, /cloneNode\(true\)/);
   assert.match(mainCss, /\.keyframe-drag-ghost-cell\s*\{[\s\S]*?height:\s*100%;[\s\S]*?outline:\s*2px dashed var\(--accent-primary\);/);
@@ -25,16 +25,30 @@ test('keyframe drag ghost renders as an exact one-frame cell', () => {
 test('keyframe drag ghost previews every selected keyframe while dragging', () => {
   assert.match(timelineSource, /this\.dragGhostItems = \[\]/);
   assert.match(timelineSource, /this\.dragSourceElements = \[\]/);
+  assert.match(timelineSource, /this\.dragGhostKeyframes = \[\]/);
   assert.match(timelineSource, /_getDragGhostKeyframes\(layerId, frame\)/);
   assert.match(timelineSource, /const ghostKeyframes = this\._getDragGhostKeyframes\(layerId, frame\);/);
+  assert.match(timelineSource, /this\.dragGhostKeyframes = ghostKeyframes\.map\(keyframe => \(\{ \.\.\.keyframe \}\)\);/);
   assert.match(timelineSource, /ghostKeyframes\.forEach\(keyframe => \{/);
   assert.match(timelineSource, /ghostCell\.dataset\.sourceFrame = keyframe\.frame;/);
   assert.match(timelineSource, /this\.dragGhostItems\.push\(ghostCell\)/);
-  assert.match(timelineSource, /const frameDelta = newFrame - this\.dragStartFrame;/);
+  assert.match(timelineSource, /const rawFrameDelta = newFrame - this\.dragStartFrame;/);
+  assert.match(timelineSource, /const frameDelta = this\._clampKeyframeDragDelta\(rawFrameDelta\);/);
   assert.match(timelineSource, /this\.dragGhostItems\.forEach\(ghostCell => \{/);
   assert.match(timelineSource, /parseInt\(ghostCell\.dataset\.sourceFrame \|\| '0', 10\) \+ frameDelta/);
   assert.match(timelineSource, /this\.dragSourceElements\.forEach\(element => \{/);
   assert.match(timelineSource, /this\.dragGhostItems\.forEach\(ghost => ghost\.remove\(\)\)/);
+});
+
+test('keyframe drag ghost clamps group delta before preview and move emit', () => {
+  assert.match(timelineSource, /_clampKeyframeDragDelta\(frameDelta\)/);
+  assert.match(timelineSource, /const minFrame = Math\.min\(\.\.\.sourceFrames\);/);
+  assert.match(timelineSource, /const maxFrame = Math\.max\(\.\.\.sourceFrames\);/);
+  assert.match(timelineSource, /const minDelta = -minFrame;/);
+  assert.match(timelineSource, /const maxDelta = \(this\.totalFrames - 1\) - maxFrame;/);
+  assert.match(timelineSource, /return Math\.max\(minDelta, Math\.min\(maxDelta, frameDelta\)\);/);
+  assert.match(timelineSource, /const targetFrame = this\.dragStartFrame \+ frameDelta;/);
+  assert.match(timelineSource, /this\.dragGhost\.dataset\.targetFrame = targetFrame;/);
 });
 
 test('frame cell mode is stored and wired through the timeline toolbar', () => {

--- a/scripts/tests/keyframe-drag-ghost-source.test.js
+++ b/scripts/tests/keyframe-drag-ghost-source.test.js
@@ -38,6 +38,12 @@ test('keyframe drag ghost previews every selected keyframe while dragging', () =
   assert.match(timelineSource, /parseInt\(ghostCell\.dataset\.sourceFrame \|\| '0', 10\) \+ frameDelta/);
   assert.match(timelineSource, /this\.dragSourceElements\.forEach\(element => \{/);
   assert.match(timelineSource, /this\.dragGhostItems\.forEach\(ghost => ghost\.remove\(\)\)/);
+  assert.match(timelineSource, /const keyframesToMove = this\.dragGhostKeyframes\.map\(kf => \(/);
+  assert.ok(
+    timelineSource.indexOf('const keyframesToMove = this.dragGhostKeyframes.map') <
+      timelineSource.indexOf('this.dragGhostKeyframes = [];', timelineSource.indexOf('const keyframesToMove = this.dragGhostKeyframes.map')),
+    'drag ghost keyframes must be cleared after move payload creation'
+  );
 });
 
 test('keyframe drag ghost clamps group delta before preview and move emit', () => {
@@ -49,6 +55,13 @@ test('keyframe drag ghost clamps group delta before preview and move emit', () =
   assert.match(timelineSource, /return Math\.max\(minDelta, Math\.min\(maxDelta, frameDelta\)\);/);
   assert.match(timelineSource, /const targetFrame = this\.dragStartFrame \+ frameDelta;/);
   assert.match(timelineSource, /this\.dragGhost\.dataset\.targetFrame = targetFrame;/);
+});
+
+test('keyframe drag ghost excludes locked layers from preview, clamp, and move emit', () => {
+  assert.match(timelineSource, /_isKeyframeLayerMovable\(layerId\)/);
+  assert.match(timelineSource, /return keyframes\.filter\(keyframe => this\._isKeyframeLayerMovable\(keyframe\.layerId\)\);/);
+  assert.match(timelineSource, /const layer = this\._lastDrawingLayers\.find\(item => item\.id === layerId\);/);
+  assert.match(timelineSource, /return layer\?\.locked !== true;/);
 });
 
 test('frame cell mode is stored and wired through the timeline toolbar', () => {

--- a/scripts/tests/keyframe-multi-select-source.test.js
+++ b/scripts/tests/keyframe-multi-select-source.test.js
@@ -62,6 +62,13 @@ test('selected keyframes can be deleted through the drawing manager', () => {
   assert.match(appSource, /drawingManager\.removeKeyframes\(selectedKeyframes\)/);
 });
 
+test('selected keyframe moves are ordered by drag direction to keep adjacent moves together', () => {
+  assert.match(drawingManagerSource, /const frameDelta = \(a\.toFrame - a\.fromFrame\) \|\| \(b\.toFrame - b\.fromFrame\);/);
+  assert.match(drawingManagerSource, /if \(frameDelta < 0\) return a\.fromFrame - b\.fromFrame;/);
+  assert.match(drawingManagerSource, /if \(frameDelta > 0\) return b\.fromFrame - a\.fromFrame;/);
+  assert.doesNotMatch(drawingManagerSource, /sort\(\(a, b\) => b\.fromFrame - a\.fromFrame\)/);
+});
+
 test('single remaining keyframe can be deleted', () => {
   assert.doesNotMatch(drawingManagerSource, /마지막 키프레임은 삭제할 수 없습니다/);
   assert.doesNotMatch(drawingManagerSource, /layer\.keyframes\.length <= 1/);


### PR DESCRIPTION
## 📋 업데이트 요약

🎞️ 여러 키프레임을 선택한 뒤 이동할 때, 이제 클릭한 키프레임 하나만 보이지 않고 선택된 키프레임 전체가 함께 움직이는 모습으로 표시됩니다.

👀 실제로 어떤 키프레임들이 같이 옮겨지는지 드래그 중에 바로 확인할 수 있어, 다중 선택 이동이 더 예측 가능해졌습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/timeline.js`
  - 기존 drag ghost는 드래그 시작 대상 1개만 `keyframe-drag-ghost-cell`로 생성했습니다.
  - `dragGhostItems`와 `dragSourceElements`를 추가해 선택된 키프레임 전체에 대해 ghost cell을 생성하고, 드래그 이동량(`frameDelta`)을 각 ghost cell에 동일하게 적용하도록 변경했습니다.
  - `_getDragGhostKeyframes(layerId, frame)`를 추가해 드래그한 키프레임이 선택 목록에 포함되어 있으면 전체 선택 목록을, 아니면 단일 키프레임만 미리보기 대상으로 사용합니다.
  - 드래그 종료 시 생성된 ghost cell 전체와 반투명 처리된 원본 요소를 함께 정리합니다.

- `renderer/styles/main.css`
  - 관리용 `keyframe-drag-ghost-group`이 레이아웃에 영향을 주지 않도록 숨김 처리했습니다.

- `scripts/tests/keyframe-drag-ghost-source.test.js`
  - 다중 선택된 키프레임 전체가 drag ghost로 생성되고, 드래그 이동량을 함께 반영하며, 종료 시 정리되는지 확인하는 회귀 테스트를 추가했습니다.

## 🚧 개발 난항

- 기존 구현은 “키프레임 하나를 드래그한다”는 시각 피드백만 가지고 있었지만, 실제 이동 로직은 선택된 키프레임 전체를 옮기고 있었습니다. 그래서 기능은 움직이지만 화면 피드백이 실제 결과와 달라 사용자가 헷갈릴 수 있었습니다.
- 선택된 키프레임은 여러 레이어에 걸쳐 있을 수 있어, 하나의 복제 요소만 움직이는 방식으로는 부족했습니다. 각 키프레임이 속한 레이어 행에 별도 ghost cell을 붙이고 같은 이동량을 적용하는 방식으로 해결했습니다.

## ✅ 테스트 가이드

실사용자용:
- 타임라인에서 여러 키프레임을 선택합니다.
- 선택된 키프레임 중 하나를 드래그합니다.
- 드래그 중 선택된 키프레임 전체가 각자의 행에서 함께 움직이는 표시로 보이는지 확인합니다.
- 마우스를 놓으면 실제 선택 키프레임들이 같은 이동량으로 옮겨지는지 확인합니다.

개발자용:
- `npm run test:frame-grid`
- `npm run test:drawing`
- `git diff --check`