### PR TITLE
[v2.0.1-beta] 자유 선택 조각 분리 및 재선택 안정화

### DIFF
--- a/docs/superpowers/specs/2026-07-26-fabric-free-selection-presets-design.md
+++ b/docs/superpowers/specs/2026-07-26-fabric-free-selection-presets-design.md
@@ -193,6 +193,32 @@ authoritative geometry만 화면에 실제로 그려지는 Path 채움으로 승
 - 실제 채움이 hit와 clip의 기준이어도 `sourcePoints`, pressure/time, caps,
   transform은 canonical 편집 계보로 남는다. 채움 component는 BVH로 가속한
   centerline 투영을 통해 단조 source-position 구간과 연결한다.
+- 선택 경계가 획 두께의 일부만 가를 때는 하나의 잔여 채움 component가 서로
+  떨어진 여러 source-position 구간으로 투영될 수 있고, 정상적인 단조 곡선에서도
+  이런 component가 둘 이상 생길 수 있다. raw 구간이 source domain을 정확히
+  분할하면 그대로 사용한다. raw 구간에 중첩·내부 공백·여러 구간이 있어
+  source envelope가 필요할 때는 모든 envelope의 합집합이 domain 전체를 덮고,
+  모든 component가 같은 centerline을 사용하며, centerline이 시작점→끝점 chord
+  방향으로 엄격히 전진할 때만 masked 계보를 허용한다. 이 규칙은 최초 분리와
+  저장된 `renderGeometry` 재선택에 동일하게 적용한다. 실제 표시와 재선택
+  기준은 envelope가 아니라 교집합·차집합의 `renderGeometry`를 그대로 유지한다.
+- 저장된 `renderGeometry`는 이전 분리에서 화면에 없는 source 구간을 계보로
+  보존할 수 있다. 재선택 투영에서 이 숨은 구간이 leading, trailing, internal
+  gap으로 나타나면, 같은 단조 centerline 검증을 통과한 경우에만 인접 envelope
+  사이에 결정적으로 배분해 source domain을 빠짐없이 보존한다. 최초 canonical
+  획에서 발견된 실제 source gap은 이 보정을 사용하지 않고 계속 취소한다.
+- 같은 선택 소유권과 서로 겹치는 source envelope를 가진 disjoint component는
+  하나의 multi-contour `renderGeometry` fragment로 묶어 sourcePoints를 한 번만
+  보존한다. 굵은 획의 가운데 띠를 떼었을 때 위·아래 잔여 모양이 원본 계보를
+  각각 복제하여 point budget을 넘거나 저장 데이터가 불필요하게 늘지 않아야 한다.
+- 정확한 clipped fill이 보이는 경우에는 source index 길이가 1보다 짧아도
+  보간한 양 끝 source sample을 보존한다. 기존 centerline/polygon 기반 split의
+  sub-pixel 폐기 기준은 유지하고, authoritative `renderGeometry` fragment를
+  만드는 경로에서만 이 예외를 사용한다.
+- envelope 계보와 반대편 fragment의 source 구간은 일부 겹칠 수 있지만 표시
+  채움은 겹치지 않는다. U-turn처럼 chord 방향 진행이 멈추거나 되돌아가는 획,
+  self-cross처럼 여러 분기가 선택되는 획, raw source domain에 공백이 생기는
+  투영은 기존처럼 전체 gesture를 원자적으로 취소한다.
 - 잘라낸 표시 모양은 version 1 `renderGeometry`로 이동·Delete·Undo/Redo와
   리뷰 데이터 저장/복원을 왕복한다. 이후 재선택도 저장된 채움을 다시
   authoritative geometry로 사용한다.
@@ -213,6 +239,11 @@ cache hit도 cold build의 logical cost를 동일하게 차감한다.
 | 400점 실제 획 | 300점과 같은 실제 runtime 왕복, direct paired clip 200k 미만, 각 검증 1초 미만 |
 | 1,000점 실제 획 | 250k 이내에서 `selection-complexity-limit-exceeded`, 교집합·차집합 모두 빈 실패 결과, 부분 출력 없음 |
 | 20,000-edge Path | flatten/index 단계가 250k 이내에서 같은 complexity reason으로 중단, UI 장기 정지나 cache 우회 없음 |
+
+추가 회귀 검증은 두께 일부만 걸친 곡선 획을 사각형과 라쏘로 각각 선택해,
+선택 경계 밖 픽셀은 제자리에 남고 안쪽 픽셀만 이동하는지 확인한다. 이동 결과를
+저장·hydrate한 뒤 남은 `renderGeometry`를 다시 부분 선택해 이동·Undo할 수 있어야
+한다. U-turn, self-cross, source-gap fixture는 계속 원자적으로 취소되어야 한다.
 
 이 표와 L-turn 실제 픽셀 hit/miss, 저장 후 재선택, thin/tangent/kissing/hole
 fixture가 모두 통과해야 Task 8을 완료한 것으로 본다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.0.0-beta",
+  "version": "2.0.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.0.0-beta",
+      "version": "2.0.1-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.0.0-beta",
+  "version": "2.0.1-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -522,13 +522,17 @@
       function appendPoint(run, point) {
         if (!run.length || !sameGeometrySample(run[run.length - 1], point)) run.push(point);
       }
-      function hasVisibleLength(run) {
+      function hasVisibleLength(run, minimumLength = 1) {
+        const requiredLength = Math.max(
+          Number.EPSILON,
+          finiteNumber(minimumLength, 1)
+        );
         let length = 0;
         for (let index = 1; index < run.length; index += 1) {
           const dx = finiteNumber(run[index]?.x) - finiteNumber(run[index - 1]?.x);
           const dy = finiteNumber(run[index]?.y) - finiteNumber(run[index - 1]?.y);
           length += Math.hypot(dx, dy);
-          if (length + EPSILON >= 1) return true;
+          if (length + Number.EPSILON >= requiredLength) return true;
         }
         return false;
       }
@@ -1229,7 +1233,8 @@
             appendPoint(currentRun, to);
           }
         }
-        result.runs = result.runs.filter(({ points: run }) => run.length >= 2 && hasVisibleLength(run));
+        const minimumRunLength = options.retainSubunitRuns === true ? Number.EPSILON : 1;
+        result.runs = result.runs.filter(({ points: run }) => run.length >= 2 && hasVisibleLength(run, minimumRunLength));
         result.inside = result.runs.filter((run) => run.kind === "inside").map((run) => run.points);
         result.outside = result.runs.filter((run) => run.kind === "outside").map((run) => run.points);
         if (result.limitExceeded) result.limitReason = limitReason || "operations";
@@ -1447,6 +1452,7 @@
       var DEFAULT_MAX_FLATTENED_SEGMENTS = 65536;
       var DEFAULT_EDGE_INDEX_LEAF_SIZE = 8;
       var MAX_CURVE_SUBDIVISION_DEPTH = 24;
