### PR TITLE
[v1.4.1] 키프레임 단축키와 프레임 변환 동작 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:playlist-comments": "node --test scripts/tests/playlist-comment-index.test.js",
     "test:playlist": "node --test scripts/tests/playlist-ordering.test.js scripts/tests/playlist-continuous-core.test.js scripts/tests/playlist-continuous-runtime.test.js scripts/tests/playlist-comment-index.test.js scripts/tests/playlist-autoplay-source.test.js scripts/tests/bplaylist-file-association-source.test.js scripts/tests/project-file-associations.test.js scripts/tests/instance-policy.test.js",
     "test:cutlist": "node --test scripts/tests/cutlist-manager.test.js scripts/tests/cutlist-schema.test.js scripts/tests/moho-scene-info-parser.test.js scripts/tests/cutlist-core.test.js scripts/tests/cutlist-runtime-source.test.js scripts/tests/cutlist-comment-index.test.js",
-    "test:drawing": "node --test scripts/tests/drawing-stroke-records.test.js scripts/tests/drawing-layer-partition.test.js scripts/tests/drawing-runtime-source.test.js scripts/tests/keyframe-multi-select-source.test.js scripts/tests/brush-settings-source.test.js",
+    "test:drawing": "node --test scripts/tests/drawing-stroke-records.test.js scripts/tests/drawing-layer-partition.test.js scripts/tests/drawing-runtime-source.test.js scripts/tests/keyframe-multi-select-source.test.js scripts/tests/keyframe-shortcuts-source.test.js scripts/tests/brush-settings-source.test.js",
     "test:video-pan": "node --test scripts/tests/video-pan-controls.test.js scripts/tests/playhead-frame-step-source.test.js",
     "test:mpv": "node --test scripts/tests/mpv-manager.test.js scripts/tests/mpv-embed-host.test.js scripts/tests/mpv-overlay-host.test.js scripts/tests/mpv-runtime-source.test.js",
     "test:audio-waveform": "node --test scripts/tests/audio-waveform-hit-area.test.js",

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1355,6 +1355,26 @@
           <span class="shortcut-label">프레임 삭제</span>
           <div class="shortcut-keys"><span class="shortcut-key">4</span></div>
         </div>
