### PR TITLE
[v1.5.0] 키프레임 다중 선택 및 그룹 이동 고스트 개선

### DIFF
--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1450,14 +1450,14 @@ async function initApp() {
 
   // 키프레임 이동
   timeline.addEventListener('keyframesMove', (e) => {
-    const { keyframes, frameDelta } = e.detail;
+    const { keyframes, frameDelta, anchor } = e.detail;
     if (drawingManager.moveKeyframes(keyframes)) {
       // 이동 성공 시 선택 상태 업데이트
       const movedSelection = keyframes.map(kf => ({
         layerId: kf.layerId,
         frame: kf.toFrame
       }));
-      timeline.setKeyframeSelection(movedSelection);
+      timeline.setKeyframeSelection(movedSelection, { anchor });
       timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
       showToast(`키프레임 ${frameDelta > 0 ? '+' : ''}${frameDelta} 프레임 이동`, 'info');
     }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1453,10 +1453,11 @@ async function initApp() {
     const { keyframes, frameDelta } = e.detail;
     if (drawingManager.moveKeyframes(keyframes)) {
       // 이동 성공 시 선택 상태 업데이트
-      timeline.selectedKeyframes = keyframes.map(kf => ({
+      const movedSelection = keyframes.map(kf => ({
         layerId: kf.layerId,
         frame: kf.toFrame
       }));
+      timeline.setKeyframeSelection(movedSelection);
       timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
       showToast(`키프레임 ${frameDelta > 0 ? '+' : ''}${frameDelta} 프레임 이동`, 'info');
     }

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -1583,7 +1583,8 @@ export class Timeline extends EventTarget {
       marker.addEventListener('mousedown', (e) => {
         if (e.button !== 0) return;
         e.stopPropagation();
-        this._handleKeyframePointerDown(e, layer.id, range.start);
+        const shouldStartDrag = this._handleKeyframePointerDown(e, layer.id, range.start);
+        if (shouldStartDrag === false) return;
         this._startKeyframeDrag(e, layer.id, range.start, marker);
       });
 
@@ -1700,7 +1701,8 @@ export class Timeline extends EventTarget {
     // 키프레임 마커 드래그 시작
     marker.addEventListener('mousedown', (e) => {
       e.stopPropagation();
-      this._handleKeyframePointerDown(e, layer.id, range.start);
+      const shouldStartDrag = this._handleKeyframePointerDown(e, layer.id, range.start);
+      if (shouldStartDrag === false) return;
       this._startKeyframeDrag(e, layer.id, range.start, clip);
     });
 
@@ -1968,21 +1970,23 @@ export class Timeline extends EventTarget {
   _handleKeyframePointerDown(e, layerId, frame) {
     if (e.shiftKey) {
       this._selectKeyframeRange(layerId, frame, e.ctrlKey || e.metaKey);
-      return;
+      return true;
     }
 
     if (e.ctrlKey || e.metaKey) {
+      const wasSelected = this._isKeyframeSelected(layerId, frame);
       this._toggleKeyframeSelection(layerId, frame, true);
-      return;
+      return !wasSelected;
     }
 
     const isSelected = this._isKeyframeSelected(layerId, frame);
     if (!isSelected || this.selectedKeyframes.length <= 1) {
       this._setKeyframeSelection([{ layerId, frame }], { anchor: { layerId, frame } });
-      return;
+      return true;
     }
 
     this.lastSelectedKeyframe = { layerId, frame };
+    return true;
   }
 
   _selectKeyframeRange(layerId, frame, addToSelection = false) {

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -108,6 +108,7 @@ export class Timeline extends EventTarget {
 
     // 다중 선택 상태
     this.selectedKeyframes = [];  // [ { layerId, frame } ]
+    this.lastSelectedKeyframe = null;
     this.isSelecting = false;  // 드래그 박스 선택 중
     this.selectionBox = null;
     this.selectionStartX = 0;
@@ -1582,13 +1583,13 @@ export class Timeline extends EventTarget {
       marker.addEventListener('mousedown', (e) => {
         if (e.button !== 0) return;
         e.stopPropagation();
+        this._handleKeyframePointerDown(e, layer.id, range.start);
         this._startKeyframeDrag(e, layer.id, range.start, marker);
       });
 
-      // 클릭으로 선택
+      // 선택은 mousedown에서 먼저 처리한다. 그래야 드래그 고스트가 최신 선택 전체를 반영한다.
       marker.addEventListener('click', (e) => {
         e.stopPropagation();
-        this._toggleKeyframeSelection(layer.id, range.start, e.ctrlKey || e.metaKey);
       });
 
       keyframeContainer.appendChild(marker);
@@ -1699,13 +1700,13 @@ export class Timeline extends EventTarget {
     // 키프레임 마커 드래그 시작
     marker.addEventListener('mousedown', (e) => {
       e.stopPropagation();
+      this._handleKeyframePointerDown(e, layer.id, range.start);
       this._startKeyframeDrag(e, layer.id, range.start, clip);
     });
 
-    // 키프레임 클릭으로 선택 토글
+    // 선택은 mousedown에서 먼저 처리한다. 그래야 드래그 고스트가 최신 선택 전체를 반영한다.
     marker.addEventListener('click', (e) => {
       e.stopPropagation();
-      this._toggleKeyframeSelection(layer.id, range.start, e.ctrlKey || e.metaKey);
     });
 
     clip.appendChild(marker);
@@ -1934,25 +1935,124 @@ export class Timeline extends EventTarget {
     const index = this.selectedKeyframes.findIndex(
       kf => kf.layerId === layerId && kf.frame === frame
     );
+    let nextSelection;
+    let anchor = { layerId, frame };
 
     if (addToSelection) {
       // Ctrl/Cmd + 클릭: 선택에 추가/제거
       if (index !== -1) {
-        this.selectedKeyframes.splice(index, 1);
+        nextSelection = this.selectedKeyframes.filter((_, itemIndex) => itemIndex !== index);
+        anchor = nextSelection.some(item =>
+          item.layerId === this.lastSelectedKeyframe?.layerId &&
+          item.frame === this.lastSelectedKeyframe?.frame
+        ) ? this.lastSelectedKeyframe : null;
       } else {
-        this.selectedKeyframes.push({ layerId, frame });
+        nextSelection = [...this.selectedKeyframes, { layerId, frame }];
       }
     } else {
       // 일반 클릭: 단독 선택
-      this.selectedKeyframes = [{ layerId, frame }];
+      nextSelection = [{ layerId, frame }];
     }
 
-    this._emit('keyframeSelectionChanged', { selected: this.selectedKeyframes });
-    this._updateKeyframeSelectionUI();
+    this._setKeyframeSelection(nextSelection, { anchor });
   }
 
   _selectKeyframe(layerId, frame, addToSelection) {
     this._toggleKeyframeSelection(layerId, frame, addToSelection);
+  }
+
+  setKeyframeSelection(selection, options = {}) {
+    this._setKeyframeSelection(selection, options);
+  }
+
+  _handleKeyframePointerDown(e, layerId, frame) {
+    if (e.shiftKey) {
+      this._selectKeyframeRange(layerId, frame, e.ctrlKey || e.metaKey);
+      return;
+    }
+
+    if (e.ctrlKey || e.metaKey) {
+      this._toggleKeyframeSelection(layerId, frame, true);
+      return;
+    }
+
+    const isSelected = this._isKeyframeSelected(layerId, frame);
+    if (!isSelected || this.selectedKeyframes.length <= 1) {
+      this._setKeyframeSelection([{ layerId, frame }], { anchor: { layerId, frame } });
+      return;
+    }
+
+    this.lastSelectedKeyframe = { layerId, frame };
+  }
+
+  _selectKeyframeRange(layerId, frame, addToSelection = false) {
+    const anchor = this.lastSelectedKeyframe?.layerId === layerId
+      ? this.lastSelectedKeyframe
+      : { layerId, frame };
+    const frames = this._getLayerKeyframeFrames(layerId);
+    const startFrame = Math.min(anchor.frame, frame);
+    const endFrame = Math.max(anchor.frame, frame);
+    const rangeSelection = frames
+      .filter(frameNumber => frameNumber >= startFrame && frameNumber <= endFrame)
+      .map(frameNumber => ({ layerId, frame: frameNumber }));
+    const nextSelection = addToSelection ? [...this.selectedKeyframes] : [];
+
+    const selectionToAdd = rangeSelection.length > 0
+      ? rangeSelection
+      : [{ layerId, frame }];
+    selectionToAdd.forEach(keyframe => {
+      if (!nextSelection.some(item => item.layerId === keyframe.layerId && item.frame === keyframe.frame)) {
+        nextSelection.push(keyframe);
+      }
+    });
+
+    this._setKeyframeSelection(nextSelection, { anchor: { layerId, frame } });
+  }
+
+  _getLayerKeyframeFrames(layerId) {
+    const layer = Array.isArray(this._lastDrawingLayers)
+      ? this._lastDrawingLayers.find(item => item.id === layerId)
+      : null;
+    return (layer?.keyframes || [])
+      .map(keyframe => Number(keyframe?.frame))
+      .filter(Number.isFinite)
+      .sort((a, b) => a - b);
+  }
+
+  _isKeyframeSelected(layerId, frame) {
+    return this.selectedKeyframes.some(
+      keyframe => keyframe.layerId === layerId && keyframe.frame === frame
+    );
+  }
+
+  _setKeyframeSelection(selection, { anchor = null } = {}) {
+    const seen = new Set();
+    const normalizedSelection = [];
+
+    (selection || []).forEach(keyframe => {
+      if (!keyframe?.layerId || !Number.isFinite(Number(keyframe.frame))) return;
+      const normalized = { layerId: keyframe.layerId, frame: Number(keyframe.frame) };
+      const key = `${normalized.layerId}:${normalized.frame}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      normalizedSelection.push(normalized);
+    });
+
+    this.selectedKeyframes = normalizedSelection;
+
+    if (anchor?.layerId && Number.isFinite(Number(anchor.frame))) {
+      this.lastSelectedKeyframe = { layerId: anchor.layerId, frame: Number(anchor.frame) };
+    } else if (this.selectedKeyframes.length === 0) {
+      this.lastSelectedKeyframe = null;
+    } else if (
+      !this.lastSelectedKeyframe ||
+      !this._isKeyframeSelected(this.lastSelectedKeyframe.layerId, this.lastSelectedKeyframe.frame)
+    ) {
+      this.lastSelectedKeyframe = { ...this.selectedKeyframes[this.selectedKeyframes.length - 1] };
+    }
+
+    this._emit('keyframeSelectionChanged', { selected: this.selectedKeyframes });
+    this._updateKeyframeSelectionUI();
   }
 
   /**
@@ -2047,7 +2147,7 @@ export class Timeline extends EventTarget {
 
     // 기존 선택 초기화 (Ctrl 안 누른 경우)
     if (!e.ctrlKey && !e.metaKey) {
-      this.selectedKeyframes = [];
+      this._setKeyframeSelection([]);
     }
   }
 
@@ -2080,21 +2180,25 @@ export class Timeline extends EventTarget {
 
     const boxRect = this.selectionBox.getBoundingClientRect();
 
-    // 선택 박스 내의 키프레임 마커 찾기
+    const nextSelection = [...this.selectedKeyframes];
+    let lastHit = null;
+
+    // 선택 박스와 겹치는 키프레임 마커 찾기
     this.tracksContainer?.querySelectorAll('.keyframe-marker, .keyframe-marker-dot').forEach(marker => {
       const markerRect = marker.getBoundingClientRect();
 
-      // 마커가 선택 박스 안에 있는지 확인
-      if (markerRect.left >= boxRect.left &&
-          markerRect.right <= boxRect.right &&
-          markerRect.top >= boxRect.top &&
-          markerRect.bottom <= boxRect.bottom) {
+      // 마커가 선택 박스와 조금이라도 겹치는지 확인
+      if (markerRect.right >= boxRect.left &&
+          markerRect.left <= boxRect.right &&
+          markerRect.bottom >= boxRect.top &&
+          markerRect.top <= boxRect.bottom) {
         const layerId = marker.dataset.layerId;
         const frame = parseInt(marker.dataset.frame);
+        lastHit = { layerId, frame };
 
         // 선택에 추가 (중복 방지)
-        if (!this.selectedKeyframes.some(kf => kf.layerId === layerId && kf.frame === frame)) {
-          this.selectedKeyframes.push({ layerId, frame });
+        if (!nextSelection.some(kf => kf.layerId === layerId && kf.frame === frame)) {
+          nextSelection.push({ layerId, frame });
         }
       }
     });
@@ -2104,17 +2208,14 @@ export class Timeline extends EventTarget {
     this.selectionBox = null;
     this.isSelecting = false;
 
-    this._emit('keyframeSelectionChanged', { selected: this.selectedKeyframes });
-    this._updateKeyframeSelectionUI();
+    this._setKeyframeSelection(nextSelection, { anchor: lastHit });
   }
 
   /**
    * 선택 초기화
    */
   clearSelection() {
-    this.selectedKeyframes = [];
-    this._emit('keyframeSelectionChanged', { selected: this.selectedKeyframes });
-    this._updateKeyframeSelectionUI();
+    this._setKeyframeSelection([]);
   }
 
   /**

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -1825,9 +1825,15 @@ export class Timeline extends EventTarget {
         fromFrame: kf.frame,
         toFrame: kf.frame + frameDelta
       }));
+      const selectionAnchor = this.draggedKeyframe
+        ? {
+            layerId: this.draggedKeyframe.layerId,
+            frame: this.draggedKeyframe.frame + frameDelta
+          }
+        : null;
 
       if (keyframesToMove.length > 0) {
-        this._emit('keyframesMove', { keyframes: keyframesToMove, frameDelta });
+        this._emit('keyframesMove', { keyframes: keyframesToMove, frameDelta, anchor: selectionAnchor });
         log.info('키프레임 이동', { keyframes: keyframesToMove, frameDelta });
       }
     }

--- a/scripts/tests/keyframe-multi-select-source.test.js
+++ b/scripts/tests/keyframe-multi-select-source.test.js
@@ -59,16 +59,18 @@ test('shift and ctrl keyframe clicks update selection before any drag ghost is c
   assert.match(timelineSource, /_handleKeyframePointerDown\(e, layerId, frame\)/);
   assert.match(timelineSource, /if \(e\.shiftKey\) \{[\s\S]*?this\._selectKeyframeRange\(layerId, frame, e\.ctrlKey \|\| e\.metaKey\);/);
   assert.match(timelineSource, /this\._toggleKeyframeSelection\(layerId, frame, true\);/);
+  assert.match(timelineSource, /const wasSelected = this\._isKeyframeSelected\(layerId, frame\);[\s\S]*?return !wasSelected;/);
   assert.match(timelineSource, /this\._setKeyframeSelection\(nextSelection, \{ anchor: \{ layerId, frame \} \}\);/);
   assert.match(timelineSource, /nextSelection\.some\(item =>[\s\S]*item\.layerId === this\.lastSelectedKeyframe\?\.layerId/);
 
   const markerMouseDown = timelineSource.match(/marker\.addEventListener\('mousedown', \(e\) => \{([\s\S]*?)\n      \}\);/);
   assert.ok(markerMouseDown, 'rendered keyframe marker mousedown handler should exist');
   assert.ok(
-    markerMouseDown[1].indexOf('this._handleKeyframePointerDown(e, layer.id, range.start);') <
+    markerMouseDown[1].indexOf('const shouldStartDrag = this._handleKeyframePointerDown(e, layer.id, range.start);') <
       markerMouseDown[1].indexOf('this._startKeyframeDrag(e, layer.id, range.start, marker);'),
     'selection must update before drag ghost creation'
   );
+  assert.match(markerMouseDown[1], /if \(shouldStartDrag === false\) return;/);
 });
 
 test('shift range selection is limited to the clicked drawing layer keyframes', () => {

--- a/scripts/tests/keyframe-multi-select-source.test.js
+++ b/scripts/tests/keyframe-multi-select-source.test.js
@@ -99,8 +99,11 @@ test('selected keyframe moves are ordered by drag direction to keep adjacent mov
 test('moved keyframes refresh selection through the timeline setter', () => {
   assert.match(timelineSource, /setKeyframeSelection\(selection, options = \{\}\) \{/);
   assert.match(timelineSource, /this\._setKeyframeSelection\(selection, options\);/);
+  assert.match(timelineSource, /const selectionAnchor = this\.draggedKeyframe/);
+  assert.match(timelineSource, /this\._emit\('keyframesMove', \{ keyframes: keyframesToMove, frameDelta, anchor: selectionAnchor \}\)/);
+  assert.match(appSource, /const \{ keyframes, frameDelta, anchor \} = e\.detail;/);
   assert.match(appSource, /const movedSelection = keyframes\.map\(kf => \(\{/);
-  assert.match(appSource, /timeline\.setKeyframeSelection\(movedSelection\)/);
+  assert.match(appSource, /timeline\.setKeyframeSelection\(movedSelection, \{ anchor \}\)/);
   assert.doesNotMatch(appSource, /timeline\.selectedKeyframes\s*=\s*keyframes\.map/);
 });
 

--- a/scripts/tests/keyframe-multi-select-source.test.js
+++ b/scripts/tests/keyframe-multi-select-source.test.js
@@ -54,6 +54,31 @@ test('plain keyframe click selects without immediately toggling the only selecte
   assert.doesNotMatch(toggleMatch[1], /이미 단독 선택된 상태면 선택 해제/);
 });
 
+test('shift and ctrl keyframe clicks update selection before any drag ghost is created', () => {
+  assert.match(timelineSource, /this\.lastSelectedKeyframe = null/);
+  assert.match(timelineSource, /_handleKeyframePointerDown\(e, layerId, frame\)/);
+  assert.match(timelineSource, /if \(e\.shiftKey\) \{[\s\S]*?this\._selectKeyframeRange\(layerId, frame, e\.ctrlKey \|\| e\.metaKey\);/);
+  assert.match(timelineSource, /this\._toggleKeyframeSelection\(layerId, frame, true\);/);
+  assert.match(timelineSource, /this\._setKeyframeSelection\(nextSelection, \{ anchor: \{ layerId, frame \} \}\);/);
+  assert.match(timelineSource, /nextSelection\.some\(item =>[\s\S]*item\.layerId === this\.lastSelectedKeyframe\?\.layerId/);
+
+  const markerMouseDown = timelineSource.match(/marker\.addEventListener\('mousedown', \(e\) => \{([\s\S]*?)\n      \}\);/);
+  assert.ok(markerMouseDown, 'rendered keyframe marker mousedown handler should exist');
+  assert.ok(
+    markerMouseDown[1].indexOf('this._handleKeyframePointerDown(e, layer.id, range.start);') <
+      markerMouseDown[1].indexOf('this._startKeyframeDrag(e, layer.id, range.start, marker);'),
+    'selection must update before drag ghost creation'
+  );
+});
+
+test('shift range selection is limited to the clicked drawing layer keyframes', () => {
+  assert.match(timelineSource, /_selectKeyframeRange\(layerId, frame, addToSelection = false\) \{/);
+  assert.match(timelineSource, /const anchor = this\.lastSelectedKeyframe\?\.layerId === layerId/);
+  assert.match(timelineSource, /this\._getLayerKeyframeFrames\(layerId\)/);
+  assert.match(timelineSource, /frameNumber >= startFrame && frameNumber <= endFrame/);
+  assert.match(timelineSource, /this\._setKeyframeSelection\(nextSelection, \{ anchor: \{ layerId, frame \} \}\);/);
+});
+
 test('selected keyframes can be deleted through the drawing manager', () => {
   assert.match(drawingManagerSource, /removeKeyframes\(selectedKeyframes = \[\]\)/);
   assert.match(drawingManagerSource, /this\._emit\('keyframeRemoved'/);
@@ -69,7 +94,38 @@ test('selected keyframe moves are ordered by drag direction to keep adjacent mov
   assert.doesNotMatch(drawingManagerSource, /sort\(\(a, b\) => b\.fromFrame - a\.fromFrame\)/);
 });
 
+test('moved keyframes refresh selection through the timeline setter', () => {
+  assert.match(timelineSource, /setKeyframeSelection\(selection, options = \{\}\) \{/);
+  assert.match(timelineSource, /this\._setKeyframeSelection\(selection, options\);/);
+  assert.match(appSource, /const movedSelection = keyframes\.map\(kf => \(\{/);
+  assert.match(appSource, /timeline\.setKeyframeSelection\(movedSelection\)/);
+  assert.doesNotMatch(appSource, /timeline\.selectedKeyframes\s*=\s*keyframes\.map/);
+});
+
 test('single remaining keyframe can be deleted', () => {
   assert.doesNotMatch(drawingManagerSource, /마지막 키프레임은 삭제할 수 없습니다/);
   assert.doesNotMatch(drawingManagerSource, /layer\.keyframes\.length <= 1/);
+});
+
+test('lasso selection selects keyframes that intersect the drag box', () => {
+  const finishSelectionMatch = timelineSource.match(/_finishSelection\(e\) \{([\s\S]*?)\n  \}/);
+  assert.ok(finishSelectionMatch, 'finish selection method should exist');
+  assert.match(finishSelectionMatch[1], /markerRect\.right >= boxRect\.left/);
+  assert.match(finishSelectionMatch[1], /markerRect\.left <= boxRect\.right/);
+  assert.match(finishSelectionMatch[1], /markerRect\.bottom >= boxRect\.top/);
+  assert.match(finishSelectionMatch[1], /markerRect\.top <= boxRect\.bottom/);
+  assert.doesNotMatch(finishSelectionMatch[1], /markerRect\.left >= boxRect\.left &&[\s\S]*markerRect\.right <= boxRect\.right/);
+});
+
+test('selection state is normalized through the shared setter', () => {
+  const setSelectionMatch = timelineSource.match(/_setKeyframeSelection\(selection, \{ anchor = null \} = \{\}\) \{([\s\S]*?)\n  \}/);
+  assert.ok(setSelectionMatch, 'shared selection setter should exist');
+  assert.match(setSelectionMatch[1], /const normalizedSelection = \[\]/);
+  assert.match(setSelectionMatch[1], /normalizedSelection\.push\(normalized\)/);
+  assert.doesNotMatch(setSelectionMatch[1], /keyframe\.layerId =/);
+  assert.doesNotMatch(setSelectionMatch[1], /keyframe\.frame =/);
+
+  const startSelectionMatch = timelineSource.match(/_startSelection\(e\) \{([\s\S]*?)\n  \}/);
+  assert.ok(startSelectionMatch, 'selection-box start method should exist');
+  assert.match(startSelectionMatch[1], /this\._setKeyframeSelection\(\[\]\)/);
 });


### PR DESCRIPTION
## 📋 업데이트 요약
- 🎞️ 드로잉 타임라인에서 Shift 클릭으로 같은 레이어의 키프레임 범위를 한 번에 선택할 수 있습니다.
- 🖱️ Ctrl 클릭으로 원하는 키프레임을 선택에 추가하거나 선택에서 뺄 수 있습니다.
- 📦 드래그 박스가 키프레임과 조금이라도 겹치면 선택되도록 바뀌어, 여러 키프레임을 쭉 고르기가 쉬워졌습니다.
- 👻 여러 키프레임을 잡고 옮길 때, 실제로 함께 움직이는 전체 키프레임의 고스트가 표시됩니다.

## 🔧 상세 기술 설명
- `renderer/scripts/modules/timeline.js`
  - `lastSelectedKeyframe`과 `setKeyframeSelection()`을 추가해 선택 목록과 Shift 기준점을 한 통로에서 관리하도록 정리했습니다.
  - 키프레임 marker의 선택 처리를 `click`이 아니라 `mousedown`에서 먼저 수행하도록 바꿨습니다. 이렇게 해야 드래그 시작 직후 만들어지는 고스트가 최신 선택 묶음을 바로 반영합니다.
  - `_selectKeyframeRange()`, `_getLayerKeyframeFrames()`, `_isKeyframeSelected()`, `_setKeyframeSelection()`을 추가해 Shift 범위 선택, Ctrl 토글, 중복 제거, UI selected 클래스 갱신을 한 흐름으로 묶었습니다.
  - 드래그 박스 선택은 완전히 박스 안에 들어온 키프레임만 고르던 방식에서, 박스와 겹치는 키프레임을 고르는 방식으로 변경했습니다.
- `renderer/scripts/app.js`
  - 키프레임 이동 후 직접 `timeline.selectedKeyframes`를 덮어쓰지 않고 `timeline.setKeyframeSelection()`을 사용하도록 바꿨습니다. 이동 직후에도 다음 Shift 선택 기준점이 새 위치에 맞게 유지됩니다.
- `scripts/tests/keyframe-multi-select-source.test.js`
  - Shift/Ctrl 선택, 박스 선택 교차 판정, 이동 후 선택 상태 갱신, 선택 상태 정규화 회귀 방지 테스트를 추가했습니다.

## 🚧 개발 난항
- 프리뷰 자동화에서 타임라인 룰러 클릭으로 테스트 키프레임을 심는 방식이 Electron 자동화 환경에서 프레임 이동을 안정적으로 반영하지 못했습니다. 그래서 검증 대상인 선택/드래그는 실제 마우스 이벤트로 유지하고, 키프레임 생성용 프레임 이동만 비디오 DOM의 `currentTime` 갱신으로 안정화했습니다.
- 이동 후 선택 목록만 갱신하면 `lastSelectedKeyframe`이 예전 프레임에 남을 수 있는 문제가 구현 검토 중 발견되었습니다. 앱 연결부도 공통 selection setter를 쓰게 바꿔 후속 Shift 선택 기준이 어긋나지 않게 했습니다.

## ✅ 테스트 가이드
실사용자용
- 드로잉 모드에서 같은 레이어에 키프레임 4개를 만듭니다.
- 첫 키프레임을 클릭한 뒤 Shift로 뒤쪽 키프레임을 클릭해 중간 키프레임까지 함께 선택되는지 확인합니다.
- Ctrl 클릭으로 다른 키프레임을 선택에 추가/해제해 봅니다.
- 타임라인에서 드래그 박스로 여러 키프레임을 쓸어 선택합니다.
- 선택된 키프레임 중 하나를 드래그했을 때 선택된 전체 키프레임의 고스트가 보이고, 놓으면 함께 이동하는지 확인합니다.

개발자용
- `node --test scripts/tests/keyframe-multi-select-source.test.js`
- `node --test scripts/tests/keyframe-drag-ghost-source.test.js`
- `npm run test:drawing`
- `npm run test:frame-grid`
- `git diff --check`
- Electron 프리뷰 자동화: Shift 선택 4/12/20, Ctrl 추가 4/12/20/28, 박스 선택 4/12/20, 드래그 고스트 4개, 이동 후 7/15/23/31 확인
- `npm run build`