### PR TITLE
[v1.4.1] 드로잉 댓글 포인트 및 타임라인 표시 개선

### DIFF
--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -7367,6 +7367,16 @@ async function initApp() {
   /**
    * 그리기 모드 토글
    */
+  function setCommentOverlaysDrawingPassthrough(enabled) {
+    markerContainer.classList.toggle('drawing-active', enabled);
+    document.body.classList.toggle('drawing-mode-active', enabled);
+    if (!enabled) return;
+
+    document.querySelectorAll('.comment-marker-tooltip').forEach(tooltip => {
+      tooltip.classList.remove('visible', 'pinned');
+    });
+  }
+
   function toggleDrawMode() {
     // 오디오 모드에서는 그리기 모드 진입 차단
     if (state.isAudioMode) return;
@@ -7375,8 +7385,7 @@ async function initApp() {
     elements.drawingTools.classList.toggle('visible', state.isDrawMode);
     elements.drawingCanvas.classList.toggle('active', state.isDrawMode);
     elements.videoWrapper?.classList.toggle('drawing-mode', state.isDrawMode);
-    // 그리기 모드에서 댓글 마커 클릭 방지
-    markerContainer.classList.toggle('drawing-active', state.isDrawMode);
+    setCommentOverlaysDrawingPassthrough(state.isDrawMode);
     log.debug('그리기 모드 변경', { isDrawMode: state.isDrawMode });
   }
 
@@ -7806,7 +7815,6 @@ async function initApp() {
       left: ${marker.x * 100}%;
       top: ${marker.y * 100}%;
       transform: translate(-50%, -50%);
-      pointer-events: auto;
       ${!marker.resolved ? `background: ${authorColor.color};` : ''}
     `;
 
@@ -10534,22 +10542,22 @@ async function initApp() {
     }
     if (userSettings.matchShortcut('drawingLayerSelectUp', e)) {
       e.preventDefault();
-      selectDrawingLayerByOffset(1);
+      selectDrawingLayerByOffset(-1);
       return;
     }
     if (userSettings.matchShortcut('drawingLayerSelectDown', e)) {
       e.preventDefault();
-      selectDrawingLayerByOffset(-1);
+      selectDrawingLayerByOffset(1);
       return;
     }
     if (userSettings.matchShortcut('drawingLayerMoveUp', e)) {
       e.preventDefault();
-      moveDrawingLayerByOffset(1);
+      moveDrawingLayerByOffset(-1);
       return;
     }
     if (userSettings.matchShortcut('drawingLayerMoveDown', e)) {
       e.preventDefault();
-      moveDrawingLayerByOffset(-1);
+      moveDrawingLayerByOffset(1);
       return;
     }
     if (userSettings.matchShortcut('timelineCenterOnPlayhead', e)) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6820,8 +6820,7 @@ async function initApp() {
 
         // 그리기 모드 비활성화 (오디오에서는 의미 없음)
         if (state.isDrawMode) {
-          state.isDrawMode = false;
-          elements.btnDrawMode?.classList.remove('active');
+          applyDrawModeState(false);
           drawingManager.disable();
         }
         elements.btnDrawMode?.setAttribute('disabled', 'true');
@@ -7377,15 +7376,19 @@ async function initApp() {
     });
   }
 
+  function applyDrawModeState(enabled) {
+    state.isDrawMode = enabled;
+    elements.btnDrawMode?.classList.toggle('active', enabled);
+    elements.drawingTools?.classList.toggle('visible', enabled);
+    elements.drawingCanvas?.classList.toggle('active', enabled);
+    elements.videoWrapper?.classList.toggle('drawing-mode', enabled);
+    setCommentOverlaysDrawingPassthrough(enabled);
+  }
+
   function toggleDrawMode() {
     // 오디오 모드에서는 그리기 모드 진입 차단
     if (state.isAudioMode) return;
-    state.isDrawMode = !state.isDrawMode;
-    elements.btnDrawMode.classList.toggle('active', state.isDrawMode);
-    elements.drawingTools.classList.toggle('visible', state.isDrawMode);
-    elements.drawingCanvas.classList.toggle('active', state.isDrawMode);
-    elements.videoWrapper?.classList.toggle('drawing-mode', state.isDrawMode);
-    setCommentOverlaysDrawingPassthrough(state.isDrawMode);
+    applyDrawModeState(!state.isDrawMode);
     log.debug('그리기 모드 변경', { isDrawMode: state.isDrawMode });
   }
 

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -919,9 +919,17 @@ export class Timeline extends EventTarget {
   /**
    * 줌 표시 업데이트
    */
+  _getDisplayZoomPercent(zoom = this.zoom) {
+    const zoomRange = Math.max(1, this.maxZoom - this.minZoom);
+    const numericZoom = Number.isFinite(zoom) ? zoom : this.minZoom;
+    const clamped = Math.max(this.minZoom, Math.min(this.maxZoom, numericZoom));
+    const normalized = 100 + ((clamped - this.minZoom) / zoomRange) * 200;
+    return Math.round(Math.max(100, Math.min(300, normalized)));
+  }
+
   _updateZoomDisplay() {
     if (this.zoomDisplay) {
-      this.zoomDisplay.textContent = `${Math.round(this.zoom)}%`;
+      this.zoomDisplay.textContent = `${this._getDisplayZoomPercent()}%`;
     }
     if (this.zoomSlider) {
       const zoomRange = Math.max(1, this.maxZoom - this.minZoom);
@@ -939,7 +947,7 @@ export class Timeline extends EventTarget {
 
     const indicator = document.createElement('div');
     indicator.className = 'zoom-indicator';
-    indicator.textContent = `${Math.round(this.zoom)}%`;
+    indicator.textContent = `${this._getDisplayZoomPercent()}%`;
     indicator.style.cssText = `
       position: absolute;
       top: 50%;
@@ -1099,8 +1107,9 @@ export class Timeline extends EventTarget {
 
   _applyCellModeMinZoom() {
     const viewportWidth = this.timelineTracks?.clientWidth || 0;
+    const totalFrames = this._getDisplayTotalFrames();
     this.minZoom = this.frameCellMode === 'on'
-      ? computeMinZoomForCellMode(this.totalFrames, viewportWidth, this.minFrameCellPx)
+      ? computeMinZoomForCellMode(totalFrames, viewportWidth, this.minFrameCellPx)
       : 100;
     this.maxZoom = Math.max(this.maxZoom, this.minZoom);
     if (this.zoom < this.minZoom) this.zoom = this.minZoom;

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -7107,7 +7107,7 @@ body.resizing .comment-panel {
 
 /* 그리기 모드에서 댓글 마커 클릭 방지 */
 .comment-markers-container.drawing-active .comment-marker {
-  pointer-events: none;
+  pointer-events: none !important;
   cursor: crosshair;
 }
 
@@ -7120,6 +7120,7 @@ body.resizing .comment-panel {
   border-radius: 50%;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
   cursor: pointer;
+  pointer-events: auto;
   transition: all 0.15s ease;
   z-index: 20;
 }
@@ -7324,6 +7325,10 @@ body.resizing .comment-panel {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
+}
+
+body.drawing-mode-active .comment-marker-tooltip.visible {
+  pointer-events: none !important;
 }
 
 .comment-marker-tooltip.pinned {

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -81,12 +81,25 @@ test('drawing mode makes video comment overlays click-through for uninterrupted 
   assert.match(appSource, /document\.body\.classList\.toggle\('drawing-mode-active', enabled\);/);
   assert.match(appSource, /document\.querySelectorAll\('\.comment-marker-tooltip'\)\.forEach\(tooltip => \{/);
   assert.match(appSource, /tooltip\.classList\.remove\('visible', 'pinned'\);/);
-  assert.match(appSource, /setCommentOverlaysDrawingPassthrough\(state\.isDrawMode\);/);
+  assert.match(appSource, /function applyDrawModeState\(enabled\) \{/);
+  assert.match(appSource, /setCommentOverlaysDrawingPassthrough\(enabled\);/);
+  assert.match(appSource, /applyDrawModeState\(!state\.isDrawMode\);/);
 
   assert.doesNotMatch(singleMarkerMatch[1], /pointer-events:\s*auto;/);
   assert.match(mainCss, /\.comment-marker\s*\{[\s\S]*?pointer-events:\s*auto;/);
   assert.match(mainCss, /\.comment-markers-container\.drawing-active \.comment-marker\s*\{[\s\S]*?pointer-events:\s*none\s*!important;/);
   assert.match(mainCss, /body\.drawing-mode-active \.comment-marker-tooltip\.visible\s*\{[\s\S]*?pointer-events:\s*none\s*!important;/);
+});
+
+test('non-toggle draw-mode shutdown paths clear drawing overlay state', () => {
+  const audioModeMatch = appSource.match(/\/\/ 그리기 모드 비활성화 \(오디오에서는 의미 없음\)([\s\S]*?)\/\/ 비디오 줌 컨트롤 숨기기/);
+  assert.ok(audioModeMatch, 'audio loading path should explicitly disable drawing mode');
+
+  assert.match(appSource, /function applyDrawModeState\(enabled\) \{/);
+  assert.match(appSource, /setCommentOverlaysDrawingPassthrough\(enabled\);/);
+  assert.match(appSource, /applyDrawModeState\(!state\.isDrawMode\);/);
+  assert.match(audioModeMatch[1], /applyDrawModeState\(false\);/);
+  assert.doesNotMatch(audioModeMatch[1], /state\.isDrawMode = false;/);
 });
 
 test('clearing the current drawing frame respects locked and hidden layers', () => {

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -72,6 +72,23 @@ test('drawing input is blocked before stroke events when the active layer is loc
   assert.match(appSource, /숨긴 레이어에는 그릴 수 없습니다/);
 });
 
+test('drawing mode makes video comment overlays click-through for uninterrupted strokes', () => {
+  const singleMarkerMatch = appSource.match(/function renderSingleMarker\(marker\) \{([\s\S]*?)\n  \}\n\n  \/\*\*/);
+  assert.ok(singleMarkerMatch, 'single marker renderer should exist');
+
+  assert.match(appSource, /function setCommentOverlaysDrawingPassthrough\(enabled\) \{/);
+  assert.match(appSource, /markerContainer\.classList\.toggle\('drawing-active', enabled\);/);
+  assert.match(appSource, /document\.body\.classList\.toggle\('drawing-mode-active', enabled\);/);
+  assert.match(appSource, /document\.querySelectorAll\('\.comment-marker-tooltip'\)\.forEach\(tooltip => \{/);
+  assert.match(appSource, /tooltip\.classList\.remove\('visible', 'pinned'\);/);
+  assert.match(appSource, /setCommentOverlaysDrawingPassthrough\(state\.isDrawMode\);/);
+
+  assert.doesNotMatch(singleMarkerMatch[1], /pointer-events:\s*auto;/);
+  assert.match(mainCss, /\.comment-marker\s*\{[\s\S]*?pointer-events:\s*auto;/);
+  assert.match(mainCss, /\.comment-markers-container\.drawing-active \.comment-marker\s*\{[\s\S]*?pointer-events:\s*none\s*!important;/);
+  assert.match(mainCss, /body\.drawing-mode-active \.comment-marker-tooltip\.visible\s*\{[\s\S]*?pointer-events:\s*none\s*!important;/);
+});
+
 test('clearing the current drawing frame respects locked and hidden layers', () => {
   assert.match(appSource, /elements\.btnClearDrawing\?\.addEventListener\('click'/);
   assert.match(appSource, /if \(layer\.locked \|\| layer\.visible === false\) \{/);

--- a/scripts/tests/keyframe-shortcuts-source.test.js
+++ b/scripts/tests/keyframe-shortcuts-source.test.js
@@ -30,6 +30,13 @@ test('Animate-style drawing layer shortcuts are configured and handled', () => {
   assert.match(appSource, /timeline\.centerOnPlayhead\(\)/);
 });
 
+test('drawing layer up/down shortcuts follow the visible layer list direction', () => {
+  assert.match(appSource, /userSettings\.matchShortcut\('drawingLayerSelectUp', e\)[\s\S]{0,140}selectDrawingLayerByOffset\(-1\);/);
+  assert.match(appSource, /userSettings\.matchShortcut\('drawingLayerSelectDown', e\)[\s\S]{0,140}selectDrawingLayerByOffset\(1\);/);
+  assert.match(appSource, /userSettings\.matchShortcut\('drawingLayerMoveUp', e\)[\s\S]{0,140}moveDrawingLayerByOffset\(-1\);/);
+  assert.match(appSource, /userSettings\.matchShortcut\('drawingLayerMoveDown', e\)[\s\S]{0,140}moveDrawingLayerByOffset\(1\);/);
+});
+
 test('DrawingManager supports selecting and moving active layers by offset', () => {
   assert.match(drawingManagerSource, /selectActiveLayerByOffset\(offset\)/);
   assert.match(drawingManagerSource, /moveActiveLayerByOffset\(offset\)/);

--- a/scripts/tests/timeline-frame-ui-source.test.js
+++ b/scripts/tests/timeline-frame-ui-source.test.js
@@ -77,6 +77,23 @@ test('frame grid overlay is pinned to the same pixel width as the tracks', () =>
   assert.match(timelineSource, /sizes\.push\(`\$\{this\._formatGridPx\(pxPerFrame\)\} 100%`\);/);
 });
 
+test('frame cell minimum zoom uses the same display frame count as the grid', () => {
+  const cellMinZoomMatch = timelineSource.match(/_applyCellModeMinZoom\(\) \{([\s\S]*?)\n  \}/);
+  assert.ok(cellMinZoomMatch, 'cell mode minimum zoom method should exist');
+
+  assert.match(cellMinZoomMatch[1], /const totalFrames = this\._getDisplayTotalFrames\(\);/);
+  assert.match(cellMinZoomMatch[1], /computeMinZoomForCellMode\(totalFrames, viewportWidth, this\.minFrameCellPx\)/);
+  assert.doesNotMatch(cellMinZoomMatch[1], /computeMinZoomForCellMode\(this\.totalFrames/);
+});
+
+test('timeline zoom display is normalized to a clean 100 to 300 percent range', () => {
+  assert.match(timelineSource, /_getDisplayZoomPercent\(zoom = this\.zoom\) \{/);
+  assert.match(timelineSource, /const normalized = 100 \+ \(\(clamped - this\.minZoom\) \/ zoomRange\) \* 200;/);
+  assert.match(timelineSource, /Math\.max\(100, Math\.min\(300, normalized\)\)/);
+  assert.match(timelineSource, /this\.zoomDisplay\.textContent = `\$\{this\._getDisplayZoomPercent\(\)\}%`;/);
+  assert.match(timelineSource, /indicator\.textContent = `\$\{this\._getDisplayZoomPercent\(\)\}%`;/);
+});
+
 test('timeline frame UI source coverage runs with frame grid tests', () => {
   assert.match(packageJson.scripts['test:frame-grid'], /timeline-frame-ui-source\.test\.js/);
 });


### PR DESCRIPTION
## 📋 업데이트 요약

- ✏️ 그리기 중 댓글 포인트가 선 긋기를 방해하지 않도록 개선했습니다.
- 🧱 프레임 칸 격자가 실제로 보이는 프레임 기준과 더 잘 맞도록 정리했습니다.
- ⌨️ Shift+X / Shift+C 레이어 단축키 방향이 화면의 위/아래 움직임과 맞게 동작하도록 수정했습니다.
- 🔍 줌 표기를 100% 기준에서 최대 300%까지 깔끔하게 보이도록 정리했습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - `setCommentOverlaysDrawingPassthrough()`를 추가해 드로잉 모드 진입 시 댓글 마커와 툴팁이 포인터 입력을 가로막지 않도록 처리했습니다.
  - 댓글 마커의 인라인 `pointer-events: auto`를 제거해 CSS의 드로잉 모드 우선 규칙이 정상 적용되게 했습니다.
  - `drawingLayerSelectUp/Down`, `drawingLayerMoveUp/Down` 단축키 offset을 화면상 레이어 방향과 맞게 반전했습니다.

- `renderer/styles/main.css`
  - 드로잉 모드에서 댓글 마커와 표시 중인 댓글 툴팁이 입력을 막지 않도록 `pointer-events: none !important` 규칙을 추가했습니다.
  - 일반 모드에서는 기존처럼 댓글 마커 클릭이 가능하도록 기본 `pointer-events: auto`를 유지했습니다.

- `renderer/scripts/modules/timeline.js`
  - `_getDisplayZoomPercent()`를 추가해 내부 줌 값을 사용자 표시용 100~300% 범위로 정규화했습니다.
  - 프레임 셀 최소 줌 계산이 `_getDisplayTotalFrames()` 기준을 쓰도록 바꿔 격자 표시 기준과 맞췄습니다.

- 테스트 보강
  - 드로잉 중 댓글 오버레이가 입력을 막지 않는지 확인하는 소스 테스트를 추가했습니다.
  - 레이어 위/아래 단축키 방향 테스트를 추가했습니다.
  - 프레임 셀 최소 줌 기준과 줌 표기 범위 테스트를 추가했습니다.

## 🚧 개발 난항

- 댓글 마커는 CSS에서 드로잉 모드 비활성화를 하고 있었지만, 개별 마커에 인라인 `pointer-events: auto`가 들어가 있어 실제 입력 우선순위에서 CSS가 밀리는 문제가 있었습니다.
- 실제 Electron 프리뷰 검증 중 최초 실행 사용자 이름 모달이 화면을 가려서, 검증 스크립트에서 초기 이름 저장 후 본 화면을 확인하도록 보정했습니다.
- 전체 `npm run lint`는 저장소 기존 CRLF 줄끝 파일들이 `linebreak-style` 규칙에 걸려 실패합니다. 이번 변경 코드 자체는 줄끝 규칙을 제외하고 확인했으며 신규 오류는 없었습니다.

## ✅ 테스트 가이드

실사용자용:
- 댓글 포인트가 있는 영상에서 그리기 모드를 켠 뒤, 댓글 포인트 위나 근처를 지나가며 선을 그려봅니다.
- 타임라인 프레임 칸 모드를 켜고 확대/축소했을 때 격자가 프레임 칸에 맞는지 확인합니다.
- 레이어가 여러 개일 때 Shift+X / Shift+C로 위아래 이동 방향이 화면과 맞는지 확인합니다.
- 타임라인 줌 표시가 100%~300% 범위로 보이는지 확인합니다.

개발자용:
- `npm run test:drawing`
- `npm run test:frame-grid`
- `npm run test:comment-input`
- `npm run test:cluster`
- `git diff --check`
- `npm run build`
- 실제 Electron 프리뷰에서 댓글 포인트 위 드로잉 입력, 드로잉 데이터 생성, 줌 300% 표시 확인