### PR TITLE
[v2.0.1-beta] mpv 드로잉 부분 선택 및 키 전환 안정화

### DIFF
--- a/docs/superpowers/specs/2026-07-26-fabric-free-selection-presets-design.md
+++ b/docs/superpowers/specs/2026-07-26-fabric-free-selection-presets-design.md
@@ -108,10 +108,14 @@ gesture 전체 연산 budget으로 최악 입력을 제한한다. 한도를 넘�
 1. scene polygon을 획의 실제 표시 Path 좌표계로 역변환한다.
 2. `renderGeometry`가 있으면 이를, 없으면 canonical `pathData`를 실제 채움으로
    삼아 polygon과 교집합·차집합을 함께 계산한다.
-3. 선택/잔여 채움 component를 원본 centerline의 단조 source-position 구간에
-   투영한다. centerline은 데이터 계보를 찾는 데만 쓰며 hit/clip 판정의 근거로
-   쓰지 않는다.
-4. source-position 구간으로 원본 pressure/time chain을 보존한 fragment를 만든다.
+3. 선택/잔여 채움 component가 원본 centerline을 중복 없이 나눌 수 있으면
+   source-position 구간에 투영한다. 굵기 방향 절단, U-turn, self-cross처럼
+   centerline 복제가 필요한 경우에는 정확한 clipped fill을 compact outline
+   fragment로 전환한다. centerline은 가능한 경우의 계보 보존에만 쓰며 hit/clip
+   판정의 근거로 쓰지 않는다.
+4. 단순 분할은 원본 pressure/time chain을 보존한다. compact outline fragment는
+   저장 스키마 호환과 fallback을 위한 결정적 2-point support만 보존하고,
+   `renderGeometry`를 이후 표시·hit·재분할의 권위 데이터로 사용한다.
 5. 선택 시점에는 투명 fragment proxy만 준비한다.
 6. 실제 이동 또는 Delete에서만 `split-stroke` command 하나로 확정한다.
 
@@ -131,9 +135,10 @@ gesture 전체 연산 budget으로 최악 입력을 제한한다. 한도를 넘�
 - fragment 하나라도 만들 수 없거나 용량 제한을 넘으면 원본 장면을 유지한다.
 - geometry 연산 한도나 역행렬 검증을 통과하지 못하면 일부 선택 없이 원본 장면을
   유지한다.
-- 선택 결과의 실제 채움은 선택/잔여 fragment별 `renderGeometry`로 저장하되,
-  `sourcePoints`, pressure/time, canonical `pathData`, transform은 계속 편집·Undo의
-  기준 데이터로 유지한다.
+- 선택 결과의 실제 채움은 선택/잔여 fragment별 `renderGeometry`로 저장한다.
+  단순 길이 분할은 `sourcePoints`, pressure/time, canonical `pathData`를 유지하고,
+  중복 계보가 필요한 복잡한 분할은 compact outline으로 전환해 `sourcePoints`를
+  두 점으로 제한한다. transform과 원본 Undo archive는 어느 경로에서도 유지한다.
 - 저장 가능한 `renderGeometry`는 exact-key `{ version: 1, pathData, fillRule:
   'evenodd' }`이며 닫힌 `M/L/Z` contour, 문자열 길이, 좌표 범위를 모두 통과해야
   한다. 저장·hydrate·host 경계 중 하나라도 거부하면 문서 전체를 원자적으로
@@ -190,35 +195,41 @@ authoritative geometry만 화면에 실제로 그려지는 Path 채움으로 승
 
 ### 7.2 계보·저장·복구
 
-- 실제 채움이 hit와 clip의 기준이어도 `sourcePoints`, pressure/time, caps,
-  transform은 canonical 편집 계보로 남는다. 채움 component는 BVH로 가속한
-  centerline 투영을 통해 단조 source-position 구간과 연결한다.
+- 실제 채움이 hit와 clip의 기준이다. 채움 component가 원본 centerline을 중복 없이
+  나눌 수 있을 때만 `sourcePoints`, pressure/time, caps를 canonical 편집 계보로
+  유지한다. 이 경로는 BVH로 가속한 centerline 투영을 통해 단조 source-position
+  구간과 연결한다.
 - 선택 경계가 획 두께의 일부만 가를 때는 하나의 잔여 채움 component가 서로
   떨어진 여러 source-position 구간으로 투영될 수 있고, 정상적인 단조 곡선에서도
   이런 component가 둘 이상 생길 수 있다. raw 구간이 source domain을 정확히
   분할하면 그대로 사용한다. raw 구간에 중첩·내부 공백·여러 구간이 있어
   source envelope가 필요할 때는 모든 envelope의 합집합이 domain 전체를 덮고,
   모든 component가 같은 centerline을 사용하며, centerline이 시작점→끝점 chord
-  방향으로 엄격히 전진할 때만 masked 계보를 허용한다. 이 규칙은 최초 분리와
-  저장된 `renderGeometry` 재선택에 동일하게 적용한다. 실제 표시와 재선택
-  기준은 envelope가 아니라 교집합·차집합의 `renderGeometry`를 그대로 유지한다.
-- 저장된 `renderGeometry`는 이전 분리에서 화면에 없는 source 구간을 계보로
-  보존할 수 있다. 재선택 투영에서 이 숨은 구간이 leading, trailing, internal
-  gap으로 나타나면, 같은 단조 centerline 검증을 통과한 경우에만 인접 envelope
-  사이에 결정적으로 배분해 source domain을 빠짐없이 보존한다. 최초 canonical
-  획에서 발견된 실제 source gap은 이 보정을 사용하지 않고 계속 취소한다.
-- 같은 선택 소유권과 서로 겹치는 source envelope를 가진 disjoint component는
-  하나의 multi-contour `renderGeometry` fragment로 묶어 sourcePoints를 한 번만
-  보존한다. 굵은 획의 가운데 띠를 떼었을 때 위·아래 잔여 모양이 원본 계보를
-  각각 복제하여 point budget을 넘거나 저장 데이터가 불필요하게 늘지 않아야 한다.
+  방향으로 엄격히 전진할 때만 masked 계보를 허용한다. 이 검사는 최초 canonical
+  분리에만 적용한다. 실제 표시 기준은 envelope가 아니라 교집합·차집합의
+  `renderGeometry`다.
+- 저장된 `renderGeometry`는 이미 outline fragment이므로 재선택 때 centerline
+  envelope를 다시 복원하거나 숨은 구간을 이웃 조각에 배분하지 않는다. 현재의
+  exact clipped fill을 다시 둘로 자르고 양쪽을 compact outline으로 저장한다.
+  이 규칙으로 leading, trailing, internal gap이 다음 세대에 재편입되지 않는다.
+  최초 canonical 획에서 발견된 실제 source gap은 계속 취소한다.
+- 같은 선택 소유권을 가진 disjoint component는 하나의 multi-contour
+  `renderGeometry` fragment로 묶는다. 굵은 획의 가운데 띠를 떼었을 때 위·아래
+  잔여 모양이 원본 계보를 각각 복제하지 않고 하나의 compact outline과 두 개의
+  support point만 저장해야 한다.
 - 정확한 clipped fill이 보이는 경우에는 source index 길이가 1보다 짧아도
   보간한 양 끝 source sample을 보존한다. 기존 centerline/polygon 기반 split의
   sub-pixel 폐기 기준은 유지하고, authoritative `renderGeometry` fragment를
   만드는 경로에서만 이 예외를 사용한다.
-- envelope 계보와 반대편 fragment의 source 구간은 일부 겹칠 수 있지만 표시
-  채움은 겹치지 않는다. U-turn처럼 chord 방향 진행이 멈추거나 되돌아가는 획,
-  self-cross처럼 여러 분기가 선택되는 획, raw source domain에 공백이 생기는
-  투영은 기존처럼 전체 gesture를 원자적으로 취소한다.
+- envelope 계보가 원본보다 의미 있게 커지거나 선택/잔여 fragment가 원본
+  centerline을 대량으로 공유해야 하면 canonical 분할을 사용하지 않는다. U-turn,
+  self-cross, 굵기 방향 절단은 선택/잔여 component를 각각 하나의 multi-contour
+  compact outline fragment로 묶고, 각 fragment의 `sourcePoints`는 결정적 두 점으로
+  제한한다. 이미 `renderGeometry`가 있는 fragment를 다시 자를 때도 항상 이 경로를
+  사용하므로 반복 선택이 이전 계보를 다시 복제하지 않는다.
+- canonical raw source domain에 실제 공백이 생기고 exact clipped fill도 만들 수
+  없는 경우, geometry operation budget이나 fragment/문자열 한도를 넘는 경우에는
+  전체 gesture를 원자적으로 취소한다.
 - 잘라낸 표시 모양은 version 1 `renderGeometry`로 이동·Delete·Undo/Redo와
   리뷰 데이터 저장/복원을 왕복한다. 이후 재선택도 저장된 채움을 다시
   authoritative geometry로 사용한다.
@@ -243,7 +254,9 @@ cache hit도 cold build의 logical cost를 동일하게 차감한다.
 추가 회귀 검증은 두께 일부만 걸친 곡선 획을 사각형과 라쏘로 각각 선택해,
 선택 경계 밖 픽셀은 제자리에 남고 안쪽 픽셀만 이동하는지 확인한다. 이동 결과를
 저장·hydrate한 뒤 남은 `renderGeometry`를 다시 부분 선택해 이동·Undo할 수 있어야