+        <div class="shortcut-row">
+          <span class="shortcut-label">키프레임을 프레임으로</span>
+          <div class="shortcut-keys"><span class="shortcut-key">Shift</span><span class="shortcut-key">2</span></div>
+        </div>
+        <div class="shortcut-row">
+          <span class="shortcut-label">프레임을 키프레임으로</span>
+          <div class="shortcut-keys"><span class="shortcut-key">Shift</span><span class="shortcut-key">3</span></div>
+        </div>
+        <div class="shortcut-row">
+          <span class="shortcut-label">레이어 추가/삭제</span>
+          <div class="shortcut-keys"><span class="shortcut-key">Shift</span><span class="shortcut-key">F1</span><span class="shortcut-key">Shift</span><span class="shortcut-key">`</span></div>
+        </div>
+        <div class="shortcut-row">
+          <span class="shortcut-label">레이어 선택/이동</span>
+          <div class="shortcut-keys"><span class="shortcut-key">Shift</span><span class="shortcut-key">X/C</span><span class="shortcut-key">Ctrl</span><span class="shortcut-key">Shift</span><span class="shortcut-key">X/C</span></div>
+        </div>
+        <div class="shortcut-row">
+          <span class="shortcut-label">현재 프레임 중앙 보기</span>
+          <div class="shortcut-keys"><span class="shortcut-key">Alt</span><span class="shortcut-key">Shift</span><span class="shortcut-key">C</span></div>
+        </div>
       </div>
 
       <!-- 편집 -->

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -3182,15 +3182,17 @@ async function initApp() {
     }
   });
 
-  // 레이어 추가 버튼
-  elements.btnAddLayer?.addEventListener('click', () => {
-    drawingManager.createLayer();
+  function renderDrawingLayerTimeline() {
     timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
-    showToast('새 레이어 추가됨', 'success');
-  });
+  }
 
-  // 레이어 삭제 버튼
-  elements.btnDeleteLayer?.addEventListener('click', () => {
+  function addDrawingLayer() {
+    drawingManager.createLayer();
+    renderDrawingLayerTimeline();
+    showToast('새 레이어 추가됨', 'success');
+  }
+
+  function deleteActiveDrawingLayer() {
     const activeLayerId = drawingManager.activeLayerId;
     if (!activeLayerId) {
       showToast('삭제할 레이어가 없습니다.', 'warn');
@@ -3201,10 +3203,29 @@ async function initApp() {
       return;
     }
     if (drawingManager.deleteLayer(activeLayerId)) {
-      timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+      renderDrawingLayerTimeline();
       showToast('레이어 삭제됨', 'info');
     }
-  });
+  }
+
+  function selectDrawingLayerByOffset(offset) {
+    if (drawingManager.selectActiveLayerByOffset(offset)) {
+      renderDrawingLayerTimeline();
+    }
+  }
+
+  function moveDrawingLayerByOffset(offset) {
+    if (drawingManager.moveActiveLayerByOffset(offset)) {
+      renderDrawingLayerTimeline();
+      showToast('레이어 순서가 변경되었습니다.', 'info');
+    }
+  }
+
+  // 레이어 추가 버튼
+  elements.btnAddLayer?.addEventListener('click', addDrawingLayer);
+
+  // 레이어 삭제 버튼
+  elements.btnDeleteLayer?.addEventListener('click', deleteActiveDrawingLayer);
 
   // ====== 그리기 도구 메뉴 이동/접기 ======
   const drawingToolsPanel = elements.drawingTools;
@@ -10501,6 +10522,42 @@ async function initApp() {
       return;
     }
 
+    if (userSettings.matchShortcut('drawingLayerAdd', e)) {
+      e.preventDefault();
+      addDrawingLayer();
+      return;
+    }
+    if (userSettings.matchShortcut('drawingLayerDelete', e)) {
+      e.preventDefault();
+      deleteActiveDrawingLayer();
+      return;
+    }
+    if (userSettings.matchShortcut('drawingLayerSelectUp', e)) {
+      e.preventDefault();
+      selectDrawingLayerByOffset(1);
+      return;
+    }
+    if (userSettings.matchShortcut('drawingLayerSelectDown', e)) {
+      e.preventDefault();
+      selectDrawingLayerByOffset(-1);
+      return;
+    }
+    if (userSettings.matchShortcut('drawingLayerMoveUp', e)) {
+      e.preventDefault();
+      moveDrawingLayerByOffset(1);
+      return;
+    }
+    if (userSettings.matchShortcut('drawingLayerMoveDown', e)) {
+      e.preventDefault();
+      moveDrawingLayerByOffset(-1);
+      return;
+    }
+    if (userSettings.matchShortcut('timelineCenterOnPlayhead', e)) {
+      e.preventDefault();
+      timeline.centerOnPlayhead();
+      return;
+    }
+
     const matchedBrushSizeAction = userSettings.findActionByEvent(e);
     if (state.isDrawMode && (matchedBrushSizeAction === 'brushSizeDown' || matchedBrushSizeAction === 'brushSizeUp')) {
       e.preventDefault();
@@ -10653,10 +10710,20 @@ async function initApp() {
       timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
       return;
     }
-    // Shift+3: 현재 키프레임 삭제
-    if (userSettings.matchShortcut('keyframeDeleteAlt', e)) {
+    // Shift+2: 키프레임을 일반 프레임으로 변환
+    if (userSettings.matchShortcut('keyframeConvertToFrame', e)) {
       e.preventDefault();
-      deleteSelectedOrCurrentKeyframes();
+      if (drawingManager.convertKeyframeToFrame()) {
+        timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+      }
+      return;
+    }
+    // Shift+3: 현재 프레임을 키프레임으로 변환
+    if (userSettings.matchShortcut('keyframeConvertToKeyframe', e)) {
+      e.preventDefault();
+      if (drawingManager.convertFrameToKeyframe()) {
+        timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+      }
       return;
     }
     // 3: 프레임 삽입 (홀드 추가)
@@ -11249,8 +11316,9 @@ async function initApp() {
     '모드': ['commentMode', 'drawMode', 'fullscreen'],
     '구간 반복': ['setInPoint', 'setOutPoint', 'toggleLoop', 'clearLoop', 'addHighlight'],
     '실행취소': ['undo', 'redo'],
-    '키프레임': ['keyframeAddWithCopy', 'keyframeAddBlank', 'keyframeAddBlank2', 'keyframeDelete', 'keyframeDeleteAlt', 'prevKeyframe', 'nextKeyframe'],
+    '키프레임': ['keyframeAddWithCopy', 'keyframeAddBlank', 'keyframeAddBlank2', 'keyframeConvertToFrame', 'keyframeConvertToKeyframe', 'keyframeDelete', 'prevKeyframe', 'nextKeyframe'],
     '프레임 편집': ['insertFrame', 'deleteFrame'],
+    '드로잉 레이어': ['drawingLayerAdd', 'drawingLayerDelete', 'drawingLayerSelectUp', 'drawingLayerSelectDown', 'drawingLayerMoveUp', 'drawingLayerMoveDown', 'timelineCenterOnPlayhead'],
     '그리기 보조': ['onionSkinToggle', 'prevFrameDraw', 'nextFrameDraw', 'brushSizeDown', 'brushSizeUp']
   };
 
@@ -11259,7 +11327,7 @@ async function initApp() {
   function keyCodeToDisplay(code) {
     const map = {
       'Space': 'Space', 'ArrowLeft': '←', 'ArrowRight': '→', 'ArrowUp': '↑', 'ArrowDown': '↓',
-      'Home': 'Home', 'End': 'End', 'Delete': 'Del', 'Backspace': 'Back',
+      'Home': 'Home', 'End': 'End', 'Delete': 'Del', 'Backspace': 'Back', 'Backquote': '`',
       'Enter': 'Enter', 'Tab': 'Tab', 'Escape': 'Esc'
     };
     if (map[code]) return map[code];