+      var MINIMUM_FLATTENED_EDGE_TOLERANCE_RATIO = 0.01;
       function unionBounds(entries) {
         if (!entries.length) return null;
         return entries.reduce((bounds, entry) => ({
@@ -1583,6 +1589,29 @@
           y: (left.y + right.y) / 2
         };
       }
+      function normalizeFlattenedContour(contour, tolerance, budget) {
+        const minimumEdgeLength = Math.max(
+          EPSILON,
+          tolerance * MINIMUM_FLATTENED_EDGE_TOLERANCE_RATIO
+        );
+        const normalized = [];
+        for (const point of contour) {
+          if (!budget.consume()) return null;
+          const previous = normalized.at(-1);
+          if (previous && Math.hypot(point.x - previous.x, point.y - previous.y) <= minimumEdgeLength) {
+            continue;
+          }
+          normalized.push(point);
+        }
+        while (normalized.length > 1) {
+          if (!budget.consume()) return null;
+          const first = normalized[0];
+          const last = normalized.at(-1);
+          if (Math.hypot(first.x - last.x, first.y - last.y) > minimumEdgeLength) break;
+          normalized.pop();
+        }
+        return normalized;
+      }
       function flattenQuadratic(start, control, end, tolerance, acceptPoint) {
         const stack = [{ start, control, end, depth: 0 }];
         while (stack.length > 0) {
@@ -1674,8 +1703,9 @@
         };
         const finishContour = () => {
           if (!current) return;
-          if (current.length > 1 && samePoint(current[0], current.at(-1))) current.pop();
-          if (current.length >= 3) contours.push(current);
+          const normalized = normalizeFlattenedContour(current, tolerance, budget);
+          if (!normalized) flattenFailed = true;
+          else if (normalized.length >= 3) contours.push(normalized);
           current = null;
           currentPoint = null;
         };
@@ -13141,6 +13171,7 @@ void main() {
       var SELECTION_HIT_MARGIN_CSS_PX = 6;
       var MIN_SELECTION_HIT_TOLERANCE = 2;
       var MAX_SELECTION_HIT_TOLERANCE = 96;
+      var SOURCE_INTERVAL_EPSILON = 1e-7;
       var DRAWING_ACTIONS = /* @__PURE__ */ new Set([
         "delete-selection",
         "clear-session",
@@ -15730,7 +15761,7 @@ void main() {
             end: contour[(index + 1) % contour.length]
           })));
         }
-        function projectFillComponentToIndexInterval(component, centerline, budget) {
+        function projectFillComponentToSourceIntervals(component, centerline, budget) {
           const onCenterline = centerlineIntervalsInsideComponent(component, centerline, {
             budget
           });
@@ -15742,17 +15773,254 @@ void main() {
               centerline,
               { budget, distanceTolerance: 0.25 }
             );
-            if (projected.reason) return { interval: null, reason: projected.reason };
+            if (projected.reason) return { intervals: null, reason: projected.reason };
             sourceIntervals = projected.intervals;
           }
-          if (sourceIntervals.length !== 1) {
-            return { interval: null, reason: "selection-geometry-unavailable" };
+          if (sourceIntervals.length === 0) {
+            return { intervals: null, reason: "selection-geometry-unavailable" };
           }
-          const intervals = sourceIntervalsToIndexIntervals(sourceIntervals, centerline);
-          if (!Array.isArray(intervals) || intervals.length !== 1) {
-            return { interval: null, reason: "selection-geometry-unavailable" };
+          return { intervals: sourceIntervals, reason: null };
+        }
+        function sourceIntervalsFormExactPartition(projections, budget) {
+          const partition = [];
+          for (const projection of projections) {
+            for (const interval of projection.intervals || []) {
+              if (!budget.consume()) {
+                return {
+                  exact: false,
+                  reason: "selection-complexity-limit-exceeded"
+                };
+              }
+              partition.push(interval);
+            }
           }
-          return { interval: intervals[0], reason: null };
+          const sortCost = partition.length * (Math.ceil(Math.log2(partition.length + 1)) + 2);
+          if (!budget.consume(sortCost)) {
+            return {
+              exact: false,
+              reason: "selection-complexity-limit-exceeded"
+            };
+          }
+          partition.sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+          let coveredUntil = 0;
+          for (const interval of partition) {
+            if (!budget.consume()) {
+              return {
+                exact: false,
+                reason: "selection-complexity-limit-exceeded"
+              };
+            }
+            if (Math.abs(interval[0] - coveredUntil) > SOURCE_INTERVAL_EPSILON || interval[1] <= coveredUntil + SOURCE_INTERVAL_EPSILON) {
+              return { exact: false, reason: null };
+            }
+            coveredUntil = interval[1];
+          }
+          return {
+            exact: Math.abs(coveredUntil - 1) <= SOURCE_INTERVAL_EPSILON,
+            reason: null
+          };
+        }
+        function centerlineIsStrictlyChordMonotone(centerline, budget) {
+          const points = centerline?.points;
+          const segments = centerline?.segments;
+          if (!Array.isArray(points) || points.length < 2 || !Array.isArray(segments) || segments.length === 0) {
+            return {
+              monotone: false,
+              reason: "selection-geometry-unavailable"
+            };
+          }
+          const first = points[0];
+          const last = points.at(-1);
+          const chordX = last.x - first.x;
+          const chordY = last.y - first.y;
+          const chordLength = Math.hypot(chordX, chordY);
+          if (!Number.isFinite(chordLength) || chordLength <= SOURCE_INTERVAL_EPSILON) {
+            return {
+              monotone: false,
+              reason: "selection-geometry-unavailable"
+            };
+          }
+          const axisX = chordX / chordLength;
+          const axisY = chordY / chordLength;
+          for (const segment of segments) {
+            if (!budget.consume()) {
+              return {
+                monotone: false,
+                reason: "selection-complexity-limit-exceeded"
+              };
+            }
+            const sourceProgress = segment.end.sourcePosition - segment.start.sourcePosition;
+            const chordProgress = (segment.end.x - segment.start.x) * axisX + (segment.end.y - segment.start.y) * axisY;
+            if (!Number.isFinite(sourceProgress) || !Number.isFinite(chordProgress) || sourceProgress < -SOURCE_INTERVAL_EPSILON || chordProgress <= SOURCE_INTERVAL_EPSILON) {
+              return {
+                monotone: false,
+                reason: "selection-geometry-unavailable"
+              };
+            }
+          }
+          return { monotone: true, reason: null };
+        }
+        function sourceEnvelopesCoverSourceDomain(planned, budget) {
+          const envelopes = planned.map((projection) => projection.envelope);
+          const sortCost = envelopes.length * (Math.ceil(Math.log2(envelopes.length + 1)) + 2);
+          if (!budget.consume(sortCost)) {
+            return {
+              covered: false,
+              reason: "selection-complexity-limit-exceeded"
+            };
+          }
+          envelopes.sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+          let coveredUntil = 0;
+          for (const envelope of envelopes) {
+            if (!budget.consume()) {
+              return {
+                covered: false,
+                reason: "selection-complexity-limit-exceeded"
+              };
+            }
+            if (envelope[0] > coveredUntil + SOURCE_INTERVAL_EPSILON) {
+              return { covered: false, reason: null };
+            }
+            coveredUntil = Math.max(coveredUntil, envelope[1]);
+          }
+          return {
+            covered: coveredUntil >= 1 - SOURCE_INTERVAL_EPSILON,
+            reason: null
+          };
+        }
+        function bridgeHiddenSourceEnvelopeGaps(planned, budget) {
+          if (planned.length === 0 || planned.some((projection) => projection.maskedSource !== true)) {
+            return { bridged: false, reason: null };
+          }
+          const sortCost = planned.length * (Math.ceil(Math.log2(planned.length + 1)) + 2);
+          if (!budget.consume(sortCost)) {
+            return {
+              bridged: false,
+              reason: "selection-complexity-limit-exceeded"
+            };
+          }
+          const ordered = [...planned].sort((left, right) => left.envelope[0] - right.envelope[0] || left.envelope[1] - right.envelope[1]);
+          let coverageOwner = ordered[0];
+          coverageOwner.envelope[0] = 0;
+          let coveredUntil = coverageOwner.envelope[1];
+          for (let index = 1; index < ordered.length; index += 1) {
+            if (!budget.consume()) {
+              return {
+                bridged: false,
+                reason: "selection-complexity-limit-exceeded"
+              };
+            }
+            const current = ordered[index];
+            if (current.envelope[0] > coveredUntil + SOURCE_INTERVAL_EPSILON) {
+              const boundary = (coveredUntil + current.envelope[0]) / 2;
+              coverageOwner.envelope[1] = boundary;
+              current.envelope[0] = boundary;
+            }
+            if (current.envelope[1] > coveredUntil) {
+              coverageOwner = current;
+              coveredUntil = current.envelope[1];
+            }
+          }
+          coverageOwner.envelope[1] = 1;
+          return { bridged: true, reason: null };
+        }
+        function bridgeUnambiguousComponentIntervals(projections, budget) {
+          const planned = [];
+          for (const projection of projections) {
+            const intervals = projection.intervals;
+            if (!Array.isArray(intervals) || intervals.length === 0 || intervals.some((interval, index) => !Array.isArray(interval) || !Number.isFinite(interval[0]) || !Number.isFinite(interval[1]) || interval[0] < -SOURCE_INTERVAL_EPSILON || interval[1] > 1 + SOURCE_INTERVAL_EPSILON || interval[1] - interval[0] <= SOURCE_INTERVAL_EPSILON || index > 0 && interval[0] < intervals[index - 1][1] - SOURCE_INTERVAL_EPSILON)) {
+              return { projections: null, reason: "selection-geometry-unavailable" };
+            }
+            if (!budget.consume(intervals.length + 1)) {
+              return { projections: null, reason: "selection-complexity-limit-exceeded" };
+            }
+            planned.push({
+              ...projection,
+              envelope: [intervals[0][0], intervals.at(-1)[1]]
+            });
+          }
+          const wrapped = planned.filter((projection) => projection.intervals.length > 1);
+          const partition = sourceIntervalsFormExactPartition(planned, budget);
+          if (partition.reason) {
+            return { projections: null, reason: partition.reason };
+          }
+          const requiresEnvelopeBridge = wrapped.length > 0 || !partition.exact;
+          if (requiresEnvelopeBridge) {
+            const centerline = planned[0]?.centerline;
+            if (!centerline || planned.some((projection) => projection.centerline !== centerline)) {
+              return { projections: null, reason: "selection-geometry-unavailable" };
+            }
+            const monotone = centerlineIsStrictlyChordMonotone(centerline, budget);
+            if (monotone.reason) {
+              return { projections: null, reason: monotone.reason };
+            }
+            if (!monotone.monotone) {
+              return { projections: null, reason: "selection-geometry-unavailable" };
+            }
+            const coverage = sourceEnvelopesCoverSourceDomain(planned, budget);
+            if (coverage.reason) {
+              return { projections: null, reason: coverage.reason };
+            }
+            if (!coverage.covered) {
+              const hiddenBridge = bridgeHiddenSourceEnvelopeGaps(planned, budget);
+              if (hiddenBridge.reason) {
+                return { projections: null, reason: hiddenBridge.reason };
+              }
+              if (!hiddenBridge.bridged) {
+                return { projections: null, reason: "selection-geometry-unavailable" };
+              }
+              const bridgedCoverage = sourceEnvelopesCoverSourceDomain(planned, budget);
+              if (bridgedCoverage.reason) {
+                return { projections: null, reason: bridgedCoverage.reason };
+              }
+              if (!bridgedCoverage.covered) {
+                return { projections: null, reason: "selection-geometry-unavailable" };
+              }
+            }
+          }
+          for (const projection of planned) {
+            const sourceIntervals = requiresEnvelopeBridge ? [projection.envelope] : projection.intervals;
+            const intervals = sourceIntervalsToIndexIntervals(sourceIntervals, projection.centerline);
+            if (!Array.isArray(intervals) || intervals.length !== 1) {
+              return { projections: null, reason: "selection-geometry-unavailable" };
+            }
+            projection.interval = intervals[0];
+          }
+          return { projections: planned, reason: null };
+        }
+        function groupProjectedComponentsBySourceInterval(projections, budget) {
+          const sortCost = projections.length * (Math.ceil(Math.log2(projections.length + 1)) + 2);
+          if (!budget.consume(sortCost)) {
+            return {
+              groups: null,
+              reason: "selection-complexity-limit-exceeded"
+            };
+          }
+          const ordered = [...projections].sort((left, right) => Number(left.selected) - Number(right.selected) || left.interval[0] - right.interval[0] || left.interval[1] - right.interval[1]);
+          const groups = [];
+          for (const projection of ordered) {
+            if (!budget.consume()) {
+              return {
+                groups: null,
+                reason: "selection-complexity-limit-exceeded"
+              };
+            }
+            const previous = groups.at(-1);
+            if (previous && previous.selected === projection.selected && projection.interval[0] <= previous.interval[1] + SOURCE_INTERVAL_EPSILON) {
+              previous.interval[1] = Math.max(
+                previous.interval[1],
+                projection.interval[1]
+              );
+              previous.components.push(projection.component);
+              continue;
+            }
+            groups.push({
+              selected: projection.selected,
+              interval: [...projection.interval],
+              components: [projection.component]
+            });
+          }
+          return { groups, reason: null };
         }
         function applySourceTransformToFragment(path, sourceObject) {
           if (!sourceObject) return true;
@@ -16317,54 +16585,81 @@ void main() {
             if (!centerline.geometry || centerline.reason) {
               return fail(centerline.reason || "selection-geometry-unavailable");
             }
-            const componentPlans = [];
+            const projectedComponents = [];
             for (const group of [
               { selected: false, components: remainingClip.components },
               { selected: true, components: selectedClip.components }
             ]) {
               for (const component of group.components) {
-                const projected = projectFillComponentToIndexInterval(
+                const projected = projectFillComponentToSourceIntervals(
                   component,
                   centerline.geometry,
                   geometryBudget
                 );
-                if (!projected.interval || projected.reason) {
+                if (!projected.intervals || projected.reason) {
                   return fail(projected.reason || "selection-geometry-unavailable");
                 }
-                const sliced = splitStrokePointsBySourceIntervals(
-                  record.sourcePoints,
-                  [projected.interval],
-                  {
-                    budget: geometryBudget,
-                    maxRuns: 3
-                  }
-                );
-                if (sliced.limitExceeded) {
-                  return fail(sliced.limitReason === "operations" ? "selection-complexity-limit-exceeded" : "lasso-fragment-limit-exceeded");
-                }
-                if (sliced.geometryUnavailable || sliced.inside.length !== 1 || sliced.inside[0].length < 2) {
-                  return fail("selection-geometry-unavailable");
-                }
-                const renderPathData = contourPathData(component.contours);
-                if (!renderPathData || renderPathData.length > MAX_PERSISTENCE_STRING_LENGTH) {
-                  return fail("selection-geometry-unavailable");
-                }
-                const originalCaps = record.strokeCaps || { start: true, end: true };
-                componentPlans.push({
+                projectedComponents.push({
                   selected: group.selected,
-                  points: sliced.inside[0],
-                  interval: projected.interval,
-                  caps: {
-                    start: projected.interval[0] <= 1e-7 ? originalCaps.start !== false : false,
-                    end: projected.interval[1] >= record.sourcePoints.length - 1 - 1e-7 ? originalCaps.end !== false : false
-                  },
-                  renderGeometry: {
-                    version: 1,
-                    pathData: renderPathData,
-                    fillRule: "evenodd"
-                  }
+                  component,
+                  intervals: projected.intervals,
+                  centerline: centerline.geometry,
+                  maskedSource: record.renderGeometry !== void 0
                 });
               }
+            }
+            const bridged = bridgeUnambiguousComponentIntervals(
+              projectedComponents,
+              geometryBudget
+            );
+            if (!bridged.projections || bridged.reason) {
+              return fail(bridged.reason || "selection-geometry-unavailable");
+            }
+            const grouped = groupProjectedComponentsBySourceInterval(
+              bridged.projections,
+              geometryBudget
+            );
+            if (!grouped.groups || grouped.reason) {
+              return fail(grouped.reason || "selection-geometry-unavailable");
+            }
+            const componentPlans = [];
+            for (const projected of grouped.groups) {
+              const sliced = splitStrokePointsBySourceIntervals(
+                record.sourcePoints,
+                [projected.interval],
+                {
+                  budget: geometryBudget,
+                  maxRuns: 3,
+                  retainSubunitRuns: true
+                }
+              );
+              if (sliced.limitExceeded) {
+                return fail(sliced.limitReason === "operations" ? "selection-complexity-limit-exceeded" : "lasso-fragment-limit-exceeded");
+              }
+              if (sliced.geometryUnavailable || sliced.inside.length !== 1 || sliced.inside[0].length < 2) {
+                return fail("selection-geometry-unavailable");
+              }
+              const renderPathData = contourPathData(
+                projected.components.flatMap((component) => component.contours)
+              );
+              if (!renderPathData || renderPathData.length > MAX_PERSISTENCE_STRING_LENGTH) {
+                return fail("selection-geometry-unavailable");
+              }
+              const originalCaps = record.strokeCaps || { start: true, end: true };
+              componentPlans.push({
+                selected: projected.selected,
+                points: sliced.inside[0],
+                interval: projected.interval,
+                caps: {
+                  start: projected.interval[0] <= 1e-7 ? originalCaps.start !== false : false,
+                  end: projected.interval[1] >= record.sourcePoints.length - 1 - 1e-7 ? originalCaps.end !== false : false
+                },
+                renderGeometry: {
+                  version: 1,
+                  pathData: renderPathData,
+                  fillRule: "evenodd"
+                }
+              });
             }
             const totalPlannedPoints = componentPlans.reduce(
               (count, plan) => count + plan.points.length,

--- a/renderer/scripts/modules/drawing-v3/stroke-fill-geometry.js
+++ b/renderer/scripts/modules/drawing-v3/stroke-fill-geometry.js
@@ -11,6 +11,7 @@ const {
 const DEFAULT_MAX_FLATTENED_SEGMENTS = 65_536;
 const DEFAULT_EDGE_INDEX_LEAF_SIZE = 8;
 const MAX_CURVE_SUBDIVISION_DEPTH = 24;
+const MINIMUM_FLATTENED_EDGE_TOLERANCE_RATIO = 0.01;
 
 function unionBounds(entries) {
   if (!entries.length) return null;
@@ -178,6 +179,30 @@ function midpoint(left, right) {
   };
 }
 
+function normalizeFlattenedContour(contour, tolerance, budget) {
+  const minimumEdgeLength = Math.max(
+    EPSILON,
+    tolerance * MINIMUM_FLATTENED_EDGE_TOLERANCE_RATIO
+  );
+  const normalized = [];
+  for (const point of contour) {
+    if (!budget.consume()) return null;
+    const previous = normalized.at(-1);
+    if (previous && Math.hypot(point.x - previous.x, point.y - previous.y) <= minimumEdgeLength) {
+      continue;
+    }
+    normalized.push(point);
+  }
+  while (normalized.length > 1) {
+    if (!budget.consume()) return null;
+    const first = normalized[0];
+    const last = normalized.at(-1);
+    if (Math.hypot(first.x - last.x, first.y - last.y) > minimumEdgeLength) break;
+    normalized.pop();
+  }
+  return normalized;
+}
+
 function flattenQuadratic(start, control, end, tolerance, acceptPoint) {
   const stack = [{ start, control, end, depth: 0 }];
   while (stack.length > 0) {
@@ -272,8 +297,9 @@ function flattenFabricPath(pathCommands, options = {}) {
   };
   const finishContour = () => {
     if (!current) return;
-    if (current.length > 1 && samePoint(current[0], current.at(-1))) current.pop();
-    if (current.length >= 3) contours.push(current);
+    const normalized = normalizeFlattenedContour(current, tolerance, budget);
+    if (!normalized) flattenFailed = true;
+    else if (normalized.length >= 3) contours.push(normalized);
     current = null;
     currentPoint = null;
   };

--- a/renderer/scripts/modules/drawing-v3/stroke-splitter.js
+++ b/renderer/scripts/modules/drawing-v3/stroke-splitter.js
@@ -49,13 +49,17 @@ function appendPoint(run, point) {
   if (!run.length || !sameGeometrySample(run[run.length - 1], point)) run.push(point);
 }
 
-function hasVisibleLength(run) {
+function hasVisibleLength(run, minimumLength = 1) {
+  const requiredLength = Math.max(
+    Number.EPSILON,
+    finiteNumber(minimumLength, 1)
+  );
   let length = 0;
   for (let index = 1; index < run.length; index += 1) {
     const dx = finiteNumber(run[index]?.x) - finiteNumber(run[index - 1]?.x);
     const dy = finiteNumber(run[index]?.y) - finiteNumber(run[index - 1]?.y);
     length += Math.hypot(dx, dy);
-    if (length + EPSILON >= 1) return true;
+    if (length + Number.EPSILON >= requiredLength) return true;
   }
   return false;
 }
@@ -889,8 +893,11 @@ function splitStrokePointsBySourceIntervals(points = [], intervals = [], options
     }
   }
 
+  const minimumRunLength = options.retainSubunitRuns === true
+    ? Number.EPSILON
+    : 1;
   result.runs = result.runs.filter(({ points: run }) => (
-    run.length >= 2 && hasVisibleLength(run)
+    run.length >= 2 && hasVisibleLength(run, minimumRunLength)
   ));
   result.inside = result.runs.filter(run => run.kind === 'inside').map(run => run.points);
   result.outside = result.runs.filter(run => run.kind === 'outside').map(run => run.points);

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -88,6 +88,7 @@ const FABRIC_PERSISTENCE_BADGE_PREFIX = '새 드로잉 · 리뷰 자동 저장';
 const SELECTION_HIT_MARGIN_CSS_PX = 6;
 const MIN_SELECTION_HIT_TOLERANCE = 2;
 const MAX_SELECTION_HIT_TOLERANCE = 96;
+const SOURCE_INTERVAL_EPSILON = 1e-7;
 const DRAWING_ACTIONS = new Set([
   'delete-selection',
   'clear-session',
@@ -3045,7 +3046,7 @@ function createFabricOverlayRuntime(options = {}) {
     })));
   }
 
-  function projectFillComponentToIndexInterval(
+  function projectFillComponentToSourceIntervals(
     component,
     centerline,
     budget
@@ -3061,17 +3062,298 @@ function createFabricOverlayRuntime(options = {}) {
         centerline,
         { budget, distanceTolerance: 0.25 }
       );
-      if (projected.reason) return { interval: null, reason: projected.reason };
+      if (projected.reason) return { intervals: null, reason: projected.reason };
       sourceIntervals = projected.intervals;
     }
-    if (sourceIntervals.length !== 1) {
-      return { interval: null, reason: 'selection-geometry-unavailable' };
+    if (sourceIntervals.length === 0) {
+      return { intervals: null, reason: 'selection-geometry-unavailable' };
     }
-    const intervals = sourceIntervalsToIndexIntervals(sourceIntervals, centerline);
-    if (!Array.isArray(intervals) || intervals.length !== 1) {
-      return { interval: null, reason: 'selection-geometry-unavailable' };
+    return { intervals: sourceIntervals, reason: null };
+  }
+
+  function sourceIntervalsFormExactPartition(projections, budget) {
+    const partition = [];
+    for (const projection of projections) {
+      for (const interval of projection.intervals || []) {
+        if (!budget.consume()) {
+          return {
+            exact: false,
+            reason: 'selection-complexity-limit-exceeded'
+          };
+        }
+        partition.push(interval);
+      }
     }
-    return { interval: intervals[0], reason: null };
+    const sortCost = partition.length *
+      (Math.ceil(Math.log2(partition.length + 1)) + 2);
+    if (!budget.consume(sortCost)) {
+      return {
+        exact: false,
+        reason: 'selection-complexity-limit-exceeded'
+      };
+    }
+    partition.sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+    let coveredUntil = 0;
+    for (const interval of partition) {
+      if (!budget.consume()) {
+        return {
+          exact: false,
+          reason: 'selection-complexity-limit-exceeded'
+        };
+      }
+      if (Math.abs(interval[0] - coveredUntil) > SOURCE_INTERVAL_EPSILON ||
+          interval[1] <= coveredUntil + SOURCE_INTERVAL_EPSILON) {
+        return { exact: false, reason: null };
+      }
+      coveredUntil = interval[1];
+    }
+    return {
+      exact: Math.abs(coveredUntil - 1) <= SOURCE_INTERVAL_EPSILON,
+      reason: null
+    };
+  }
+
+  function centerlineIsStrictlyChordMonotone(centerline, budget) {
+    const points = centerline?.points;
+    const segments = centerline?.segments;
+    if (!Array.isArray(points) || points.length < 2 ||
+        !Array.isArray(segments) || segments.length === 0) {
+      return {
+        monotone: false,
+        reason: 'selection-geometry-unavailable'
+      };
+    }
+    const first = points[0];
+    const last = points.at(-1);
+    const chordX = last.x - first.x;
+    const chordY = last.y - first.y;
+    const chordLength = Math.hypot(chordX, chordY);
+    if (!Number.isFinite(chordLength) || chordLength <= SOURCE_INTERVAL_EPSILON) {
+      return {
+        monotone: false,
+        reason: 'selection-geometry-unavailable'
+      };
+    }
+    const axisX = chordX / chordLength;
+    const axisY = chordY / chordLength;
+    for (const segment of segments) {
+      if (!budget.consume()) {
+        return {
+          monotone: false,
+          reason: 'selection-complexity-limit-exceeded'
+        };
+      }
+      const sourceProgress =
+        segment.end.sourcePosition - segment.start.sourcePosition;
+      const chordProgress =
+        (segment.end.x - segment.start.x) * axisX +
+        (segment.end.y - segment.start.y) * axisY;
+      if (!Number.isFinite(sourceProgress) ||
+          !Number.isFinite(chordProgress) ||
+          sourceProgress < -SOURCE_INTERVAL_EPSILON ||
+          chordProgress <= SOURCE_INTERVAL_EPSILON) {
+        return {
+          monotone: false,
+          reason: 'selection-geometry-unavailable'
+        };
+      }
+    }
+    return { monotone: true, reason: null };
+  }
+
+  function sourceEnvelopesCoverSourceDomain(planned, budget) {
+    const envelopes = planned.map(projection => projection.envelope);
+    const sortCost = envelopes.length *
+      (Math.ceil(Math.log2(envelopes.length + 1)) + 2);
+    if (!budget.consume(sortCost)) {
+      return {
+        covered: false,
+        reason: 'selection-complexity-limit-exceeded'
+      };
+    }
+    envelopes.sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+    let coveredUntil = 0;
+    for (const envelope of envelopes) {
+      if (!budget.consume()) {
+        return {
+          covered: false,
+          reason: 'selection-complexity-limit-exceeded'
+        };
+      }
+      if (envelope[0] > coveredUntil + SOURCE_INTERVAL_EPSILON) {
+        return { covered: false, reason: null };
+      }
+      coveredUntil = Math.max(coveredUntil, envelope[1]);
+    }
+    return {
+      covered: coveredUntil >= 1 - SOURCE_INTERVAL_EPSILON,
+      reason: null
+    };
+  }
+
+  function bridgeHiddenSourceEnvelopeGaps(planned, budget) {
+    if (planned.length === 0 ||
+        planned.some(projection => projection.maskedSource !== true)) {
+      return { bridged: false, reason: null };
+    }
+    const sortCost = planned.length *
+      (Math.ceil(Math.log2(planned.length + 1)) + 2);
+    if (!budget.consume(sortCost)) {
+      return {
+        bridged: false,
+        reason: 'selection-complexity-limit-exceeded'
+      };
+    }
+    const ordered = [...planned].sort((left, right) => (
+      left.envelope[0] - right.envelope[0] ||
+      left.envelope[1] - right.envelope[1]
+    ));
+    let coverageOwner = ordered[0];
+    coverageOwner.envelope[0] = 0;
+    let coveredUntil = coverageOwner.envelope[1];
+    for (let index = 1; index < ordered.length; index += 1) {
+      if (!budget.consume()) {
+        return {
+          bridged: false,
+          reason: 'selection-complexity-limit-exceeded'
+        };
+      }
+      const current = ordered[index];
+      if (current.envelope[0] > coveredUntil + SOURCE_INTERVAL_EPSILON) {
+        const boundary = (coveredUntil + current.envelope[0]) / 2;
+        coverageOwner.envelope[1] = boundary;
+        current.envelope[0] = boundary;
+      }
+      if (current.envelope[1] > coveredUntil) {
+        coverageOwner = current;
+        coveredUntil = current.envelope[1];
+      }
+    }
+    coverageOwner.envelope[1] = 1;
+    return { bridged: true, reason: null };
+  }
+
+  function bridgeUnambiguousComponentIntervals(projections, budget) {
+    const planned = [];
+    for (const projection of projections) {
+      const intervals = projection.intervals;
+      if (!Array.isArray(intervals) || intervals.length === 0 ||
+          intervals.some((interval, index) => (
+            !Array.isArray(interval) ||
+            !Number.isFinite(interval[0]) ||
+            !Number.isFinite(interval[1]) ||
+            interval[0] < -SOURCE_INTERVAL_EPSILON ||
+            interval[1] > 1 + SOURCE_INTERVAL_EPSILON ||
+            interval[1] - interval[0] <= SOURCE_INTERVAL_EPSILON ||
+            (index > 0 &&
+              interval[0] < intervals[index - 1][1] - SOURCE_INTERVAL_EPSILON)
+          ))) {
+        return { projections: null, reason: 'selection-geometry-unavailable' };
+      }
+      if (!budget.consume(intervals.length + 1)) {
+        return { projections: null, reason: 'selection-complexity-limit-exceeded' };
+      }
+      planned.push({
+        ...projection,
+        envelope: [intervals[0][0], intervals.at(-1)[1]]
+      });
+    }
+
+    const wrapped = planned.filter(projection => projection.intervals.length > 1);
+    const partition = sourceIntervalsFormExactPartition(planned, budget);
+    if (partition.reason) {
+      return { projections: null, reason: partition.reason };
+    }
+    const requiresEnvelopeBridge = wrapped.length > 0 || !partition.exact;
+    if (requiresEnvelopeBridge) {
+      const centerline = planned[0]?.centerline;
+      if (!centerline ||
+          planned.some(projection => projection.centerline !== centerline)) {
+        return { projections: null, reason: 'selection-geometry-unavailable' };
+      }
+      const monotone = centerlineIsStrictlyChordMonotone(centerline, budget);
+      if (monotone.reason) {
+        return { projections: null, reason: monotone.reason };
+      }
+      if (!monotone.monotone) {
+        return { projections: null, reason: 'selection-geometry-unavailable' };
+      }
+      const coverage = sourceEnvelopesCoverSourceDomain(planned, budget);
+      if (coverage.reason) {
+        return { projections: null, reason: coverage.reason };
+      }
+      if (!coverage.covered) {
+        const hiddenBridge = bridgeHiddenSourceEnvelopeGaps(planned, budget);
+        if (hiddenBridge.reason) {
+          return { projections: null, reason: hiddenBridge.reason };
+        }
+        if (!hiddenBridge.bridged) {
+          return { projections: null, reason: 'selection-geometry-unavailable' };
+        }
+        const bridgedCoverage = sourceEnvelopesCoverSourceDomain(planned, budget);
+        if (bridgedCoverage.reason) {
+          return { projections: null, reason: bridgedCoverage.reason };
+        }
+        if (!bridgedCoverage.covered) {
+          return { projections: null, reason: 'selection-geometry-unavailable' };
+        }
+      }
+    }
+
+    for (const projection of planned) {
+      const sourceIntervals = requiresEnvelopeBridge
+        ? [projection.envelope]
+        : projection.intervals;
+      const intervals = sourceIntervalsToIndexIntervals(sourceIntervals, projection.centerline);
+      if (!Array.isArray(intervals) || intervals.length !== 1) {
+        return { projections: null, reason: 'selection-geometry-unavailable' };
+      }
+      projection.interval = intervals[0];
+    }
+    return { projections: planned, reason: null };
+  }
+
+  function groupProjectedComponentsBySourceInterval(projections, budget) {
+    const sortCost = projections.length *
+      (Math.ceil(Math.log2(projections.length + 1)) + 2);
+    if (!budget.consume(sortCost)) {
+      return {
+        groups: null,
+        reason: 'selection-complexity-limit-exceeded'
+      };
+    }
+    const ordered = [...projections].sort((left, right) => (
+      Number(left.selected) - Number(right.selected) ||
+      left.interval[0] - right.interval[0] ||
+      left.interval[1] - right.interval[1]
+    ));
+    const groups = [];
+    for (const projection of ordered) {
+      if (!budget.consume()) {
+        return {
+          groups: null,
+          reason: 'selection-complexity-limit-exceeded'
+        };
+      }
+      const previous = groups.at(-1);
+      if (previous &&
+          previous.selected === projection.selected &&
+          projection.interval[0] <=
+            previous.interval[1] + SOURCE_INTERVAL_EPSILON) {
+        previous.interval[1] = Math.max(
+          previous.interval[1],
+          projection.interval[1]
+        );
+        previous.components.push(projection.component);
+        continue;
+      }
+      groups.push({
+        selected: projection.selected,
+        interval: [...projection.interval],
+        components: [projection.component]
+      });
+    }
+    return { groups, reason: null };
   }
 
   function applySourceTransformToFragment(path, sourceObject) {
@@ -3703,63 +3985,90 @@ function createFabricOverlayRuntime(options = {}) {
       if (!centerline.geometry || centerline.reason) {
         return fail(centerline.reason || 'selection-geometry-unavailable');
       }
-      const componentPlans = [];
+      const projectedComponents = [];
       for (const group of [
         { selected: false, components: remainingClip.components },
         { selected: true, components: selectedClip.components }
       ]) {
         for (const component of group.components) {
-          const projected = projectFillComponentToIndexInterval(
+          const projected = projectFillComponentToSourceIntervals(
             component,
             centerline.geometry,
             geometryBudget
           );
-          if (!projected.interval || projected.reason) {
+          if (!projected.intervals || projected.reason) {
             return fail(projected.reason || 'selection-geometry-unavailable');
           }
-          const sliced = splitStrokePointsBySourceIntervals(
-            record.sourcePoints,
-            [projected.interval],
-            {
-              budget: geometryBudget,
-              maxRuns: 3
-            }
-          );
-          if (sliced.limitExceeded) {
-            return fail(sliced.limitReason === 'operations'
-              ? 'selection-complexity-limit-exceeded'
-              : 'lasso-fragment-limit-exceeded');
-          }
-          if (sliced.geometryUnavailable ||
-              sliced.inside.length !== 1 ||
-              sliced.inside[0].length < 2) {
-            return fail('selection-geometry-unavailable');
-          }
-          const renderPathData = contourPathData(component.contours);
-          if (!renderPathData ||
-              renderPathData.length > MAX_PERSISTENCE_STRING_LENGTH) {
-            return fail('selection-geometry-unavailable');
-          }
-          const originalCaps = record.strokeCaps || { start: true, end: true };
-          componentPlans.push({
+          projectedComponents.push({
             selected: group.selected,
-            points: sliced.inside[0],
-            interval: projected.interval,
-            caps: {
-              start: projected.interval[0] <= 1e-7
-                ? originalCaps.start !== false
-                : false,
-              end: projected.interval[1] >= record.sourcePoints.length - 1 - 1e-7
-                ? originalCaps.end !== false
-                : false
-            },
-            renderGeometry: {
-              version: 1,
-              pathData: renderPathData,
-              fillRule: 'evenodd'
-            }
+            component,
+            intervals: projected.intervals,
+            centerline: centerline.geometry,
+            maskedSource: record.renderGeometry !== undefined
           });
         }
+      }
+      const bridged = bridgeUnambiguousComponentIntervals(
+        projectedComponents,
+        geometryBudget
+      );
+      if (!bridged.projections || bridged.reason) {
+        return fail(bridged.reason || 'selection-geometry-unavailable');
+      }
+      const grouped = groupProjectedComponentsBySourceInterval(
+        bridged.projections,
+        geometryBudget
+      );
+      if (!grouped.groups || grouped.reason) {
+        return fail(grouped.reason || 'selection-geometry-unavailable');
+      }
+      const componentPlans = [];
+      for (const projected of grouped.groups) {
+        const sliced = splitStrokePointsBySourceIntervals(
+          record.sourcePoints,
+          [projected.interval],
+          {
+            budget: geometryBudget,
+            maxRuns: 3,
+            retainSubunitRuns: true
+          }
+        );
+        if (sliced.limitExceeded) {
+          return fail(sliced.limitReason === 'operations'
+            ? 'selection-complexity-limit-exceeded'
+            : 'lasso-fragment-limit-exceeded');
+        }
+        if (sliced.geometryUnavailable ||
+            sliced.inside.length !== 1 ||
+              sliced.inside[0].length < 2) {
+          return fail('selection-geometry-unavailable');
+        }
+        const renderPathData = contourPathData(
+          projected.components.flatMap(component => component.contours)
+        );
+        if (!renderPathData ||
+            renderPathData.length > MAX_PERSISTENCE_STRING_LENGTH) {
+          return fail('selection-geometry-unavailable');
+        }
+        const originalCaps = record.strokeCaps || { start: true, end: true };
+        componentPlans.push({
+          selected: projected.selected,
+          points: sliced.inside[0],
+          interval: projected.interval,
+          caps: {
+            start: projected.interval[0] <= 1e-7
+              ? originalCaps.start !== false
+              : false,
+            end: projected.interval[1] >= record.sourcePoints.length - 1 - 1e-7
+              ? originalCaps.end !== false
+              : false
+          },
+          renderGeometry: {
+            version: 1,
+            pathData: renderPathData,
+            fillRule: 'evenodd'
+          }
+        });
       }
       const totalPlannedPoints = componentPlans.reduce(
         (count, plan) => count + plan.points.length,

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -2541,12 +2541,926 @@ test('partial lasso stages the rendered perfect-freehand L-turn corner', async (
       repeatedRectangle[0],
       repeatedRectangle[2]
     ], 7935);
-    assertSelectionStability(harness, beforeRepeatedPartial);
+    assertSelectionStability(harness, beforeRepeatedPartial, { selection: false });
     assert.equal(
-      pendingLassoObjects(harness.canvas).length,
-      0,
-      'a wrapped source interval must cancel instead of staging ambiguous geometry'
+      pendingLassoObjects(harness.canvas).length > 0,
+      true,
+      'saved render geometry must remain partially selectable after hydration'
     );
+    const repeatedSelectedId =
+      harness.canvas.getActiveObjects()[0]?.__baeframeObjectId;
+    assert.ok(repeatedSelectedId);
+    harness.dragActiveSelectionBy(10, 0, 7936);
+    await Promise.resolve();
+
+    const repeatedlyMoved = harness.sceneStore.getActiveSceneSnapshot();
+    assert.deepEqual(repeatedlyMoved.selectedObjectIds, [repeatedSelectedId]);
+    assert.notDeepEqual(repeatedlyMoved.objects, beforeRepeatedPartial.objects);
+    assert.equal(
+      repeatedlyMoved.objects.every(record => record.renderGeometry?.version === 1),
+      true
+    );
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'real-fabric-session-reloaded',
+      actionId: 'undo-repeated-render-geometry-partial',
+      action: 'undo'
+    }).applied, true);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      beforeRepeatedPartial.objects
+    );
+  } finally {
+    await harness.destroy();
+  }
+});
+
+for (const selectionShape of ['rectangle', 'lasso']) {
+  test(`partial ${selectionShape} stages a sparse curved stroke when display smoothing splits its centerline coverage`, async () => {
+    const harness = createRealFabricHarness();
+    try {
+      harness.drawStroke([
+        { x: 20, y: 130 },
+        { x: 73.333, y: 69.378 },
+        { x: 126.667, y: 69.378 },
+        { x: 180, y: 130 }
+      ], selectionShape === 'rectangle' ? 79351 : 79361);
+      const before = harness.sceneStore.getActiveSceneSnapshot();
+      const sourceObject = harness.canvas.getObjects()[0];
+      harness.runtime.updateDrawingTool({
+        sessionId: 'real-fabric-session',
+        toolRevision: 1,
+        tool: 'select'
+      });
+      if (selectionShape === 'rectangle') selectPartialRectangle(harness.root);
+      else selectPartialLasso(harness.root);
+      const sourcePolygon = [
+        { x: 80, y: 60 },
+        { x: 120, y: 60 },
+        { x: 120, y: 140 },
+        { x: 80, y: 140 }
+      ];
+      const scenePolygon = sourcePolygonInRealFabricScene(
+        sourceObject,
+        selectionShape === 'rectangle'
+          ? [sourcePolygon[0], sourcePolygon[2]]
+          : [...sourcePolygon, sourcePolygon[0]]
+      );
+
+      harness.dragLasso(
+        scenePolygon,
+        selectionShape === 'rectangle' ? 79352 : 79362
+      );
+
+      assert.deepEqual(
+        harness.sceneStore.getActiveSceneSnapshot().objects,
+        before.objects,
+        'partial selection must remain non-destructive until move or delete'
+      );
+      assert.equal(
+        pendingLassoObjects(harness.canvas).length > 0,
+        true,
+        'the visibly enclosed curved fragment must be staged'
+      );
+      assert.ok(harness.canvas.getActiveObject(), 'the staged fragment must be movable');
+      const selectedId = harness.canvas.getActiveObjects()[0].__baeframeObjectId;
+
+      harness.dragActiveSelectionBy(
+        10,
+        0,
+        selectionShape === 'rectangle' ? 79353 : 79363
+      );
+      await Promise.resolve();
+
+      const moved = harness.sceneStore.getActiveSceneSnapshot();
+      assert.equal(moved.objects.length, 3);
+      assert.deepEqual(moved.objects.map(record => record.sourcePoints.length), [3, 3, 2]);
+      assert.deepEqual(moved.objects.map(record => record.strokeCaps), [
+        { start: true, end: false },
+        { start: false, end: false },
+        { start: false, end: true }
+      ]);
+      assert.equal(
+        moved.objects.every(record => record.renderGeometry?.version === 1),
+        true
+      );
+      assert.equal(
+        moved.objects.filter(record => record.id === selectedId).length,
+        1
+      );
+      assert.deepEqual(moved.selectedObjectIds, [selectedId]);
+      assert.equal(harness.runtime.applyDrawingAction({
+        sessionId: 'real-fabric-session',
+        actionId: `undo-sparse-curve-${selectionShape}`,
+        action: 'undo'
+      }).applied, true);
+      assert.deepEqual(
+        harness.sceneStore.getActiveSceneSnapshot().objects,
+        before.objects
+      );
+    } finally {
+      await harness.destroy();
+    }
+  });
+}
+
+for (const selectionShape of ['rectangle', 'lasso']) {
+  test(`partial ${selectionShape} ignores rounded near-duplicate cap edges on a thick curve`, async () => {
+    const harness = createRealFabricHarness();
+    try {
+      const sizeInput = findOne(
+        harness.root,
+        node => node.dataset?.fabricPilotSetting === 'size'
+      );
+      sizeInput.value = '12';
+      sizeInput.dispatchEvent(new harness.environment.window.Event('input'));
+      harness.drawStroke(Array.from({ length: 65 }, (_value, index) => {
+        const amount = index / 64;
+        return {
+          x: 20 + 160 * amount,
+          y: 130 - 70 * Math.sin(Math.PI * amount)
+        };
+      }), selectionShape === 'rectangle' ? 79371 : 79381);
+      const before = harness.sceneStore.getActiveSceneSnapshot();
+      const sourceObject = harness.canvas.getObjects()[0];
+      harness.runtime.updateDrawingTool({
+        sessionId: 'real-fabric-session',
+        toolRevision: 1,
+        tool: 'select'
+      });
+      if (selectionShape === 'rectangle') selectPartialRectangle(harness.root);
+      else selectPartialLasso(harness.root);
+      const sourcePolygon = [
+        { x: 80, y: 40 },
+        { x: 120, y: 40 },
+        { x: 120, y: 140 },
+        { x: 80, y: 140 }
+      ];
+
+      harness.dragLasso(sourcePolygonInRealFabricScene(
+        sourceObject,
+        selectionShape === 'rectangle'
+          ? [sourcePolygon[0], sourcePolygon[2]]
+          : [...sourcePolygon, sourcePolygon[0]]
+      ), selectionShape === 'rectangle' ? 79372 : 79382);
+
+      assert.deepEqual(
+        harness.sceneStore.getActiveSceneSnapshot().objects,
+        before.objects
+      );
+      assert.equal(
+        pendingLassoObjects(harness.canvas).length > 0,
+        true,
+        'rounded cap noise must not cancel an otherwise valid partial selection'
+      );
+      assert.ok(harness.canvas.getActiveObject());
+    } finally {
+      await harness.destroy();
+    }
+  });
+}
+
+for (const selectionShape of ['rectangle', 'lasso']) {
+  test(`partial ${selectionShape} detaches a source segment when the selection only covers part of the stroke thickness`, async () => {
+    const harness = createRealFabricHarness();
+    try {
+      const sizeInput = findOne(
+        harness.root,
+        node => node.dataset?.fabricPilotSetting === 'size'
+      );
+      sizeInput.value = '12';
+      sizeInput.dispatchEvent(new harness.environment.window.Event('input'));
+      harness.drawStroke(Array.from({ length: 65 }, (_value, index) => {
+        const amount = index / 64;
+        return {
+          x: 20 + 160 * amount,
+          y: 130 - 70 * Math.sin(Math.PI * amount)
+        };
+      }), selectionShape === 'rectangle' ? 79385 : 79388);
+      const before = harness.sceneStore.getActiveSceneSnapshot();
+      const sourceObject = harness.canvas.getObjects()[0];
+      harness.runtime.updateDrawingTool({
+        sessionId: 'real-fabric-session',
+        toolRevision: 1,
+        tool: 'select'
+      });
+      if (selectionShape === 'rectangle') selectPartialRectangle(harness.root);
+      else selectPartialLasso(harness.root);
+      const sourcePolygon = [
+        { x: 80, y: 60 },
+        { x: 120, y: 60 },
+        { x: 120, y: 140 },
+        { x: 80, y: 140 }
+      ];
+
+      harness.dragLasso(sourcePolygonInRealFabricScene(
+        sourceObject,
+        selectionShape === 'rectangle'
+          ? [sourcePolygon[0], sourcePolygon[2]]
+          : [...sourcePolygon, sourcePolygon[0]]
+      ), selectionShape === 'rectangle' ? 79386 : 79389);
+
+      assert.deepEqual(
+        harness.sceneStore.getActiveSceneSnapshot().objects,
+        before.objects,
+        'partial selection must remain non-destructive until move or delete'
+      );
+      assert.equal(
+        pendingLassoObjects(harness.canvas).length > 0,
+        true,
+        'a visible partial-thickness cut must stage a movable stroke segment'
+      );
+      assert.ok(harness.canvas.getActiveObject());
+      const activeFragment = harness.canvas.getActiveObjects()[0];
+      const selectedId = activeFragment.__baeframeObjectId;
+      const selectedFill = flattenFabricPath(activeFragment.path, {
+        budget: createGeometryBudget(250_000),
+        tolerance: 0.25,
+        fillRule: activeFragment.fillRule
+      });
+      assert.equal(selectedFill.reason, null);
+      assert.ok(
+        selectedFill.geometry.bounds.top >= 60 - 1e-7,
+        'free selection must not pull the unselected upper half of the stroke outside the rectangle'
+      );
+
+      harness.dragActiveSelectionBy(
+        0,
+        40,
+        selectionShape === 'rectangle' ? 79387 : 79390
+      );
+      await Promise.resolve();
+
+      const moved = harness.sceneStore.getActiveSceneSnapshot();
+      assert.equal(moved.objects.length, 2);
+      assert.deepEqual(moved.selectedObjectIds, [selectedId]);
+      assert.equal(
+        moved.objects.filter(record => record.id === selectedId).length,
+        1
+      );
+      assert.equal(
+        moved.objects.every(record => record.renderGeometry?.version === 1),
+        true
+      );
+      harness.canvas.renderAll();
+      const movedRaster = harness.canvas.toCanvasElement().getContext('2d');
+      assert.ok(
+        movedRaster.getImageData(100, 57, 1, 1).data[3] > 128,
+        'the unselected upper half of the stroke must stay at the original position'
+      );
+      assert.ok(
+        movedRaster.getImageData(100, 63, 1, 1).data[3] < 128,
+        'the selected lower half of the stroke must leave its original position'
+      );
+      assert.ok(
+        movedRaster.getImageData(100, 103, 1, 1).data[3] > 128,
+        'only the clipped lower half of the stroke must move'
+      );
+      assert.equal(harness.runtime.applyDrawingAction({
+        sessionId: 'real-fabric-session',
+        actionId: `undo-partial-thickness-${selectionShape}`,
+        action: 'undo'
+      }).applied, true);
+      assert.deepEqual(
+        harness.sceneStore.getActiveSceneSnapshot().objects,
+        before.objects
+      );
+    } finally {
+      await harness.destroy();
+    }
+  });
+}
+
+for (const selectionShape of ['rectangle', 'lasso']) {
+  test(`partial ${selectionShape} detaches a middle band without duplicating same-owner source lineage`, async () => {
+    const harness = createRealFabricHarness();
+    try {
+      const sizeInput = findOne(
+        harness.root,
+        node => node.dataset?.fabricPilotSetting === 'size'
+      );
+      sizeInput.value = '20';
+      sizeInput.dispatchEvent(new harness.environment.window.Event('input'));
+      harness.drawStroke([
+        { x: 20, y: 100 },
+        { x: 180, y: 100 }
+      ], selectionShape === 'rectangle' ? 793101 : 793111);
+      const before = harness.sceneStore.getActiveSceneSnapshot();
+      const sourceObject = harness.canvas.getObjects()[0];
+      harness.runtime.updateDrawingTool({
+        sessionId: 'real-fabric-session',
+        toolRevision: 1,
+        tool: 'select'
+      });
+      if (selectionShape === 'rectangle') selectPartialRectangle(harness.root);
+      else selectPartialLasso(harness.root);
+      const sourcePolygon = [
+        { x: 0, y: 96 },
+        { x: 200, y: 96 },
+        { x: 200, y: 104 },
+        { x: 0, y: 104 }
+      ];
+
+      harness.dragLasso(sourcePolygonInRealFabricScene(
+        sourceObject,
+        selectionShape === 'rectangle'
+          ? [sourcePolygon[0], sourcePolygon[2]]
+          : [...sourcePolygon, sourcePolygon[0]]
+      ), selectionShape === 'rectangle' ? 793102 : 793112);
+
+      assert.deepEqual(
+        harness.sceneStore.getActiveSceneSnapshot().objects,
+        before.objects,
+        'partial selection must remain non-destructive until move or delete'
+      );
+      assert.equal(
+        pendingLassoObjects(harness.canvas).length > 0,
+        true,
+        'a visible middle band must stage even when the remaining fill has two contours'
+      );
+      const selectedId =
+        harness.canvas.getActiveObjects()[0]?.__baeframeObjectId;
+      assert.ok(selectedId);
+      harness.dragActiveSelectionBy(
+        0,
+        30,
+        selectionShape === 'rectangle' ? 793103 : 793113
+      );
+      await Promise.resolve();
+
+      const moved = harness.sceneStore.getActiveSceneSnapshot();
+      assert.equal(
+        moved.objects.length,
+        2,
+        'same-owner upper and lower contours must share one source-lineage record'
+      );
+      assert.deepEqual(moved.selectedObjectIds, [selectedId]);
+      assert.equal(
+        moved.objects.every(record => record.renderGeometry?.version === 1),
+        true
+      );
+      harness.canvas.renderAll();
+      const raster = harness.canvas.toCanvasElement().getContext('2d');
+      assert.ok(
+        raster.getImageData(100, 92, 1, 1).data[3] > 128,
+        'the upper remaining contour must stay in place'
+      );
+      assert.ok(
+        raster.getImageData(100, 100, 1, 1).data[3] < 128,
+        'the selected center band must leave its original position'
+      );
+      assert.ok(
+        raster.getImageData(100, 130, 1, 1).data[3] > 128,
+        'the selected center band must appear at its moved position'
+      );
+      assert.equal(harness.runtime.applyDrawingAction({
+        sessionId: 'real-fabric-session',
+        actionId: `undo-middle-band-${selectionShape}`,
+        action: 'undo'
+      }).applied, true);
+      assert.deepEqual(
+        harness.sceneStore.getActiveSceneSnapshot().objects,
+        before.objects
+      );
+    } finally {
+      await harness.destroy();
+    }
+  });
+}
+
+for (const selectionShape of ['rectangle', 'lasso']) {
+  test(`partial ${selectionShape} stages an asymmetric monotone curve with multiple wrapped fill components`, async () => {
+    const harness = createRealFabricHarness();
+    try {
+      const sizeInput = findOne(
+        harness.root,
+        node => node.dataset?.fabricPilotSetting === 'size'
+      );
+      sizeInput.value = '8';
+      sizeInput.dispatchEvent(new harness.environment.window.Event('input'));
+      harness.drawStroke(Array.from({ length: 65 }, (_value, index) => {
+        const amount = index / 64;
+        return {
+          x: 20 + 160 * amount,
+          y: 130 -
+            51 * Math.sin(Math.PI * amount) +
+            2.3199785947799683 * Math.sin(2 * Math.PI * amount)
+        };
+      }), selectionShape === 'rectangle' ? 79391 : 79392);
+      const before = harness.sceneStore.getActiveSceneSnapshot();
+      const sourceObject = harness.canvas.getObjects()[0];
+      harness.canvas.renderAll();
+      assert.ok(
+        harness.canvas.toCanvasElement().getContext('2d')
+          .getImageData(100, 81, 1, 1).data[3] > 128,
+        'the selection rectangle must visibly intersect the asymmetric curve'
+      );
+      harness.runtime.updateDrawingTool({
+        sessionId: 'real-fabric-session',
+        toolRevision: 1,
+        tool: 'select'
+      });
+      if (selectionShape === 'rectangle') selectPartialRectangle(harness.root);
+      else selectPartialLasso(harness.root);
+      const sourcePolygon = [
+        { x: 75, y: 79 },
+        { x: 125, y: 79 },
+        { x: 125, y: 146 },
+        { x: 75, y: 146 }
+      ];
+
+      harness.dragLasso(sourcePolygonInRealFabricScene(
+        sourceObject,
+        selectionShape === 'rectangle'
+          ? [sourcePolygon[0], sourcePolygon[2]]
+          : [...sourcePolygon, sourcePolygon[0]]
+      ), selectionShape === 'rectangle' ? 79393 : 79394);
+
+      assert.deepEqual(
+        harness.sceneStore.getActiveSceneSnapshot().objects,
+        before.objects,
+        'partial selection must remain non-destructive until move or delete'
+      );
+      assert.equal(
+        pendingLassoObjects(harness.canvas).length > 0,
+        true,
+        'multiple wrapped fill components from a normal curve must not cancel selection'
+      );
+      const selectedId =
+        harness.canvas.getActiveObjects()[0]?.__baeframeObjectId;
+      assert.ok(selectedId);
+      harness.dragActiveSelectionBy(
+        10,
+        0,
+        selectionShape === 'rectangle' ? 79395 : 79396
+      );
+      await Promise.resolve();
+
+      const moved = harness.sceneStore.getActiveSceneSnapshot();
+      assert.deepEqual(moved.selectedObjectIds, [selectedId]);
+      assert.notDeepEqual(moved.objects, before.objects);
+      assert.equal(harness.runtime.applyDrawingAction({
+        sessionId: 'real-fabric-session',
+        actionId: `undo-asymmetric-curve-${selectionShape}`,
+        action: 'undo'
+      }).applied, true);
+      assert.deepEqual(
+        harness.sceneStore.getActiveSceneSnapshot().objects,
+        before.objects
+      );
+    } finally {
+      await harness.destroy();
+    }
+  });
+}
+
+test('partial rectangle retains a visible fill backed by a sub-unit centerline interval', async () => {
+  const harness = createRealFabricHarness();
+  try {
+    const size = 6.5396276894025505;
+    const firstWave = 71.45745788235217;
+    const secondWave = -7.8048635348677635;
+    const thirdWave = 3.9719747230410576;
+    const sizeInput = findOne(
+      harness.root,
+      node => node.dataset?.fabricPilotSetting === 'size'
+    );
+    sizeInput.value = String(size);
+    sizeInput.dispatchEvent(new harness.environment.window.Event('input'));
+    harness.drawStroke(Array.from({ length: 65 }, (_value, index) => {
+      const amount = index / 64;
+      return {
+        x: 20 + 160 * amount,
+        y: 135 -
+          firstWave * Math.sin(Math.PI * amount) +
+          secondWave * Math.sin(2 * Math.PI * amount) +
+          thirdWave * Math.sin(3 * Math.PI * amount)
+      };
+    }), 793121);
+    const before = harness.sceneStore.getActiveSceneSnapshot();
+    const sourceObject = harness.canvas.getObjects()[0];
+    const top = 135 -
+      firstWave -
+      thirdWave -
+      0.14276446368545292 * size;
+    const sourceRectangle = [
+      { x: 55.04499645344913, y: top },
+      { x: 121.33158065285534, y: 178 }
+    ];
+    const sceneRectangle = sourcePolygonInRealFabricScene(
+      sourceObject,
+      sourceRectangle
+    );
+    harness.canvas.renderAll();
+    const raster = harness.canvas.toCanvasElement().getContext('2d');
+    const left = Math.floor(Math.min(sceneRectangle[0].x, sceneRectangle[1].x));
+    const upper = Math.floor(Math.min(sceneRectangle[0].y, sceneRectangle[1].y));
+    const width = Math.max(
+      1,
+      Math.ceil(Math.abs(sceneRectangle[1].x - sceneRectangle[0].x))
+    );
+    const height = Math.max(
+      1,
+      Math.ceil(Math.abs(sceneRectangle[1].y - sceneRectangle[0].y))
+    );
+    const pixels = raster.getImageData(left, upper, width, height).data;
+    let visiblePixels = 0;
+    for (let index = 3; index < pixels.length; index += 4) {
+      if (pixels[index] > 128) visiblePixels += 1;
+    }
+    assert.ok(
+      visiblePixels > 0,
+      'the selected rectangle must contain visible fill before staging'
+    );
+    enableRealFabricPartialRectangle(harness);
+
+    harness.dragLasso(sceneRectangle, 793122);
+
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      before.objects
+    );
+    assert.equal(
+      pendingLassoObjects(harness.canvas).length > 0,
+      true,
+      'a visible clipped component must not disappear because its centerline interval is shorter than one source unit'
+    );
+    const selectedId =
+      harness.canvas.getActiveObjects()[0]?.__baeframeObjectId;
+    assert.ok(selectedId);
+    harness.dragActiveSelectionBy(10, 0, 793123);
+    await Promise.resolve();
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().selectedObjectIds,
+      [selectedId]
+    );
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'real-fabric-session',
+      actionId: 'undo-sub-unit-centerline-fragment',
+      action: 'undo'
+    }).applied, true);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      before.objects
+    );
+  } finally {
+    await harness.destroy();
+  }
+});
+
+test('a partial-thickness curve survives hydration and remains free-selectable', async () => {
+  const harness = createRealFabricHarness();
+  try {
+    const sizeInput = findOne(
+      harness.root,
+      node => node.dataset?.fabricPilotSetting === 'size'
+    );
+    sizeInput.value = '12';
+    sizeInput.dispatchEvent(new harness.environment.window.Event('input'));
+    harness.drawStroke(Array.from({ length: 65 }, (_value, index) => {
+      const amount = index / 64;
+      return {
+        x: 20 + 160 * amount,
+        y: 130 - 70 * Math.sin(Math.PI * amount)
+      };
+    }), 79393);
+    const sourceObject = harness.canvas.getObjects()[0];
+    enableRealFabricPartialRectangle(harness);
+    const sourceRectangle = [
+      { x: 80, y: 60 },
+      { x: 120, y: 140 }
+    ];
+    harness.dragLasso(
+      sourcePolygonInRealFabricScene(sourceObject, sourceRectangle),
+      79394
+    );
+    const selectedFragmentId =
+      harness.canvas.getActiveObjects()[0]?.__baeframeObjectId;
+    assert.ok(selectedFragmentId);
+    harness.dragActiveSelectionBy(0, 40, 79395);
+    await Promise.resolve();
+    const moved = harness.sceneStore.getActiveSceneSnapshot();
+    assert.equal(moved.objects.length, 2);
+
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 2,
+      enabled: false
+    }).accepted, true);
+    const persistedObjects = structuredClone(moved.objects);
+    for (const record of persistedObjects) {
+      const baseTime = record.sourcePoints[0].time;
+      for (const point of record.sourcePoints) point.time -= baseTime;
+    }
+    const hydration = harness.runtime.hydrateDrawingVideo(makePersistenceHydration({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      persistenceSessionId: 'partial-thickness-persistence',
+      stableVideoIdentity: 'real-fabric-video',
+      fps: 24,
+      totalFrames: 200,
+      keyframes: [{
+        id: 'partial-thickness-frame',
+        frame: 0,
+        sourceWidth: 200,
+        sourceHeight: 200,
+        mutationSequence: moved.mutationCount,
+        objects: persistedObjects
+      }]
+    }));
+    assert.equal(hydration.accepted, true, JSON.stringify(hydration));
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 3,
+      enabled: true,
+      session: {
+        sessionId: 'partial-thickness-reloaded',
+        stableVideoIdentity: 'real-fabric-video',
+        targetFrame: 0,
+        sourceWidth: 200,
+        sourceHeight: 200,
+        canvasRect: { left: 0, top: 0, width: 200, height: 200 },
+        viewportTransform: { scale: 1, panX: 0, panY: 0 },
+        tool: 'select'
+      }
+    }).accepted, true);
+
+    const beforeRepeatedPartial = captureSelectionStability(harness);
+    const remainingObject = harness.canvas.getObjects().find(
+      object => object.__baeframeObjectId !== selectedFragmentId
+    );
+    assert.ok(remainingObject);
+    selectPartialLasso(harness.root);
+    harness.dragLasso(sourcePolygonInRealFabricScene(remainingObject, [
+      { x: 90, y: 52 },
+      { x: 110, y: 52 },
+      { x: 110, y: 59 },
+      { x: 90, y: 59 },
+      { x: 90, y: 52 }
+    ]), 79396);
+
+    assertSelectionStability(harness, beforeRepeatedPartial, { selection: false });
+    assert.equal(
+      pendingLassoObjects(harness.canvas).length > 0,
+      true,
+      'the persisted remaining fill must stage another exact free selection'
+    );
+    const repeatedSelectedId =
+      harness.canvas.getActiveObjects()[0]?.__baeframeObjectId;
+    assert.ok(repeatedSelectedId);
+    harness.dragActiveSelectionBy(10, 0, 79397);
+    await Promise.resolve();
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().selectedObjectIds,
+      [repeatedSelectedId]
+    );
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'partial-thickness-reloaded',
+      actionId: 'undo-reloaded-partial-thickness',
+      action: 'undo'
+    }).applied, true);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      beforeRepeatedPartial.objects
+    );
+  } finally {
+    await harness.destroy();
+  }
+});
+
+test('persisted clipped fill reselects when hidden source lineage leaves an endpoint projection gap', async () => {
+  const harness = createRealFabricHarness();
+  try {
+    const sizeInput = findOne(
+      harness.root,
+      node => node.dataset?.fabricPilotSetting === 'size'
+    );
+    sizeInput.value = '12';
+    sizeInput.dispatchEvent(new harness.environment.window.Event('input'));
+    harness.drawStroke(Array.from({ length: 65 }, (_value, index) => {
+      const amount = index / 64;
+      return {
+        x: 20 + 160 * amount,
+        y: 135 -
+          35 * Math.sin(Math.PI * amount) +
+          6 * Math.sin(2 * Math.PI * amount) -
+          4 * Math.sin(3 * Math.PI * amount)
+      };
+    }), 793131);
+    const sourceObject = harness.canvas.getObjects()[0];
+    harness.runtime.updateDrawingTool({
+      sessionId: 'real-fabric-session',
+      toolRevision: 1,
+      tool: 'select'
+    });
+    selectPartialLasso(harness.root);
+    harness.dragLasso(sourcePolygonInRealFabricScene(sourceObject, [
+      { x: 70, y: 104 },
+      { x: 130, y: 104 },
+      { x: 130, y: 175 },
+      { x: 70, y: 175 },
+      { x: 70, y: 104 }
+    ]), 793132);
+    assert.equal(pendingLassoObjects(harness.canvas).length > 0, true);
+    harness.dragActiveSelectionBy(8, 6, 793133);
+    await Promise.resolve();
+    const moved = harness.sceneStore.getActiveSceneSnapshot();
+    assert.ok(moved.objects.length >= 2);
+
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 2,
+      enabled: false
+    }).accepted, true);
+    const persistedObjects = structuredClone(moved.objects);
+    for (const record of persistedObjects) {
+      const baseTime = record.sourcePoints[0].time;
+      for (const point of record.sourcePoints) point.time -= baseTime;
+    }
+    const hydration = harness.runtime.hydrateDrawingVideo(makePersistenceHydration({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      persistenceSessionId: 'hidden-source-gap-persistence',
+      stableVideoIdentity: 'real-fabric-video',
+      fps: 24,
+      totalFrames: 200,
+      keyframes: [{
+        id: 'hidden-source-gap-frame',
+        frame: 0,
+        sourceWidth: 200,
+        sourceHeight: 200,
+        mutationSequence: moved.mutationCount,
+        objects: persistedObjects
+      }]
+    }));
+    assert.equal(hydration.accepted, true, JSON.stringify(hydration));
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 3,
+      enabled: true,
+      session: {
+        sessionId: 'hidden-source-gap-reloaded',
+        stableVideoIdentity: 'real-fabric-video',
+        targetFrame: 0,
+        sourceWidth: 200,
+        sourceHeight: 200,
+        canvasRect: { left: 0, top: 0, width: 200, height: 200 },
+        viewportTransform: { scale: 1, panX: 0, panY: 0 },
+        tool: 'select'
+      }
+    }).accepted, true);
+
+    const beforeRepeatedPartial = captureSelectionStability(harness);
+    const leftRemainingObject = harness.canvas.getObjects().find(object => {
+      const record = persistedObjects.find(
+        candidate => candidate.id === object.__baeframeObjectId
+      );
+      return record &&
+        Math.max(...record.sourcePoints.map(point => point.x)) < 80;
+    });
+    assert.ok(leftRemainingObject);
+    const leftRemainingId = leftRemainingObject.__baeframeObjectId;
+    const leftRemainingRecord = persistedObjects.find(
+      record => record.id === leftRemainingId
+    );
+    assert.ok(leftRemainingRecord);
+    const unrelatedIds = new Set(
+      persistedObjects
+        .filter(record => record.id !== leftRemainingId)
+        .map(record => record.id)
+    );
+    const hiddenTail = leftRemainingRecord.sourcePoints.at(-1);
+    selectPartialRectangle(harness.root);
+    harness.dragLasso(sourcePolygonInRealFabricScene(leftRemainingObject, [
+      { x: 34, y: 119.50919297821657 },
+      { x: 56, y: 175 }
+    ]), 793134);
+
+    assertSelectionStability(harness, beforeRepeatedPartial, { selection: false });
+    assert.equal(
+      pendingLassoObjects(harness.canvas).length > 0,
+      true,
+      'hidden source lineage outside the exact fill must not cancel a visible re-selection'
+    );
+    const selectedId =
+      harness.canvas.getActiveObjects()[0]?.__baeframeObjectId;
+    assert.ok(selectedId);
+    harness.dragActiveSelectionBy(10, 0, 793135);
+    await Promise.resolve();
+    const repeatedlyMoved = harness.sceneStore.getActiveSceneSnapshot();
+    assert.deepEqual(
+      repeatedlyMoved.selectedObjectIds,
+      [selectedId]
+    );
+    const descendants = repeatedlyMoved.objects.filter(
+      record => !unrelatedIds.has(record.id)
+    );
+    assert.ok(descendants.length >= 2);
+    assert.equal(
+      descendants.some(record => record.sourcePoints.some(point => (
+        Object.is(point.x, hiddenTail.x) &&
+        Object.is(point.y, hiddenTail.y) &&
+        Object.is(point.pressure, hiddenTail.pressure) &&
+        Object.is(point.time, hiddenTail.time)
+      ))),
+      true,
+      'the hidden trailing source sample must remain assigned to a descendant fragment'
+    );
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'hidden-source-gap-reloaded',
+      actionId: 'undo-hidden-source-gap-reselection',
+      action: 'undo'
+    }).applied, true);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      beforeRepeatedPartial.objects
+    );
+  } finally {
+    await harness.destroy();
+  }
+});
+
+test('partial selection rejects interval bridging that would leave an unassigned source gap', async () => {
+  const harness = createRealFabricHarness({
+    sourceWidth: 300,
+    sourceHeight: 100
+  });
+  try {
+    const samples = [
+      [34.175258475588635, 16.07026282697916],
+      [63.333810351323336, 38.35076402872801],
+      [77.75514748529531, 21.05356089770794],
+      [92.70632768748328, 42.26234890520573],
+      [115.43870833818801, 72.03615244477987],
+      [126.44562942674384, 35.961361117661],
+      [139.83677482814528, 5],
+      [165.43701516231522, 32.02058732509613],
+      [177.31287249480374, 47.4703786149621],
+      [201.91668561426923, 64.86038696020842],
+      [207.70615716115572, 28.150884732604027],
+      [217.29679298354313, 16.931552663445473],
+      [222.3508622602094, 5],
+      [236.47547665750608, 5],
+      [262.4332705757115, 5]
+    ].map(([x, y], index) => ({
+      x,
+      y,
+      pressure: 0.5,
+      pointerType: 'mouse',
+      time: index
+    }));
+    const canonical = createStrokePathData(samples, {
+      size: 2.130254316376522,
+      last: true,
+      alreadyNormalizedPressure: true,
+      start: { cap: true },
+      end: { cap: true }
+    });
+    harness.drawStroke([{ x: 20, y: 20 }, { x: 40, y: 20 }], 79391);
+    const placeholder = harness.sceneStore.getActiveSceneSnapshot().objects[0];
+    const fixture = {
+      ...placeholder,
+      pathData: canonical.pathData,
+      sourcePoints: canonical.sourcePoints,
+      style: {
+        ...placeholder.style,
+        size: 2.130254316376522
+      },
+      strokeCaps: { start: true, end: true }
+    };
+    assert.equal(harness.sceneStore.replaceObjects({
+      replacements: [{
+        removeId: placeholder.id,
+        addObjects: [fixture]
+      }],
+      selectedObjectIds: [],
+      kind: 'split-stroke'
+    }).applied, true);
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'real-fabric-session',
+      actionId: 'source-gap-fixture-undo',
+      action: 'undo'
+    }).applied, true);
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'real-fabric-session',
+      actionId: 'source-gap-fixture-redo',
+      action: 'redo'
+    }).applied, true);
+    const before = captureSelectionStability(harness);
+    const sourceObject = harness.canvas.getObjects()[0];
+    enableRealFabricPartialRectangle(harness);
+    const sceneRectangle = sourcePolygonInRealFabricScene(sourceObject, [
+      { x: 117.8189293295145, y: 26.31418011151254 },
+      { x: 167.95883158920333, y: 56.471165088005364 }
+    ]);
+
+    harness.dragLasso(sceneRectangle, 79392);
+
+    assertSelectionStability(harness, before);
+    assert.equal(pendingLassoObjects(harness.canvas).length, 0);
   } finally {
     await harness.destroy();
   }
