### PR TITLE
[v1.4.0-beta] 배프레임 파일 지연 생성 및 협업 합류 개선

### DIFF
--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -302,15 +302,22 @@ function setupIpcHandlers() {
   });
 
   // 리뷰 데이터 저장 (경로 검증 포함)
-  ipcMain.handle('file:save-review', async (event, filePath, data) => {
+  ipcMain.handle('file:save-review', async (event, filePath, data, options = {}) => {
     const trace = log.trace('file:save-review');
     try {
       // 보안: 경로 검증 (.bframe, .json, .bak만 허용)
       const validatedPath = validateFilePath(filePath);
-      await fs.promises.writeFile(validatedPath, JSON.stringify(data, null, 2), 'utf-8');
-      trace.end({ filePath: validatedPath });
+      await fs.promises.writeFile(validatedPath, JSON.stringify(data, null, 2), {
+        encoding: 'utf-8',
+        flag: options?.failIfExists ? 'wx' : 'w'
+      });
+      trace.end({ filePath: validatedPath, failIfExists: options?.failIfExists === true });
       return { success: true };
     } catch (error) {
+      if (options?.failIfExists && error.code === 'EEXIST') {
+        trace.end({ filePath, exists: true });
+        return { success: false, exists: true };
+      }
       trace.error(error);
       throw error;
     }
@@ -572,42 +579,65 @@ function setupIpcHandlers() {
   // 파일 감시 시작
   ipcMain.handle('file:watch-start', async (event, filePath) => {
     try {
+      const validatedPath = validateFilePath(filePath);
+
       // 이미 감시 중이면 무시
-      if (fileWatchers.has(filePath)) {
+      if (fileWatchers.has(validatedPath)) {
         return { success: true, alreadyWatching: true };
       }
 
-      const watcher = fs.watch(filePath, { persistent: false }, (eventType) => {
+      let watchTarget = validatedPath;
+      let watchMode = 'file';
+      let targetBasename = null;
+
+      if (!fs.existsSync(validatedPath)) {
+        watchTarget = path.dirname(validatedPath);
+        watchMode = 'directory';
+        targetBasename = path.basename(validatedPath).toLowerCase();
+      }
+
+      const watcher = fs.watch(watchTarget, { persistent: false }, (eventType, changedName) => {
+        if (watchMode === 'directory') {
+          const changedBasename = changedName ? String(changedName).toLowerCase() : '';
+          if (changedBasename && changedBasename !== targetBasename) {
+            return;
+          }
+          if (!changedBasename && !fs.existsSync(validatedPath)) {
+            return;
+          }
+        }
+
         // 디바운스 (같은 파일의 연속 이벤트 방지)
-        if (watchDebounceTimers.has(filePath)) {
-          clearTimeout(watchDebounceTimers.get(filePath));
+        if (watchDebounceTimers.has(validatedPath)) {
+          clearTimeout(watchDebounceTimers.get(validatedPath));
         }
 
         const timer = setTimeout(() => {
-          watchDebounceTimers.delete(filePath);
+          watchDebounceTimers.delete(validatedPath);
 
           // 렌더러에 파일 변경 알림
           const mainWindow = getMainWindow();
           if (mainWindow && !mainWindow.isDestroyed()) {
             mainWindow.webContents.send('file:changed', {
-              filePath,
-              eventType
+              filePath: validatedPath,
+              eventType,
+              watchMode
             });
-            log.info('파일 변경 감지됨', { filePath, eventType });
+            log.info('파일 변경 감지됨', { filePath: validatedPath, eventType, watchMode });
           }
         }, 300); // 300ms 디바운스
 
-        watchDebounceTimers.set(filePath, timer);
+        watchDebounceTimers.set(validatedPath, timer);
       });
 
       watcher.on('error', (error) => {
-        log.warn('파일 감시 에러', { filePath, error: error.message });
-        fileWatchers.delete(filePath);
+        log.warn('파일 감시 에러', { filePath: validatedPath, error: error.message });
+        fileWatchers.delete(validatedPath);
       });
 
-      fileWatchers.set(filePath, watcher);
-      log.info('파일 감시 시작', { filePath });
-      return { success: true };
+      fileWatchers.set(validatedPath, watcher);
+      log.info('파일 감시 시작', { filePath: validatedPath, watchTarget, watchMode });
+      return { success: true, watchMode };
     } catch (error) {
       log.error('파일 감시 시작 실패', { filePath, error: error.message });
       return { success: false, error: error.message };
@@ -617,17 +647,18 @@ function setupIpcHandlers() {
   // 파일 감시 중지
   ipcMain.handle('file:watch-stop', async (event, filePath) => {
     try {
-      const watcher = fileWatchers.get(filePath);
+      const validatedPath = validateFilePath(filePath);
+      const watcher = fileWatchers.get(validatedPath);
       if (watcher) {
         watcher.close();
-        fileWatchers.delete(filePath);
-        log.info('파일 감시 중지', { filePath });
+        fileWatchers.delete(validatedPath);
+        log.info('파일 감시 중지', { filePath: validatedPath });
       }
 
       // 타이머도 정리
-      if (watchDebounceTimers.has(filePath)) {
-        clearTimeout(watchDebounceTimers.get(filePath));
-        watchDebounceTimers.delete(filePath);
+      if (watchDebounceTimers.has(validatedPath)) {
+        clearTimeout(watchDebounceTimers.get(validatedPath));
+        watchDebounceTimers.delete(validatedPath);
       }
 
       return { success: true };

--- a/preload/preload.js
+++ b/preload/preload.js
@@ -10,7 +10,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // ====== 파일 관련 ======
   openFileDialog: (options) => ipcRenderer.invoke('file:open-dialog', options),
   getFileInfo: (filePath) => ipcRenderer.invoke('file:get-info', filePath),
-  saveReview: (filePath, data) => ipcRenderer.invoke('file:save-review', filePath, data),
+  saveReview: (filePath, data, options = {}) => ipcRenderer.invoke('file:save-review', filePath, data, options),
   loadReview: (filePath) => ipcRenderer.invoke('file:load-review', filePath),
   fileExists: (filePath) => ipcRenderer.invoke('file:exists', filePath),
   scanVersions: (filePath) => ipcRenderer.invoke('file:scan-versions', filePath),

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -862,7 +862,7 @@ async function initApp() {
 
   // 앱 종료/새로고침 시 정리
   window.addEventListener('beforeunload', () => {
-    stopDeferredReviewFileDiscovery();
+    void stopDeferredReviewFileDiscovery();
     // Liveblocks Room 퇴장 시 Presence 자동 정리됨
     liveblocksManager.releaseAllEditingLocks();
     // 모든 파일 감시 중지 (누적 방지)
@@ -5286,7 +5286,7 @@ async function initApp() {
       isSameFilePath(deferredReviewFileDiscovery.bframePath, bframePath);
   }
 
-  function stopDeferredReviewFileDiscovery(bframePath = null) {
+  async function stopDeferredReviewFileDiscovery(bframePath = null) {
     if (!deferredReviewFileDiscovery) return;
     if (bframePath && !isSameFilePath(deferredReviewFileDiscovery.bframePath, bframePath)) return;
 
@@ -5295,7 +5295,11 @@ async function initApp() {
       clearInterval(pollTimer);
     }
     deferredReviewFileDiscovery = null;
-    void window.electronAPI.watchFileStop(pendingPath);
+    try {
+      await window.electronAPI.watchFileStop(pendingPath);
+    } catch (error) {
+      log.warn('지연 .bframe 생성 감지 중지 실패', { path: pendingPath, error: error.message });
+    }
     log.info('지연 .bframe 생성 감지 중지', { path: pendingPath });
   }
 
@@ -5316,18 +5320,16 @@ async function initApp() {
     const synced = await syncReviewFileFromDisk(bframePath, {
       startCollaborationIfNeeded: true,
       bypassDebounce: true,
+      replaceDeferredDiscovery: true,
       source
     });
-    if (synced) {
-      stopDeferredReviewFileDiscovery(bframePath);
-    }
     return synced;
   }
 
   function startDeferredReviewFileDiscovery(loadToken, bframePath) {
     if (!bframePath || isStaleVideoLoadToken(loadToken)) return;
 
-    stopDeferredReviewFileDiscovery();
+    void stopDeferredReviewFileDiscovery();
     const pollTimer = setInterval(() => {
       void handleDeferredReviewFileDiscovered(bframePath, 'poll');
     }, DEFERRED_REVIEW_FILE_POLL_INTERVAL_MS);
@@ -5441,7 +5443,7 @@ async function initApp() {
   async function prepareReviewFileBeforeSave({ path: bframePath, hasPersistedFile }) {
     if (!bframePath || hasPersistedFile || !isCurrentReviewPath(bframePath)) return;
 
-    stopDeferredReviewFileDiscovery(bframePath);
+    await stopDeferredReviewFileDiscovery(bframePath);
 
     let fileExists = false;
     try {
@@ -5455,7 +5457,7 @@ async function initApp() {
 
     if (fileExists) {
       log.info('첫 저장 전 기존 .bframe 발견, 병합 후 협업 시작', { path: bframePath });
-      await reviewDataManager.reloadAndMerge({ merge: true, force: true });
+      await reviewDataManager.reloadAndMerge({ merge: true, force: true, preserveLocal: true });
       await startCollaborationForVideoLoad(latestVideoLoadToken, bframePath, {
         persistNewRoom: false
       });
@@ -5471,7 +5473,7 @@ async function initApp() {
     if (!bframePath || !isCurrentReviewPath(bframePath)) return;
 
     log.info('첫 .bframe 저장 충돌 처리 시작', { path: bframePath });
-    const mergeResult = await reviewDataManager.reloadAndMerge({ merge: true, force: true });
+    const mergeResult = await reviewDataManager.reloadAndMerge({ merge: true, force: true, preserveLocal: true });
     if (!mergeResult.success) {
       return mergeResult;
     }
@@ -6805,7 +6807,7 @@ async function initApp() {
       allowNavigationGuardAbort = false;
 
       // ====== 이전 파일 감시 및 협업 세션 정리 (누적 방지) ======
-      stopDeferredReviewFileDiscovery();
+      void stopDeferredReviewFileDiscovery();
       if (reviewDataManager.currentBframePath) {
         await window.electronAPI.watchFileStop(reviewDataManager.currentBframePath);
         if (!canContinueVideoLoad()) return false;
@@ -14151,6 +14153,7 @@ async function initApp() {
     const {
       startCollaborationIfNeeded = false,
       bypassDebounce = false,
+      replaceDeferredDiscovery = false,
       source = 'watch'
     } = options;
 
@@ -14188,6 +14191,10 @@ async function initApp() {
         if (result.added > 0 || result.updated > 0) {
           showToast(`동기화 완료 (${result.added > 0 ? `추가 ${result.added}` : ''}${result.updated > 0 ? ` 수정 ${result.updated}` : ''})`, 'info');
         }
+      }
+
+      if (result.success && startCollaborationIfNeeded && replaceDeferredDiscovery) {
+        await stopDeferredReviewFileDiscovery(filePath);
       }
 
       if (result.success && startCollaborationIfNeeded && !liveblocksManager.isConnected) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5312,13 +5312,16 @@ async function initApp() {
     }
     if (!exists) return false;
 
-    stopDeferredReviewFileDiscovery(bframePath);
     log.info('지연 .bframe 생성 감지됨', { path: bframePath, source });
-    await syncReviewFileFromDisk(bframePath, {
+    const synced = await syncReviewFileFromDisk(bframePath, {
       startCollaborationIfNeeded: true,
+      bypassDebounce: true,
       source
     });
-    return true;
+    if (synced) {
+      stopDeferredReviewFileDiscovery(bframePath);
+    }
+    return synced;
   }
 
   function startDeferredReviewFileDiscovery(loadToken, bframePath) {
@@ -5468,10 +5471,14 @@ async function initApp() {
     if (!bframePath || !isCurrentReviewPath(bframePath)) return;
 
     log.info('첫 .bframe 저장 충돌 처리 시작', { path: bframePath });
-    await reviewDataManager.reloadAndMerge({ merge: true, force: true });
+    const mergeResult = await reviewDataManager.reloadAndMerge({ merge: true, force: true });
+    if (!mergeResult.success) {
+      return mergeResult;
+    }
     await startCollaborationForVideoLoad(latestVideoLoadToken, bframePath, {
       persistNewRoom: false
     });
+    return mergeResult;
   }
 
   async function prepareCompositionLayerMedia(filePath) {
@@ -14143,6 +14150,7 @@ async function initApp() {
   async function syncReviewFileFromDisk(filePath, options = {}) {
     const {
       startCollaborationIfNeeded = false,
+      bypassDebounce = false,
       source = 'watch'
     } = options;
 
@@ -14158,7 +14166,7 @@ async function initApp() {
     // 오프라인 모드: 파일 기반 동기화 실행
     // 너무 빠른 연속 호출 방지
     const now = Date.now();
-    if (source !== 'poll' && now - lastSyncTime < MIN_SYNC_INTERVAL) return false;
+    if (!bypassDebounce && source !== 'poll' && now - lastSyncTime < MIN_SYNC_INTERVAL) return false;
     lastSyncTime = now;
 
     log.info('파일 변경 감지됨, 오프라인 모드 동기화', { filePath, source });

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -857,9 +857,12 @@ async function initApp() {
 
   // ReviewDataManager에 LiveblocksManager 연결
   reviewDataManager.setLiveblocksManager(liveblocksManager);
+  reviewDataManager.setBeforeSaveHandler(prepareReviewFileBeforeSave);
+  reviewDataManager.setInitialSaveConflictHandler(handleInitialReviewFileSaveConflict);
 
   // 앱 종료/새로고침 시 정리
   window.addEventListener('beforeunload', () => {
+    stopDeferredReviewFileDiscovery();
     // Liveblocks Room 퇴장 시 Presence 자동 정리됨
     liveblocksManager.releaseAllEditingLocks();
     // 모든 파일 감시 중지 (누적 방지)
@@ -5239,6 +5242,8 @@ async function initApp() {
   let latestVideoLoadToken = 0;
   let activeVideoLoadPath = null;
   let activeMpvPilotLoadToken = null;
+  let deferredReviewFileDiscovery = null;
+  const DEFERRED_REVIEW_FILE_POLL_INTERVAL_MS = 3000;
 
   function hasActiveVideoLoadForDifferentFile(filePath) {
     return typeof activeVideoLoadPath === 'string' && !isSameFilePath(activeVideoLoadPath, filePath);
@@ -5273,7 +5278,73 @@ async function initApp() {
   }
 
   function isCurrentReviewPath(bframePath) {
-    return !!bframePath && reviewDataManager.currentBframePath === bframePath;
+    return !!bframePath && isSameFilePath(reviewDataManager.currentBframePath, bframePath);
+  }
+
+  function isDeferredReviewFileDiscoveryActive(bframePath) {
+    return !!deferredReviewFileDiscovery &&
+      isSameFilePath(deferredReviewFileDiscovery.bframePath, bframePath);
+  }
+
+  function stopDeferredReviewFileDiscovery(bframePath = null) {
+    if (!deferredReviewFileDiscovery) return;
+    if (bframePath && !isSameFilePath(deferredReviewFileDiscovery.bframePath, bframePath)) return;
+
+    const { bframePath: pendingPath, pollTimer } = deferredReviewFileDiscovery;
+    if (pollTimer) {
+      clearInterval(pollTimer);
+    }
+    deferredReviewFileDiscovery = null;
+    void window.electronAPI.watchFileStop(pendingPath);
+    log.info('지연 .bframe 생성 감지 중지', { path: pendingPath });
+  }
+
+  async function handleDeferredReviewFileDiscovered(bframePath, source = 'watch') {
+    if (!isDeferredReviewFileDiscoveryActive(bframePath)) return false;
+    const { loadToken } = deferredReviewFileDiscovery;
+    if (isStaleVideoLoadToken(loadToken) || !isCurrentReviewPath(bframePath)) return false;
+
+    let exists = false;
+    try {
+      exists = await window.electronAPI.fileExists(bframePath);
+    } catch (error) {
+      log.debug('지연 .bframe 존재 확인 실패', { path: bframePath, error: error.message });
+    }
+    if (!exists) return false;
+
+    stopDeferredReviewFileDiscovery(bframePath);
+    log.info('지연 .bframe 생성 감지됨', { path: bframePath, source });
+    await syncReviewFileFromDisk(bframePath, {
+      startCollaborationIfNeeded: true,
+      source
+    });
+    return true;
+  }
+
+  function startDeferredReviewFileDiscovery(loadToken, bframePath) {
+    if (!bframePath || isStaleVideoLoadToken(loadToken)) return;
+
+    stopDeferredReviewFileDiscovery();
+    const pollTimer = setInterval(() => {
+      void handleDeferredReviewFileDiscovered(bframePath, 'poll');
+    }, DEFERRED_REVIEW_FILE_POLL_INTERVAL_MS);
+
+    deferredReviewFileDiscovery = {
+      bframePath,
+      loadToken,
+      pollTimer
+    };
+
+    void window.electronAPI.watchFileStart(bframePath).then((result) => {
+      if (!result?.success) {
+        log.debug('지연 .bframe 파일 감시 시작 실패, 폴링으로 대체', {
+          path: bframePath,
+          error: result?.error
+        });
+      }
+    });
+
+    log.info('지연 .bframe 생성 감지 시작', { path: bframePath });
   }
 
   async function stopStaleCollaborationRoom(roomId) {
@@ -5288,7 +5359,8 @@ async function initApp() {
     }
   }
 
-  async function startCollaborationForVideoLoad(loadToken, bframePath) {
+  async function startCollaborationForVideoLoad(loadToken, bframePath, options = {}) {
+    const { persistNewRoom = true } = options;
     if (isStaleVideoLoadToken(loadToken) || !isCurrentReviewPath(bframePath)) return false;
 
     const userName = userSettings.getUserName();
@@ -5314,10 +5386,12 @@ async function initApp() {
 
       if (isNewRoom && isCurrentReviewPath(bframePath)) {
         reviewDataManager.setLiveblocksRoomId(roomId);
-        await reviewDataManager.save({ skipMerge: true });
-        if (isStaleVideoLoadToken(loadToken) || !isCurrentReviewPath(bframePath)) {
-          await stopStaleCollaborationRoom(roomId);
-          return false;
+        if (persistNewRoom) {
+          await reviewDataManager.save({ skipMerge: true });
+          if (isStaleVideoLoadToken(loadToken) || !isCurrentReviewPath(bframePath)) {
+            await stopStaleCollaborationRoom(roomId);
+            return false;
+          }
         }
       }
 
@@ -5359,6 +5433,45 @@ async function initApp() {
     } else {
       setTimeout(start, 0);
     }
+  }
+
+  async function prepareReviewFileBeforeSave({ path: bframePath, hasPersistedFile }) {
+    if (!bframePath || hasPersistedFile || !isCurrentReviewPath(bframePath)) return;
+
+    stopDeferredReviewFileDiscovery(bframePath);
+
+    let fileExists = false;
+    try {
+      fileExists = await window.electronAPI.fileExists(bframePath);
+    } catch (error) {
+      log.debug('첫 .bframe 저장 전 파일 존재 확인 실패', {
+        path: bframePath,
+        error: error.message
+      });
+    }
+
+    if (fileExists) {
+      log.info('첫 저장 전 기존 .bframe 발견, 병합 후 협업 시작', { path: bframePath });
+      await reviewDataManager.reloadAndMerge({ merge: true, force: true });
+      await startCollaborationForVideoLoad(latestVideoLoadToken, bframePath, {
+        persistNewRoom: false
+      });
+      return;
+    }
+
+    await startCollaborationForVideoLoad(latestVideoLoadToken, bframePath, {
+      persistNewRoom: false
+    });
+  }
+
+  async function handleInitialReviewFileSaveConflict({ path: bframePath }) {
+    if (!bframePath || !isCurrentReviewPath(bframePath)) return;
+
+    log.info('첫 .bframe 저장 충돌 처리 시작', { path: bframePath });
+    await reviewDataManager.reloadAndMerge({ merge: true, force: true });
+    await startCollaborationForVideoLoad(latestVideoLoadToken, bframePath, {
+      persistNewRoom: false
+    });
   }
 
   async function prepareCompositionLayerMedia(filePath) {
@@ -6685,6 +6798,7 @@ async function initApp() {
       allowNavigationGuardAbort = false;
 
       // ====== 이전 파일 감시 및 협업 세션 정리 (누적 방지) ======
+      stopDeferredReviewFileDiscovery();
       if (reviewDataManager.currentBframePath) {
         await window.electronAPI.watchFileStop(reviewDataManager.currentBframePath);
         if (!canContinueVideoLoad()) return false;
@@ -7015,11 +7129,15 @@ async function initApp() {
         showToast(`"${fileInfo.name}" 로드됨`, 'success');
       }
 
-      if (deferCollaborationStart) {
-        scheduleDeferredCollaborationStart(loadToken, currentBframePath);
+      if (hasExistingData) {
+        if (deferCollaborationStart) {
+          scheduleDeferredCollaborationStart(loadToken, currentBframePath);
+        } else {
+          await startCollaborationForVideoLoad(loadToken, currentBframePath);
+          if (!canContinueVideoLoad()) return false;
+        }
       } else {
-        await startCollaborationForVideoLoad(loadToken, currentBframePath);
-        if (!canContinueVideoLoad()) return false;
+        startDeferredReviewFileDiscovery(loadToken, currentBframePath);
       }
 
       // 마커 및 그리기 렌더링 업데이트 (항상 실행)
@@ -14022,23 +14140,28 @@ async function initApp() {
   let lastSyncTime = 0;
   const MIN_SYNC_INTERVAL = 500; // 최소 500ms 간격
 
-  window.electronAPI.onFileChanged(async ({ filePath }) => {
+  async function syncReviewFileFromDisk(filePath, options = {}) {
+    const {
+      startCollaborationIfNeeded = false,
+      source = 'watch'
+    } = options;
+
     // 현재 열린 파일이 아니면 무시
-    if (filePath !== reviewDataManager.currentBframePath) return;
+    if (!isSameFilePath(filePath, reviewDataManager.currentBframePath)) return false;
 
     // Liveblocks 연결 중이면 Broadcast가 실시간 동기화를 담당하므로
     // 파일 기반 동기화 건너뛰기 (구버전 파일로 덮어쓰는 것 방지)
     if (liveblocksManager.isConnected) {
-      return;
+      return false;
     }
 
     // 오프라인 모드: 파일 기반 동기화 실행
     // 너무 빠른 연속 호출 방지
     const now = Date.now();
-    if (now - lastSyncTime < MIN_SYNC_INTERVAL) return;
+    if (source !== 'poll' && now - lastSyncTime < MIN_SYNC_INTERVAL) return false;
     lastSyncTime = now;
 
-    log.info('파일 변경 감지됨, 오프라인 모드 동기화', { filePath });
+    log.info('파일 변경 감지됨, 오프라인 모드 동기화', { filePath, source });
 
     try {
       // ReviewDataManager의 reloadAndMerge 사용 (오프라인 모드 전용)
@@ -14058,9 +14181,25 @@ async function initApp() {
           showToast(`동기화 완료 (${result.added > 0 ? `추가 ${result.added}` : ''}${result.updated > 0 ? ` 수정 ${result.updated}` : ''})`, 'info');
         }
       }
+
+      if (result.success && startCollaborationIfNeeded && !liveblocksManager.isConnected) {
+        await startCollaborationForVideoLoad(latestVideoLoadToken, filePath);
+      }
+
+      return result.success === true;
     } catch (error) {
       log.warn('파일 변경 동기화 실패', { error: error.message });
+      return false;
     }
+  }
+
+  window.electronAPI.onFileChanged(async ({ filePath }) => {
+    if (isDeferredReviewFileDiscoveryActive(filePath)) {
+      await handleDeferredReviewFileDiscovered(filePath, 'watch');
+      return;
+    }
+
+    await syncReviewFileFromDisk(filePath);
   });
 
   // ====== 재생목록 초기화 ======

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -5365,7 +5365,10 @@ async function initApp() {
   }
 
   async function startCollaborationForVideoLoad(loadToken, bframePath, options = {}) {
-    const { persistNewRoom = true } = options;
+    const {
+      persistNewRoom = true,
+      seedCurrentState = false
+    } = options;
     if (isStaleVideoLoadToken(loadToken) || !isCurrentReviewPath(bframePath)) return false;
 
     const userName = userSettings.getUserName();
@@ -5407,6 +5410,10 @@ async function initApp() {
       }
       drawingSync.start();
       playbackSync.start();
+      if (seedCurrentState) {
+        commentSync.broadcastCurrentState?.();
+        drawingSync.broadcastCurrentState?.();
+      }
       log.info('Liveblocks 협업 세션 시작됨', { roomId, isNewRoom });
     } catch (error) {
       log.warn('Liveblocks 연결 실패, 로컬 모드로 계속', { error: error.message });
@@ -5459,13 +5466,15 @@ async function initApp() {
       log.info('첫 저장 전 기존 .bframe 발견, 병합 후 협업 시작', { path: bframePath });
       await reviewDataManager.reloadAndMerge({ merge: true, force: true, preserveLocal: true });
       await startCollaborationForVideoLoad(latestVideoLoadToken, bframePath, {
-        persistNewRoom: false
+        persistNewRoom: false,
+        seedCurrentState: true
       });
       return;
     }
 
     await startCollaborationForVideoLoad(latestVideoLoadToken, bframePath, {
-      persistNewRoom: false
+      persistNewRoom: false,
+      seedCurrentState: true
     });
   }
 
@@ -5478,7 +5487,8 @@ async function initApp() {
       return mergeResult;
     }
     await startCollaborationForVideoLoad(latestVideoLoadToken, bframePath, {
-      persistNewRoom: false
+      persistNewRoom: false,
+      seedCurrentState: true
     });
     return mergeResult;
   }

--- a/renderer/scripts/modules/comment-sync.js
+++ b/renderer/scripts/modules/comment-sync.js
@@ -63,6 +63,35 @@ export class CommentSync {
     log.info('댓글 동기화 시작됨 (Broadcast 모드)');
   }
 
+  broadcastCurrentState() {
+    if (!this._started || !this._lm.hasOtherCollaborators()) return;
+
+    const data = this._cm.toJSON?.();
+    for (const layer of data?.layers || []) {
+      this._lm.broadcastEvent({
+        type: 'COMMENT_LAYER_ADDED',
+        layer: {
+          id: layer.id,
+          name: layer.name || '새 레이어',
+          visible: layer.visible !== false
+        }
+      });
+
+      for (const marker of layer.markers || []) {
+        if (marker.deleted) continue;
+        this._lm.broadcastEvent({
+          type: 'COMMENT_MARKER_ADDED',
+          marker: this._serializeMarker(marker),
+          layerId: layer.id
+        });
+      }
+    }
+
+    log.info('현재 댓글 상태 브로드캐스트 완료', {
+      layers: data?.layers?.length || 0
+    });
+  }
+
   /**
    * 동기화 중지
    */

--- a/renderer/scripts/modules/drawing-sync.js
+++ b/renderer/scripts/modules/drawing-sync.js
@@ -69,6 +69,40 @@ export class DrawingSync {
     log.info('그리기 동기화 시작됨 (Broadcast 모드)');
   }
 
+  broadcastCurrentState() {
+    if (!this._started || !this._lm.hasOtherCollaborators()) return;
+
+    const layers = this._dm.getLayers?.() || this._dm.layers || [];
+    for (const layer of layers) {
+      this._lm.broadcastEvent({
+        type: 'DRAWING_LAYER_CREATED',
+        layer: {
+          id: layer.id,
+          name: layer.name,
+          visible: layer.visible,
+          color: layer.color,
+          opacity: layer.opacity
+        }
+      });
+
+      for (const keyframe of layer.keyframes || []) {
+        if (!keyframe?.canvasData) continue;
+        this._lm.broadcastEvent({
+          type: 'DRAWING_KEYFRAME_UPDATE',
+          layerId: layer.id,
+          frame: keyframe.frame,
+          canvasData: keyframe.canvasData,
+          baseCanvasData: keyframe.baseCanvasData,
+          strokeRecords: keyframe.strokeRecords
+        });
+      }
+    }
+
+    log.info('현재 그리기 상태 브로드캐스트 완료', {
+      layers: layers.length
+    });
+  }
+
   /**
    * 동기화 중지
    */

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -142,6 +142,9 @@ export class ReviewDataManager extends EventTarget {
 
     // 저장 동시성 제어
     this._savePromise = null;  // 저장 중인 Promise (락)
+    this._hasPersistedFile = false;
+    this._beforeSaveHandler = null;
+    this._initialSaveConflictHandler = null;
 
     // 이벤트 바인딩
     this._onDataChanged = this._onDataChanged.bind(this);
@@ -162,6 +165,22 @@ export class ReviewDataManager extends EventTarget {
   setLiveblocksManager(manager) {
     this._liveblocksManager = manager;
     log.info('LiveblocksManager 연결됨');
+  }
+
+  /**
+   * 저장 직전 훅 설정
+   * @param {Function|null} handler
+   */
+  setBeforeSaveHandler(handler) {
+    this._beforeSaveHandler = typeof handler === 'function' ? handler : null;
+  }
+
+  /**
+   * 첫 저장 중 다른 사용자가 먼저 파일을 만든 경우의 처리 훅 설정
+   * @param {Function|null} handler
+   */
+  setInitialSaveConflictHandler(handler) {
+    this._initialSaveConflictHandler = typeof handler === 'function' ? handler : null;
   }
 
   /**
@@ -257,6 +276,12 @@ export class ReviewDataManager extends EventTarget {
 
     this.currentVideoPath = videoPath;
     this.currentBframePath = getBframePath(videoPath);
+    this._createdAt = null;
+    this._modifiedAt = null;
+    this._fps = 24;
+    this._liveblocksRoomId = null;
+    this._manualVersions = [];
+    this._hasPersistedFile = false;
     this.isDirty = false;
 
     log.info('영상 파일 설정됨', {
@@ -322,16 +347,46 @@ export class ReviewDataManager extends EventTarget {
    */
   async _doSave(_options = {}) {
     try {
-      const data = this._collectData();
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const wasInitialPersist = !this._hasPersistedFile;
 
-      // Liveblocks 연결 시 CRDT가 머지를 처리하므로 _mergeBeforeSave 불필요
-      // 로컬 .bframe 스냅샷만 저장 (오프라인 백업 역할)
-      if (this._liveblocksManager?.isConnected) {
-        // liveblocksRoomId 포함
-        data.liveblocksRoomId = this._liveblocksManager.roomId || null;
+        if (this._beforeSaveHandler) {
+          await this._beforeSaveHandler({
+            path: this.currentBframePath,
+            videoPath: this.currentVideoPath,
+            hasPersistedFile: this._hasPersistedFile,
+            options: _options
+          });
+        }
+
+        const data = this._collectData();
+
+        // Liveblocks 연결 시 CRDT가 머지를 처리하므로 _mergeBeforeSave 불필요
+        // 로컬 .bframe 스냅샷만 저장 (오프라인 백업 역할)
+        if (this._liveblocksManager?.isConnected) {
+          // liveblocksRoomId 포함
+          data.liveblocksRoomId = this._liveblocksManager.roomId || null;
+        }
+
+        const saveResult = await window.electronAPI.saveReview(this.currentBframePath, data, {
+          failIfExists: wasInitialPersist
+        });
+
+        if (saveResult?.exists === true && wasInitialPersist) {
+          this._hasPersistedFile = true;
+          log.info('첫 .bframe 저장 충돌 감지, 기존 파일과 병합 시도', {
+            path: this.currentBframePath
+          });
+          await this._initialSaveConflictHandler?.({
+            path: this.currentBframePath,
+            videoPath: this.currentVideoPath
+          });
+          continue;
+        }
+
+        this._hasPersistedFile = true;
+        break;
       }
-
-      await window.electronAPI.saveReview(this.currentBframePath, data);
 
       this.isDirty = false;
 
@@ -420,9 +475,12 @@ export class ReviewDataManager extends EventTarget {
       if (!data) {
         log.info('.bframe 파일 없음 (새 리뷰)', { path: this.currentBframePath });
         this.compositionLayerManager?.fromJSON?.([]);
+        this._hasPersistedFile = false;
         this.isLoading = false;
         return false;
       }
+
+      this._hasPersistedFile = true;
 
       // 버전 확인 및 마이그레이션
       const dataVersion = getDataVersion(data);
@@ -527,6 +585,8 @@ export class ReviewDataManager extends EventTarget {
         this.isLoading = wasLoading;
         return { success: false, added: 0, updated: 0 };
       }
+
+      this._hasPersistedFile = true;
 
       const result = { added: 0, updated: 0 };
 
@@ -923,6 +983,13 @@ export class ReviewDataManager extends EventTarget {
    */
   getBframePath() {
     return this.currentBframePath;
+  }
+
+  /**
+   * 현재 .bframe 파일이 실제로 존재하는 상태인지 반환
+   */
+  hasPersistedFile() {
+    return this._hasPersistedFile;
   }
 }
 

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -101,7 +101,7 @@ function mergeLayers(localLayers, remoteLayers) {
 }
 
 function cloneJson(value) {
-  return value == null ? value : JSON.parse(JSON.stringify(value));
+  return value === null || value === undefined ? value : JSON.parse(JSON.stringify(value));
 }
 
 function jsonEquals(a, b) {
@@ -212,6 +212,48 @@ function mergeHighlightData(localData = {}, remoteData = {}) {
     ...(Array.isArray(localData) ? {} : localData),
     highlights: mergedHighlights
   };
+}
+
+function mergeManualVersions(localVersions = [], remoteVersions = []) {
+  const merged = Array.isArray(localVersions) ? localVersions.map(version => cloneJson(version)) : [];
+  const keySet = new Set(merged.map(version => version.filePath || version.path || version.fileName).filter(Boolean));
+
+  for (const remoteVersion of Array.isArray(remoteVersions) ? remoteVersions : []) {
+    const key = remoteVersion.filePath || remoteVersion.path || remoteVersion.fileName;
+    if (key && keySet.has(key)) continue;
+    if (key) keySet.add(key);
+    merged.push(cloneJson(remoteVersion));
+  }
+
+  return merged;
+}
+
+function mergeCompositionLayers(localLayers = [], remoteLayers = []) {
+  const merged = Array.isArray(localLayers) ? localLayers.map(layer => cloneJson(layer)) : [];
+  const usedIds = new Set(merged.map(layer => layer.id).filter(Boolean));
+
+  for (const remoteLayer of Array.isArray(remoteLayers) ? remoteLayers : []) {
+    const remoteCopy = cloneJson(remoteLayer);
+    const existingIndex = merged.findIndex(layer => layer.id === remoteCopy.id);
+
+    if (existingIndex === -1) {
+      usedIds.add(remoteCopy.id);
+      merged.push(remoteCopy);
+      continue;
+    }
+
+    if (jsonEquals(merged[existingIndex], remoteCopy)) continue;
+
+    remoteCopy.id = `composition_${Date.now()}_${getNextPrefixedId('remote', usedIds)}`;
+    remoteCopy.name = `${remoteCopy.name || '원격 합성 레이어'} (원격)`;
+    remoteCopy.order = merged.length;
+    usedIds.add(remoteCopy.id);
+    merged.push(remoteCopy);
+  }
+
+  return merged
+    .map((layer, index) => ({ ...layer, order: Number.isFinite(layer.order) ? layer.order : index }))
+    .sort((a, b) => a.order - b.order);
 }
 
 const log = createLogger('ReviewDataManager');
@@ -583,6 +625,29 @@ export class ReviewDataManager extends EventTarget {
         log.info('원격 드로잉이 더 최신, 원격 데이터로 교체');
       }
 
+      if (remoteData.highlights) {
+        localData.highlights = mergeHighlightData(localData.highlights, remoteData.highlights);
+      }
+
+      if (remoteData.compositionLayers) {
+        localData.compositionLayers = mergeCompositionLayers(
+          localData.compositionLayers,
+          remoteData.compositionLayers
+        );
+      }
+
+      if (remoteData.manualVersions) {
+        localData.manualVersions = mergeManualVersions(localData.manualVersions, remoteData.manualVersions);
+      }
+
+      if (!localData.versionInfo && remoteData.versionInfo) {
+        localData.versionInfo = remoteData.versionInfo;
+      }
+
+      if (!localData.liveblocksRoomId && remoteData.liveblocksRoomId) {
+        localData.liveblocksRoomId = remoteData.liveblocksRoomId;
+      }
+
       // 머지 후 modifiedAt 갱신
       localData.modifiedAt = new Date().toISOString();
 
@@ -784,6 +849,33 @@ export class ReviewDataManager extends EventTarget {
             this.highlightManager.fromJSON(remoteData.highlights);
             log.info('reloadAndMerge: 하이라이트 데이터 업데이트됨');
           }
+        }
+
+        if (remoteData.liveblocksRoomId && !this._liveblocksRoomId) {
+          this._liveblocksRoomId = remoteData.liveblocksRoomId;
+        }
+
+        if (remoteData.versionInfo && !this._versionInfo) {
+          this._versionInfo = remoteData.versionInfo;
+        }
+
+        if (remoteData.manualVersions) {
+          this._manualVersions = mergeManualVersions(this._manualVersions, remoteData.manualVersions);
+        }
+
+        if (Array.isArray(remoteData.compositionLayers) && this.compositionLayerManager) {
+          const mergedCompositionLayers = mergeCompositionLayers(
+            this.compositionLayerManager.toJSON(),
+            remoteData.compositionLayers
+          );
+          this.compositionLayerManager.fromJSON(mergedCompositionLayers);
+          log.info('reloadAndMerge: 합성 레이어 데이터 병합 완료', {
+            layers: mergedCompositionLayers.length
+          });
+        }
+
+        if (remoteData.modifiedAt && toTime(remoteData.modifiedAt) > toTime(this._modifiedAt)) {
+          this._modifiedAt = remoteData.modifiedAt;
         }
 
       } else {

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -347,6 +347,8 @@ export class ReviewDataManager extends EventTarget {
    */
   async _doSave(_options = {}) {
     try {
+      let savedData = null;
+
       for (let attempt = 0; attempt < 2; attempt += 1) {
         const wasInitialPersist = !this._hasPersistedFile;
 
@@ -385,6 +387,7 @@ export class ReviewDataManager extends EventTarget {
         }
 
         this._hasPersistedFile = true;
+        savedData = data;
         break;
       }
 
@@ -392,8 +395,8 @@ export class ReviewDataManager extends EventTarget {
 
       log.info('.bframe 파일 저장됨', {
         path: this.currentBframePath,
-        commentLayers: data.comments?.layers?.length || 0,
-        drawingLayers: data.drawings?.layers?.length || 0,
+        commentLayers: savedData?.comments?.layers?.length || 0,
+        drawingLayers: savedData?.drawings?.layers?.length || 0,
         liveblocksConnected: !!this._liveblocksManager?.isConnected
       });
 

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -100,6 +100,120 @@ function mergeLayers(localLayers, remoteLayers) {
   return { merged, added: totalAdded, updated: totalUpdated };
 }
 
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function jsonEquals(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function getNextPrefixedId(prefix, usedIds) {
+  let maxId = 0;
+  for (const id of usedIds) {
+    const match = String(id).match(new RegExp(`^${prefix}-(\\d+)$`));
+    if (match) {
+      maxId = Math.max(maxId, parseInt(match[1], 10));
+    }
+  }
+
+  let nextId = maxId + 1;
+  let candidate = `${prefix}-${nextId}`;
+  while (usedIds.has(candidate)) {
+    nextId += 1;
+    candidate = `${prefix}-${nextId}`;
+  }
+  usedIds.add(candidate);
+  return candidate;
+}
+
+function hasDrawingLayerContent(layer) {
+  return (layer?.keyframes || []).some(keyframe => {
+    return !keyframe?.isEmpty
+      || !!keyframe?.canvasData
+      || !!keyframe?.baseCanvasData
+      || (keyframe?.strokeRecords || []).length > 0;
+  });
+}
+
+function mergeDrawingData(localData = {}, remoteData = {}) {
+  const localLayers = Array.isArray(localData?.layers) ? localData.layers : [];
+  const remoteLayers = Array.isArray(remoteData?.layers) ? remoteData.layers : [];
+  const usedIds = new Set(localLayers.map(layer => layer.id).filter(Boolean));
+  const mergedLayers = localLayers.map(layer => cloneJson(layer));
+
+  for (const remoteLayer of remoteLayers) {
+    const remoteCopy = cloneJson(remoteLayer);
+    const existingIndex = mergedLayers.findIndex(layer => layer.id === remoteCopy.id);
+
+    if (existingIndex === -1) {
+      usedIds.add(remoteCopy.id);
+      mergedLayers.push(remoteCopy);
+      continue;
+    }
+
+    const localLayer = mergedLayers[existingIndex];
+    if (jsonEquals(localLayer, remoteCopy)) continue;
+
+    const localHasContent = hasDrawingLayerContent(localLayer);
+    const remoteHasContent = hasDrawingLayerContent(remoteCopy);
+
+    if (!localHasContent && remoteHasContent) {
+      usedIds.add(remoteCopy.id);
+      mergedLayers[existingIndex] = remoteCopy;
+    } else if (remoteHasContent) {
+      remoteCopy.id = getNextPrefixedId('layer', usedIds);
+      remoteCopy.name = `${remoteCopy.name || '원격 드로잉'} (원격)`;
+      mergedLayers.push(remoteCopy);
+    }
+  }
+
+  const activeLayerId = mergedLayers.some(layer => layer.id === localData?.activeLayerId)
+    ? localData.activeLayerId
+    : remoteData?.activeLayerId || mergedLayers[0]?.id || null;
+
+  return {
+    ...remoteData,
+    ...localData,
+    layers: mergedLayers,
+    activeLayerId
+  };
+}
+
+function getHighlightList(data) {
+  if (Array.isArray(data)) return data;
+  return Array.isArray(data?.highlights) ? data.highlights : [];
+}
+
+function mergeHighlightData(localData = {}, remoteData = {}) {
+  const localHighlights = getHighlightList(localData);
+  const remoteHighlights = getHighlightList(remoteData);
+  const usedIds = new Set(localHighlights.map(highlight => highlight.id).filter(Boolean));
+  const mergedHighlights = localHighlights.map(highlight => cloneJson(highlight));
+
+  for (const remoteHighlight of remoteHighlights) {
+    const remoteCopy = cloneJson(remoteHighlight);
+    const existingIndex = mergedHighlights.findIndex(highlight => highlight.id === remoteCopy.id);
+
+    if (existingIndex === -1) {
+      usedIds.add(remoteCopy.id);
+      mergedHighlights.push(remoteCopy);
+      continue;
+    }
+
+    if (jsonEquals(mergedHighlights[existingIndex], remoteCopy)) continue;
+
+    remoteCopy.id = getNextPrefixedId('highlight', usedIds);
+    mergedHighlights.push(remoteCopy);
+  }
+
+  return {
+    ...(Array.isArray(remoteData) ? {} : remoteData),
+    ...(Array.isArray(localData) ? {} : localData),
+    highlights: mergedHighlights
+  };
+}
+
 const log = createLogger('ReviewDataManager');
 
 /**
@@ -638,8 +752,14 @@ export class ReviewDataManager extends EventTarget {
           }
         }
 
-        // 드로잉 데이터 머지 (원격이 더 최신이면 적용)
-        if (!options.preserveLocal && remoteData.drawings && this.drawingManager) {
+        // 드로잉 데이터 머지
+        if (options.preserveLocal && remoteData.drawings && this.drawingManager) {
+          const mergedDrawings = mergeDrawingData(this.drawingManager.exportData(), remoteData.drawings);
+          this.drawingManager.importData(mergedDrawings);
+          log.info('reloadAndMerge: 드로잉 데이터 보존 병합 완료', {
+            layers: mergedDrawings.layers?.length || 0
+          });
+        } else if (remoteData.drawings && this.drawingManager) {
           const localModified = new Date(this._modifiedAt || 0).getTime();
           const remoteModified = new Date(remoteData.modifiedAt || 0).getTime();
 
@@ -649,8 +769,14 @@ export class ReviewDataManager extends EventTarget {
           }
         }
 
-        // 하이라이트 데이터 (원격이 더 최신이면 적용)
-        if (!options.preserveLocal && remoteData.highlights && this.highlightManager) {
+        // 하이라이트 데이터
+        if (options.preserveLocal && remoteData.highlights && this.highlightManager) {
+          const mergedHighlights = mergeHighlightData(this.highlightManager.toJSON(), remoteData.highlights);
+          this.highlightManager.fromJSON(mergedHighlights);
+          log.info('reloadAndMerge: 하이라이트 데이터 보존 병합 완료', {
+            highlights: mergedHighlights.highlights?.length || 0
+          });
+        } else if (remoteData.highlights && this.highlightManager) {
           const localModified = new Date(this._modifiedAt || 0).getTime();
           const remoteModified = new Date(remoteData.modifiedAt || 0).getTime();
 

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -639,7 +639,7 @@ export class ReviewDataManager extends EventTarget {
         }
 
         // 드로잉 데이터 머지 (원격이 더 최신이면 적용)
-        if (remoteData.drawings && this.drawingManager) {
+        if (!options.preserveLocal && remoteData.drawings && this.drawingManager) {
           const localModified = new Date(this._modifiedAt || 0).getTime();
           const remoteModified = new Date(remoteData.modifiedAt || 0).getTime();
 
@@ -650,7 +650,7 @@ export class ReviewDataManager extends EventTarget {
         }
 
         // 하이라이트 데이터 (원격이 더 최신이면 적용)
-        if (remoteData.highlights && this.highlightManager) {
+        if (!options.preserveLocal && remoteData.highlights && this.highlightManager) {
           const localModified = new Date(this._modifiedAt || 0).getTime();
           const remoteModified = new Date(remoteData.modifiedAt || 0).getTime();
 

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -348,8 +348,10 @@ export class ReviewDataManager extends EventTarget {
   async _doSave(_options = {}) {
     try {
       let savedData = null;
+      let lastConflictResult = null;
+      const maxAttempts = 5;
 
-      for (let attempt = 0; attempt < 2; attempt += 1) {
+      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
         const wasInitialPersist = !this._hasPersistedFile;
 
         if (this._beforeSaveHandler) {
@@ -375,20 +377,37 @@ export class ReviewDataManager extends EventTarget {
         });
 
         if (saveResult?.exists === true && wasInitialPersist) {
-          this._hasPersistedFile = true;
           log.info('첫 .bframe 저장 충돌 감지, 기존 파일과 병합 시도', {
             path: this.currentBframePath
           });
-          await this._initialSaveConflictHandler?.({
+          lastConflictResult = await this._initialSaveConflictHandler?.({
             path: this.currentBframePath,
             videoPath: this.currentVideoPath
           });
+
+          if (lastConflictResult?.success === true) {
+            this._hasPersistedFile = true;
+          } else {
+            this._hasPersistedFile = false;
+            if (attempt < maxAttempts - 1) {
+              await new Promise(resolve => setTimeout(resolve, 100));
+            }
+          }
+
           continue;
+        }
+
+        if (saveResult?.success !== true) {
+          throw new Error(saveResult?.error || '.bframe 저장 실패');
         }
 
         this._hasPersistedFile = true;
         savedData = data;
         break;
+      }
+
+      if (!savedData) {
+        throw new Error(lastConflictResult?.error || '첫 .bframe 저장 충돌 병합 실패');
       }
 
       this.isDirty = false;

--- a/scripts/tests/cutlist-runtime-source.test.js
+++ b/scripts/tests/cutlist-runtime-source.test.js
@@ -221,7 +221,7 @@ test('cutlist source switches defer collaboration startup until after the target
   const seekToCutBody = extractBalancedBlock(appSource, 'async function seekToCut');
   const commentReadyBody = extractBalancedBlock(appSource, 'async function ensureCutlistCommentTargetReady');
 
-  assert.match(appSource, /async function startCollaborationForVideoLoad\(loadToken, bframePath\)/);
+  assert.match(appSource, /async function startCollaborationForVideoLoad\(loadToken, bframePath, options = \{\}\)/);
   assert.match(appSource, /function scheduleDeferredCollaborationStart\(loadToken, bframePath\)/);
   assert.match(mappedSeekBody, /loadVideo\(source\.videoPath,\s*\{[\s\S]*deferCollaborationStart:\s*true[\s\S]*\}\)/);
   assert.match(seekToCutBody, /loadVideo\(source\.videoPath,\s*\{[\s\S]*deferCollaborationStart:\s*true[\s\S]*\}\)/);

--- a/scripts/tests/lazy-bframe-creation-source.test.js
+++ b/scripts/tests/lazy-bframe-creation-source.test.js
@@ -15,6 +15,8 @@ const reviewDataManagerSource = normalizeNewlines(
 );
 const preloadSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'preload/preload.js'), 'utf8'));
 const ipcHandlersSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'main/ipc-handlers.js'), 'utf8'));
+const commentSyncSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/comment-sync.js'), 'utf8'));
+const drawingSyncSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/drawing-sync.js'), 'utf8'));
 
 test('missing .bframe loads enter deferred discovery instead of immediate collaboration save', () => {
   assert.match(appSource, /function startDeferredReviewFileDiscovery\(loadToken, bframePath\)/);
@@ -39,7 +41,9 @@ test('missing .bframe loads enter deferred discovery instead of immediate collab
 
 test('new review room can be attached to first save without recursively saving at load time', () => {
   assert.match(appSource, /async function startCollaborationForVideoLoad\(loadToken, bframePath, options = \{\}\)/);
-  assert.match(appSource, /const \{ persistNewRoom = true \} = options;/);
+  assert.match(appSource, /persistNewRoom = true,/);
+  assert.match(appSource, /seedCurrentState = false/);
+  assert.match(appSource, /if \(seedCurrentState\) \{[\s\S]*commentSync\.broadcastCurrentState\?\.\(\);[\s\S]*drawingSync\.broadcastCurrentState\?\.\(\);/);
 
   const newRoomBranch = appSource.match(/if \(isNewRoom && isCurrentReviewPath\(bframePath\)\) \{([\s\S]*?)\n      \}/);
   assert.ok(newRoomBranch, 'startCollaborationForVideoLoad should handle newly-created rooms explicitly');
@@ -57,12 +61,19 @@ test('first .bframe save is protected against another user creating the file fir
   assert.match(reviewDataManagerSource, /if \(lastConflictResult\?\.success === true\) \{[\s\S]*this\._hasPersistedFile = true;[\s\S]*\} else \{[\s\S]*this\._hasPersistedFile = false;/);
   assert.match(reviewDataManagerSource, /if \(!savedData\) \{[\s\S]*throw new Error\(lastConflictResult\?\.error/);
   assert.match(appSource, /const mergeResult = await reviewDataManager\.reloadAndMerge\(\{ merge: true, force: true, preserveLocal: true \}\);[\s\S]*if \(!mergeResult\.success\) \{[\s\S]*return mergeResult;/);
+  assert.match(appSource, /persistNewRoom: false,\s*seedCurrentState: true/);
+  assert.match(commentSyncSource, /broadcastCurrentState\(\) \{[\s\S]*type: 'COMMENT_MARKER_ADDED'/);
+  assert.match(drawingSyncSource, /broadcastCurrentState\(\) \{[\s\S]*type: 'DRAWING_KEYFRAME_UPDATE'/);
   assert.match(reviewDataManagerSource, /function mergeDrawingData\(localData = \{\}, remoteData = \{\}\)/);
   assert.match(reviewDataManagerSource, /remoteCopy\.id = getNextPrefixedId\('layer', usedIds\);/);
   assert.match(reviewDataManagerSource, /function mergeHighlightData\(localData = \{\}, remoteData = \{\}\)/);
   assert.match(reviewDataManagerSource, /remoteCopy\.id = getNextPrefixedId\('highlight', usedIds\);/);
+  assert.match(reviewDataManagerSource, /function mergeManualVersions\(localVersions = \[\], remoteVersions = \[\]\)/);
+  assert.match(reviewDataManagerSource, /function mergeCompositionLayers\(localLayers = \[\], remoteLayers = \[\]\)/);
   assert.match(reviewDataManagerSource, /const mergedDrawings = mergeDrawingData\(this\.drawingManager\.exportData\(\), remoteData\.drawings\);/);
   assert.match(reviewDataManagerSource, /const mergedHighlights = mergeHighlightData\(this\.highlightManager\.toJSON\(\), remoteData\.highlights\);/);
+  assert.match(reviewDataManagerSource, /this\._manualVersions = mergeManualVersions\(this\._manualVersions, remoteData\.manualVersions\);/);
+  assert.match(reviewDataManagerSource, /const mergedCompositionLayers = mergeCompositionLayers\([\s\S]*this\.compositionLayerManager\.toJSON\(\),[\s\S]*remoteData\.compositionLayers/);
 
   assert.match(preloadSource, /saveReview: \(filePath, data, options = \{\}\) => ipcRenderer\.invoke\('file:save-review', filePath, data, options\)/);
   assert.match(ipcHandlersSource, /failIfExists/);

--- a/scripts/tests/lazy-bframe-creation-source.test.js
+++ b/scripts/tests/lazy-bframe-creation-source.test.js
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+
+function normalizeNewlines(value) {
+  return value.replace(/\r\n/g, '\n');
+}
+
+const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
+const reviewDataManagerSource = normalizeNewlines(
+  fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/review-data-manager.js'), 'utf8')
+);
+const preloadSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'preload/preload.js'), 'utf8'));
+const ipcHandlersSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'main/ipc-handlers.js'), 'utf8'));
+
+test('missing .bframe loads enter deferred discovery instead of immediate collaboration save', () => {
+  assert.match(appSource, /function startDeferredReviewFileDiscovery\(loadToken, bframePath\)/);
+  assert.match(appSource, /function stopDeferredReviewFileDiscovery\(bframePath = null\)/);
+  assert.match(appSource, /async function handleDeferredReviewFileDiscovered\(bframePath, source = 'watch'\)/);
+  assert.match(appSource, /function isCurrentReviewPath\(bframePath\) \{\s*return !!bframePath && isSameFilePath\(reviewDataManager\.currentBframePath, bframePath\);/);
+
+  const renderMarkerIndex = appSource.indexOf('// 마커 및 그리기 렌더링 업데이트');
+  const branchStart = appSource.lastIndexOf('if (hasExistingData) {', renderMarkerIndex);
+  assert.ok(branchStart > -1, 'loadVideo should branch on existing .bframe data before rendering markers');
+  const loadBranch = appSource.slice(branchStart, renderMarkerIndex);
+
+  assert.match(loadBranch, /if \(deferCollaborationStart\) \{[\s\S]*scheduleDeferredCollaborationStart\(loadToken, currentBframePath\);/);
+  assert.match(loadBranch, /await startCollaborationForVideoLoad\(loadToken, currentBframePath\);/);
+  assert.match(loadBranch, /else \{\s*startDeferredReviewFileDiscovery\(loadToken, currentBframePath\);\s*\}/);
+});
+
+test('new review room can be attached to first save without recursively saving at load time', () => {
+  assert.match(appSource, /async function startCollaborationForVideoLoad\(loadToken, bframePath, options = \{\}\)/);
+  assert.match(appSource, /const \{ persistNewRoom = true \} = options;/);
+
+  const newRoomBranch = appSource.match(/if \(isNewRoom && isCurrentReviewPath\(bframePath\)\) \{([\s\S]*?)\n      \}/);
+  assert.ok(newRoomBranch, 'startCollaborationForVideoLoad should handle newly-created rooms explicitly');
+  assert.match(newRoomBranch[1], /reviewDataManager\.setLiveblocksRoomId\(roomId\);/);
+  assert.match(newRoomBranch[1], /if \(persistNewRoom\) \{/);
+  assert.match(newRoomBranch[1], /await reviewDataManager\.save\(\{ skipMerge: true \}\);/);
+});
+
+test('first .bframe save is protected against another user creating the file first', () => {
+  assert.match(reviewDataManagerSource, /setBeforeSaveHandler\(handler\)/);
+  assert.match(reviewDataManagerSource, /setInitialSaveConflictHandler\(handler\)/);
+  assert.match(reviewDataManagerSource, /failIfExists: wasInitialPersist/);
+  assert.match(reviewDataManagerSource, /saveResult\?\.exists === true/);
+  assert.match(reviewDataManagerSource, /await this\._initialSaveConflictHandler\?\.\(\{/);
+
+  assert.match(preloadSource, /saveReview: \(filePath, data, options = \{\}\) => ipcRenderer\.invoke\('file:save-review', filePath, data, options\)/);
+  assert.match(ipcHandlersSource, /failIfExists/);
+  assert.match(ipcHandlersSource, /flag: options\?\.failIfExists \? 'wx' : 'w'/);
+  assert.match(ipcHandlersSource, /error\.code === 'EEXIST'/);
+});

--- a/scripts/tests/lazy-bframe-creation-source.test.js
+++ b/scripts/tests/lazy-bframe-creation-source.test.js
@@ -18,11 +18,13 @@ const ipcHandlersSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, '
 
 test('missing .bframe loads enter deferred discovery instead of immediate collaboration save', () => {
   assert.match(appSource, /function startDeferredReviewFileDiscovery\(loadToken, bframePath\)/);
-  assert.match(appSource, /function stopDeferredReviewFileDiscovery\(bframePath = null\)/);
+  assert.match(appSource, /async function stopDeferredReviewFileDiscovery\(bframePath = null\)/);
   assert.match(appSource, /async function handleDeferredReviewFileDiscovered\(bframePath, source = 'watch'\)/);
   assert.match(appSource, /function isCurrentReviewPath\(bframePath\) \{\s*return !!bframePath && isSameFilePath\(reviewDataManager\.currentBframePath, bframePath\);/);
   assert.match(appSource, /const synced = await syncReviewFileFromDisk\(bframePath, \{[\s\S]*bypassDebounce: true,/);
-  assert.match(appSource, /if \(synced\) \{\s*stopDeferredReviewFileDiscovery\(bframePath\);\s*\}/);
+  assert.match(appSource, /replaceDeferredDiscovery: true,/);
+  assert.match(appSource, /replaceDeferredDiscovery = false,/);
+  assert.match(appSource, /if \(result\.success && startCollaborationIfNeeded && replaceDeferredDiscovery\) \{[\s\S]*await stopDeferredReviewFileDiscovery\(filePath\);[\s\S]*if \(result\.success && startCollaborationIfNeeded && !liveblocksManager\.isConnected\) \{[\s\S]*await startCollaborationForVideoLoad/);
   assert.doesNotMatch(appSource, /stopDeferredReviewFileDiscovery\(bframePath\);\s*log\.info\('지연 \.bframe 생성 감지됨'/);
 
   const renderMarkerIndex = appSource.indexOf('// 마커 및 그리기 렌더링 업데이트');
@@ -54,7 +56,9 @@ test('first .bframe save is protected against another user creating the file fir
   assert.match(reviewDataManagerSource, /lastConflictResult = await this\._initialSaveConflictHandler\?\.\(\{/);
   assert.match(reviewDataManagerSource, /if \(lastConflictResult\?\.success === true\) \{[\s\S]*this\._hasPersistedFile = true;[\s\S]*\} else \{[\s\S]*this\._hasPersistedFile = false;/);
   assert.match(reviewDataManagerSource, /if \(!savedData\) \{[\s\S]*throw new Error\(lastConflictResult\?\.error/);
-  assert.match(appSource, /const mergeResult = await reviewDataManager\.reloadAndMerge\(\{ merge: true, force: true \}\);[\s\S]*if \(!mergeResult\.success\) \{[\s\S]*return mergeResult;/);
+  assert.match(appSource, /const mergeResult = await reviewDataManager\.reloadAndMerge\(\{ merge: true, force: true, preserveLocal: true \}\);[\s\S]*if \(!mergeResult\.success\) \{[\s\S]*return mergeResult;/);
+  assert.match(reviewDataManagerSource, /if \(!options\.preserveLocal && remoteData\.drawings && this\.drawingManager\)/);
+  assert.match(reviewDataManagerSource, /if \(!options\.preserveLocal && remoteData\.highlights && this\.highlightManager\)/);
 
   assert.match(preloadSource, /saveReview: \(filePath, data, options = \{\}\) => ipcRenderer\.invoke\('file:save-review', filePath, data, options\)/);
   assert.match(ipcHandlersSource, /failIfExists/);

--- a/scripts/tests/lazy-bframe-creation-source.test.js
+++ b/scripts/tests/lazy-bframe-creation-source.test.js
@@ -57,8 +57,12 @@ test('first .bframe save is protected against another user creating the file fir
   assert.match(reviewDataManagerSource, /if \(lastConflictResult\?\.success === true\) \{[\s\S]*this\._hasPersistedFile = true;[\s\S]*\} else \{[\s\S]*this\._hasPersistedFile = false;/);
   assert.match(reviewDataManagerSource, /if \(!savedData\) \{[\s\S]*throw new Error\(lastConflictResult\?\.error/);
   assert.match(appSource, /const mergeResult = await reviewDataManager\.reloadAndMerge\(\{ merge: true, force: true, preserveLocal: true \}\);[\s\S]*if \(!mergeResult\.success\) \{[\s\S]*return mergeResult;/);
-  assert.match(reviewDataManagerSource, /if \(!options\.preserveLocal && remoteData\.drawings && this\.drawingManager\)/);
-  assert.match(reviewDataManagerSource, /if \(!options\.preserveLocal && remoteData\.highlights && this\.highlightManager\)/);
+  assert.match(reviewDataManagerSource, /function mergeDrawingData\(localData = \{\}, remoteData = \{\}\)/);
+  assert.match(reviewDataManagerSource, /remoteCopy\.id = getNextPrefixedId\('layer', usedIds\);/);
+  assert.match(reviewDataManagerSource, /function mergeHighlightData\(localData = \{\}, remoteData = \{\}\)/);
+  assert.match(reviewDataManagerSource, /remoteCopy\.id = getNextPrefixedId\('highlight', usedIds\);/);
+  assert.match(reviewDataManagerSource, /const mergedDrawings = mergeDrawingData\(this\.drawingManager\.exportData\(\), remoteData\.drawings\);/);
+  assert.match(reviewDataManagerSource, /const mergedHighlights = mergeHighlightData\(this\.highlightManager\.toJSON\(\), remoteData\.highlights\);/);
 
   assert.match(preloadSource, /saveReview: \(filePath, data, options = \{\}\) => ipcRenderer\.invoke\('file:save-review', filePath, data, options\)/);
   assert.match(ipcHandlersSource, /failIfExists/);

--- a/scripts/tests/lazy-bframe-creation-source.test.js
+++ b/scripts/tests/lazy-bframe-creation-source.test.js
@@ -21,6 +21,9 @@ test('missing .bframe loads enter deferred discovery instead of immediate collab
   assert.match(appSource, /function stopDeferredReviewFileDiscovery\(bframePath = null\)/);
   assert.match(appSource, /async function handleDeferredReviewFileDiscovered\(bframePath, source = 'watch'\)/);
   assert.match(appSource, /function isCurrentReviewPath\(bframePath\) \{\s*return !!bframePath && isSameFilePath\(reviewDataManager\.currentBframePath, bframePath\);/);
+  assert.match(appSource, /const synced = await syncReviewFileFromDisk\(bframePath, \{[\s\S]*bypassDebounce: true,/);
+  assert.match(appSource, /if \(synced\) \{\s*stopDeferredReviewFileDiscovery\(bframePath\);\s*\}/);
+  assert.doesNotMatch(appSource, /stopDeferredReviewFileDiscovery\(bframePath\);\s*log\.info\('지연 \.bframe 생성 감지됨'/);
 
   const renderMarkerIndex = appSource.indexOf('// 마커 및 그리기 렌더링 업데이트');
   const branchStart = appSource.lastIndexOf('if (hasExistingData) {', renderMarkerIndex);
@@ -48,7 +51,10 @@ test('first .bframe save is protected against another user creating the file fir
   assert.match(reviewDataManagerSource, /setInitialSaveConflictHandler\(handler\)/);
   assert.match(reviewDataManagerSource, /failIfExists: wasInitialPersist/);
   assert.match(reviewDataManagerSource, /saveResult\?\.exists === true/);
-  assert.match(reviewDataManagerSource, /await this\._initialSaveConflictHandler\?\.\(\{/);
+  assert.match(reviewDataManagerSource, /lastConflictResult = await this\._initialSaveConflictHandler\?\.\(\{/);
+  assert.match(reviewDataManagerSource, /if \(lastConflictResult\?\.success === true\) \{[\s\S]*this\._hasPersistedFile = true;[\s\S]*\} else \{[\s\S]*this\._hasPersistedFile = false;/);
+  assert.match(reviewDataManagerSource, /if \(!savedData\) \{[\s\S]*throw new Error\(lastConflictResult\?\.error/);
+  assert.match(appSource, /const mergeResult = await reviewDataManager\.reloadAndMerge\(\{ merge: true, force: true \}\);[\s\S]*if \(!mergeResult\.success\) \{[\s\S]*return mergeResult;/);
 
   assert.match(preloadSource, /saveReview: \(filePath, data, options = \{\}\) => ipcRenderer\.invoke\('file:save-review', filePath, data, options\)/);
   assert.match(ipcHandlersSource, /failIfExists/);

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -833,10 +833,11 @@ test('continuous playlist source switches defer collaboration startup off the tr
   assert.notEqual(loadVideoEnd, -1, 'loadVideo boundary should exist');
   const loadVideoSource = appSource.slice(loadVideoStart, loadVideoEnd);
 
-  assert.match(appSource, /async function startCollaborationForVideoLoad\(loadToken, bframePath\)/);
+  assert.match(appSource, /async function startCollaborationForVideoLoad\(loadToken, bframePath, options = \{\}\)/);
   assert.match(appSource, /function scheduleDeferredCollaborationStart\(loadToken, bframePath\)/);
   assert.match(loadVideoSource, /deferCollaborationStart = false/);
-  assert.match(loadVideoSource, /if \(deferCollaborationStart\) \{[\s\S]*scheduleDeferredCollaborationStart\(loadToken, currentBframePath\);[\s\S]*\} else \{[\s\S]*await startCollaborationForVideoLoad\(loadToken, currentBframePath\);/);
+  assert.match(loadVideoSource, /if \(hasExistingData\) \{[\s\S]*if \(deferCollaborationStart\) \{[\s\S]*scheduleDeferredCollaborationStart\(loadToken, currentBframePath\);[\s\S]*\} else \{[\s\S]*await startCollaborationForVideoLoad\(loadToken, currentBframePath\);/);
+  assert.match(loadVideoSource, /else \{\s*startDeferredReviewFileDiscovery\(loadToken, currentBframePath\);\s*\}/);
 
   const continuousLoadMatch = appSource.match(/async function loadContinuousPlaylistItem\(item, sessionId\) \{([\s\S]*?)\n  \}\n\n  function waitForContinuousDelay/);
   assert.ok(continuousLoadMatch, 'continuous playlist loader should exist');


### PR DESCRIPTION
## 📋 업데이트 요약

🎬 영상이나 음원 파일을 단순히 열어 보는 경우에는 이제 배프레임 파일이 바로 생기지 않습니다.

💬 코멘트처럼 실제 리뷰 내용을 남기는 순간 배프레임 파일이 생성됩니다. 그래서 간단한 플레이어처럼 사용할 때 폴더가 불필요하게 지저분해지는 문제가 줄어듭니다.

👥 같은 파일을 여러 사람이 열고 있는 상태에서 한 사람이 먼저 코멘트를 남기면, 그때 생성된 배프레임 파일을 다른 사람들도 감지해서 같은 리뷰 흐름에 합류할 수 있게 했습니다.

📂 이미 배프레임 파일이 있는 경우에는 기존처럼 파일을 열자마자 리뷰 내용과 협업 상태를 불러옵니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`
  - 기존에는 미디어 파일을 열면 `.bframe` 경로를 즉시 저장하고 협업 방을 바로 생성했습니다.
  - 이제 기존 `.bframe`이 없으면 저장을 미루고, `startDeferredReviewFileDiscovery()`로 같은 경로의 `.bframe` 생성 여부를 감시합니다.
  - 첫 저장 직전에 `prepareReviewFileBeforeSave()`가 협업 room id를 준비하고, 기존 파일이 뒤늦게 생긴 경우 `handleInitialReviewFileSaveConflict()`에서 디스크 내용을 다시 읽어 병합합니다.
  - 다른 사용자가 먼저 `.bframe`을 만들면 `handleDeferredReviewFileDiscovered()`가 감지해서 현재 화면을 같은 리뷰 파일 기준으로 전환합니다.

- `renderer/scripts/modules/review-data-manager.js`
  - 실제로 저장된 파일이 있는지 `_hasPersistedFile`로 추적하도록 했습니다.
  - 첫 저장 시에만 `failIfExists` 옵션을 사용해, 동시에 여러 사람이 첫 코멘트를 남기는 상황에서 한쪽 파일을 덮어쓰지 않도록 했습니다.
  - 파일이 이미 생긴 경우 `reloadAndMerge()`로 기존 데이터와 현재 변경 사항을 합친 뒤 다시 저장합니다.

- `main/ipc-handlers.js`, `preload/preload.js`
  - `file:save-review`가 `failIfExists` 옵션을 받아 첫 저장 충돌을 구분할 수 있게 했습니다.
  - 아직 존재하지 않는 `.bframe`도 감시할 수 있도록, 파일이 없으면 부모 폴더를 감시하고 해당 파일명이 생겼을 때만 변경 이벤트를 보내도록 했습니다.

- `scripts/tests/lazy-bframe-creation-source.test.js`
  - 미디어 열기만으로 `.bframe`을 저장하지 않는지
  - 첫 저장 시 협업 room id를 준비하되 재귀 저장하지 않는지
  - 동시에 첫 저장이 겹칠 때 기존 파일을 병합하는지
  를 소스 테스트로 추가했습니다.

## 🚧 개발 난항

기존 구조는 안정성을 위해 파일을 열자마자 `.bframe`을 만들도록 되어 있었습니다. 이 방식은 협업 기준점이 빨리 생기는 장점이 있지만, 단순 재생만 해도 파일이 생기는 문제가 있었습니다.

가짜 임시 파일을 만들었다가 지우는 방식도 검토할 수 있었지만, 공유 폴더에서는 임시 파일 자체가 다른 사용자에게 보일 수 있고 삭제 타이밍에 따라 혼란이 생길 수 있습니다. 그래서 이번에는 실제 리뷰 내용이 생기기 전까지 디스크 파일은 만들지 않고, 첫 저장 순간에 충돌을 감지해 병합하는 쪽으로 정리했습니다.

여러 사용자가 동시에 첫 코멘트를 남기는 경우가 핵심 위험이었습니다. 이를 막기 위해 첫 저장은 “파일이 없을 때만 생성”으로 처리하고, 이미 누가 먼저 만들었으면 그 파일을 다시 읽어서 현재 변경 사항과 합치도록 했습니다.

기존 테스트 중 일부는 협업 시작 함수의 인자 형태를 고정해서 보고 있었기 때문에, 새 옵션 구조에 맞춰 테스트 기대값을 함께 조정했습니다.

## ✅ 테스트 가이드

실사용자용:

1. 영상 파일을 그냥 열고 닫았을 때 같은 폴더에 새 배프레임 파일이 생기지 않는지 확인합니다.
2. 코멘트를 하나 남겼을 때 그 순간 배프레임 파일이 생성되는지 확인합니다.
3. 같은 영상 파일을 두 앱 또는 두 PC에서 열어 두고, 한쪽에서 코멘트를 남긴 뒤 다른 쪽도 같은 리뷰 내용으로 합류하는지 확인합니다.
4. 이미 배프레임 파일이 있는 영상은 기존처럼 바로 리뷰 내용이 불러와지는지 확인합니다.

개발자용:

- `node --test scripts/tests/lazy-bframe-creation-source.test.js`
- `npm run test:comment-input`
- `npm run test:collaboration`
- `node --test scripts/tests/playlist-continuous-runtime.test.js`
- `node --test scripts/tests/cutlist-runtime-source.test.js`
- `npm run test:playlist`
- `npm run build`

참고: `npm run lint`는 저장소 전반의 기존 CRLF `linebreak-style` 오류 때문에 실패합니다. 변경 파일 기준으로 `linebreak-style`만 끄고 ESLint를 실행했을 때는 새 오류 없이 통과했습니다.