### PR TITLE
[v2.0.0-beta] B 키 드로잉 도구 지연 표시 수정

### DIFF
--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -2215,6 +2215,8 @@ class MPVOverlayHost {
     if (enabled) {
       // Windows의 focusable:false native 창은 mouseup/move와 달리 pointerdown을
       // Chromium에 전달하지 않는다. Fabric이 activation을 승인한 뒤에만 열어 둔다.
+      // 투명 BrowserWindow는 DOM visibility 변경을 다음 입력까지 늦게 그릴 수 있다.
+      hostWindow.webContents?.invalidate?.();
       hostWindow.setFocusable?.(true);
       hostWindow.setIgnoreMouseEvents?.(false);
       return;

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -123,7 +123,8 @@ function createDrawingHostHarness(options = {}) {
             };
           }
           return undefined;
-        }
+        },
+        invalidate: () => events.push(['webContents.invalidate'])
       };
       events.push(['construct', windowOptions]);
       windows.push(this);
@@ -1343,6 +1344,55 @@ test('injects and prepares Fabric once per host generation before enabling nativ
   await host.getDrawingDiagnostics();
   await host.ensure({ x: 1, y: 2, width: 640, height: 360 });
   assert.equal(getReadCount(), 1);
+});
+
+test('successful drawing activation repaints before pointer input without z-order churn', async () => {
+  const { host, events } = createDrawingHostHarness();
+  const ensured = await host.ensure({ x: 0, y: 0, width: 640, height: 360 });
+  const { hostGeneration } = ensured.drawingCapability;
+  await host.setDrawingInput(makeDrawingInput(hostGeneration));
+  events.length = 0;
+
+  const enabled = await host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    inputRevision: 2,
+    enabled: true,
+    session: {
+      sessionId: 'session-immediate-toolbar',
+      stableVideoIdentity: 'video-immediate-toolbar',
+      targetFrame: 24,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      canvasRect: { left: 0, top: 0, width: 640, height: 360 },
+      tool: 'brush'
+    }
+  }));
+
+  assert.equal(enabled.success, true);
+  const runtimeEnableIndex = events.findIndex(([name, value]) =>
+    name === 'executeJavaScript' &&
+    value.includes?.('.setDrawingInput(') &&
+    value.includes('"enabled":true'));
+  const repaintIndex = events.findIndex(([name]) =>
+    name === 'webContents.invalidate');
+  const focusableEnableIndex = events.findIndex(([name, value]) =>
+    name === 'setFocusable' && value === true);
+  const nativeEnableIndex = events.findIndex(([name, value]) =>
+    name === 'setIgnoreMouseEvents' && value === false);
+  assert.ok(runtimeEnableIndex >= 0);
+  assert.ok(
+    repaintIndex > runtimeEnableIndex,
+    'the activated toolbar must schedule a repaint after its DOM becomes visible'
+  );
+  assert.ok(
+    focusableEnableIndex > repaintIndex,
+    'pointer activation must wait until the visible toolbar repaint is scheduled'
+  );
+  assert.ok(nativeEnableIndex > focusableEnableIndex);
+  assert.equal(
+    events.filter(([name]) => name === 'moveTop').length,
+    0,
+    'toggling drawing input must not restack the native window or reintroduce flicker'
+  );
 });
 
 test('returns focus to the main window and relays keyboard input while the drawing overlay owns focus', async () => {


### PR DESCRIPTION
## 📋 업데이트 요약

- 🖌️ `B` 키를 누르면 추가 클릭 없이 드로잉 도구가 바로 나타납니다.
- 📂 기존 리뷰 데이터가 있는 파일에서도 동일하게 즉시 표시됩니다.
- ✨ 드로잉 화면을 반복해서 켜고 꺼도 영상 창을 불필요하게 재배치하지 않아 깜빡임 가능성을 줄였습니다.
- 💾 기존 리뷰와 드로잉 데이터의 저장 방식은 변경하지 않았습니다.

## 🔧 상세 기술 설명

- `main/mpv-overlay-host.js`
  - `_setNativeDrawingInput()`에서 Fabric 활성화가 승인된 직후 `webContents.invalidate()`를 호출합니다.
  - 툴바 표시 상태가 변경된 후 마우스 입력을 열기 전에 전체 화면 갱신을 예약합니다.
  - `moveTop()`은 사용하지 않아 반복 토글 시 네이티브 창 순서가 변경되지 않도록 유지했습니다.

- `scripts/tests/mpv-overlay-host.test.js`
  - 드로잉 활성화 승인 → 화면 갱신 예약 → 입력 활성화 순서를 검증합니다.
  - 다음 클릭에 의존하지 않는지와 불필요한 창 재배치가 없는지를 함께 검사합니다.

## 🚧 개발 난항

처음에는 드로잉 창이 영상 뒤로 밀리는 문제로 판단해 창을 매번 최상단으로 올리는 방식을 검토했습니다. 하지만 100회 토글 검증에서 창 순서 변경이 50회 추가되어 깜빡임 위험을 만들 수 있음이 확인됐습니다.

해당 방식은 제거하고, 실제 원인인 투명 화면의 다시 그리기 지연만 해결하도록 수정 범위를 줄였습니다.

## ✅ 테스트 가이드

### 실사용자용

1. 기존 리뷰 데이터가 있는 파일을 엽니다.
2. `B`를 누른 즉시 상단 드로잉 도구가 나타나는지 확인합니다.
3. 화면을 클릭하지 않고 `B`를 반복해 켜고 끕니다.
4. 획을 그린 뒤 저장하고 파일을 다시 열어 확인합니다.
5. 영상 재생 중에도 `B`를 켜고 끄며 조작과 재생이 정상인지 확인합니다.

### 개발자용

- mpv 전체 검사: 229/229 통과
- Fabric 드로잉 검사: 206/206 통과
- 드로잉 저장·복원 검사: 136/136 통과
- 전체 코드 검사: 오류 0
- 독립 코드 검토: P0–P3 발견 사항 없음
- `2.0.0-beta` 안정화 패키지 빌드 성공