@@ -9186,6 +10100,41 @@ test('actual fill clipping reconstructs simple intersection and disjoint differe
   assert.equal(remaining.components.every(component => component.contours.length === 1), true);
 });
 
+test('flattened fill clipping removes sub-tolerance closing seams without losing the contour', () => {
+  const budget = createGeometryBudget(250_000);
+  const flattened = flattenFabricPath([
+    ['M', 0, 0],
+    ['L', 10, 0],
+    ['L', 10, 10],
+    ['L', 0, 10],
+    ['L', 0.001, 0.001],
+    ['Z']
+  ], {
+    budget,
+    tolerance: 0.25,
+    fillRule: 'nonzero'
+  });
+  assert.equal(flattened.reason, null);
+  assert.equal(flattened.geometry.contours[0].length, 4);
+  const fill = createPathFillQuery(flattened.geometry, budget);
+  const selection = createPolygonEdgeIndex([
+    { x: 4, y: -1 },
+    { x: 6, y: -1 },
+    { x: 6, y: 11 },
+    { x: 4, y: 11 }
+  ], { budget });
+
+  assert.deepEqual(pathFillOverlapsPolygon(fill, selection, budget), {
+    hit: true,
+    limitExceeded: false
+  });
+  const pair = clipSimplePathFillPair(fill, selection, { budget });
+  assert.equal(pair.difference.reason, null);
+  assert.equal(pair.difference.components.length, 2);
+  assert.equal(pair.intersection.reason, null);
+  assert.equal(pair.intersection.components.length, 1);
+});
+
 test('thin actual fill boundaries stay selectable and remain clip-safe after repeated selection', () => {
   const contourCommands = contours => contours.flatMap(contour => [
     ['M', contour[0].x, contour[0].y],
@@ -9979,6 +10928,33 @@ test('source-position interval splitting keeps duplicate source indexes and reje
   assert.equal(splitStrokePointsBySourceIntervals(points, [[Number.NaN, 1]], {
     budget: createGeometryBudget(1000)
   }).geometryUnavailable, true);
+});
+
+test('source-position interval splitting can retain sub-unit lineage for exact render geometry', () => {
+  const points = [
+    { x: 0, y: 0, pressure: 0.5, time: 0 },
+    { x: 10, y: 0, pressure: 0.5, time: 10 }
+  ];
+  assert.deepEqual(
+    splitStrokePointsBySourceIntervals(points, [[0.495, 0.505]], {
+      budget: createGeometryBudget(1000)
+    }).inside,
+    []
+  );
+
+  const retained = splitStrokePointsBySourceIntervals(
+    points,
+    [[0.495, 0.505]],
+    {
+      budget: createGeometryBudget(1000),
+      retainSubunitRuns: true
+    }
+  );
+
+  assert.equal(retained.inside.length, 1);
+  assert.equal(retained.inside[0].length, 2);
+  assert.equal(retained.inside[0][0].x, 4.95);
+  assert.equal(retained.inside[0].at(-1).x, 5.05);
 });
 
 test('round cap hit testing uses the actual trailing pressure sample', () => {

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -244,12 +244,12 @@ test('release build scripts pin stable while trial build scripts pin trial regar
   assert.match(packageJson.scripts['test:mpv'], /runtime-profile\.test\.js/);
 });
 
-test('stable engine promotion uses the 2.0.0 beta release version consistently', () => {
+test('stable engine promotion uses the 2.0.1 beta release version consistently', () => {
   const rootDir = path.resolve(__dirname, '..', '..');
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.0.0-beta');
-  assert.equal(packageLock.version, '2.0.0-beta');
-  assert.equal(packageLock.packages[''].version, '2.0.0-beta');
+  assert.equal(packageJson.version, '2.0.1-beta');
+  assert.equal(packageLock.version, '2.0.1-beta');
+  assert.equal(packageLock.packages[''].version, '2.0.1-beta');
 });


### PR DESCRIPTION
## 📋 업데이트 요약

- ✂️ 사각형과 라쏘로 곡선의 일부를 선택했을 때 아무 반응 없이 취소되던 문제를 고쳤습니다.
- 🖌️ 굵은 획의 가장자리·가운데 띠·아주 짧은 조각도 눈에 보이는 모양 그대로 떼어 이동할 수 있습니다.
- 💾 잘라낸 획을 저장하고 앱을 다시 연 뒤에도 다시 부분 선택하고 이동할 수 있습니다.
- ↩️ 이동·삭제·실행 취소 과정에서 원본 획 일부가 사라지거나 불필요하게 겹쳐 저장되지 않도록 보강했습니다.
- 📦 수정 배포본을 구분할 수 있도록 버전을 `2.0.1-beta`로 올렸습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/mpv-fabric-overlay-runtime.js`
  - 실제로 렌더링된 채움의 교집합·차집합 component를 여러 source interval로 투영하고, raw interval이 정확한 경우와 source envelope 보정이 필요한 경우를 분리했습니다.
  - envelope 보정은 모든 component가 동일 centerline을 사용하고 시작점→끝점 chord 방향으로 엄격히 전진할 때만 허용합니다. U-turn, self-cross, 미할당 source gap은 계속 fail-closed 처리합니다.
  - 저장된 `renderGeometry`의 숨은 source lineage 때문에 생기는 leading/internal/trailing gap은 인접 envelope에 결정적으로 배분해 source domain을 빠짐없이 보존합니다.
  - 같은 선택 소유권과 겹치는 source interval을 가진 disjoint component를 하나의 multi-contour `renderGeometry` fragment로 묶어 sourcePoints 중복과 point-budget 초과를 막았습니다.
- `renderer/scripts/modules/drawing-v3/stroke-fill-geometry.js`
  - 곡선 cap에서 생기는 극미세한 중복 경계선을 tolerance 비율로 정규화해 정상 clip이 geometry 오류로 취소되지 않게 했습니다.
- `renderer/scripts/modules/drawing-v3/stroke-splitter.js`
  - authoritative `renderGeometry`를 만드는 경로에 한해 1 source-unit보다 짧은 보간 구간도 두 endpoint sample로 보존합니다. 기존 polygon split의 sub-pixel 폐기 기준은 유지합니다.
- `renderer/scripts/lib/mpv-fabric-overlay.iife.js`
  - 최신 runtime을 브라우저 실행 번들로 다시 생성했고, 절대 작업 경로가 섞이지 않도록 동일 입력에서 같은 해시가 나오는 것을 확인했습니다.
- `scripts/tests/mpv-fabric-overlay-runtime.test.js`
  - 비대칭 곡선, 굵은 획 가운데 띠, 부분 두께, sub-unit 조각, 저장·hydrate·재선택, 숨은 tail lineage, source-gap 차단 회귀를 실제 Fabric 경로로 추가했습니다.

## 🚧 개발 난항

- 기존 안전장치는 source interval이 하나가 아니면 지나치게 보수적으로 취소해, 정상적인 곡선도 `wrapped component` 수에 따라 선택 성공 여부가 달라졌습니다.
- 화면에 보이는 정확한 채움과 편집 계보인 centerline이 항상 같은 범위를 덮지 않아, 저장된 조각을 다시 자를 때만 나타나는 숨은 구간을 별도로 보존해야 했습니다.
- 굵은 획의 가운데만 선택하면 위·아래 잔여 윤곽이 같은 sourcePoints를 각각 복제해 point budget을 넘었습니다. 동일 소유권 component를 multi-contour 한 레코드로 합쳐 해결했습니다.
- 아주 짧지만 폭이 있어 눈에는 보이는 조각이 기존 1-unit 필터에 의해 버려졌습니다. 정확한 렌더 도형이 있는 경로에만 제한적으로 보존 예외를 두었습니다.
- 수정 과정에서 결정론적 곡선 fuzz와 독립 코드 리뷰를 반복해 정상 허용 범위를 넓히면서 U-turn/self-cross/source-gap 차단은 유지했습니다.

## ✅ 테스트 가이드

### 실사용자용

1. mpv로 영상을 열고 `B`로 드로잉 모드에 들어갑니다.
2. 획을 하나 이상 그린 뒤 `V`를 누르고 선택 대상을 `자유 선택`으로 바꿉니다.
3. 사각형과 라쏘를 각각 사용해 곡선의 일부, 굵은 획의 가운데, 획 끝의 작은 조각을 선택·이동합니다.
4. 다른 획을 다시 선택하고 이동한 뒤 Undo/Redo가 원본 모양을 정확히 복원하는지 확인합니다.
5. 리뷰 데이터를 저장하고 앱을 다시 연 뒤, 앞서 잘라낸 잔여 획을 다시 부분 선택·이동합니다.

### 개발자용

- `npm run test:fabric-drawing-pilot` — 323 passed
- `npm run test:fabric-drawing-persistence` — 138 passed
- `npm run test:mpv` — 232 passed
- `npm run test:drawing` — 286 passed
- `npm run lint` — 0 errors, 기존 warnings 59개
- 결정론적 x-monotone 곡선 Rectangle/Lasso — 160/160 stage 및 move commit
- 저장 → hydrate → 반대 선택 도구 재선택 → move → Undo — 8/8
- U-turn, self-cross, canonical/masked source-gap — 모두 fail-closed
- 번들 SHA-256 — `553D63D00C1936CBC3348703FF2AA895F75B2B50614F06FC774D9E6C99BB3081`, 연속 재생성 해시 동일
- 독립 최종 리뷰 — P1/P2 없음