-한다. U-turn, self-cross, source-gap fixture는 계속 원자적으로 취소되어야 한다.
+한다. U-turn과 self-cross는 compact outline으로 성공해야 하며, 반복 분할 뒤 모든
+outline fragment의 `sourcePoints`는 두 점을 유지해야 한다. 실제 source-gap,
+geometry/budget 실패 fixture는 계속 원자적으로 취소되어야 한다.
 
 이 표와 L-turn 실제 픽셀 hit/miss, 저장 후 재선택, thin/tangent/kissing/hole
 fixture가 모두 통과해야 Task 8을 완료한 것으로 본다.

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -367,6 +367,7 @@ const OVERLAY_HTML = String.raw`
       min-height: 40px;
       line-height: 40px;
       padding: 0 12px;
+      box-sizing: border-box;
       border-radius: 8px;
       background: rgba(0, 0, 0, 0.28);
       color: var(--text-tertiary);
@@ -376,7 +377,7 @@ const OVERLAY_HTML = String.raw`
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    @media (max-width: 640px) {
+    @media (max-width: 800px) {
       .mpv-fabric-pilot-toolbar {
         --fabric-toolbar-gap: 4px;
         padding: 4px;
@@ -385,7 +386,25 @@ const OVERLAY_HTML = String.raw`
       .mpv-fabric-pilot-toolbar button {
         padding-inline: 8px;
       }
-      .mpv-fabric-pilot-toolbar [data-fabric-pilot-output="summary"] {
+      .mpv-fabric-pilot-toolbar [data-fabric-pilot-group="selection-controls"] {
+        gap: 4px !important;
+        padding: 0 !important;
+        background: transparent !important;
+      }
+      .mpv-fabric-pilot-toolbar [data-fabric-pilot-group="selection-target"] {
+        gap: 2px !important;
+        padding-right: 4px !important;
+      }
+      .mpv-fabric-pilot-toolbar [data-fabric-pilot-group="selection-shape"] {
+        gap: 2px !important;
+      }
+      .mpv-fabric-pilot-toolbar [data-fabric-pilot-group="selection-controls"] button {
+        padding-inline: 4px;
+        font-size: 11px;
+      }
+      .mpv-fabric-pilot-toolbar [data-fabric-pilot-output="summary"],
+      .mpv-fabric-pilot-toolbar [data-fabric-pilot-output="selection-summary"],
+      .mpv-fabric-pilot-toolbar [data-fabric-pilot-label] {
         display: none;
       }
       .mpv-fabric-pilot-badge {
@@ -1091,6 +1110,16 @@ function createForwardedKeyboardInput(input = {}) {
   };
 }
 
+function forwardedInputNeedsMainFocus(input = {}) {
+  return input.type === 'keyDown' &&
+    input.code === 'KeyB' &&
+    input.repeat !== true &&
+    input.shiftKey !== true &&
+    input.ctrlKey !== true &&
+    input.altKey !== true &&
+    input.metaKey !== true;
+}
+
 function overlayHistoryActionFromInput(input = {}) {
   if (input.type !== 'keyDown' ||
       input.isComposing === true ||
@@ -1689,6 +1718,8 @@ class MPVOverlayHost {
     this.desiredInputEnabled = false;
     this.activeSessionId = null;
     this.currentToolRevision = -1;
+    this.keyboardRelayCount = 0;
+    this.lastKeyboardRelayCode = null;
     this.completedActionIds = new Map();
     this.inFlightDrawingActions = new Map();
     this.maxProcessedActionIds = 2048;
@@ -1812,6 +1843,7 @@ class MPVOverlayHost {
   }
 
   async updateDrawingTool(request = {}) {
+    const hostWindow = this.window;
     const toolRevision = Number(request.toolRevision);
     const currentTokensMatch = request.hostGeneration === this.hostGeneration &&
       request.videoGeneration === this.currentVideoGeneration &&
@@ -1835,6 +1867,12 @@ class MPVOverlayHost {
         return { success: false, accepted: false, error: 'stale drawing tool response' };
       }
       this.currentToolRevision = toolRevision;
+      // V는 overlay에서 메인 renderer로 전달되며 처리 중 main 창이 잠시 포커스를
+      // 소유한다. 도구 변경이 확정된 뒤 overlay를 다시 활성화해야 다음 툴바
+      // 클릭이 Windows의 창 활성화 클릭으로 소모되지 않는다.
+      if (this.window === hostWindow && !hostWindow?.isDestroyed?.()) {
+        hostWindow.focus?.();
+      }
       return { success: true, accepted: true, tool: result.tool === 'select' ? 'select' : 'brush' };
     } catch (error) {
       return { success: false, accepted: false, error: error.message };
@@ -1926,7 +1964,9 @@ class MPVOverlayHost {
       hostGeneration: this.hostGeneration,
       videoGeneration: this.currentVideoGeneration,
       inputRevision: this.currentInputRevision,
-      desiredInputEnabled: this.desiredInputEnabled
+      desiredInputEnabled: this.desiredInputEnabled,
+      keyboardRelayCount: this.keyboardRelayCount,
+      lastKeyboardRelayCode: this.lastKeyboardRelayCode
     };
     if (this.fabricReadyGeneration !== this.hostGeneration) {
       return {
@@ -1946,6 +1986,18 @@ class MPVOverlayHost {
         };
       }
       const cache = result?.cache && typeof result.cache === 'object' ? result.cache : {};
+      const activeSelectionGesture = result?.activeSelectionGesture &&
+        typeof result.activeSelectionGesture === 'object'
+        ? result.activeSelectionGesture
+        : null;
+      const lastSelectionGesture = result?.lastSelectionGesture &&
+        typeof result.lastSelectionGesture === 'object'
+        ? result.lastSelectionGesture
+        : null;
+      const lastSelectionBounds = lastSelectionGesture?.polygonBounds &&
+        typeof lastSelectionGesture.polygonBounds === 'object'
+        ? lastSelectionGesture.polygonBounds
+        : null;
       return {
         success: true,
         ...hostDiagnostics,
@@ -1955,6 +2007,69 @@ class MPVOverlayHost {
         activeSessionId: this.activeSessionId,
         targetFrame: Number.isInteger(Number(result?.targetFrame)) ? Number(result.targetFrame) : null,
         tool: result?.tool === 'select' ? 'select' : 'brush',
+        selectionTarget: result?.selectionTarget === 'partial' ? 'partial' : 'stroke',
+        selectionShape: result?.selectionShape === 'lasso' ? 'lasso' : 'rectangle',
+        selectionControlEventCount: Math.max(
+          0,
+          Math.trunc(finiteDiagnosticNumber(result?.selectionControlEventCount))
+        ),
+        lastSelectionControlAction: result?.lastSelectionControlAction &&
+          typeof result.lastSelectionControlAction === 'object'
+          ? {
+            kind: result.lastSelectionControlAction.kind === 'shape' ? 'shape' : 'target',
+            value: result.lastSelectionControlAction.kind === 'shape'
+              ? (result.lastSelectionControlAction.value === 'lasso' ? 'lasso' : 'rectangle')
+              : (result.lastSelectionControlAction.value === 'partial' ? 'partial' : 'stroke'),
+            source: result.lastSelectionControlAction.source === 'pointerdown'
+              ? 'pointerdown'
+              : 'click',
+            eventCount: Math.max(
+              0,
+              Math.trunc(finiteDiagnosticNumber(result.lastSelectionControlAction.eventCount))
+            )
+          }
+          : null,
+        activeSelectionGesture: activeSelectionGesture
+          ? {
+            target: activeSelectionGesture.target === 'partial' ? 'partial' : 'stroke',
+            shape: activeSelectionGesture.shape === 'lasso' ? 'lasso' : 'rectangle',
+            pointerPointCount: Math.max(
+              0,
+              Math.trunc(finiteDiagnosticNumber(activeSelectionGesture.pointerPointCount))
+            )
+          }
+          : null,
+        lastSelectionGesture: lastSelectionGesture
+          ? {
+            target: lastSelectionGesture.target === 'partial' ? 'partial' : 'stroke',
+            shape: lastSelectionGesture.shape === 'lasso' ? 'lasso' : 'rectangle',
+            pointerPointCount: Math.max(
+              0,
+              Math.trunc(finiteDiagnosticNumber(lastSelectionGesture.pointerPointCount))
+            ),
+            polygonPointCount: Math.max(
+              0,
+              Math.trunc(finiteDiagnosticNumber(lastSelectionGesture.polygonPointCount))
+            ),
+            polygonBounds: lastSelectionBounds
+              ? {
+                left: finiteDiagnosticNumber(lastSelectionBounds.left),
+                right: finiteDiagnosticNumber(lastSelectionBounds.right),
+                top: finiteDiagnosticNumber(lastSelectionBounds.top),
+                bottom: finiteDiagnosticNumber(lastSelectionBounds.bottom)
+              }
+              : null,
+            pending: lastSelectionGesture.pending === true,
+            applied: lastSelectionGesture.applied === true,
+            selectedCount: Math.max(
+              0,
+              Math.trunc(finiteDiagnosticNumber(lastSelectionGesture.selectedCount))
+            ),
+            reason: typeof lastSelectionGesture.reason === 'string'
+              ? lastSelectionGesture.reason.slice(0, 128)
+              : null
+          }
+          : null,
         objectCount: Math.trunc(finiteDiagnosticNumber(result?.objectCount)),
         selectionCount: Math.trunc(finiteDiagnosticNumber(result?.selectionCount)),
         mutationCount: Math.trunc(finiteDiagnosticNumber(result?.mutationCount)),
@@ -2544,6 +2659,8 @@ class MPVOverlayHost {
     this.desiredInputEnabled = false;
     this.activeSessionId = null;
     this.currentToolRevision = -1;
+    this.keyboardRelayCount = 0;
+    this.lastKeyboardRelayCode = null;
     this.completedActionIds.clear();
     this.inFlightDrawingActions.clear();
     this.suppressedOverlayHistoryKeys.clear();
@@ -2603,6 +2720,8 @@ class MPVOverlayHost {
     this.desiredInputEnabled = false;
     this.activeSessionId = null;
     this.currentToolRevision = -1;
+    this.keyboardRelayCount = 0;
+    this.lastKeyboardRelayCode = null;
     this.completedActionIds.clear();
     this.inFlightDrawingActions.clear();
     this.suppressedOverlayHistoryKeys.clear();
@@ -2673,14 +2792,33 @@ class MPVOverlayHost {
           typeof mainWindow.webContents?.send !== 'function') {
         return;
       }
+      const needsMainFocusHandoff = forwardedInputNeedsMainFocus(forwardedInput);
       try {
         // overlay가 획 클릭으로 포커스를 얻어도 물리 키 위치(code)를 보존해
         // 사용자 지정 단축키를 메인 renderer의 단일 처리 경로로 보낸다.
-        mainWindow.focus?.();
+        // 기본 B 토글은 Windows의 창 비활성화 handoff를 위해 main을 먼저
+        // 활성화하되, renderer 전달 직후 overlay를 되돌려 둔다. B가 실제
+        // 토글이면 disable 경로가 main으로 최종 handoff하고, 커스텀 단축키
+        // 설정이나 전달 실패라면 다음 툴바 클릭이 소모되지 않는다.
+        if (needsMainFocusHandoff) {
+          mainWindow.focus?.();
+        }
         mainWindow.webContents.send(FORWARDED_KEYBOARD_CHANNEL, forwardedInput);
+        this.keyboardRelayCount += 1;
+        this.lastKeyboardRelayCode = forwardedInput.code;
         event?.preventDefault?.();
       } catch (error) {
         this.logger.debug('Fabric overlay keyboard relay failed', { error: error.message });
+      } finally {
+        if (needsMainFocusHandoff &&
+            this.window === hostWindow &&
+            this.hostGeneration === hostGeneration &&
+            this.desiredInputEnabled === true &&
+            !hostWindow.isDestroyed?.()) {
+          try {
+            hostWindow.focus?.();
+          } catch (_error) { /* best-effort focus restoration */ }
+        }
       }
     });
     hostWindow.webContents?.on?.('render-process-gone', () => {
@@ -2702,6 +2840,8 @@ class MPVOverlayHost {
       this.desiredInputEnabled = false;
       this.activeSessionId = null;
       this.currentToolRevision = -1;
+      this.keyboardRelayCount = 0;
+      this.lastKeyboardRelayCode = null;
       this.completedActionIds.clear();
       this.inFlightDrawingActions.clear();
       this.suppressedOverlayHistoryKeys.clear();

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:hybrid": "node --test scripts/tests/hybrid-review-engine-source.test.js",
     "bundle:liveblocks": "esbuild ./node_modules/@liveblocks/client/dist/index.js --bundle --format=esm --outfile=renderer/scripts/lib/liveblocks-client.js",
     "bundle:perfect-freehand": "esbuild ./node_modules/perfect-freehand/dist/esm/index.mjs --bundle --format=esm --outfile=renderer/scripts/lib/perfect-freehand.js",
-    "bundle:mpv-fabric-overlay": "esbuild renderer/scripts/modules/mpv-fabric-overlay-runtime.js --bundle --platform=browser --format=iife --target=chrome120 --outfile=renderer/scripts/lib/mpv-fabric-overlay.iife.js --legal-comments=eof",
+    "bundle:mpv-fabric-overlay": "esbuild renderer/scripts/modules/mpv-fabric-overlay-runtime.js --bundle --platform=browser --format=iife --target=chrome120 --outfile=renderer/scripts/lib/mpv-fabric-overlay.iife.js --legal-comments=eof --preserve-symlinks",
     "build:review-file-cas-helper": "node scripts/build-review-file-cas-helper.js",
     "postinstall": "npm run bundle:liveblocks && npm run bundle:perfect-freehand && npm run bundle:mpv-fabric-overlay && npm run build:review-file-cas-helper"
   },

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -9612,6 +9612,17 @@ async function initApp() {
   function handleFabricDrawingPilotStateChange(nextState, snapshot) {
     const ownsDrawingShortcut =
       fabricDrawingPilotController.shouldOwnDrawingShortcut();
+    const bInput = snapshot?.bInput || {};
+    document.body.dataset.fabricDrawingPilotState = String(nextState || 'unknown');
+    document.body.dataset.fabricDrawingBInputAttempted = String(
+      Math.max(0, Math.trunc(Number(bInput.attempted) || 0))
+    );
+    document.body.dataset.fabricDrawingBInputAccepted = String(
+      Math.max(0, Math.trunc(Number(bInput.accepted) || 0))
+    );
+    document.body.dataset.fabricDrawingBInputRejected = String(
+      Math.max(0, Math.trunc(Number(bInput.rejected) || 0))
+    );
     document.body.classList.toggle(
       'fabric-drawing-pilot-enabled',
       ownsDrawingShortcut

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -14837,6 +14837,7 @@ void main() {
         let currentSession = null;
         let activeStroke = null;
         let activeLasso = null;
+        let lastSelectionGesture = null;
         let pendingLassoSelection = null;
         let preservingPendingLassoSelectionEvent = false;
         let brushStyle = { ...DEFAULT_BRUSH_STYLE };
@@ -14844,6 +14845,8 @@ void main() {
         let brushPanelOpen = false;
         let selectionTarget = "stroke";
         let selectionShape = "rectangle";
+        let selectionControlEventCount = 0;
+        let lastSelectionControlAction = null;
         let selectionControls = null;
         let transformStart = null;
         let selectGesture = null;
@@ -14910,6 +14913,7 @@ void main() {
             button.dataset.active = String(active);
             button.setAttribute?.("aria-pressed", String(active));
           }
+          selectionControls.summary.textContent = selectionTarget === "partial" ? `\uD604\uC7AC: \uBD80\uBD84 \uC790\uB974\uAE30 \xB7 ${selectionShape === "lasso" ? "\uB77C\uC3D8 \uC601\uC5ED" : "\uC0AC\uAC01 \uC601\uC5ED"}` : `\uD604\uC7AC: \uD68D \uC804\uCCB4 \xB7 ${selectionShape === "lasso" ? "\uB77C\uC3D8 \uC601\uC5ED" : "\uC0AC\uAC01 \uC601\uC5ED"}`;
         }
         function usesNativeRectangleSelection(tool = currentSession?.tool) {
           return tool === "select" && selectionTarget === "stroke" && selectionShape === "rectangle";
@@ -14938,8 +14942,18 @@ void main() {
             syncSelectionControls();
           }
         }
-        function setSelectionTarget(target) {
+        function recordSelectionControlAction(kind, value, source = "click") {
+          selectionControlEventCount += 1;
+          lastSelectionControlAction = {
+            kind,
+            value,
+            source,
+            eventCount: selectionControlEventCount
+          };
+        }
+        function setSelectionTarget(target, source = "click") {
           const nextTarget = target === "partial" ? "partial" : "stroke";
+          recordSelectionControlAction("target", nextTarget, source);
           if (selectionTarget === nextTarget) return selectionTarget;
           const viewportContext = clearSelectionForConfigurationChange();
           selectionTarget = nextTarget;
@@ -14947,8 +14961,9 @@ void main() {
           settleDeferredViewport(viewportContext.sessionId, viewportContext.inputRevision);
           return selectionTarget;
         }
-        function setSelectionShape(shape) {
+        function setSelectionShape(shape, source = "click") {
           const nextShape = shape === "lasso" ? "lasso" : "rectangle";
+          recordSelectionControlAction("shape", nextShape, source);
           if (selectionShape === nextShape) return selectionShape;
           const viewportContext = clearSelectionForConfigurationChange();
           selectionShape = nextShape;
@@ -14964,7 +14979,7 @@ void main() {
           setStyles(group, {
             display: "none",
             alignItems: "center",
-            gap: "4px",
+            gap: "8px",
             padding: "3px",
             borderRadius: "8px",
             background: "rgba(255, 255, 255, 0.08)"
@@ -14973,19 +14988,35 @@ void main() {
           targetGroup.dataset.fabricPilotGroup = "selection-target";
           targetGroup.setAttribute?.("role", "group");
           targetGroup.setAttribute?.("aria-label", "\uC120\uD0DD \uB300\uC0C1");
-          setStyles(targetGroup, { display: "flex", alignItems: "center", gap: "4px" });
+          setStyles(targetGroup, {
+            display: "flex",
+            alignItems: "center",
+            gap: "4px",
+            paddingRight: "8px",
+            borderRight: "1px solid rgba(255, 255, 255, 0.18)"
+          });
+          const targetLabel = documentRef.createElement("span");
+          targetLabel.dataset.fabricPilotLabel = "selection-target";
+          targetLabel.textContent = "\uC120\uD0DD \uB300\uC0C1";
+          setStyles(targetLabel, {
+            color: "rgba(255, 255, 255, 0.64)",
+            fontSize: "11px",
+            fontWeight: "600",
+            whiteSpace: "nowrap"
+          });
           const strokeTargetButton = labelToolbarButton(
-            createButton("\uD68D", "select-target-stroke"),
+            createButton("\uD68D \uC804\uCCB4", "select-target-stroke"),
             "\uD68D \uC804\uCCB4 \uC120\uD0DD"
           );
           const partialTargetButton = labelToolbarButton(
-            createButton("\uBD80\uBD84", "select-target-partial"),
+            createButton("\uBD80\uBD84 \uC790\uB974\uAE30", "select-target-partial"),
             "\uD68D \uC77C\uBD80 \uC120\uD0DD"
           );
           const targetButtons = /* @__PURE__ */ new Map([
             ["stroke", strokeTargetButton],
             ["partial", partialTargetButton]
           ]);
+          targetGroup.appendChild(targetLabel);
           for (const button of targetButtons.values()) {
             button.setAttribute?.("aria-pressed", "false");
             targetGroup.appendChild(button);
@@ -14995,29 +15026,65 @@ void main() {
           shapeGroup.setAttribute?.("role", "group");
           shapeGroup.setAttribute?.("aria-label", "\uC120\uD0DD \uBAA8\uC591");
           setStyles(shapeGroup, { display: "flex", alignItems: "center", gap: "4px" });
+          const shapeLabel = documentRef.createElement("span");
+          shapeLabel.dataset.fabricPilotLabel = "selection-shape";
+          shapeLabel.textContent = "\uC601\uC5ED \uBAA8\uC591";
+          setStyles(shapeLabel, {
+            color: "rgba(255, 255, 255, 0.64)",
+            fontSize: "11px",
+            fontWeight: "600",
+            whiteSpace: "nowrap"
+          });
           const rectangleShapeButton = labelToolbarButton(
-            createButton("\uC0AC\uAC01\uD615", "select-shape-rectangle"),
+            createButton("\uC0AC\uAC01 \uC601\uC5ED", "select-shape-rectangle"),
             "\uC0AC\uAC01\uD615 \uC120\uD0DD"
           );
           const lassoShapeButton = labelToolbarButton(
-            createButton("\uB77C\uC3D8", "select-shape-lasso"),
+            createButton("\uB77C\uC3D8 \uC601\uC5ED", "select-shape-lasso"),
             "\uB77C\uC3D8 \uC120\uD0DD"
           );
           const shapeButtons = /* @__PURE__ */ new Map([
             ["rectangle", rectangleShapeButton],
             ["lasso", lassoShapeButton]
           ]);
+          shapeGroup.appendChild(shapeLabel);
           for (const button of shapeButtons.values()) {
             button.setAttribute?.("aria-pressed", "false");
             shapeGroup.appendChild(button);
           }
+          const summary = documentRef.createElement("span");
+          summary.dataset.fabricPilotOutput = "selection-summary";
+          summary.setAttribute?.("role", "status");
+          summary.setAttribute?.("aria-live", "polite");
+          setStyles(summary, {
+            minWidth: "150px",
+            color: "rgba(255, 255, 255, 0.76)",
+            fontSize: "11px",
+            fontWeight: "650",
+            whiteSpace: "nowrap"
+          });
           group.appendChild(targetGroup);
           group.appendChild(shapeGroup);
-          addDomListener(strokeTargetButton, "click", () => setSelectionTarget("stroke"));
-          addDomListener(partialTargetButton, "click", () => setSelectionTarget("partial"));
-          addDomListener(rectangleShapeButton, "click", () => setSelectionShape("rectangle"));
-          addDomListener(lassoShapeButton, "click", () => setSelectionShape("lasso"));
-          return { group, targetGroup, shapeGroup, targetButtons, shapeButtons };
+          group.appendChild(summary);
+          const bindSelectionControl = (button, action) => {
+            addDomListener(button, "pointerdown", (event) => {
+              if (event?.button !== void 0 && event.button !== 0) return;
+              action("pointerdown");
+            });
+            addDomListener(button, "click", () => action("click"));
+          };
+          bindSelectionControl(strokeTargetButton, (source) => setSelectionTarget("stroke", source));
+          bindSelectionControl(partialTargetButton, (source) => setSelectionTarget("partial", source));
+          bindSelectionControl(rectangleShapeButton, (source) => setSelectionShape("rectangle", source));
+          bindSelectionControl(lassoShapeButton, (source) => setSelectionShape("lasso", source));
+          return {
+            group,
+            targetGroup,
+            shapeGroup,
+            targetButtons,
+            shapeButtons,
+            summary
+          };
         }
         function setBrushColor(color) {
           if (!BRUSH_COLORS.includes(color)) return brushStyle.color;
@@ -15524,6 +15591,12 @@ void main() {
           removeLassoPreview();
           activeLasso = null;
           releasePointerCapture(fabricCanvas?.upperCanvasEl || canvasElement, pointerId);
+          if (previousSelectionContext?.pendingSelection && pendingLassoSelection === previousSelectionContext.pendingSelection) {
+            abortPendingLassoSelection({
+              authoritative: !pendingLassoIsFresh(previousSelectionContext.pendingSelection)
+            });
+            return;
+          }
           restoreSelectionContext(previousSelectionContext);
         }
         function strokeObjectSceneBounds(record, object, padding = 0) {
@@ -15837,7 +15910,7 @@ void main() {
           if (!Number.isFinite(chordLength) || chordLength <= SOURCE_INTERVAL_EPSILON) {
             return {
               monotone: false,
-              reason: "selection-geometry-unavailable"
+              reason: Number.isFinite(chordLength) ? null : "selection-geometry-unavailable"
             };
           }
           const axisX = chordX / chordLength;
@@ -15851,11 +15924,14 @@ void main() {
             }
             const sourceProgress = segment.end.sourcePosition - segment.start.sourcePosition;
             const chordProgress = (segment.end.x - segment.start.x) * axisX + (segment.end.y - segment.start.y) * axisY;
-            if (!Number.isFinite(sourceProgress) || !Number.isFinite(chordProgress) || sourceProgress < -SOURCE_INTERVAL_EPSILON || chordProgress <= SOURCE_INTERVAL_EPSILON) {
+            if (!Number.isFinite(sourceProgress) || !Number.isFinite(chordProgress) || sourceProgress < -SOURCE_INTERVAL_EPSILON) {
               return {
                 monotone: false,
                 reason: "selection-geometry-unavailable"
               };
+            }
+            if (chordProgress <= SOURCE_INTERVAL_EPSILON) {
+              return { monotone: false, reason: null };
             }
           }
           return { monotone: true, reason: null };
@@ -15955,7 +16031,10 @@ void main() {
               return { projections: null, reason: monotone.reason };
             }
             if (!monotone.monotone) {
-              return { projections: null, reason: "selection-geometry-unavailable" };
+              return {
+                projections: null,
+                reason: "selection-nonmonotone-centerline"
+              };
             }
             const coverage = sourceEnvelopesCoverSourceDomain(planned, budget);
             if (coverage.reason) {
@@ -16050,6 +16129,71 @@ void main() {
           path.setPositionByOrigin(fragmentCenter, "center", "center");
           path.setCoords?.();
           return true;
+        }
+        function compactOutlineSourcePoints(sourcePoints, budget) {
+          if (!Array.isArray(sourcePoints) || sourcePoints.length < 2) {
+            return { points: null, reason: "selection-geometry-unavailable" };
+          }
+          if (!budget.consume(sourcePoints.length)) {
+            return { points: null, reason: "selection-complexity-limit-exceeded" };
+          }
+          const first = sourcePoints[0];
+          let furthest = sourcePoints.at(-1);
+          let furthestDistance = -1;
+          for (let index = 1; index < sourcePoints.length; index += 1) {
+            const candidate = sourcePoints[index];
+            const dx = finiteNumber(candidate.x) - finiteNumber(first.x);
+            const dy = finiteNumber(candidate.y) - finiteNumber(first.y);
+            const distance = dx * dx + dy * dy;
+            if (distance > furthestDistance) {
+              furthestDistance = distance;
+              furthest = candidate;
+            }
+          }
+          return {
+            points: [clonePlain(first), clonePlain(furthest)],
+            reason: null
+          };
+        }
+        function createCompactOutlineComponentPlans(record, remainingComponents, selectedComponents, budget) {
+          const support = compactOutlineSourcePoints(record.sourcePoints, budget);
+          if (!support.points || support.reason) {
+            return { plans: null, reason: support.reason };
+          }
+          const plans = [];
+          for (const group of [
+            { selected: false, components: remainingComponents },
+            { selected: true, components: selectedComponents }
+          ]) {
+            const contourCount = group.components.reduce(
+              (count, component) => count + (component?.contours?.length || 0),
+              0
+            );
+            if (!budget.consume(group.components.length + contourCount + 1)) {
+              return {
+                plans: null,
+                reason: "selection-complexity-limit-exceeded"
+              };
+            }
+            const renderPathData = contourPathData(
+              group.components.flatMap((component) => component.contours)
+            );
+            if (!renderPathData || renderPathData.length > MAX_PERSISTENCE_STRING_LENGTH) {
+              return { plans: null, reason: "selection-geometry-unavailable" };
+            }
+            plans.push({
+              selected: group.selected,
+              points: support.points.map((point) => clonePlain(point)),
+              interval: [0, record.sourcePoints.length - 1],
+              caps: { start: false, end: false },
+              renderGeometry: {
+                version: 1,
+                pathData: renderPathData,
+                fillRule: "evenodd"
+              }
+            });
+          }
+          return { plans, reason: null };
         }
         function createStrokeFragment(record, points, selected, caps = {}, sourceObject = null, renderGeometry = null) {
           if (!Array.isArray(points) || points.length < 2) return null;
@@ -16527,6 +16671,15 @@ void main() {
               selectedObjectIds: restoredSelectionIds
             };
           };
+          const queueReplacementPlan = (record, object, componentPlans) => {
+            accumulatedFragments += componentPlans.length;
+            const projectedObjectCount = snapshot.objects.length - (replacementPlans.length + 1) + accumulatedFragments;
+            if (accumulatedFragments > maxLassoFragments || projectedObjectCount > sceneLimits.maxObjects) {
+              return false;
+            }
+            replacementPlans.push({ record, object, componentPlans });
+            return true;
+          };
           if (!validateSimpleContour(polygon, geometryBudget)) {
             return fail(geometryBudget.limitExceeded ? "selection-complexity-limit-exceeded" : "selection-geometry-unavailable");
           }
@@ -16581,6 +16734,21 @@ void main() {
             const selectedClip = clipped.intersection;
             if (selectedClip.reason) return fail(selectedClip.reason);
             if (selectedClip.components.length === 0) continue;
+            if (record.renderGeometry !== void 0) {
+              const compact = createCompactOutlineComponentPlans(
+                record,
+                remainingClip.components,
+                selectedClip.components,
+                geometryBudget
+              );
+              if (!compact.plans || compact.reason) {
+                return fail(compact.reason || "selection-geometry-unavailable");
+              }
+              if (!queueReplacementPlan(record, object, compact.plans)) {
+                return fail("lasso-fragment-limit-exceeded");
+              }
+              continue;
+            }
             const centerline = createStoredCenterline(record, geometryBudget);
             if (!centerline.geometry || centerline.reason) {
               return fail(centerline.reason || "selection-geometry-unavailable");
@@ -16613,6 +16781,21 @@ void main() {
               geometryBudget
             );
             if (!bridged.projections || bridged.reason) {
+              if (bridged.reason === "selection-nonmonotone-centerline") {
+                const compact = createCompactOutlineComponentPlans(
+                  record,
+                  remainingClip.components,
+                  selectedClip.components,
+                  geometryBudget
+                );
+                if (!compact.plans || compact.reason) {
+                  return fail(compact.reason || "selection-geometry-unavailable");
+                }
+                if (!queueReplacementPlan(record, object, compact.plans)) {
+                  return fail("lasso-fragment-limit-exceeded");
+                }
+                continue;
+              }
               return fail(bridged.reason || "selection-geometry-unavailable");
             }
             const grouped = groupProjectedComponentsBySourceInterval(
@@ -16661,20 +16844,30 @@ void main() {
                 }
               });
             }
-            const totalPlannedPoints = componentPlans.reduce(
+            let totalPlannedPoints = componentPlans.reduce(
               (count, plan) => count + plan.points.length,
               0
             );
-            if (totalPlannedPoints > record.sourcePoints.length * 2 + componentPlans.length * 2) {
-              return fail("selection-geometry-unavailable");
+            if (totalPlannedPoints > record.sourcePoints.length + componentPlans.length * 2) {
+              const compact = createCompactOutlineComponentPlans(
+                record,
+                remainingClip.components,
+                selectedClip.components,
+                geometryBudget
+              );
+              if (!compact.plans || compact.reason) {
+                return fail(compact.reason || "selection-geometry-unavailable");
+              }
+              componentPlans.splice(0, componentPlans.length, ...compact.plans);
+              totalPlannedPoints = componentPlans.reduce(
+                (count, plan) => count + plan.points.length,
+                0
+              );
             }
             componentPlans.sort((left, right) => left.interval[0] - right.interval[0] || Number(left.selected) - Number(right.selected) || left.interval[1] - right.interval[1]);
-            accumulatedFragments += componentPlans.length;
-            const projectedObjectCount = snapshot.objects.length - (replacementPlans.length + 1) + accumulatedFragments;
-            if (accumulatedFragments > maxLassoFragments || projectedObjectCount > sceneLimits.maxObjects) {
+            if (!queueReplacementPlan(record, object, componentPlans)) {
               return fail("lasso-fragment-limit-exceeded");
             }
-            replacementPlans.push({ record, object, componentPlans });
           }
           const replacements = [];
           const selectedFragmentIds = /* @__PURE__ */ new Set();
@@ -16738,7 +16931,25 @@ void main() {
           );
           removeLassoPreview();
           activeLasso = null;
-          return selectionTarget === "stroke" ? finalizeWholeStrokeSelectionPolygon(polygon, gesture.previousSelectionContext) : finalizePartialSelectionPolygon(polygon, gesture.previousSelectionContext);
+          const result = selectionTarget === "stroke" ? finalizeWholeStrokeSelectionPolygon(polygon, gesture.previousSelectionContext) : finalizePartialSelectionPolygon(polygon, gesture.previousSelectionContext);
+          const polygonBounds = boundsForPoints(polygon);
+          lastSelectionGesture = {
+            target: selectionTarget,
+            shape: gesture.shape,
+            pointerPointCount: gesture.points.length,
+            polygonPointCount: polygon.length,
+            polygonBounds: polygonBounds ? {
+              left: finiteNumber(polygonBounds.left),
+              right: finiteNumber(polygonBounds.right),
+              top: finiteNumber(polygonBounds.top),
+              bottom: finiteNumber(polygonBounds.bottom)
+            } : null,
+            pending: result?.pending === true,
+            applied: result?.applied === true,
+            selectedCount: Array.isArray(result?.selectedObjectIds) ? result.selectedObjectIds.length : 0,
+            reason: typeof result?.reason === "string" ? result.reason.slice(0, 128) : null
+          };
+          return result;
         }
         function pointerTargetsActiveSelection(event) {
           const activeObject = fabricCanvas?.getActiveObject?.();
@@ -16946,6 +17157,7 @@ void main() {
               pointerId: event.pointerId,
               sessionId: currentSession?.sessionId,
               inputRevision: tokenState.inputRevision,
+              phase: "tracking",
               shape: selectionShape,
               previousSelectionContext: {
                 objectIds: [...previousSelectedObjectIds],
@@ -17002,6 +17214,7 @@ void main() {
           if (activeLasso) {
             if (event.pointerId !== activeLasso.pointerId) return;
             const { sessionId, inputRevision } = activeLasso;
+            activeLasso.phase = "settling";
             appendLassoPoint(event);
             releasePointerCapture(event.currentTarget || fabricCanvas?.upperCanvasEl, event.pointerId);
             finalizeActiveLasso();
@@ -17026,6 +17239,7 @@ void main() {
         function onPointerCancel(event) {
           if (activeLasso) {
             if (event.pointerId !== void 0 && event.pointerId !== activeLasso.pointerId) return;
+            if (event.type === "lostpointercapture" && activeLasso.phase === "settling") return;
             cancelActiveLasso();
             deferredViewport = null;
             return;
@@ -17037,6 +17251,7 @@ void main() {
           }
           const gesture = selectGesture;
           if (!gesture) {
+            if (event.type === "lostpointercapture") return;
             if (pendingLassoSelection) abortPendingLassoSelection();
             return;
           }
@@ -17669,6 +17884,14 @@ void main() {
             tool: scene.tool,
             selectionTarget,
             selectionShape,
+            selectionControlEventCount,
+            lastSelectionControlAction: lastSelectionControlAction ? clonePlain(lastSelectionControlAction) : null,
+            activeSelectionGesture: activeLasso ? {
+              target: selectionTarget,
+              shape: activeLasso.shape,
+              pointerPointCount: activeLasso.points.length
+            } : null,
+            lastSelectionGesture: lastSelectionGesture ? clonePlain(lastSelectionGesture) : null,
             objectCount: scene.objectCount,
             selectionCount: scene.selectionCount,
             mutationCount: scene.mutationCount,

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -2006,6 +2006,7 @@ function createFabricOverlayRuntime(options = {}) {
   let currentSession = null;
   let activeStroke = null;
   let activeLasso = null;
+  let lastSelectionGesture = null;
   let pendingLassoSelection = null;
   let preservingPendingLassoSelectionEvent = false;
   let brushStyle = { ...DEFAULT_BRUSH_STYLE };
@@ -2013,6 +2014,8 @@ function createFabricOverlayRuntime(options = {}) {
   let brushPanelOpen = false;
   let selectionTarget = 'stroke';
   let selectionShape = 'rectangle';
+  let selectionControlEventCount = 0;
+  let lastSelectionControlAction = null;
   let selectionControls = null;
   let transformStart = null;
   let selectGesture = null;
@@ -2087,6 +2090,9 @@ function createFabricOverlayRuntime(options = {}) {
       button.dataset.active = String(active);
       button.setAttribute?.('aria-pressed', String(active));
     }
+    selectionControls.summary.textContent = selectionTarget === 'partial'
+      ? `현재: 부분 자르기 · ${selectionShape === 'lasso' ? '라쏘 영역' : '사각 영역'}`
+      : `현재: 획 전체 · ${selectionShape === 'lasso' ? '라쏘 영역' : '사각 영역'}`;
   }
 
   function usesNativeRectangleSelection(tool = currentSession?.tool) {
@@ -2121,8 +2127,19 @@ function createFabricOverlayRuntime(options = {}) {
     }
   }
 
-  function setSelectionTarget(target) {
+  function recordSelectionControlAction(kind, value, source = 'click') {
+    selectionControlEventCount += 1;
+    lastSelectionControlAction = {
+      kind,
+      value,
+      source,
+      eventCount: selectionControlEventCount
+    };
+  }
+
+  function setSelectionTarget(target, source = 'click') {
     const nextTarget = target === 'partial' ? 'partial' : 'stroke';
+    recordSelectionControlAction('target', nextTarget, source);
     if (selectionTarget === nextTarget) return selectionTarget;
     const viewportContext = clearSelectionForConfigurationChange();
     selectionTarget = nextTarget;
@@ -2131,8 +2148,9 @@ function createFabricOverlayRuntime(options = {}) {
     return selectionTarget;
   }
 
-  function setSelectionShape(shape) {
+  function setSelectionShape(shape, source = 'click') {
     const nextShape = shape === 'lasso' ? 'lasso' : 'rectangle';
+    recordSelectionControlAction('shape', nextShape, source);
     if (selectionShape === nextShape) return selectionShape;
     const viewportContext = clearSelectionForConfigurationChange();
     selectionShape = nextShape;
@@ -2149,7 +2167,7 @@ function createFabricOverlayRuntime(options = {}) {
     setStyles(group, {
       display: 'none',
       alignItems: 'center',
-      gap: '4px',
+      gap: '8px',
       padding: '3px',
       borderRadius: '8px',
       background: 'rgba(255, 255, 255, 0.08)'
@@ -2159,20 +2177,37 @@ function createFabricOverlayRuntime(options = {}) {
     targetGroup.dataset.fabricPilotGroup = 'selection-target';
     targetGroup.setAttribute?.('role', 'group');
     targetGroup.setAttribute?.('aria-label', '선택 대상');
-    setStyles(targetGroup, { display: 'flex', alignItems: 'center', gap: '4px' });
+    setStyles(targetGroup, {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '4px',
+      paddingRight: '8px',
+      borderRight: '1px solid rgba(255, 255, 255, 0.18)'
+    });
+
+    const targetLabel = documentRef.createElement('span');
+    targetLabel.dataset.fabricPilotLabel = 'selection-target';
+    targetLabel.textContent = '선택 대상';
+    setStyles(targetLabel, {
+      color: 'rgba(255, 255, 255, 0.64)',
+      fontSize: '11px',
+      fontWeight: '600',
+      whiteSpace: 'nowrap'
+    });
 
     const strokeTargetButton = labelToolbarButton(
-      createButton('획', 'select-target-stroke'),
+      createButton('획 전체', 'select-target-stroke'),
       '획 전체 선택'
     );
     const partialTargetButton = labelToolbarButton(
-      createButton('부분', 'select-target-partial'),
+      createButton('부분 자르기', 'select-target-partial'),
       '획 일부 선택'
     );
     const targetButtons = new Map([
       ['stroke', strokeTargetButton],
       ['partial', partialTargetButton]
     ]);
+    targetGroup.appendChild(targetLabel);
     for (const button of targetButtons.values()) {
       button.setAttribute?.('aria-pressed', 'false');
       targetGroup.appendChild(button);
@@ -2184,30 +2219,68 @@ function createFabricOverlayRuntime(options = {}) {
     shapeGroup.setAttribute?.('aria-label', '선택 모양');
     setStyles(shapeGroup, { display: 'flex', alignItems: 'center', gap: '4px' });
 
+    const shapeLabel = documentRef.createElement('span');
+    shapeLabel.dataset.fabricPilotLabel = 'selection-shape';
+    shapeLabel.textContent = '영역 모양';
+    setStyles(shapeLabel, {
+      color: 'rgba(255, 255, 255, 0.64)',
+      fontSize: '11px',
+      fontWeight: '600',
+      whiteSpace: 'nowrap'
+    });
+
     const rectangleShapeButton = labelToolbarButton(
-      createButton('사각형', 'select-shape-rectangle'),
+      createButton('사각 영역', 'select-shape-rectangle'),
       '사각형 선택'
     );
     const lassoShapeButton = labelToolbarButton(
-      createButton('라쏘', 'select-shape-lasso'),
+      createButton('라쏘 영역', 'select-shape-lasso'),
       '라쏘 선택'
     );
     const shapeButtons = new Map([
       ['rectangle', rectangleShapeButton],
       ['lasso', lassoShapeButton]
     ]);
+    shapeGroup.appendChild(shapeLabel);
     for (const button of shapeButtons.values()) {
       button.setAttribute?.('aria-pressed', 'false');
       shapeGroup.appendChild(button);
     }
 
+    const summary = documentRef.createElement('span');
+    summary.dataset.fabricPilotOutput = 'selection-summary';
+    summary.setAttribute?.('role', 'status');
+    summary.setAttribute?.('aria-live', 'polite');
+    setStyles(summary, {
+      minWidth: '150px',
+      color: 'rgba(255, 255, 255, 0.76)',
+      fontSize: '11px',
+      fontWeight: '650',
+      whiteSpace: 'nowrap'
+    });
+
     group.appendChild(targetGroup);
     group.appendChild(shapeGroup);
-    addDomListener(strokeTargetButton, 'click', () => setSelectionTarget('stroke'));
-    addDomListener(partialTargetButton, 'click', () => setSelectionTarget('partial'));
-    addDomListener(rectangleShapeButton, 'click', () => setSelectionShape('rectangle'));
-    addDomListener(lassoShapeButton, 'click', () => setSelectionShape('lasso'));
-    return { group, targetGroup, shapeGroup, targetButtons, shapeButtons };
+    group.appendChild(summary);
+    const bindSelectionControl = (button, action) => {
+      addDomListener(button, 'pointerdown', event => {
+        if (event?.button !== undefined && event.button !== 0) return;
+        action('pointerdown');
+      });
+      addDomListener(button, 'click', () => action('click'));
+    };
+    bindSelectionControl(strokeTargetButton, source => setSelectionTarget('stroke', source));
+    bindSelectionControl(partialTargetButton, source => setSelectionTarget('partial', source));
+    bindSelectionControl(rectangleShapeButton, source => setSelectionShape('rectangle', source));
+    bindSelectionControl(lassoShapeButton, source => setSelectionShape('lasso', source));
+    return {
+      group,
+      targetGroup,
+      shapeGroup,
+      targetButtons,
+      shapeButtons,
+      summary
+    };
   }
 
   function setBrushColor(color) {
@@ -2763,6 +2836,13 @@ function createFabricOverlayRuntime(options = {}) {
     removeLassoPreview();
     activeLasso = null;
     releasePointerCapture(fabricCanvas?.upperCanvasEl || canvasElement, pointerId);
+    if (previousSelectionContext?.pendingSelection &&
+        pendingLassoSelection === previousSelectionContext.pendingSelection) {
+      abortPendingLassoSelection({
+        authoritative: !pendingLassoIsFresh(previousSelectionContext.pendingSelection)
+      });
+      return;
+    }
     restoreSelectionContext(previousSelectionContext);
   }
 
@@ -3131,7 +3211,9 @@ function createFabricOverlayRuntime(options = {}) {
     if (!Number.isFinite(chordLength) || chordLength <= SOURCE_INTERVAL_EPSILON) {
       return {
         monotone: false,
-        reason: 'selection-geometry-unavailable'
+        reason: Number.isFinite(chordLength)
+          ? null
+          : 'selection-geometry-unavailable'
       };
     }
     const axisX = chordX / chordLength;
@@ -3150,12 +3232,14 @@ function createFabricOverlayRuntime(options = {}) {
         (segment.end.y - segment.start.y) * axisY;
       if (!Number.isFinite(sourceProgress) ||
           !Number.isFinite(chordProgress) ||
-          sourceProgress < -SOURCE_INTERVAL_EPSILON ||
-          chordProgress <= SOURCE_INTERVAL_EPSILON) {
+          sourceProgress < -SOURCE_INTERVAL_EPSILON) {
         return {
           monotone: false,
           reason: 'selection-geometry-unavailable'
         };
+      }
+      if (chordProgress <= SOURCE_INTERVAL_EPSILON) {
+        return { monotone: false, reason: null };
       }
     }
     return { monotone: true, reason: null };
@@ -3276,7 +3360,10 @@ function createFabricOverlayRuntime(options = {}) {
         return { projections: null, reason: monotone.reason };
       }
       if (!monotone.monotone) {
-        return { projections: null, reason: 'selection-geometry-unavailable' };
+        return {
+          projections: null,
+          reason: 'selection-nonmonotone-centerline'
+        };
       }
       const coverage = sourceEnvelopesCoverSourceDomain(planned, budget);
       if (coverage.reason) {
@@ -3387,6 +3474,79 @@ function createFabricOverlayRuntime(options = {}) {
     path.setPositionByOrigin(fragmentCenter, 'center', 'center');
     path.setCoords?.();
     return true;
+  }
+
+  function compactOutlineSourcePoints(sourcePoints, budget) {
+    if (!Array.isArray(sourcePoints) || sourcePoints.length < 2) {
+      return { points: null, reason: 'selection-geometry-unavailable' };
+    }
+    if (!budget.consume(sourcePoints.length)) {
+      return { points: null, reason: 'selection-complexity-limit-exceeded' };
+    }
+    const first = sourcePoints[0];
+    let furthest = sourcePoints.at(-1);
+    let furthestDistance = -1;
+    for (let index = 1; index < sourcePoints.length; index += 1) {
+      const candidate = sourcePoints[index];
+      const dx = finiteNumber(candidate.x) - finiteNumber(first.x);
+      const dy = finiteNumber(candidate.y) - finiteNumber(first.y);
+      const distance = dx * dx + dy * dy;
+      if (distance > furthestDistance) {
+        furthestDistance = distance;
+        furthest = candidate;
+      }
+    }
+    return {
+      points: [clonePlain(first), clonePlain(furthest)],
+      reason: null
+    };
+  }
+
+  function createCompactOutlineComponentPlans(
+    record,
+    remainingComponents,
+    selectedComponents,
+    budget
+  ) {
+    const support = compactOutlineSourcePoints(record.sourcePoints, budget);
+    if (!support.points || support.reason) {
+      return { plans: null, reason: support.reason };
+    }
+    const plans = [];
+    for (const group of [
+      { selected: false, components: remainingComponents },
+      { selected: true, components: selectedComponents }
+    ]) {
+      const contourCount = group.components.reduce(
+        (count, component) => count + (component?.contours?.length || 0),
+        0
+      );
+      if (!budget.consume(group.components.length + contourCount + 1)) {
+        return {
+          plans: null,
+          reason: 'selection-complexity-limit-exceeded'
+        };
+      }
+      const renderPathData = contourPathData(
+        group.components.flatMap(component => component.contours)
+      );
+      if (!renderPathData ||
+          renderPathData.length > MAX_PERSISTENCE_STRING_LENGTH) {
+        return { plans: null, reason: 'selection-geometry-unavailable' };
+      }
+      plans.push({
+        selected: group.selected,
+        points: support.points.map(point => clonePlain(point)),
+        interval: [0, record.sourcePoints.length - 1],
+        caps: { start: false, end: false },
+        renderGeometry: {
+          version: 1,
+          pathData: renderPathData,
+          fillRule: 'evenodd'
+        }
+      });
+    }
+    return { plans, reason: null };
   }
 
   function createStrokeFragment(
@@ -3855,7 +4015,6 @@ function createFabricOverlayRuntime(options = {}) {
         selectedObjectIds: restoredSelectionIds
       };
     };
-
     for (const record of snapshot?.objects || []) {
       if (record.type !== 'stroke') continue;
       const maximumRadius = Math.max(1, finiteNumber(record.style?.size, 1)) * 0.825;
@@ -3922,6 +4081,18 @@ function createFabricOverlayRuntime(options = {}) {
         selectedObjectIds: restoredSelectionIds
       };
     };
+    const queueReplacementPlan = (record, object, componentPlans) => {
+      accumulatedFragments += componentPlans.length;
+      const projectedObjectCount = snapshot.objects.length -
+        (replacementPlans.length + 1) +
+        accumulatedFragments;
+      if (accumulatedFragments > maxLassoFragments ||
+          projectedObjectCount > sceneLimits.maxObjects) {
+        return false;
+      }
+      replacementPlans.push({ record, object, componentPlans });
+      return true;
+    };
     if (!validateSimpleContour(polygon, geometryBudget)) {
       return fail(geometryBudget.limitExceeded
         ? 'selection-complexity-limit-exceeded'
@@ -3981,6 +4152,21 @@ function createFabricOverlayRuntime(options = {}) {
       const selectedClip = clipped.intersection;
       if (selectedClip.reason) return fail(selectedClip.reason);
       if (selectedClip.components.length === 0) continue;
+      if (record.renderGeometry !== undefined) {
+        const compact = createCompactOutlineComponentPlans(
+          record,
+          remainingClip.components,
+          selectedClip.components,
+          geometryBudget
+        );
+        if (!compact.plans || compact.reason) {
+          return fail(compact.reason || 'selection-geometry-unavailable');
+        }
+        if (!queueReplacementPlan(record, object, compact.plans)) {
+          return fail('lasso-fragment-limit-exceeded');
+        }
+        continue;
+      }
       const centerline = createStoredCenterline(record, geometryBudget);
       if (!centerline.geometry || centerline.reason) {
         return fail(centerline.reason || 'selection-geometry-unavailable');
@@ -4013,6 +4199,21 @@ function createFabricOverlayRuntime(options = {}) {
         geometryBudget
       );
       if (!bridged.projections || bridged.reason) {
+        if (bridged.reason === 'selection-nonmonotone-centerline') {
+          const compact = createCompactOutlineComponentPlans(
+            record,
+            remainingClip.components,
+            selectedClip.components,
+            geometryBudget
+          );
+          if (!compact.plans || compact.reason) {
+            return fail(compact.reason || 'selection-geometry-unavailable');
+          }
+          if (!queueReplacementPlan(record, object, compact.plans)) {
+            return fail('lasso-fragment-limit-exceeded');
+          }
+          continue;
+        }
         return fail(bridged.reason || 'selection-geometry-unavailable');
       }
       const grouped = groupProjectedComponentsBySourceInterval(
@@ -4070,27 +4271,35 @@ function createFabricOverlayRuntime(options = {}) {
           }
         });
       }
-      const totalPlannedPoints = componentPlans.reduce(
+      let totalPlannedPoints = componentPlans.reduce(
         (count, plan) => count + plan.points.length,
         0
       );
       if (totalPlannedPoints >
-          record.sourcePoints.length * 2 + componentPlans.length * 2) {
-        return fail('selection-geometry-unavailable');
+          record.sourcePoints.length + componentPlans.length * 2) {
+        const compact = createCompactOutlineComponentPlans(
+          record,
+          remainingClip.components,
+          selectedClip.components,
+          geometryBudget
+        );
+        if (!compact.plans || compact.reason) {
+          return fail(compact.reason || 'selection-geometry-unavailable');
+        }
+        componentPlans.splice(0, componentPlans.length, ...compact.plans);
+        totalPlannedPoints = componentPlans.reduce(
+          (count, plan) => count + plan.points.length,
+          0
+        );
       }
       componentPlans.sort((left, right) => (
         left.interval[0] - right.interval[0] ||
         Number(left.selected) - Number(right.selected) ||
         left.interval[1] - right.interval[1]
       ));
-      accumulatedFragments += componentPlans.length;
-      const projectedObjectCount = snapshot.objects.length -
-        (replacementPlans.length + 1) +
-        accumulatedFragments;
-      if (accumulatedFragments > maxLassoFragments || projectedObjectCount > sceneLimits.maxObjects) {
+      if (!queueReplacementPlan(record, object, componentPlans)) {
         return fail('lasso-fragment-limit-exceeded');
       }
-      replacementPlans.push({ record, object, componentPlans });
     }
 
     const replacements = [];
@@ -4162,9 +4371,31 @@ function createFabricOverlayRuntime(options = {}) {
       );
     removeLassoPreview();
     activeLasso = null;
-    return selectionTarget === 'stroke'
+    const result = selectionTarget === 'stroke'
       ? finalizeWholeStrokeSelectionPolygon(polygon, gesture.previousSelectionContext)
       : finalizePartialSelectionPolygon(polygon, gesture.previousSelectionContext);
+    const polygonBounds = boundsForPoints(polygon);
+    lastSelectionGesture = {
+      target: selectionTarget,
+      shape: gesture.shape,
+      pointerPointCount: gesture.points.length,
+      polygonPointCount: polygon.length,
+      polygonBounds: polygonBounds
+        ? {
+          left: finiteNumber(polygonBounds.left),
+          right: finiteNumber(polygonBounds.right),
+          top: finiteNumber(polygonBounds.top),
+          bottom: finiteNumber(polygonBounds.bottom)
+        }
+        : null,
+      pending: result?.pending === true,
+      applied: result?.applied === true,
+      selectedCount: Array.isArray(result?.selectedObjectIds)
+        ? result.selectedObjectIds.length
+        : 0,
+      reason: typeof result?.reason === 'string' ? result.reason.slice(0, 128) : null
+    };
+    return result;
   }
 
   function pointerTargetsActiveSelection(event) {
@@ -4384,6 +4615,7 @@ function createFabricOverlayRuntime(options = {}) {
         pointerId: event.pointerId,
         sessionId: currentSession?.sessionId,
         inputRevision: tokenState.inputRevision,
+        phase: 'tracking',
         shape: selectionShape,
         previousSelectionContext: {
           objectIds: [...previousSelectedObjectIds],
@@ -4440,6 +4672,7 @@ function createFabricOverlayRuntime(options = {}) {
     if (activeLasso) {
       if (event.pointerId !== activeLasso.pointerId) return;
       const { sessionId, inputRevision } = activeLasso;
+      activeLasso.phase = 'settling';
       appendLassoPoint(event);
       releasePointerCapture(event.currentTarget || fabricCanvas?.upperCanvasEl, event.pointerId);
       finalizeActiveLasso();
@@ -4465,6 +4698,7 @@ function createFabricOverlayRuntime(options = {}) {
   function onPointerCancel(event) {
     if (activeLasso) {
       if (event.pointerId !== undefined && event.pointerId !== activeLasso.pointerId) return;
+      if (event.type === 'lostpointercapture' && activeLasso.phase === 'settling') return;
       cancelActiveLasso();
       deferredViewport = null;
       return;
@@ -4476,6 +4710,9 @@ function createFabricOverlayRuntime(options = {}) {
     }
     const gesture = selectGesture;
     if (!gesture) {
+      // 정상 pointerup에서 releasePointerCapture()가 뒤늦게 발생시킨 이벤트다.
+      // 이미 확정된 부분 선택을 취소 사유로 해석하면 선택 상자가 즉시 사라진다.
+      if (event.type === 'lostpointercapture') return;
       if (pendingLassoSelection) abortPendingLassoSelection();
       return;
     }
@@ -5158,6 +5395,18 @@ function createFabricOverlayRuntime(options = {}) {
       tool: scene.tool,
       selectionTarget,
       selectionShape,
+      selectionControlEventCount,
+      lastSelectionControlAction: lastSelectionControlAction
+        ? clonePlain(lastSelectionControlAction)
+        : null,
+      activeSelectionGesture: activeLasso
+        ? {
+          target: selectionTarget,
+          shape: activeLasso.shape,
+          pointerPointCount: activeLasso.points.length
+        }
+        : null,
+      lastSelectionGesture: lastSelectionGesture ? clonePlain(lastSelectionGesture) : null,
       objectCount: scene.objectCount,
       selectionCount: scene.selectionCount,
       mutationCount: scene.mutationCount,

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -1775,6 +1775,63 @@ test('one hundred B-style warm reentries never duplicate the shadow document or 
   runtime.destroy();
 });
 
+test('B disable keeps committed Fabric drawings visible and restores the same scene on reentry', async () => {
+  const harness = createRealFabricHarness();
+  try {
+    harness.drawStroke([
+      { x: 30, y: 70 },
+      { x: 80, y: 90 },
+      { x: 140, y: 75 }
+    ], 507);
+    const before = harness.sceneStore.getActiveSceneSnapshot();
+    assert.equal(before.objects.length, 1);
+
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 2,
+      enabled: false
+    }).accepted, true);
+    assert.deepEqual(
+      harness.sceneStore.getSceneSnapshot('real-fabric-video', 0).objects,
+      before.objects
+    );
+    assert.equal(
+      harness.canvas.getObjects().filter(object => !object.__baeframeTransient).length,
+      1,
+      'B-off must leave committed vector paths on the overlay canvas'
+    );
+    assert.notEqual(harness.canvas.lowerCanvasEl.style.visibility, 'hidden');
+
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 3,
+      enabled: true,
+      session: {
+        sessionId: 'real-fabric-session',
+        stableVideoIdentity: 'real-fabric-video',
+        targetFrame: 0,
+        sourceWidth: 200,
+        sourceHeight: 200,
+        canvasRect: { left: 0, top: 0, width: 200, height: 200 },
+        viewportTransform: { scale: 1, panX: 0, panY: 0 },
+        tool: 'brush'
+      }
+    }).accepted, true);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      before.objects
+    );
+    assert.equal(
+      harness.canvas.getObjects().filter(object => !object.__baeframeTransient).length,
+      1
+    );
+  } finally {
+    await harness.destroy();
+  }
+});
+
 const crossingStrokePoints = (y = 100) => [
   { x: 20, y },
   { x: 50, y },
@@ -2190,7 +2247,7 @@ test('partial selection keeps a fully enclosed self-crossing stroke whole', asyn
   }
 });
 
-test('partial selection atomically rejects tied branches at a self-crossing stroke', async () => {
+test('partial selection moves exactly partitioned branches at a self-crossing stroke', async () => {
   const harness = createRealFabricHarness();
   try {
     harness.drawStroke(selfCrossingStrokePoints(), 79330);
@@ -2205,15 +2262,47 @@ test('partial selection atomically rejects tied branches at a self-crossing stro
       { x: 92, y: 92 }
     ], 79331);
 
-    assertSelectionStability(harness, before);
-    assert.deepEqual(harness.sceneStore.getActiveSceneSnapshot().selectedObjectIds, []);
-    assert.equal(pendingLassoObjects(harness.canvas).length, 0);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      before.objects
+    );
+    assert.deepEqual(lassoHistoryState(harness.runtime), before.history);
+    assert.equal(
+      pendingLassoObjects(harness.canvas).length > 0,
+      true,
+      'an exact crossing partition must stage its intersecting branches'
+    );
+    harness.dragActiveSelectionBy(20, 10, 793311);
+    await Promise.resolve();
+
+    const moved = harness.sceneStore.getActiveSceneSnapshot();
+    assert.equal(moved.objects.length > before.objects.length, true);
+    assert.equal(moved.objects.some(object => object.id === before.objects[0].id), false);
+    assert.equal(
+      moved.objects.every(record => record.renderGeometry?.version === 1),
+      true
+    );
+    assert.equal(
+      moved.objects.every(record => record.sourcePoints.length === 2),
+      true,
+      'a complex outline split must not duplicate the original centerline'
+    );
+    assert.equal(moved.selectedObjectIds.length > 0, true);
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'real-fabric-session',
+      actionId: 'self-crossing-partial-move-undo',
+      action: 'undo'
+    }).applied, true);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      before.objects
+    );
   } finally {
     await harness.destroy();
   }
 });
 
-test('partial selection atomically restores prior selection when one retained fill maps to wrapped source intervals', async () => {
+test('partial selection moves a U-turn whose retained fill maps to wrapped source intervals', async () => {
   const harness = createRealFabricHarness();
   try {
     const uTurnSamples = [
@@ -2307,8 +2396,219 @@ test('partial selection atomically restores prior selection when one retained fi
 
     assert.deepEqual(before.selectedObjectIds, priorIds);
     assert.deepEqual(before.activeObjectIds, priorIds);
-    assertSelectionStability(harness, before);
-    assert.equal(pendingLassoObjects(harness.canvas).length, 0);
+    assert.equal(
+      pendingLassoObjects(harness.canvas).length > 0,
+      true,
+      'the wrapped U-turn must stage an exact partial selection'
+    );
+    assert.equal(
+      harness.canvas.getActiveObjects()
+        .some(object => object.__baeframeObjectId === uTurnRecord.id),
+      false,
+      'the successful partial selection must not restore the whole U-turn'
+    );
+    assert.deepEqual(lassoHistoryState(harness.runtime), before.history);
+
+    harness.dragActiveSelectionBy(25, 15, 79336);
+    await Promise.resolve();
+    const moved = harness.sceneStore.getActiveSceneSnapshot();
+    assert.equal(moved.objects.length > before.objects.length, true);
+    assert.equal(moved.objects.some(object => object.id === uTurnRecord.id), false);
+    assert.equal(
+      moved.selectedObjectIds.length > 0,
+      true,
+      'moving the staged fragments must commit their selection'
+    );
+
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'real-fabric-session',
+      actionId: 'wrapped-source-interval-move-undo',
+      action: 'undo'
+    }).applied, true);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      before.objects
+    );
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'real-fabric-session',
+      actionId: 'wrapped-source-interval-move-redo',
+      action: 'redo'
+    }).applied, true);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      moved.objects
+    );
+
+    const uTurnFragments = moved.objects.filter(record => record.style?.size === 20);
+    assert.equal(uTurnFragments.length > 1, true);
+    assert.equal(
+      uTurnFragments.every(record => record.renderGeometry?.version === 1),
+      true,
+      'every U-turn fragment must persist its exact two-dimensional fill'
+    );
+    assert.equal(
+      uTurnFragments.every(record => record.sourcePoints.length === 2),
+      true,
+      'U-turn fragments must use bounded outline support instead of duplicated lineage'
+    );
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 2,
+      enabled: false
+    }).accepted, true);
+    const persistedObjects = structuredClone(moved.objects);
+    for (const record of persistedObjects) {
+      const baseTime = record.sourcePoints[0].time;
+      for (const point of record.sourcePoints) point.time -= baseTime;
+    }
+    const hydration = harness.runtime.hydrateDrawingVideo(makePersistenceHydration({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      persistenceSessionId: 'wrapped-u-turn-persistence',
+      stableVideoIdentity: 'real-fabric-video',
+      fps: 24,
+      totalFrames: 200,
+      keyframes: [{
+        id: 'wrapped-u-turn-frame',
+        frame: 0,
+        sourceWidth: 200,
+        sourceHeight: 200,
+        mutationSequence: moved.mutationCount,
+        objects: persistedObjects
+      }]
+    }));
+    assert.equal(hydration.accepted, true, JSON.stringify(hydration));
+    const exported = harness.runtime.exportDrawingVideo(makePersistenceExport({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      persistenceSessionId: 'wrapped-u-turn-persistence',
+      stableVideoIdentity: 'real-fabric-video',
+      fps: 24,
+      totalFrames: 200
+    }));
+    assert.equal(exported.accepted, true, JSON.stringify(exported));
+    assert.deepEqual(exported.snapshot.scenes[0].objects, persistedObjects);
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 3,
+      enabled: true,
+      session: {
+        sessionId: 'wrapped-u-turn-reloaded',
+        stableVideoIdentity: 'real-fabric-video',
+        targetFrame: 0,
+        sourceWidth: 200,
+        sourceHeight: 200,
+        canvasRect: { left: 0, top: 0, width: 200, height: 200 },
+        viewportTransform: { scale: 1, panX: 0, panY: 0 },
+        tool: 'select'
+      }
+    }).accepted, true);
+    selectPartialRectangle(harness.root);
+    harness.dragLasso([
+      { x: 49, y: 42 },
+      { x: 65, y: 58 }
+    ], 793361);
+    assert.equal(
+      pendingLassoObjects(harness.canvas).length > 0,
+      true,
+      'the persisted wrapped U-turn must remain partially selectable'
+    );
+    harness.dragActiveSelectionBy(10, 5, 793362);
+    await Promise.resolve();
+    const repeatedlyMoved = harness.sceneStore.getActiveSceneSnapshot();
+    assert.notDeepEqual(repeatedlyMoved.objects, persistedObjects);
+    assert.equal(
+      repeatedlyMoved.objects
+        .filter(record => record.style?.size === 20)
+        .every(record => record.sourcePoints.length === 2),
+      true,
+      'reselection must keep complex outline support bounded after hydration'
+    );
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'wrapped-u-turn-reloaded',
+      actionId: 'wrapped-u-turn-reselection-undo',
+      action: 'undo'
+    }).applied, true);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      persistedObjects
+    );
+  } finally {
+    await harness.destroy();
+  }
+});
+
+test('partial rectangle moves a non-monotone U-turn and restores it with Undo', async () => {
+  const harness = createRealFabricHarness();
+  try {
+    const sizeInput = findOne(
+      harness.root,
+      node => node.dataset?.fabricPilotSetting === 'size'
+    );
+    sizeInput.value = '20';
+    sizeInput.dispatchEvent(new harness.environment.window.Event('input'));
+    const points = [
+      ...Array.from({ length: 31 }, (_value, index) => ({
+        x: 40 + index * 4,
+        y: 60
+      })),
+      ...Array.from({ length: 20 }, (_value, index) => ({
+        x: 160,
+        y: 64 + index * 4
+      })),
+      ...Array.from({ length: 31 }, (_value, index) => ({
+        x: 156 - index * 4,
+        y: 140
+      }))
+    ];
+    harness.drawStroke(points, 79337);
+    const before = captureSelectionStability(harness);
+    enableRealFabricPartialRectangle(harness);
+
+    harness.dragLasso([
+      { x: 90, y: 20 },
+      { x: 190, y: 180 }
+    ], 79338);
+
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      before.objects
+    );
+    assert.deepEqual(lassoHistoryState(harness.runtime), before.history);
+    assert.equal(
+      pendingLassoObjects(harness.canvas).length > 0,
+      true,
+      'the rectangle must stage the visible right side of the U-turn'
+    );
+    harness.dragActiveSelectionBy(15, 10, 79339);
+    await Promise.resolve();
+
+    const moved = harness.sceneStore.getActiveSceneSnapshot();
+    assert.equal(moved.objects.length > before.objects.length, true);
+    assert.equal(moved.selectedObjectIds.length > 0, true);
+    assert.equal(
+      moved.objects.every(record => record.renderGeometry?.version === 1),
+      true
+    );
+    assert.equal(
+      moved.objects.reduce(
+        (count, record) => count + record.sourcePoints.length,
+        0
+      ) <= before.objects[0].sourcePoints.length + moved.objects.length * 2,
+      true,
+      'an exact axial split may retain lineage but must not duplicate it'
+    );
+    assert.equal(harness.runtime.applyDrawingAction({
+      sessionId: 'real-fabric-session',
+      actionId: 'non-monotone-u-turn-rectangle-undo',
+      action: 'undo'
+    }).applied, true);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().objects,
+      before.objects
+    );
   } finally {
     await harness.destroy();
   }
@@ -2758,6 +3058,7 @@ for (const selectionShape of ['rectangle', 'lasso']) {
           ? [sourcePolygon[0], sourcePolygon[2]]
           : [...sourcePolygon, sourcePolygon[0]]
       ), selectionShape === 'rectangle' ? 79386 : 79389);
+      await Promise.resolve();
 
       assert.deepEqual(
         harness.sceneStore.getActiveSceneSnapshot().objects,
@@ -2769,6 +3070,14 @@ for (const selectionShape of ['rectangle', 'lasso']) {
         true,
         'a visible partial-thickness cut must stage a movable stroke segment'
       );
+      const gestureDiagnostics = harness.runtime.getDiagnostics().lastSelectionGesture;
+      assert.equal(gestureDiagnostics.target, 'partial');
+      assert.equal(gestureDiagnostics.shape, selectionShape);
+      assert.ok(gestureDiagnostics.pointerPointCount >= 2);
+      assert.ok(gestureDiagnostics.polygonPointCount >= 3);
+      assert.equal(gestureDiagnostics.pending, true);
+      assert.equal(gestureDiagnostics.selectedCount > 0, true);
+      assert.equal(gestureDiagnostics.reason, null);
       assert.ok(harness.canvas.getActiveObject());
       const activeFragment = harness.canvas.getActiveObjects()[0];
       const selectedId = activeFragment.__baeframeObjectId;
@@ -8378,6 +8687,12 @@ test('V exposes independent selection target and shape controls', () => {
     node.dataset.fabricPilotAction === 'select-shape-rectangle');
   const lassoShape = findOne(toolbar, node =>
     node.dataset.fabricPilotAction === 'select-shape-lasso');
+  const targetLabel = findOne(toolbar, node =>
+    node.dataset.fabricPilotLabel === 'selection-target');
+  const shapeLabel = findOne(toolbar, node =>
+    node.dataset.fabricPilotLabel === 'selection-shape');
+  const selectionSummary = findOne(toolbar, node =>
+    node.dataset.fabricPilotOutput === 'selection-summary');
   const canvas = FakeCanvas.instances[0];
 
   assert.ok(controlsGroup);
@@ -8387,6 +8702,11 @@ test('V exposes independent selection target and shape controls', () => {
   assert.ok(partialTarget);
   assert.ok(rectangleShape);
   assert.ok(lassoShape);
+  assert.equal(targetLabel.textContent, '선택 대상');
+  assert.equal(shapeLabel.textContent, '영역 모양');
+  assert.equal(strokeTarget.textContent, '획 전체');
+  assert.equal(partialTarget.textContent, '부분 자르기');
+  assert.equal(selectionSummary.textContent, '현재: 획 전체 · 사각 영역');
   assert.equal(controlsGroup.style.display, 'none');
   assert.equal(targetGroup.getAttribute('role'), 'group');
   assert.equal(shapeGroup.getAttribute('role'), 'group');
@@ -8411,6 +8731,13 @@ test('V exposes independent selection target and shape controls', () => {
   assert.equal(lassoShape.getAttribute('aria-pressed'), 'true');
   assert.equal(after.selectionTarget, 'partial');
   assert.equal(after.selectionShape, 'lasso');
+  assert.equal(selectionSummary.textContent, '현재: 부분 자르기 · 라쏘 영역');
+  assert.deepEqual(after.lastSelectionControlAction, {
+    kind: 'shape',
+    value: 'lasso',
+    source: 'click',
+    eventCount: 2
+  });
   assert.equal(canvas.selection, false);
   assert.equal(after.mutationCount, before.mutationCount);
   assert.equal(after.dirty, before.dirty);
@@ -8424,6 +8751,37 @@ test('V exposes independent selection target and shape controls', () => {
   assert.equal(lassoShape.getAttribute('aria-pressed'), 'true');
   assert.equal(runtime.getDiagnostics().selectionTarget, 'partial');
   assert.equal(runtime.getDiagnostics().selectionShape, 'lasso');
+});
+
+test('selection controls apply on pointerdown before a Windows activation click can be lost', () => {
+  FakeCanvas.instances = [];
+  const document = new FakeDocument();
+  const root = document.createElement('div');
+  const runtime = createFabricOverlayRuntime({
+    fabric: { Canvas: FakeCanvas, Path: FakePath },
+    document
+  });
+  runtime.prepare(root);
+  runtime.setDrawingInput(makeInput({
+    session: {
+      ...makeInput().session,
+      tool: 'select'
+    }
+  }));
+
+  const partialTarget = findOne(root, node =>
+    node.dataset.fabricPilotAction === 'select-target-partial');
+  partialTarget.dispatch('pointerdown', { button: 0 });
+
+  const diagnostics = runtime.getDiagnostics();
+  assert.equal(diagnostics.selectionTarget, 'partial');
+  assert.equal(diagnostics.selectionControlEventCount, 1);
+  assert.deepEqual(diagnostics.lastSelectionControlAction, {
+    kind: 'target',
+    value: 'partial',
+    source: 'pointerdown',
+    eventCount: 1
+  });
 });
 
 test('brush settings expose the familiar bounded palette without mutating the scene', () => {

--- a/scripts/tests/mpv-fabric-overlay-toolbar-layout.test.js
+++ b/scripts/tests/mpv-fabric-overlay-toolbar-layout.test.js
@@ -103,7 +103,7 @@ async function runElectronProbe() {
       true;
     `, true);
 
-    const widths = [400, 500, 640];
+    const widths = [400, 500, 640, 641, 768, 800, 801];
     const measurements = [];
     const panelMeasurements = [];
     for (const width of widths) {
@@ -254,7 +254,7 @@ if (process.versions.electron) {
   const assert = require('node:assert/strict');
   const { spawnSync } = require('node:child_process');
 
-  test('hidden Chromium keeps every Fabric toolbar control usable at 400 500 and 640px', {
+  test('hidden Chromium keeps every Fabric toolbar control usable across compact breakpoints', {
     timeout: 45000
   }, () => {
     const electronPath = require('electron');
@@ -290,11 +290,22 @@ if (process.versions.electron) {
       const { root, toolbar, controls, directItems } = measurement;
       assert.equal(measurement.toolbarCount, 1, `${measurement.width}px toolbar count`);
       assert.equal(measurement.sameToolbar, true, `${measurement.width}px toolbar identity`);
-      assert.equal(measurement.summaryDisplay, 'none', `${measurement.width}px compact summary`);
+      assert.equal(
+        measurement.summaryDisplay,
+        measurement.width <= 800 ? 'none' : 'block',
+        `${measurement.width}px responsive summary`
+      );
       assert.ok(toolbar.left >= root.left + 11.5, `${measurement.width}px left inset`);
       assert.ok(toolbar.right <= root.right - 11.5, `${measurement.width}px right inset`);
-      assert.ok(toolbar.height <= 100.5, `${measurement.width}px two-row toolbar height`);
-      assert.ok(clusterRows(directItems).length <= 2, `${measurement.width}px row count`);
+      const maxTwoRowHeight = measurement.width <= 800 ? 100.5 : 104.5;
+      assert.ok(
+        toolbar.height <= maxTwoRowHeight,
+        `${measurement.width}px two-row toolbar height (actual ${toolbar.height}px)`
+      );
+      assert.ok(
+        clusterRows(directItems).length <= 2,
+        `${measurement.width}px row count (actual ${clusterRows(directItems).length})`
+      );
       assert.equal(measurement.badgeDisplay, 'block', `${measurement.width}px badge container`);
       assert.equal(measurement.badgeTextOverflow, 'ellipsis', `${measurement.width}px badge ellipsis`);
       assert.equal(measurement.badgeOverflowX, 'hidden', `${measurement.width}px badge overflow`);
@@ -326,7 +337,7 @@ if (process.versions.electron) {
       }
     }
 
-    assert.equal(probe.panelMeasurements.length, 3);
+    assert.equal(probe.panelMeasurements.length, 7);
     for (const measurement of probe.panelMeasurements) {
       const { root, toolbar, panel, overflowY } = measurement;
       assert.ok(

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -108,6 +108,29 @@ function createDrawingHostHarness(options = {}) {
               activeSessionId: 'session-1',
               targetFrame: 24,
               tool: 'select',
+              selectionTarget: 'partial',
+              selectionShape: 'lasso',
+              selectionControlEventCount: 4,
+              lastSelectionControlAction: {
+                kind: 'shape',
+                value: 'lasso',
+                source: 'pointerdown',
+                eventCount: 4,
+                scene: { mustNotLeak: true }
+              },
+              activeSelectionGesture: null,
+              lastSelectionGesture: {
+                target: 'partial',
+                shape: 'lasso',
+                pointerPointCount: 7,
+                polygonPointCount: 5,
+                polygonBounds: { left: 10, right: 110, top: 20, bottom: 120 },
+                pending: true,
+                applied: false,
+                selectedCount: 2,
+                reason: null,
+                scene: { mustNotLeak: true }
+              },
               objectCount: 1,
               selectionCount: 1,
               mutationCount: 2,
@@ -147,6 +170,10 @@ function createDrawingHostHarness(options = {}) {
           fakeMainWindow.focused = false;
         }
       }
+    }
+    focus() {
+      this.focused = true;
+      events.push(['overlay.focus']);
     }
     showInactive() {
       events.push(['showInactive']);
@@ -1454,7 +1481,7 @@ test('successful drawing activation repaints before pointer input without z-orde
   );
 });
 
-test('returns focus to the main window and relays keyboard input while the drawing overlay owns focus', async () => {
+test('relays keyboard input through the focused main renderer and restores main focus on disable', async () => {
   const { host, events, windows } = createDrawingHostHarness();
   const ensured = await host.ensure({ x: 0, y: 0, width: 640, height: 360 });
   const { hostGeneration } = ensured.drawingCapability;
@@ -1484,10 +1511,10 @@ test('returns focus to the main window and relays keyboard input while the drawi
     key: 'b',
     code: 'KeyB',
     shift: false,
-    control: true,
+    control: false,
     alt: false,
     meta: false,
-    isAutoRepeat: true
+    isAutoRepeat: false
   });
 
   assert.equal(prevented, true);
@@ -1498,12 +1525,16 @@ test('returns focus to the main window and relays keyboard input while the drawi
       key: 'b',
       code: 'KeyB',
       shiftKey: false,
-      ctrlKey: true,
+      ctrlKey: false,
       altKey: false,
       metaKey: false,
-      repeat: true
-    }]
+      repeat: false
+    }],
+    ['overlay.focus']
   ]);
+  const relayDiagnostics = await host.getDrawingDiagnostics();
+  assert.equal(relayDiagnostics.keyboardRelayCount, 1);
+  assert.equal(relayDiagnostics.lastKeyboardRelayCode, 'KeyB');
 
   events.length = 0;
   windows[0].focused = true;
@@ -1519,6 +1550,85 @@ test('returns focus to the main window and relays keyboard input while the drawi
   assert.ok(ignoreIndex >= 0);
   assert.ok(focusableDisableIndex > ignoreIndex);
   assert.ok(mainFocusIndex > focusableDisableIndex);
+});
+
+test('V Delete Space and repeat relay keep the active drawing overlay focused', async () => {
+  const { host, events, windows, mainWindow } = createDrawingHostHarness();
+  await activateDrawingHost({ host, events, windows, mainWindow }, {
+    sessionId: 'session-toolbar-focus-relay'
+  });
+  windows[0].focused = true;
+  mainWindow.focused = false;
+  events.length = 0;
+
+  const emit = input => {
+    let prevented = false;
+    windows[0].webContents.emit('before-input-event', {
+      preventDefault() {
+        prevented = true;
+      }
+    }, {
+      type: 'keyDown',
+      key: '',
+      code: '',
+      shift: false,
+      control: false,
+      alt: false,
+      meta: false,
+      isAutoRepeat: false,
+      ...input
+    });
+    assert.equal(prevented, true);
+  };
+
+  emit({ key: 'v', code: 'KeyV' });
+  emit({ key: 'v', code: 'KeyV', isAutoRepeat: true });
+  emit({ key: 'Delete', code: 'Delete' });
+  emit({ key: ' ', code: 'Space' });
+  emit({ type: 'keyUp', key: 'v', code: 'KeyV' });
+  emit({ key: 'b', code: 'KeyB', isAutoRepeat: true });
+  emit({ type: 'keyUp', key: 'b', code: 'KeyB' });
+
+  assert.equal(
+    events.filter(([name]) => name === 'mainWindow.send').length,
+    7
+  );
+  assert.equal(
+    events.some(([name]) => name === 'mainWindow.focus'),
+    false,
+    'non-toggle relay must not turn the next toolbar click into a window activation click'
+  );
+  assert.equal(windows[0].focused, true);
+  assert.equal(mainWindow.focused, false);
+});
+
+test('disabling a focused overlay completes main focus handoff without B pre-focus', async () => {
+  const harness = createDrawingHostHarness({
+    simulateFocusableDisableDeactivation: true
+  });
+  const tokens = await activateDrawingHost(harness, {
+    sessionId: 'session-custom-toggle-focus-handoff'
+  });
+  harness.windows[0].focused = true;
+  harness.mainWindow.focused = false;
+  harness.events.length = 0;
+
+  await harness.host.setDrawingInput(makeDrawingInput(tokens.hostGeneration, {
+    videoGeneration: tokens.videoGeneration,
+    inputRevision: tokens.inputRevision + 1,
+    enabled: false
+  }));
+
+  const focusableDisableIndex = harness.events.findIndex(([name, value]) =>
+    name === 'setFocusable' && value === false);
+  const mainFocusIndex = harness.events.findIndex(([name]) =>
+    name === 'mainWindow.focus');
+  const mainWebContentsFocusIndex = harness.events.findIndex(([name]) =>
+    name === 'mainWindow.webContents.focus');
+  assert.ok(focusableDisableIndex >= 0);
+  assert.ok(mainFocusIndex > focusableDisableIndex);
+  assert.ok(mainWebContentsFocusIndex > mainFocusIndex);
+  assert.equal(harness.mainWindow.focused, true);
 });
 
 test('completes the main-window focus handoff when relayed B disables a focused drawing overlay', async () => {
@@ -1542,9 +1652,8 @@ test('completes the main-window focus handoff when relayed B disables a focused 
     }
   }));
 
-  // A pointer interaction gives the native overlay keyboard focus. Relaying B moves
-  // focus to main, then Electron's Windows setFocusable(false) deactivation can move
-  // it again to a sibling owned window unless main is restored afterward.
+  // A pointer interaction gives the native overlay keyboard focus. Relaying B keeps
+  // that focus until disable so the host can complete one deterministic handoff.
   windows[0].focused = true;
   windows[0].webContents.emit('before-input-event', { preventDefault() {} }, {
     type: 'keyDown',
@@ -2063,10 +2172,35 @@ test('leaves the original overlay key untouched when forwarding fails', async ()
   }, { type: 'keyDown', key: 'v', code: 'KeyV' }));
   assert.equal(prevented, false);
   assert.equal(events.some(([name]) => name === 'mainWindow.send'), true);
+
+  events.length = 0;
+  prevented = false;
+  windows[0].focused = true;
+  assert.doesNotThrow(() => windows[0].webContents.emit('before-input-event', {
+    preventDefault: () => {
+      prevented = true;
+    }
+  }, {
+    type: 'keyDown',
+    key: 'b',
+    code: 'KeyB',
+    shift: false,
+    control: false,
+    alt: false,
+    meta: false,
+    isAutoRepeat: false
+  }));
+  assert.equal(prevented, false);
+  assert.deepEqual(events.map(([name]) => name), [
+    'mainWindow.focus',
+    'mainWindow.send',
+    'overlay.focus'
+  ]);
+  assert.equal(windows[0].focused, true);
 });
 
 test('rejects stale host video input session and tool revisions at the host boundary', async () => {
-  const { host } = createDrawingHostHarness();
+  const { host, events } = createDrawingHostHarness();
   const ensured = await host.ensure({ x: 0, y: 0, width: 640, height: 360 });
   const { hostGeneration } = ensured.drawingCapability;
   const session = {
@@ -2117,6 +2251,11 @@ test('rejects stale host video input session and tool revisions at the host boun
   assert.equal((await host.updateDrawingTool({ ...currentTool, sessionId: 'session-stale' })).success, false);
   assert.equal((await host.updateDrawingTool(currentTool)).success, true);
   assert.equal((await host.updateDrawingTool({ ...currentTool, toolRevision: 1, tool: 'brush' })).success, false);
+  assert.equal(
+    events.filter(([name]) => name === 'overlay.focus').length,
+    1,
+    'only the accepted V tool change restores overlay focus for the next toolbar click'
+  );
 });
 
 test('stale disable requests cannot close native input owned by the current active session', async () => {
@@ -2212,6 +2351,26 @@ test('deduplicates drawing actions and allowlists lightweight host responses', a
   assert.equal(diagnostics.inputRevision, 2);
   assert.equal(diagnostics.activeSessionId, 'session-actions');
   assert.equal(diagnostics.objectCount, 1);
+  assert.equal(diagnostics.selectionTarget, 'partial');
+  assert.equal(diagnostics.selectionShape, 'lasso');
+  assert.equal(diagnostics.selectionControlEventCount, 4);
+  assert.deepEqual(diagnostics.lastSelectionControlAction, {
+    kind: 'shape',
+    value: 'lasso',
+    source: 'pointerdown',
+    eventCount: 4
+  });
+  assert.deepEqual(diagnostics.lastSelectionGesture, {
+    target: 'partial',
+    shape: 'lasso',
+    pointerPointCount: 7,
+    polygonPointCount: 5,
+    polygonBounds: { left: 10, right: 110, top: 20, bottom: 120 },
+    pending: true,
+    applied: false,
+    selectedCount: 2,
+    reason: null
+  });
   assert.equal(diagnostics.undoDepth, 2);
   assert.equal(diagnostics.redoDepth, 1);
   assert.equal(diagnostics.historyBytes, 1024);
@@ -3701,18 +3860,18 @@ test('Fabric 시험 툴바는 작은 화면에서도 읽기 쉽고 현재 도구
     hostSource,
     /\.mpv-fabric-pilot-badge\s*\{[^}]*font-variant-numeric:\s*tabular-nums[^}]*overflow:\s*hidden[^}]*text-overflow:\s*ellipsis/s
   );
-  assert.match(hostSource, /@media\s*\(max-width:\s*640px\)\s*\{/s);
+  assert.match(hostSource, /@media\s*\(max-width:\s*800px\)\s*\{/s);
   assert.match(
     hostSource,
-    /@media\s*\(max-width:\s*640px\)[\s\S]*?--fabric-toolbar-gap:\s*4px[\s\S]*?padding:\s*4px/s
+    /@media\s*\(max-width:\s*800px\)[\s\S]*?--fabric-toolbar-gap:\s*4px[\s\S]*?padding:\s*4px/s
   );
   assert.match(
     hostSource,
-    /@media\s*\(max-width:\s*640px\)[\s\S]*?\.mpv-fabric-pilot-toolbar button\s*\{[^}]*padding-inline:\s*8px/s
+    /@media\s*\(max-width:\s*800px\)[\s\S]*?\.mpv-fabric-pilot-toolbar button\s*\{[^}]*padding-inline:\s*8px/s
   );
   assert.match(
     hostSource,
-    /@media\s*\(max-width:\s*640px\)[\s\S]*?data-fabric-pilot-output="summary"[\s\S]*?display:\s*none/s
+    /@media\s*\(max-width:\s*800px\)[\s\S]*?data-fabric-pilot-output="summary"[\s\S]*?display:\s*none/s
   );
   assert.match(hostSource, /#root\s*\{[^}]*overflow:\s*hidden/s);
   assert.doesNotMatch(

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -514,6 +514,13 @@ test('package exposes an mpv pilot test command', () => {
   );
 });
 
+test('Fabric overlay bundling preserves logical node_modules paths in linked worktrees', () => {
+  assert.match(
+    packageJson.scripts['bundle:mpv-fabric-overlay'],
+    /(?:^|\s)--preserve-symlinks(?:\s|$)/
+  );
+});
+
 test('preload exposes a narrow mpv API surface', () => {
   assert.match(preloadSource, /mpvIsEnabled: \(\) => ipcRenderer\.invoke\('mpv:is-enabled'\)/);
   assert.match(preloadSource, /mpvIsAvailable: \(\) => ipcRenderer\.invoke\('mpv:is-available'\)/);


### PR DESCRIPTION
## 📋 업데이트 요약

- ✂️ 사각형·라쏘의 **부분 자르기**가 실제로 선택한 획 조각만 떼어내고 옮기도록 바로잡았습니다.
- 🖌️ 재생 중 `B`로 그리기 모드를 켜고 끈 뒤에도 그림과 조작 상태가 안정적으로 유지됩니다.
- 🖱️ `V` 선택 모드에서 획 전체와 부분 자르기를 명확히 구분하고, 선택·이동·다른 획 재선택이 자연스럽게 이어집니다.
- ⌨️ `B`·`V` 단축키를 누른 직후 별도 클릭 없이 도구가 바로 반응하도록 포커스 전환을 안정화했습니다.
- 📐 창이 좁아져도 선택 도구가 겹치거나 눌리지 않는 문제를 정리했습니다.
- 💾 그리기 모드를 껐다 켜거나 리뷰 파일을 다시 불러와도 새 드로잉 데이터가 유지되는 저장 경로를 검증했습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/mpv-fabric-overlay-runtime.js`
  - 부분 선택 제스처를 `tracking`과 `settling` 상태로 분리했습니다. `pointerup` 뒤 늦게 발생하는 정상 `lostpointercapture`는 완료된 선택을 취소하지 않으며, 실제 `pointercancel`이나 새 제스처 시작은 임시 선택을 명시적으로 정리합니다.
  - 단순 직선 계열은 원본 점을 유지하고, U턴·자가 교차·폭만 걸치는 복잡 획은 compact outline 조각으로 변환합니다. 숨은 중심선 중복과 반복 재선택 시 데이터 팽창을 방지하면서 화면상 잘린 조각만 유지합니다.
  - 획 전체/부분 자르기와 사각/라쏘 영역을 독립된 선택 상태로 관리하고, 활성 제스처·마지막 제스처 진단 상태를 노출했습니다.
- `main/mpv-overlay-host.js`, `renderer/scripts/app.js`
  - 기본 `B` keydown에서 메인 창으로 입력을 전달한 뒤, 드로잉 모드가 유지되거나 전달이 실패하면 overlay 포커스를 `finally`에서 복구합니다. 실제 비활성화 시에는 메인 창과 webContents 포커스가 이어지도록 했습니다.
  - `V`, `Delete`, `Space`, 키 반복, keyup은 overlay 포커스를 불필요하게 빼앗지 않습니다.
  - B 시도/수락/거절과 키 전달 횟수를 진단 데이터로 기록해 회귀 원인을 추적할 수 있게 했습니다.
- `renderer/scripts/lib/mpv-fabric-overlay.iife.js`, `package.json`
  - 최신 런타임을 배포 번들에 다시 반영했으며, `--preserve-symlinks`로 작업 폴더 절대 경로가 번들에 섞이지 않도록 빌드 경로를 고정했습니다.
- 테스트 파일들
  - 지연 capture 해제, 명시적 취소, 복잡 획 분할, 반복 hydrate/reselect, B/V 포커스, 키 전달 실패, 400~801px 툴바 배치를 회귀 테스트로 고정했습니다.

## 🚧 개발 난항

- 포인터를 놓은 뒤 Chromium이 보내는 늦은 `lostpointercapture`가 정상 완료와 취소를 같은 사건처럼 처리하면서, 화면에는 선택된 듯 보이지만 내부 임시 조각이 즉시 폐기되는 문제가 있었습니다. 제스처 종료 단계를 별도로 모델링해 해결했습니다.
- 부분 자르기를 단순 중심선 분할로만 처리하면 U턴·교차 획의 보이지 않는 구간까지 함께 선택되거나, 재선택할 때 데이터가 계속 커졌습니다. 단순 획과 복잡 획의 저장 표현을 분리했습니다.
- Windows에서 `B` 입력을 메인 창에 전달하려는 포커스 이동이 overlay 도구 클릭을 한 번씩 잃게 만들었습니다. 실제 모드 전환 결과에 따라 포커스를 복구하거나 넘기도록 경계를 명시했습니다.
- 반응형 툴바의 CSS 기준과 검사 기준이 달라 640px 부근만 보던 테스트가 800px 전환점을 놓쳤습니다. 실제 Chromium 창 너비를 여러 구간으로 나눠 검사하도록 수정했습니다.
- 소스 시험 앱과 패키지 번들의 내용이 달라질 수 있어, 생성 번들과 원본 소스의 일치 여부 및 패키지 `app.asar` 해시를 별도로 검증했습니다.

## ✅ 테스트 가이드

### 실사용자용

1. mpv 영상 재생 중 `B`를 눌러 그리기 모드를 켭니다.
2. 펜과 브러시로 여러 획을 그리고 `V`를 누릅니다.
3. **부분 자르기 + 사각 영역**, **부분 자르기 + 라쏘 영역**으로 획의 일부만 감싸 선택·이동합니다.
4. 획 전체 선택으로 바꿔 여러 획을 선택·이동하고, 바로 다른 획을 클릭해 선택이 자연스럽게 바뀌는지 확인합니다.
5. 재생 중 `B`로 모드를 끄고 다시 켜 그림과 조작이 유지되는지 확인합니다.
6. 리뷰 파일을 저장하고 앱을 다시 실행해 드로잉이 복원되는지 확인합니다.
7. 좁은 창에서도 선택 대상과 영역 모양 버튼이 겹치지 않고 모두 눌리는지 확인합니다.

### 개발자용

- `npm run lint`: 오류 0개
- `npm run test:fabric-drawing-pilot`: 326/326 통과
- `npm run test:mpv`: 235/235 통과
- `npm run test:drawing`: 286/286 통과
- `npm run test:fabric-drawing-persistence`: 138/138 통과
- `npm run build`: `2.0.1-beta` win-unpacked 생성 성공
- 패키지 런타임 프로필: `fabric-v3-stable`, mpv/Fabric/V3 shadow/persistence 모두 활성화
- 패키지에 mpv.exe, ffmpeg.exe, ffprobe.exe 포함 확인
- 소스와 `app.asar` 내부 host/runtime/IIFE SHA-256 일치 확인
- 실제 시험 앱에서 사용자가 B 토글 → 그리기 → V 부분 선택·이동 → B 해제를 직접 검증 완료