--- a/renderer/scripts/modules/drawing-layer.js
+++ b/renderer/scripts/modules/drawing-layer.js
@@ -289,7 +289,7 @@ export class DrawingLayer {
       .sort((a, b) => b.frame - a.frame)[0];
     const hasTimelineTail = Number.isFinite(totalFrames) ? frame < totalFrames - 1 : true;
     const currentHasHold = nextKeyframe ? nextKeyframe.frame > frame + 1 : hasTimelineTail;
-    const deletesTailHeldFrame = heldKeyframe && !nextKeyframe && Number.isFinite(totalFrames)
+    const deletesTailHeldFrame = heldKeyframe && !heldKeyframe.isEmpty && !nextKeyframe && Number.isFinite(totalFrames)
       && (heldKeyframe.frame < frame || currentHasHold);
     if (deletesTailHeldFrame) {
       const tailBoundaryFrame = frame < totalFrames - 1 ? totalFrames : frame;

--- a/renderer/scripts/modules/drawing-layer.js
+++ b/renderer/scripts/modules/drawing-layer.js
@@ -284,10 +284,16 @@ export class DrawingLayer {
   deleteFrame(frame, totalFrames = null) {
     const currentKeyframeIndex = this.keyframes.findIndex(kf => kf.frame === frame);
     const nextKeyframe = this.keyframes.find(kf => kf.frame > frame);
+    const heldKeyframe = this.keyframes
+      .filter(kf => kf.frame <= frame)
+      .sort((a, b) => b.frame - a.frame)[0];
     const hasTimelineTail = Number.isFinite(totalFrames) ? frame < totalFrames - 1 : true;
     const currentHasHold = nextKeyframe ? nextKeyframe.frame > frame + 1 : hasTimelineTail;
-    if (currentKeyframeIndex !== -1 && !nextKeyframe && currentHasHold && Number.isFinite(totalFrames)) {
-      const tailBoundaryKeyframe = new Keyframe(totalFrames, null);
+    const deletesTailHeldFrame = heldKeyframe && !nextKeyframe && Number.isFinite(totalFrames)
+      && (heldKeyframe.frame < frame || currentHasHold);
+    if (deletesTailHeldFrame) {
+      const tailBoundaryFrame = frame < totalFrames - 1 ? totalFrames : frame;
+      const tailBoundaryKeyframe = new Keyframe(tailBoundaryFrame, null);
       this.keyframes.push(tailBoundaryKeyframe);
     }
     if (currentKeyframeIndex !== -1 && !currentHasHold) {

--- a/renderer/scripts/modules/drawing-layer.js
+++ b/renderer/scripts/modules/drawing-layer.js
@@ -296,7 +296,10 @@ export class DrawingLayer {
       const tailBoundaryKeyframe = new Keyframe(tailBoundaryFrame, null);
       this.keyframes.push(tailBoundaryKeyframe);
     }
-    if (currentKeyframeIndex !== -1 && !currentHasHold) {
+    const currentKeyframe = currentKeyframeIndex !== -1 ? this.keyframes[currentKeyframeIndex] : null;
+    const preservesTailBlankBoundary = currentKeyframe?.isEmpty && !nextKeyframe && Number.isFinite(totalFrames)
+      && frame === totalFrames - 1 && this.keyframes.some(kf => kf.frame < frame);
+    if (currentKeyframeIndex !== -1 && !currentHasHold && !preservesTailBlankBoundary) {
       this.keyframes.splice(currentKeyframeIndex, 1);
     }
 

--- a/renderer/scripts/modules/drawing-layer.js
+++ b/renderer/scripts/modules/drawing-layer.js
@@ -279,11 +279,14 @@ export class DrawingLayer {
   /**
    * 프레임 삭제 - 현재 프레임 이후의 모든 키프레임을 1프레임씩 앞으로 이동
    * @param {number} frame - 삭제할 프레임
+   * @param {number|null} totalFrames - 마지막 키프레임 홀드 판정용 전체 프레임 수
    */
-  deleteFrame(frame) {
-    // 현재 프레임에 키프레임이 있으면 먼저 삭제
+  deleteFrame(frame, totalFrames = null) {
     const currentKeyframeIndex = this.keyframes.findIndex(kf => kf.frame === frame);
-    if (currentKeyframeIndex !== -1) {
+    const nextKeyframe = this.keyframes.find(kf => kf.frame > frame);
+    const hasTimelineTail = Number.isFinite(totalFrames) ? frame < totalFrames - 1 : true;
+    const currentHasHold = nextKeyframe ? nextKeyframe.frame > frame + 1 : hasTimelineTail;
+    if (currentKeyframeIndex !== -1 && !currentHasHold) {
       this.keyframes.splice(currentKeyframeIndex, 1);
     }
 

--- a/renderer/scripts/modules/drawing-layer.js
+++ b/renderer/scripts/modules/drawing-layer.js
@@ -286,6 +286,10 @@ export class DrawingLayer {
     const nextKeyframe = this.keyframes.find(kf => kf.frame > frame);
     const hasTimelineTail = Number.isFinite(totalFrames) ? frame < totalFrames - 1 : true;
     const currentHasHold = nextKeyframe ? nextKeyframe.frame > frame + 1 : hasTimelineTail;
+    if (currentKeyframeIndex !== -1 && !nextKeyframe && currentHasHold && Number.isFinite(totalFrames)) {
+      const tailBoundaryKeyframe = new Keyframe(totalFrames, null);
+      this.keyframes.push(tailBoundaryKeyframe);
+    }
     if (currentKeyframeIndex !== -1 && !currentHasHold) {
       this.keyframes.splice(currentKeyframeIndex, 1);
     }

--- a/renderer/scripts/modules/drawing-manager.js
+++ b/renderer/scripts/modules/drawing-manager.js
@@ -514,6 +514,34 @@ export class DrawingManager extends EventTarget {
     }
   }
 
+  selectActiveLayerByOffset(offset) {
+    const index = this.layers.findIndex(layer => layer.id === this.activeLayerId);
+    if (index === -1) return false;
+
+    const targetIndex = index + offset;
+    if (targetIndex < 0 || targetIndex >= this.layers.length) return false;
+
+    this.setActiveLayer(this.layers[targetIndex].id);
+    return true;
+  }
+
+  moveActiveLayerByOffset(offset) {
+    const index = this.layers.findIndex(layer => layer.id === this.activeLayerId);
+    if (index === -1) return false;
+
+    const targetIndex = index + offset;
+    if (targetIndex < 0 || targetIndex >= this.layers.length) return false;
+
+    this._saveToHistory();
+    const [layer] = this.layers.splice(index, 1);
+    this.layers.splice(targetIndex, 0, layer);
+    this.activeLayerId = layer.id;
+    this._emit('activeLayerChanged', { layer });
+    this._emit('layersChanged');
+    this.renderFrame(this.currentFrame);
+    return true;
+  }
+
   /**
    * 레이어 가시성 토글
    */
@@ -683,6 +711,28 @@ export class DrawingManager extends EventTarget {
     return true;
   }
 
+  convertKeyframeToFrame() {
+    const layer = this.getActiveLayer();
+    if (!layer || layer.locked) return false;
+    if (!layer.isKeyframe(this.currentFrame)) return false;
+
+    this._saveToHistory();
+    layer.removeKeyframe(this.currentFrame);
+    this.renderFrame(this.currentFrame);
+    this._emit('keyframeConvertedToFrame', { layer, frame: this.currentFrame });
+    this._emit('layersChanged');
+    return true;
+  }
+
+  convertFrameToKeyframe() {
+    const layer = this.getActiveLayer();
+    if (!layer || layer.locked) return false;
+
+    this.addKeyframeWithContent();
+    this._emit('keyframeConvertedToKeyframe', { layer, frame: this.currentFrame });
+    return true;
+  }
+
   /**
    * 선택된 여러 키프레임 삭제
    * @param {Array<{layerId: string, frame: number}>} selectedKeyframes
@@ -791,7 +841,7 @@ export class DrawingManager extends EventTarget {
     // Undo를 위해 현재 상태 저장
     this._saveToHistory();
 
-    layer.deleteFrame(this.currentFrame);
+    layer.deleteFrame(this.currentFrame, this.totalFrames);
     this.renderFrame(this.currentFrame);
 
     this._emit('frameDeleted', { layer, frame: this.currentFrame });

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -607,6 +607,20 @@ export class Timeline extends EventTarget {
     }
   }
 
+  centerOnPlayhead() {
+    const duration = this._getTimelineDuration();
+    if (!this.timelineTracks || duration === 0) return;
+
+    const containerWidth = this.tracksContainer?.offsetWidth || 0;
+    if (containerWidth === 0) return;
+
+    const percent = this.currentTime / duration;
+    const playheadPx = containerWidth * percent;
+    const viewportWidth = this.timelineTracks.clientWidth;
+    const targetScrollLeft = playheadPx - (viewportWidth / 2);
+    this.timelineTracks.scrollLeft = Math.max(0, targetScrollLeft);
+  }
+
   /**
    * 플레이헤드 위치 업데이트
    * 핸들과 라인 모두 동일한 left 값을 사용 (CSS에서 margin-left로 핸들 중앙 정렬)

--- a/renderer/scripts/modules/user-settings.js
+++ b/renderer/scripts/modules/user-settings.js
@@ -46,13 +46,23 @@ const DEFAULT_SHORTCUTS = {
   keyframeAddBlank: { key: 'F7', ctrl: false, shift: false, alt: false, label: '빈 키프레임 추가' },
   keyframeAddBlank2: { key: 'Digit2', ctrl: false, shift: false, alt: false, label: '빈 키프레임 삽입 (2)' },
   keyframeDelete: { key: 'Delete', ctrl: false, shift: false, alt: false, label: '키프레임 삭제' },
-  keyframeDeleteAlt: { key: 'Digit3', ctrl: false, shift: true, alt: false, label: '키프레임 삭제 (Shift+3)' },
+  keyframeConvertToFrame: { key: 'Digit2', ctrl: false, shift: true, alt: false, label: '키프레임을 일반 프레임으로' },
+  keyframeConvertToKeyframe: { key: 'Digit3', ctrl: false, shift: true, alt: false, label: '프레임을 키프레임으로' },
   prevKeyframe: { key: 'KeyA', ctrl: false, shift: false, alt: false, label: '이전 키프레임' },
   nextKeyframe: { key: 'KeyD', ctrl: false, shift: false, alt: false, label: '다음 키프레임' },
 
   // 프레임 편집
   insertFrame: { key: 'Digit3', ctrl: false, shift: false, alt: false, label: '프레임 삽입 (홀드)' },
   deleteFrame: { key: 'Digit4', ctrl: false, shift: false, alt: false, label: '프레임 삭제' },
+
+  // 드로잉 레이어 편집
+  drawingLayerAdd: { key: 'F1', ctrl: false, shift: true, alt: false, label: '드로잉 레이어 추가' },
+  drawingLayerDelete: { key: 'Backquote', ctrl: false, shift: true, alt: false, label: '드로잉 레이어 삭제' },
+  drawingLayerSelectUp: { key: 'KeyX', ctrl: false, shift: true, alt: false, label: '위 레이어 선택' },
+  drawingLayerSelectDown: { key: 'KeyC', ctrl: false, shift: true, alt: false, label: '아래 레이어 선택' },
+  drawingLayerMoveUp: { key: 'KeyX', ctrl: true, shift: true, alt: false, label: '레이어 위로 이동' },
+  drawingLayerMoveDown: { key: 'KeyC', ctrl: true, shift: true, alt: false, label: '레이어 아래로 이동' },
+  timelineCenterOnPlayhead: { key: 'KeyC', ctrl: false, shift: true, alt: true, label: '현재 프레임 중앙 보기' },
 
   // 그리기 보조
   onionSkinToggle: { key: 'Digit1', ctrl: false, shift: false, alt: false, label: '어니언 스킨 토글' },

--- a/scripts/tests/drawing-layer-partition.test.js
+++ b/scripts/tests/drawing-layer-partition.test.js
@@ -88,6 +88,21 @@ test('deleteFrame shortens an ordinary frame in the final held range', () => {
   ]);
 });
 
+test('deleteFrame preserves a blank final boundary after a tail hold was shortened', () => {
+  const drawingLayer = new DrawingLayer({ id: 'layer-tail-boundary', name: 'Tail Boundary' });
+  drawingLayer.keyframes = [
+    new Keyframe(10, 'tail-content'),
+    new Keyframe(14, null)
+  ];
+
+  drawingLayer.deleteFrame(14, 15);
+
+  assert.deepEqual(drawingLayer.keyframes.map(kf => [kf.frame, kf.canvasData]), [
+    [10, 'tail-content'],
+    [14, null]
+  ]);
+});
+
 test('deleteFrame removes a one-frame keyframe when the next keyframe starts immediately', () => {
   const drawingLayer = new DrawingLayer({ id: 'layer-adjacent', name: 'Adjacent' });
   drawingLayer.keyframes = [

--- a/scripts/tests/drawing-layer-partition.test.js
+++ b/scripts/tests/drawing-layer-partition.test.js
@@ -1,10 +1,17 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
+global.window = global.window || {};
+global.window.logPanel = null;
+global.window.electronAPI = null;
+
 let partitionDrawingLayersForActive;
+let DrawingLayer;
+let Keyframe;
 
 test('drawing manager partition helper loads', async () => {
   ({ partitionDrawingLayersForActive } = await import('../../renderer/scripts/modules/drawing-manager.js'));
+  ({ DrawingLayer, Keyframe } = await import('../../renderer/scripts/modules/drawing-layer.js'));
 });
 
 function layer(id) {
@@ -49,4 +56,36 @@ test('partition treats every layer as static when active layer is missing', () =
   assert.deepEqual(ids(result.below), ['layer-1', 'layer-2']);
   assert.equal(result.active, null);
   assert.deepEqual(ids(result.above), []);
+});
+
+test('deleteFrame shortens a tail-held final keyframe by adding a blank boundary', () => {
+  const drawingLayer = new DrawingLayer({ id: 'layer-tail', name: 'Tail' });
+  drawingLayer.keyframes = [new Keyframe(10, 'tail-content')];
+
+  drawingLayer.deleteFrame(10, 15);
+
+  assert.deepEqual(drawingLayer.keyframes.map(kf => [kf.frame, kf.canvasData]), [
+    [10, 'tail-content'],
+    [14, null]
+  ]);
+
+  const ranges = drawingLayer.getKeyframeRanges(15);
+  assert.deepEqual(ranges.map(range => [range.start, range.end, range.keyframe.canvasData]), [
+    [10, 13, 'tail-content'],
+    [14, 14, null]
+  ]);
+});
+
+test('deleteFrame removes a one-frame keyframe when the next keyframe starts immediately', () => {
+  const drawingLayer = new DrawingLayer({ id: 'layer-adjacent', name: 'Adjacent' });
+  drawingLayer.keyframes = [
+    new Keyframe(10, 'one-frame'),
+    new Keyframe(11, 'next-frame')
+  ];
+
+  drawingLayer.deleteFrame(10, 20);
+
+  assert.deepEqual(drawingLayer.keyframes.map(kf => [kf.frame, kf.canvasData]), [
+    [10, 'next-frame']
+  ]);
 });

--- a/scripts/tests/drawing-layer-partition.test.js
+++ b/scripts/tests/drawing-layer-partition.test.js
@@ -103,6 +103,21 @@ test('deleteFrame preserves a blank final boundary after a tail hold was shorten
   ]);
 });
 
+test('deleteFrame does not duplicate blank tail boundary keyframes', () => {
+  const drawingLayer = new DrawingLayer({ id: 'layer-blank-tail', name: 'Blank Tail' });
+  drawingLayer.keyframes = [
+    new Keyframe(10, 'tail-content'),
+    new Keyframe(13, null)
+  ];
+
+  drawingLayer.deleteFrame(13, 15);
+
+  assert.deepEqual(drawingLayer.keyframes.map(kf => [kf.frame, kf.canvasData]), [
+    [10, 'tail-content'],
+    [13, null]
+  ]);
+});
+
 test('deleteFrame removes a one-frame keyframe when the next keyframe starts immediately', () => {
   const drawingLayer = new DrawingLayer({ id: 'layer-adjacent', name: 'Adjacent' });
   drawingLayer.keyframes = [

--- a/scripts/tests/drawing-layer-partition.test.js
+++ b/scripts/tests/drawing-layer-partition.test.js
@@ -76,6 +76,18 @@ test('deleteFrame shortens a tail-held final keyframe by adding a blank boundary
   ]);
 });
 
+test('deleteFrame shortens an ordinary frame in the final held range', () => {
+  const drawingLayer = new DrawingLayer({ id: 'layer-tail-held', name: 'Tail Held' });
+  drawingLayer.keyframes = [new Keyframe(10, 'tail-content')];
+
+  drawingLayer.deleteFrame(12, 15);
+
+  assert.deepEqual(drawingLayer.keyframes.map(kf => [kf.frame, kf.canvasData]), [
+    [10, 'tail-content'],
+    [14, null]
+  ]);
+});
+
 test('deleteFrame removes a one-frame keyframe when the next keyframe starts immediately', () => {
   const drawingLayer = new DrawingLayer({ id: 'layer-adjacent', name: 'Adjacent' });
   drawingLayer.keyframes = [

--- a/scripts/tests/keyframe-shortcuts-source.test.js
+++ b/scripts/tests/keyframe-shortcuts-source.test.js
@@ -54,7 +54,10 @@ test('delete frame removes a frame cell without deleting a held keyframe marker'
   assert.match(drawingLayerSource, /deleteFrame\(frame, totalFrames = null\)/);
   assert.match(drawingLayerSource, /const hasTimelineTail = Number\.isFinite\(totalFrames\) \? frame < totalFrames - 1 : true;/);
   assert.match(drawingLayerSource, /const currentHasHold = nextKeyframe \? nextKeyframe\.frame > frame \+ 1 : hasTimelineTail;/);
-  assert.match(drawingLayerSource, /const tailBoundaryKeyframe = new Keyframe\(totalFrames, null\);/);
+  assert.match(drawingLayerSource, /const heldKeyframe = this\.keyframes/);
+  assert.match(drawingLayerSource, /const deletesTailHeldFrame = heldKeyframe && !nextKeyframe && Number\.isFinite\(totalFrames\)/);
+  assert.match(drawingLayerSource, /const tailBoundaryFrame = frame < totalFrames - 1 \? totalFrames : frame;/);
+  assert.match(drawingLayerSource, /const tailBoundaryKeyframe = new Keyframe\(tailBoundaryFrame, null\);/);
   assert.match(drawingLayerSource, /this\.keyframes\.push\(tailBoundaryKeyframe\);/);
   assert.match(drawingLayerSource, /if \(currentKeyframeIndex !== -1 && !currentHasHold\) \{/);
   assert.doesNotMatch(drawingLayerSource, /현재 프레임에 키프레임이 있으면 먼저 삭제/);

--- a/scripts/tests/keyframe-shortcuts-source.test.js
+++ b/scripts/tests/keyframe-shortcuts-source.test.js
@@ -55,7 +55,7 @@ test('delete frame removes a frame cell without deleting a held keyframe marker'
   assert.match(drawingLayerSource, /const hasTimelineTail = Number\.isFinite\(totalFrames\) \? frame < totalFrames - 1 : true;/);
   assert.match(drawingLayerSource, /const currentHasHold = nextKeyframe \? nextKeyframe\.frame > frame \+ 1 : hasTimelineTail;/);
   assert.match(drawingLayerSource, /const heldKeyframe = this\.keyframes/);
-  assert.match(drawingLayerSource, /const deletesTailHeldFrame = heldKeyframe && !nextKeyframe && Number\.isFinite\(totalFrames\)/);
+  assert.match(drawingLayerSource, /const deletesTailHeldFrame = heldKeyframe && !heldKeyframe\.isEmpty && !nextKeyframe && Number\.isFinite\(totalFrames\)/);
   assert.match(drawingLayerSource, /const tailBoundaryFrame = frame < totalFrames - 1 \? totalFrames : frame;/);
   assert.match(drawingLayerSource, /const tailBoundaryKeyframe = new Keyframe\(tailBoundaryFrame, null\);/);
   assert.match(drawingLayerSource, /this\.keyframes\.push\(tailBoundaryKeyframe\);/);

--- a/scripts/tests/keyframe-shortcuts-source.test.js
+++ b/scripts/tests/keyframe-shortcuts-source.test.js
@@ -1,0 +1,69 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
+const drawingLayerSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/drawing-layer.js'), 'utf8'));
+const drawingManagerSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/drawing-manager.js'), 'utf8'));
+const timelineSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/timeline.js'), 'utf8'));
+const userSettingsSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/user-settings.js'), 'utf8'));
+const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+
+test('Animate-style drawing layer shortcuts are configured and handled', () => {
+  assert.match(userSettingsSource, /drawingLayerAdd:\s*\{ key: 'F1', ctrl: false, shift: true, alt: false/);
+  assert.match(userSettingsSource, /drawingLayerDelete:\s*\{ key: 'Backquote', ctrl: false, shift: true, alt: false/);
+  assert.match(userSettingsSource, /drawingLayerSelectUp:\s*\{ key: 'KeyX', ctrl: false, shift: true, alt: false/);
+  assert.match(userSettingsSource, /drawingLayerSelectDown:\s*\{ key: 'KeyC', ctrl: false, shift: true, alt: false/);
+  assert.match(userSettingsSource, /drawingLayerMoveUp:\s*\{ key: 'KeyX', ctrl: true, shift: true, alt: false/);
+  assert.match(userSettingsSource, /drawingLayerMoveDown:\s*\{ key: 'KeyC', ctrl: true, shift: true, alt: false/);
+  assert.match(userSettingsSource, /timelineCenterOnPlayhead:\s*\{ key: 'KeyC', ctrl: false, shift: true, alt: true/);
+  assert.match(appSource, /userSettings\.matchShortcut\('drawingLayerAdd', e\)/);
+  assert.match(appSource, /userSettings\.matchShortcut\('drawingLayerDelete', e\)/);
+  assert.match(appSource, /userSettings\.matchShortcut\('drawingLayerSelectUp', e\)/);
+  assert.match(appSource, /userSettings\.matchShortcut\('drawingLayerSelectDown', e\)/);
+  assert.match(appSource, /userSettings\.matchShortcut\('drawingLayerMoveUp', e\)/);
+  assert.match(appSource, /userSettings\.matchShortcut\('drawingLayerMoveDown', e\)/);
+  assert.match(appSource, /userSettings\.matchShortcut\('timelineCenterOnPlayhead', e\)/);
+  assert.match(appSource, /timeline\.centerOnPlayhead\(\)/);
+});
+
+test('DrawingManager supports selecting and moving active layers by offset', () => {
+  assert.match(drawingManagerSource, /selectActiveLayerByOffset\(offset\)/);
+  assert.match(drawingManagerSource, /moveActiveLayerByOffset\(offset\)/);
+  assert.match(drawingManagerSource, /const targetIndex = index \+ offset;/);
+  assert.match(drawingManagerSource, /this\.layers\.splice\(targetIndex, 0, layer\);/);
+  assert.match(drawingManagerSource, /this\._emit\('activeLayerChanged'/);
+  assert.match(drawingManagerSource, /this\._emit\('layersChanged'\)/);
+});
+
+test('frame and keyframe conversion shortcuts are configured and handled', () => {
+  assert.match(userSettingsSource, /keyframeConvertToFrame:\s*\{ key: 'Digit2', ctrl: false, shift: true, alt: false/);
+  assert.match(userSettingsSource, /keyframeConvertToKeyframe:\s*\{ key: 'Digit3', ctrl: false, shift: true, alt: false/);
+  assert.match(appSource, /userSettings\.matchShortcut\('keyframeConvertToFrame', e\)/);
+  assert.match(appSource, /drawingManager\.convertKeyframeToFrame\(\)/);
+  assert.match(appSource, /userSettings\.matchShortcut\('keyframeConvertToKeyframe', e\)/);
+  assert.match(appSource, /drawingManager\.convertFrameToKeyframe\(\)/);
+  assert.doesNotMatch(userSettingsSource, /keyframeDeleteAlt/);
+});
+
+test('delete frame removes a frame cell without deleting a held keyframe marker', () => {
+  assert.match(drawingManagerSource, /layer\.deleteFrame\(this\.currentFrame, this\.totalFrames\);/);
+  assert.match(drawingLayerSource, /deleteFrame\(frame, totalFrames = null\)/);
+  assert.match(drawingLayerSource, /const hasTimelineTail = Number\.isFinite\(totalFrames\) \? frame < totalFrames - 1 : true;/);
+  assert.match(drawingLayerSource, /const currentHasHold = nextKeyframe \? nextKeyframe\.frame > frame \+ 1 : hasTimelineTail;/);
+  assert.match(drawingLayerSource, /if \(currentKeyframeIndex !== -1 && !currentHasHold\) \{/);
+  assert.doesNotMatch(drawingLayerSource, /현재 프레임에 키프레임이 있으면 먼저 삭제/);
+});
+
+test('timeline can center the viewport on the current playhead', () => {
+  assert.match(timelineSource, /centerOnPlayhead\(\)/);
+  assert.match(timelineSource, /const targetScrollLeft = playheadPx - \(viewportWidth \/ 2\);/);
+  assert.match(timelineSource, /this\.timelineTracks\.scrollLeft = Math\.max\(0, targetScrollLeft\);/);
+});
+
+test('keyframe shortcut source coverage is part of the drawing test command', () => {
+  assert.match(packageJson.scripts['test:drawing'], /keyframe-shortcuts-source\.test\.js/);
+});

--- a/scripts/tests/keyframe-shortcuts-source.test.js
+++ b/scripts/tests/keyframe-shortcuts-source.test.js
@@ -59,7 +59,8 @@ test('delete frame removes a frame cell without deleting a held keyframe marker'
   assert.match(drawingLayerSource, /const tailBoundaryFrame = frame < totalFrames - 1 \? totalFrames : frame;/);
   assert.match(drawingLayerSource, /const tailBoundaryKeyframe = new Keyframe\(tailBoundaryFrame, null\);/);
   assert.match(drawingLayerSource, /this\.keyframes\.push\(tailBoundaryKeyframe\);/);
-  assert.match(drawingLayerSource, /if \(currentKeyframeIndex !== -1 && !currentHasHold\) \{/);
+  assert.match(drawingLayerSource, /const preservesTailBlankBoundary = currentKeyframe\?\.isEmpty && !nextKeyframe && Number\.isFinite\(totalFrames\)/);
+  assert.match(drawingLayerSource, /if \(currentKeyframeIndex !== -1 && !currentHasHold && !preservesTailBlankBoundary\) \{/);
   assert.doesNotMatch(drawingLayerSource, /현재 프레임에 키프레임이 있으면 먼저 삭제/);
 });
 

--- a/scripts/tests/keyframe-shortcuts-source.test.js
+++ b/scripts/tests/keyframe-shortcuts-source.test.js
@@ -54,6 +54,8 @@ test('delete frame removes a frame cell without deleting a held keyframe marker'
   assert.match(drawingLayerSource, /deleteFrame\(frame, totalFrames = null\)/);
   assert.match(drawingLayerSource, /const hasTimelineTail = Number\.isFinite\(totalFrames\) \? frame < totalFrames - 1 : true;/);
   assert.match(drawingLayerSource, /const currentHasHold = nextKeyframe \? nextKeyframe\.frame > frame \+ 1 : hasTimelineTail;/);
+  assert.match(drawingLayerSource, /const tailBoundaryKeyframe = new Keyframe\(totalFrames, null\);/);
+  assert.match(drawingLayerSource, /this\.keyframes\.push\(tailBoundaryKeyframe\);/);
   assert.match(drawingLayerSource, /if \(currentKeyframeIndex !== -1 && !currentHasHold\) \{/);
   assert.doesNotMatch(drawingLayerSource, /현재 프레임에 키프레임이 있으면 먼저 삭제/);
 });


### PR DESCRIPTION
## 📋 업데이트 요약

⌨️ Animate 스타일에 맞춰 드로잉 레이어와 키프레임 단축키를 추가했습니다.

🎞️ `4`번 키의 동작을 “키프레임 삭제”가 아니라 “프레임 한 칸 삭제”에 가깝게 바꿨습니다. 키프레임이 뒤로 유지 구간을 가지고 있으면 키프레임 마커는 남고, 더 이상 유지할 프레임이 없을 때만 마커가 사라집니다.

🔁 `Shift+2`는 현재 키프레임을 일반 프레임으로 바꾸고, `Shift+3`은 현재 프레임을 키프레임으로 바꿉니다. 프레임을 밀거나 당기지 않습니다.

🎯 `Alt+Shift+C`로 현재 프레임이 타임라인 가운데 오도록 이동할 수 있습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/user-settings.js`
  - 드로잉 레이어 추가/삭제/선택/이동 및 타임라인 중앙 정렬 단축키를 기본 설정에 추가했습니다.
  - 기존 `Shift+3` 키프레임 삭제 별칭을 제거하고, `Shift+2`/`Shift+3`을 프레임-키프레임 변환 액션으로 분리했습니다.

- `renderer/scripts/app.js`
  - 레이어 추가/삭제 버튼 로직을 helper로 정리하고 단축키에서도 같은 helper를 사용하도록 연결했습니다.
  - 새 단축키 분기를 `handleKeydown()`에 추가했습니다.
  - 앱 설정의 단축키 카테고리에 새 액션을 노출했습니다.

- `renderer/scripts/modules/drawing-manager.js`, `renderer/scripts/modules/drawing-layer.js`
  - 활성 드로잉 레이어 선택/이동 메서드를 추가했습니다.
  - `convertKeyframeToFrame()`, `convertFrameToKeyframe()`를 추가했습니다.
  - `deleteFrame()`이 현재 키프레임을 무조건 삭제하지 않고, 홀드 구간이 남아 있는지 보고 프레임 한 칸 삭제 의미를 유지하도록 바꿨습니다.

- `renderer/scripts/modules/timeline.js`
  - 현재 플레이헤드를 타임라인 중앙으로 보내는 `centerOnPlayhead()`를 추가했습니다.

- `renderer/index.html`
  - 앱 내 단축키 목록에 새 키 조합을 표시했습니다.

- `scripts/tests/keyframe-shortcuts-source.test.js`, `package.json`
  - 새 단축키와 프레임/키프레임 변환 의미를 고정하는 source 회귀 테스트를 추가하고 `npm run test:drawing`에 포함했습니다.

## 🚧 개발 난항

- 기존 `Shift+3`은 키프레임 삭제로 쓰이고 있었지만, 요청사항에서는 프레임을 키프레임으로 바꾸는 의미였습니다. 기존 이름을 유지하지 않고 새 액션 이름으로 분리해 충돌을 줄였습니다.
- `4`번 프레임 삭제는 단순히 현재 키프레임을 삭제하면 안 됐습니다. 현재 키프레임 뒤에 유지 구간이 남아 있으면 마커를 유지하고, 실제로 한 프레임짜리 키프레임이 사라지는 경우에만 마커를 제거하도록 조건을 나눴습니다.
- 레이어 단축키는 버튼 클릭과 같은 렌더 갱신을 해야 해서, 버튼/키보드 양쪽이 같은 helper를 호출하도록 정리했습니다.

## ✅ 테스트 가이드

실사용자용:
- `Shift+F1`로 드로잉 레이어가 추가되는지 확인합니다.
- `Shift+``로 활성 드로잉 레이어가 삭제되는지 확인합니다.
- `Shift+X/C`로 위/아래 레이어 선택, `Ctrl+Shift+X/C`로 레이어 순서 이동이 되는지 확인합니다.
- `Alt+Shift+C`를 눌렀을 때 현재 프레임이 타임라인 가운데로 오는지 확인합니다.
- `4`, `Shift+2`, `Shift+3`이 프레임을 밀거나 당기지 않는 변환 의미로 동작하는지 확인합니다.

개발자용:
- `npm run test:drawing`
- `npm run test:frame-grid`
- `git diff --check`