### PR TITLE
[v2.1.0-beta] 드로잉 되돌리기·협업·영상 입력 안정화

### DIFF
--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -16,7 +16,7 @@
 | 작업 4 | B 입력 예약·취소와 레거시 준비 표시의 경합 안정화 | `renderer/scripts/app.js`, `renderer/scripts/modules/fabric-drawing-pilot-controller.js`, 관련 테스트 2개 | ✅ 완료 | `eeb8bb1` |
 | 작업 5 | Fabric `drawingsV3` 협업 전파·외부 반영·세션 경계 보호 | `renderer/scripts/modules/fabric-drawing-sync.js` 외 생산 코드 2개, 테스트 2개 | ✅ 완료 | `ee4dd1e` |
 | 작업 6 | mpv 자식 창의 키·마우스 입력 소비 차단과 버전 갱신 | `main/mpv-manager.js`, `scripts/tests/mpv-manager.test.js`, 버전 파일·계약 테스트 | ✅ 완료 | 마지막 커밋 |
-| PR 리뷰 보강 | 저장 대기 알림·늦은 합류 seed·외부 루트·전역 히스토리의 추가 경합 차단 | 생산 코드 7개, 테스트 5개, 본 문서 | ✅ 완료 | PR 리뷰 반영 커밋 |
+| PR 리뷰 보강 | 저장 대기 알림·늦은 합류 seed·외부 루트·전역 히스토리의 추가 경합 차단 | 생산 코드 7개, 테스트 6개, 본 문서 | ✅ 완료 | PR 리뷰 반영 커밋 |
 
 ## 배경 및 목적
 
@@ -148,7 +148,7 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 - 같은 파일의 디스크 reload 요청마다 세대를 올리고 reconcile의 owner predicate까지 전달해, 느린 이전 hydration이 빠른 최신 reload 뒤에 완료돼도 설치하지 않는다.
 - 명시 Broadcast 적용이 시작되거나 같은 내용의 더 높은 인과 버전을 수락하면 그보다 먼저 시작한 디스크 reload 세대를 무효화해, 파일 읽기 B가 보류된 동안 협업 루트 C가 확정된 뒤 B가 C를 덮지 못하게 한다.
 - 연결 중 파일 감지는 comments/레거시 전체 reload를 계속 막되 `drawingsV3`만 제한적으로 다시 읽고, 500ms 안의 후속 알림은 한 번의 trailing reload로 합쳐 최신 상태를 놓치지 않는다.
-- 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 현재 상태를 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다. 합류 요청에는 현재 인과 버전을 실어 안정 참가자가 요청자보다 높은 버전으로 응답하며, `drawingsV3` 부재도 명시 tombstone으로 전파한다.
+- 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 댓글 상태와 causal Fabric root를 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다. 삭제 tombstone이 없는 additive 레거시 드로잉 전체 상태는 검증되지 않은 기존 peer가 자동 seed하지 않으며, 명시적 복구·재연결 seed만 유지한다. Fabric 합류 요청에는 현재 인과 버전을 실어 안정 참가자가 요청자보다 높은 버전으로 응답하고, `drawingsV3` 부재도 명시 tombstone으로 전파한다.
 - 신규 참가자는 Fabric 수신 리스너 설치 직후 seed를 한 번 요청하고, 10초 이상 안정된 기존 참가자만 응답한다. 방 입장 직후의 1회 seed가 구독 창에서 유실돼도 복구되며 새 참가자의 구버전 seed 억제는 유지된다.
 - 동시 저장 루트는 세션 actor와 Lamport clock으로 결정적 순서를 부여한다. 스트로크 병합 없이 한쪽 루트가 이기는 기존 정책은 유지하되, 양쪽 화면이 서로 반대 루트를 적용하는 분기는 막고 패자 지문을 stale로 기록해 Drive rollback도 차단한다.
 - stop→start를 넘은 적용 큐는 `_sessionGeneration`으로 폐기하며, 새 세션 A3는 정상 적용한다.
@@ -156,7 +156,7 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 ### 예상/실제 리스크
 
 - 예상: 큰 payload, 파일 A→B 전환, 저장 에코, 늦은 합류, 세션 재시작이 서로 영향을 줄 수 있다.
-- 실제: owner 경합, 협업 방의 잔존 인원 기준값, 이전 세션 큐 누출, 동시 저장의 상호 교체 분기를 구현·리뷰 과정에서 추가 발견해 각각 fence를 넣었다. 루트 단위 동시 편집은 결정적 last-save-wins로 수렴하지만 패자 획은 대체될 수 있고, 10초 안 동시 합류 seed 억제와 대용량 청크 수신 슬롯 1개라는 계획상 한계는 유지했다. 실제 앱 두 개로 같은 `.bframe`을 열었지만 두 번째 격리 프로필의 Fabric 진입이 준비 상태에 머물러 원격 획 전파는 끝까지 확인하지 못했다.
+- 실제: owner 경합, 협업 방의 잔존 인원 기준값, 이전 세션 큐 누출, 동시 저장의 상호 교체 분기를 구현·리뷰 과정에서 추가 발견해 각각 fence를 넣었다. 루트 단위 동시 편집은 결정적 last-save-wins로 수렴하지만 패자 획은 대체될 수 있고, 삭제를 표현하지 못하는 레거시 late-join 전체 seed는 데이터 부활보다 안전한 파일 reload·후속 delta 경로를 택해 자동 실행을 중단했다. 10초 안 동시 합류 Fabric seed 억제와 대용량 청크 수신 슬롯 1개라는 한계는 유지했다. 실제 앱 두 개로 같은 `.bframe`을 열었지만 두 번째 격리 프로필의 Fabric 진입이 준비 상태에 머물러 원격 획 전파는 끝까지 확인하지 못했다.
 
 ## Phase 6: mpv 입력 소비 차단과 버전 갱신
 
@@ -208,6 +208,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 21. 6차 Codex 재리뷰에서 Drive가 D0에 머문 동안 Broadcast D1~D10을 수락하면 아직 파일에서 관측하지 못한 D1도 8개 stale cap에서 먼저 축출돼, 뒤늦은 D1 파일이 현재 D10을 되돌리는 P1을 발견했다. full canonical 지문을 고정 길이 compact identity로 바꾸고 count eviction을 제거해 세션 동안 수락한 중간 루트를 잊지 않도록 했다. 서로 다른 `documentId`의 D1~D10 뒤 D1 reload import 0회·D10 유지, 미지 파일 루트 정상 설치, 명시 Broadcast 우회를 실제 provider로 검증했다.
 22. 같은 재리뷰에서 Ctrl/Cmd+Z/Y의 Fabric IPC가 느린 동안 새 댓글·하이라이트가 전역 스택에 들어오면, 뒤늦은 `history-empty` 폴백이 키 입력 당시 없던 새 항목을 지우는 P2를 발견했다. 모든 전역 undo/redo 스택 변경에 단조 revision을 올리고 active Fabric 단축키가 입력 시점 revision과 응답 시점 revision을 비교하도록 보강했다. 중간 변경 시 폴백 0회, 무변경 시 undo/redo 각 1회를 deferred 기능 테스트로 검증했다.
 23. 6차 보강의 독립 경로 감사에서 mpv 오버레이가 포커스를 가진 경우 host가 먼저 Fabric 히스토리를 비동기로 조회한 뒤 renderer에 키를 넘겨, revision 캡처가 물리 입력보다 늦고 Fabric 조회도 두 번 일어나는 P2를 확인했다. host의 로컬 히스토리 실행을 제거하고 Ctrl/Cmd+Z/Y를 즉시 renderer에 릴레이해 단일 owner가 입력 시점 revision 캡처부터 조건부 폴백까지 한 번만 수행하도록 고정했다. 메인 창의 직전 댓글 입력 포커스가 남아도 history chord는 문서 타깃을 그대로 보존해 컨트롤러에 도달시키되, Tab 등 일반 릴레이 키는 기존 활성 요소로 보내는 기능 테스트도 추가했다.
+24. 7차 Codex 재리뷰에서 10초 억제가 끝난 stale peer도 새 참가자가 들어오면 삭제 tombstone이 없는 레거시 `broadcastCurrentState()`를 실행해, 삭제된 키프레임·레이어를 `getOrCreateKeyframe()`/`restore: true`로 부활시키고 RDM 자동 저장으로 영속화하는 P1을 재현했다. 참가자 증가 자동 seed에서 레거시 호출만 제거하고 댓글·인과 버전 Fabric seed와 명시적 복구·재연결 seed는 유지했다. 소스 계약은 두 블록을 각각 잘라 과잉 제거와 재도입을 함께 막는다.
 
 ## 리스크 및 우려 사항
 
@@ -230,6 +231,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 디스크 관측이 전진한 뒤 직전 관측 루트가 보호에서 빠져 rollback | 높음 | scalar 이동 시 직전 관측 지문도 compact stale 이력에 보존, 현재 권위 루트는 stale 판정에서 제외 |
 | 보류 중인 파일 reload가 더 최신 Broadcast 적용 뒤 완료되어 역전 | 높음 | explicit apply와 same-root 고버전 수락 시 이전 disk reload epoch 무효화, 후속 fresh reload 정상 경로 보존 |
 | `drawingsV3` 부재 상태를 seed하지 못해 지연 복제본의 구버전 획이 부활 | 높음 | 명시 tombstone + 요청 clock causal floor + provider reset 경로 |
+| stale peer의 additive 레거시 전체 seed가 삭제된 키프레임·레이어를 부활 | 높음 | 참가자 증가 자동 seed에서는 레거시 호출 제외, causal Fabric·댓글 seed와 명시적 복구·재연결 seed만 유지 |
 | 500ms 안의 후속 파일 알림이 누락돼 최신 루트가 미적용 | 중간 | leading 즉시 실행 + 최신 trailing 1회 coalescing, 실행 시 파일 경로 재검증 |
 | 저장 대기 중 Undo된 댓글의 Slack 알림이 뒤늦게 발송 | 중간 | 저장 뒤 현재 마커 null/deleted 재검증 |
 | Fabric 동시 편집에서 패자 획이 대체 | 중간 | 양쪽은 결정적 root-level last-save-wins로 수렴, 스트로크 단위 병합은 후속 범위 |
@@ -251,7 +253,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
 | 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
 | 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
-| PR 리뷰 보강 최종 | 25/25 | 1,899/1,899 | PASS |
+| PR 리뷰 보강 최종 | 25/25 | 1,901/1,901 | PASS |
 
 Task 6 TDD focused 검증:
 
@@ -274,7 +276,7 @@ npm.cmd run test:mpv
 | 스크립트 | Tests | Pass | Fail |
 |---|---:|---:|---:|
 | `test:fabric-drawing-pilot` | 328 | 328 | 0 |
-| `test:fabric-drawing-persistence` | 153 | 153 | 0 |
+| `test:fabric-drawing-persistence` | 154 | 154 | 0 |
 | `test:recent` | 18 | 18 | 0 |
 | `test:frame-grid` | 35 | 35 | 0 |
 | `test:cluster` | 43 | 43 | 0 |
@@ -282,7 +284,7 @@ npm.cmd run test:mpv
 | `test:playlist-ordering` | 17 | 17 | 0 |
 | `test:playlist-continuous` | 13 | 13 | 0 |
 | `test:playlist-comments` | 9 | 9 | 0 |
-| `test:playlist` | 263 | 263 | 0 |
+| `test:playlist` | 264 | 264 | 0 |
 | `test:cutlist` | 82 | 82 | 0 |
 | `test:drawing` | 291 | 291 | 0 |
 | `test:drawing-v3-hardening` | 174 | 174 | 0 |
@@ -298,7 +300,7 @@ npm.cmd run test:mpv
 | `test:version` | 2 | 2 | 0 |
 | `test:file-drop` | 4 | 4 | 0 |
 | `test:hybrid` | 5 | 5 | 0 |
-| **합계** | **1,899** | **1,899** | **0** |
+| **합계** | **1,901** | **1,901** | **0** |
 
 최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
 
@@ -320,4 +322,4 @@ npm.cmd run test:mpv
 | 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
 | 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
 
-수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,899건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,901건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -140,6 +140,7 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 - `reloadDrawingsV3FromDisk()`는 await 전에 owner를 캡처하고, await 뒤 재검증한 같은 owner를 reconcile에 명시 전달한다.
 - 수락한 원격 루트를 opaque 저장 기준에도 즉시 반영해, Drive의 구버전 파일을 읽은 뒤 관련 없는 댓글을 저장해도 최신 `drawingsV3`가 되돌아가지 않게 한다.
 - provider 설치가 성공한 뒤에만 stale 지문·디스크 상태·opaque 기준을 확정해, 첫 설치 실패 뒤 같은 payload를 실제로 다시 설치할 수 있게 한다.
+- 같은 파일의 디스크 reload 요청마다 세대를 올리고 reconcile의 owner predicate까지 전달해, 느린 이전 hydration이 빠른 최신 reload 뒤에 완료돼도 설치하지 않는다.
 - 연결 중 파일 감지는 comments/레거시 전체 reload를 계속 막되 `drawingsV3`만 제한적으로 다시 읽는다.
 - 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 현재 상태를 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다.
 - 신규 참가자는 Fabric 수신 리스너 설치 직후 seed를 한 번 요청하고, 10초 이상 안정된 기존 참가자만 응답한다. 방 입장 직후의 1회 seed가 구독 창에서 유실돼도 복구되며 새 참가자의 구버전 seed 억제는 유지된다.
@@ -188,6 +189,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 9. PR #174 Codex 리뷰에서 Liveblocks 방 입장과 Fabric 수신 리스너 설치 사이의 창에 기존 참가자의 1회 seed가 유실될 수 있음을 발견했다. post-subscription 요청/응답 handshake를 추가하되, 신규 참가자의 구버전 seed를 막는 기존 10초 조건을 응답자에도 적용했다.
 10. PR #174 Codex 리뷰에서 Broadcast로 수락한 최신 루트가 provider에만 설치되고 opaque 저장 기준에는 남지 않아, 관련 없는 저장이 구버전 디스크 루트를 다시 기록할 수 있음을 발견했다. 계획서는 이를 잔여 한계로 수용하고 수정 금지로 두었지만 실제 데이터 되돌림 P1으로 판정되어 사용자 승인 후 예외적으로 보강했다.
 11. 위 보강의 독립 검토에서 provider 설치 실패 전에 `_drawingsV3DiskState`를 갱신하면 같은 payload 재시도가 fingerprint no-op 성공으로 오인되는 P1을 추가 발견했다. 사용자에게 중단 보고하고 승인받은 뒤, provider accepted/preserved 확인 후에만 기준 상태를 확정하도록 순서를 바꿨다.
+12. 첫 리뷰 반영 커밋의 Codex 재리뷰에서 같은 파일의 Drive 알림 B·C가 겹치면 빠른 C 적용 뒤 느린 B hydration이 완료되어 다시 B로 역전되는 P1을 발견했다. `reloadDrawingsV3FromDisk()` 요청 세대를 읽기 await 뒤와 reconcile 설치 직전에 모두 재검증해 최신 요청만 적용되도록 했다.
 
 ## 리스크 및 우려 사항
 
@@ -201,6 +203,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 방 입장 직후 기존 Fabric seed가 수신 구독 전에 유실 | 높음 | post-subscription seed 요청 + 안정된 peer 응답 테스트 |
 | 원격 최신 루트 적용 뒤 관련 없는 저장이 구버전 루트를 재기록 | 높음 | accepted 루트를 opaque 기준에 채택하고 Drive 지연 저장 회귀 테스트 추가 |
 | provider 설치 실패를 동일 payload 재시도에서 성공으로 오인 | 높음 | 설치 성공 후에만 기준 상태 확정, 실패→동일 payload 재시도 기능 테스트 추가 |
+| 같은 파일의 느린 이전 reload가 빠른 최신 reload를 역전 | 높음 | RDM reload request generation fence를 reconcile owner 검사까지 전달 |
 | 저장 대기 중 Undo된 댓글의 Slack 알림이 뒤늦게 발송 | 중간 | 저장 뒤 현재 마커 null/deleted 재검증 |
 | Fabric 동시 편집 충돌 | 중간 | 현재는 루트 단위 last-save-wins로 수용, 후속 정교화 필요 |
 | 늦은 합류 seed가 10초 이내에는 억제됨 | 중간 | 계획된 기준 유지, 자동 경합 계약 통과; 격리 프로필의 준비 정체로 실제 원격 획 전파는 미확인 |
@@ -220,7 +223,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
 | 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
 | 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
-| PR 리뷰 보강 최종 | 25/25 | 1,880/1,880 | PASS |
+| PR 리뷰 보강 최종 | 25/25 | 1,882/1,882 | PASS |
 
 Task 6 TDD focused 검증:
 
@@ -243,7 +246,7 @@ npm.cmd run test:mpv
 | 스크립트 | Tests | Pass | Fail |
 |---|---:|---:|---:|
 | `test:fabric-drawing-pilot` | 327 | 327 | 0 |
-| `test:fabric-drawing-persistence` | 144 | 144 | 0 |
+| `test:fabric-drawing-persistence` | 145 | 145 | 0 |
 | `test:recent` | 18 | 18 | 0 |
 | `test:frame-grid` | 35 | 35 | 0 |
 | `test:cluster` | 43 | 43 | 0 |
@@ -251,7 +254,7 @@ npm.cmd run test:mpv
 | `test:playlist-ordering` | 17 | 17 | 0 |
 | `test:playlist-continuous` | 13 | 13 | 0 |
 | `test:playlist-comments` | 9 | 9 | 0 |
-| `test:playlist` | 254 | 254 | 0 |
+| `test:playlist` | 255 | 255 | 0 |
 | `test:cutlist` | 82 | 82 | 0 |
 | `test:drawing` | 291 | 291 | 0 |
 | `test:drawing-v3-hardening` | 174 | 174 | 0 |
@@ -267,7 +270,7 @@ npm.cmd run test:mpv
 | `test:version` | 2 | 2 | 0 |
 | `test:file-drop` | 4 | 4 | 0 |
 | `test:hybrid` | 5 | 5 | 0 |
-| **합계** | **1,880** | **1,880** | **0** |
+| **합계** | **1,882** | **1,882** | **0** |
 
 최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
 
@@ -289,4 +292,4 @@ npm.cmd run test:mpv
 | 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
 | 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
 
-수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,880건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,882건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -148,7 +148,7 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 - 같은 파일의 디스크 reload 요청마다 세대를 올리고 reconcile의 owner predicate까지 전달해, 느린 이전 hydration이 빠른 최신 reload 뒤에 완료돼도 설치하지 않는다.
 - 명시 Broadcast 적용이 시작되거나 같은 내용의 더 높은 인과 버전을 수락하면 그보다 먼저 시작한 디스크 reload 세대를 무효화해, 파일 읽기 B가 보류된 동안 협업 루트 C가 확정된 뒤 B가 C를 덮지 못하게 한다.
 - 연결 중 파일 감지는 comments/레거시 전체 reload를 계속 막되 `drawingsV3`만 제한적으로 다시 읽고, 500ms 안의 후속 알림은 한 번의 trailing reload로 합쳐 최신 상태를 놓치지 않는다.
-- 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 댓글 상태와 causal Fabric root를 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다. 삭제 tombstone이 없는 additive 레거시 드로잉 전체 상태는 검증되지 않은 기존 peer가 자동 seed하지 않으며, 명시적 복구·재연결 seed만 유지한다. Fabric 합류 요청에는 현재 인과 버전을 실어 안정 참가자가 요청자보다 높은 버전으로 응답하고, `drawingsV3` 부재도 명시 tombstone으로 전파한다.
+- 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 causal Fabric root만 자동 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다. 삭제 상태를 포함하지 않는 additive 댓글·레거시 드로잉 전체 상태는 자동 합류·첫 저장·충돌 병합·종료 취소 재연결 어디에서도 seed하지 않는다. 기존 `seedCurrentState` 옵션은 causal Fabric root만 전송하며, 종료 취소 재연결은 이 옵션도 false로 둔다. Fabric 합류 요청에는 현재 인과 버전을 실어 안정 참가자가 요청자보다 높은 버전으로 응답하고, `drawingsV3` 부재도 명시 tombstone으로 전파한다.
 - 신규 참가자는 Fabric 수신 리스너 설치 직후 seed를 한 번 요청하고, 10초 이상 안정된 기존 참가자만 응답한다. 방 입장 직후의 1회 seed가 구독 창에서 유실돼도 복구되며 새 참가자의 구버전 seed 억제는 유지된다.
 - 동시 저장 루트는 세션 actor와 Lamport clock으로 결정적 순서를 부여한다. 스트로크 병합 없이 한쪽 루트가 이기는 기존 정책은 유지하되, 양쪽 화면이 서로 반대 루트를 적용하는 분기는 막고 패자 지문을 stale로 기록해 Drive rollback도 차단한다.
 - stop→start를 넘은 적용 큐는 `_sessionGeneration`으로 폐기하며, 새 세션 A3는 정상 적용한다.
@@ -156,7 +156,7 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 ### 예상/실제 리스크
 
 - 예상: 큰 payload, 파일 A→B 전환, 저장 에코, 늦은 합류, 세션 재시작이 서로 영향을 줄 수 있다.
-- 실제: owner 경합, 협업 방의 잔존 인원 기준값, 이전 세션 큐 누출, 동시 저장의 상호 교체 분기를 구현·리뷰 과정에서 추가 발견해 각각 fence를 넣었다. 루트 단위 동시 편집은 결정적 last-save-wins로 수렴하지만 패자 획은 대체될 수 있고, 삭제를 표현하지 못하는 레거시 late-join 전체 seed는 데이터 부활보다 안전한 파일 reload·후속 delta 경로를 택해 자동 실행을 중단했다. 10초 안 동시 합류 Fabric seed 억제와 대용량 청크 수신 슬롯 1개라는 한계는 유지했다. 실제 앱 두 개로 같은 `.bframe`을 열었지만 두 번째 격리 프로필의 Fabric 진입이 준비 상태에 머물러 원격 획 전파는 끝까지 확인하지 못했다.
+- 실제: owner 경합, 협업 방의 잔존 인원 기준값, 이전 세션 큐 누출, 동시 저장의 상호 교체 분기를 구현·리뷰 과정에서 추가 발견해 각각 fence를 넣었다. 루트 단위 동시 편집은 결정적 last-save-wins로 수렴하지만 패자 획은 대체될 수 있고, 삭제를 표현하지 못하는 댓글·레거시 드로잉 전체 seed는 데이터 부활보다 안전한 파일 reload·후속 delta 경로를 택해 자동·명시 실행을 모두 중단했다. 이에 따라 첫 저장 전에 만든 댓글·레거시 드로잉의 다른 클라이언트 즉시 반영은 파일 재개방이나 후속 delta까지 지연될 수 있다. 10초 안 동시 합류 Fabric seed 억제와 대용량 청크 수신 슬롯 1개라는 한계는 유지했다. 실제 앱 두 개로 같은 `.bframe`을 열었지만 두 번째 격리 프로필의 Fabric 진입이 준비 상태에 머물러 원격 획 전파는 끝까지 확인하지 못했다.
 
 ## Phase 6: mpv 입력 소비 차단과 버전 갱신
 
@@ -209,6 +209,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 22. 같은 재리뷰에서 Ctrl/Cmd+Z/Y의 Fabric IPC가 느린 동안 새 댓글·하이라이트가 전역 스택에 들어오면, 뒤늦은 `history-empty` 폴백이 키 입력 당시 없던 새 항목을 지우는 P2를 발견했다. 모든 전역 undo/redo 스택 변경에 단조 revision을 올리고 active Fabric 단축키가 입력 시점 revision과 응답 시점 revision을 비교하도록 보강했다. 중간 변경 시 폴백 0회, 무변경 시 undo/redo 각 1회를 deferred 기능 테스트로 검증했다.
 23. 6차 보강의 독립 경로 감사에서 mpv 오버레이가 포커스를 가진 경우 host가 먼저 Fabric 히스토리를 비동기로 조회한 뒤 renderer에 키를 넘겨, revision 캡처가 물리 입력보다 늦고 Fabric 조회도 두 번 일어나는 P2를 확인했다. host의 로컬 히스토리 실행을 제거하고 Ctrl/Cmd+Z/Y를 즉시 renderer에 릴레이해 단일 owner가 입력 시점 revision 캡처부터 조건부 폴백까지 한 번만 수행하도록 고정했다. 메인 창의 직전 댓글 입력 포커스가 남아도 history chord는 문서 타깃을 그대로 보존해 컨트롤러에 도달시키되, Tab 등 일반 릴레이 키는 기존 활성 요소로 보내는 기능 테스트도 추가했다.
 24. 7차 Codex 재리뷰에서 10초 억제가 끝난 stale peer도 새 참가자가 들어오면 삭제 tombstone이 없는 레거시 `broadcastCurrentState()`를 실행해, 삭제된 키프레임·레이어를 `getOrCreateKeyframe()`/`restore: true`로 부활시키고 RDM 자동 저장으로 영속화하는 P1을 재현했다. 참가자 증가 자동 seed에서 레거시 호출만 제거하고 댓글·인과 버전 Fabric seed와 명시적 복구·재연결 seed는 유지했다. 소스 계약은 두 블록을 각각 잘라 과잉 제거와 재도입을 함께 막는다.
+25. 같은 HEAD의 후속 Codex 재리뷰에서 댓글 current-state seed도 삭제 marker를 보내지 않고 살아 있는 marker만 `COMMENT_MARKER_ADDED`로 전파하므로, 삭제 전 파일을 가진 stale peer가 신규 참가자에게 댓글을 부활시키고 자동 저장할 수 있는 P1을 확인했다. 참가자 증가 자동 seed는 causal tombstone/version을 가진 Fabric만 남기고 댓글·레거시 additive seed를 모두 제외했다. 교차 감사에서는 종료 취소 후 reload 없이 재접속하는 두 경로뿐 아니라, 첫 저장·충돌 병합에서 디스크 read 직후 리스너 설치 전에 발생한 원격 삭제도 놓칠 수 있음을 확인했다. 따라서 공통 `seedCurrentState` 블록도 causal Fabric-only로 고정하고 종료 취소의 두 caller는 `seedCurrentState: false`로 두었다. 소스 계약은 자동·명시 블록에서 additive seed 0건, 병합 caller의 Fabric seed 옵션 true 3건, 재연결 false 2건을 함께 검증한다.
 
 ## 리스크 및 우려 사항
 
@@ -231,7 +232,8 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 디스크 관측이 전진한 뒤 직전 관측 루트가 보호에서 빠져 rollback | 높음 | scalar 이동 시 직전 관측 지문도 compact stale 이력에 보존, 현재 권위 루트는 stale 판정에서 제외 |
 | 보류 중인 파일 reload가 더 최신 Broadcast 적용 뒤 완료되어 역전 | 높음 | explicit apply와 same-root 고버전 수락 시 이전 disk reload epoch 무효화, 후속 fresh reload 정상 경로 보존 |
 | `drawingsV3` 부재 상태를 seed하지 못해 지연 복제본의 구버전 획이 부활 | 높음 | 명시 tombstone + 요청 clock causal floor + provider reset 경로 |
-| stale peer의 additive 레거시 전체 seed가 삭제된 키프레임·레이어를 부활 | 높음 | 참가자 증가 자동 seed에서는 레거시 호출 제외, causal Fabric·댓글 seed와 명시적 복구·재연결 seed만 유지 |
+| stale peer의 additive 레거시 전체 seed가 삭제된 키프레임·레이어를 부활 | 높음 | 자동·명시 seed 모두 causal Fabric-only, 종료 취소 재연결 옵션 false |
+| stale peer의 additive 댓글 전체 seed가 삭제된 marker를 부활 | 높음 | 자동·명시 seed 모두 causal Fabric-only, 종료 취소 재연결 옵션 false |
 | 500ms 안의 후속 파일 알림이 누락돼 최신 루트가 미적용 | 중간 | leading 즉시 실행 + 최신 trailing 1회 coalescing, 실행 시 파일 경로 재검증 |
 | 저장 대기 중 Undo된 댓글의 Slack 알림이 뒤늦게 발송 | 중간 | 저장 뒤 현재 마커 null/deleted 재검증 |
 | Fabric 동시 편집에서 패자 획이 대체 | 중간 | 양쪽은 결정적 root-level last-save-wins로 수렴, 스트로크 단위 병합은 후속 범위 |

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -136,7 +136,7 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 ### 구현 내용
 
 - 저장 완료 루트를 크기에 따라 인라인 또는 청크로 전송하고, 원격 루트는 순서대로 적용한다.
-- stale 지문을 최대 8개 보관해 Drive에서 늦게 되돌아온 구버전 루트의 재설치를 막는다.
+- stale 지문은 최대 8개를 유지하고, 실제 디스크에서 마지막으로 관측한 지문은 별도 상태로 보호해 현재 디스크에 머문 지연 루트가 8개 stale 이력에서 밀려나도 되돌아오지 않게 한다.
 - `reloadDrawingsV3FromDisk()`는 await 전에 owner를 캡처하고, await 뒤 재검증한 같은 owner를 reconcile에 명시 전달한다.
 - 수락한 원격 루트를 opaque 저장 기준에도 즉시 반영해, Drive의 구버전 파일을 읽은 뒤 관련 없는 댓글을 저장해도 최신 `drawingsV3`가 되돌아가지 않게 한다.
 - provider 설치가 성공한 뒤에만 stale 지문·디스크 상태·opaque 기준을 확정해, 첫 설치 실패 뒤 같은 payload를 실제로 다시 설치할 수 있게 한다.
@@ -194,6 +194,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 13. 두 번째 Codex 재리뷰에서 두 사용자가 서로의 Broadcast를 받기 전에 각각 저장하면 A는 B, B는 A를 적용해 반대 상태로 고착되는 P1을 발견했다. 계획의 스트로크 병합 범위 외 결정은 유지하면서 root-level Lamport LWW, local-dirty 후속 저장의 clock 전진, 패자 stale 연동, seed·청크 버전 보존을 추가했다.
 14. 같은 재리뷰에서 연결 중 500ms 이내 두 번째 파일 알림이 trailing 예약 없이 버려지는 P2를 발견했다. 첫 reload는 즉시 유지하고 interval 안의 최신 알림을 남은 시간 뒤 한 번 실행하며, 파일 전환 시 이전 예약을 폐기하도록 보강했다.
 15. 3차 보강의 독립 적대 검토에서 적용 await 중 로컬 저장의 버전 강등, 동일 revision 합류 seed의 지문 의존, 대용량 청크 헤더 교차·clock 미관측·동일 버전 재시도 차단, 상충 stale 이력의 재수렴 실패를 추가 재현했다. 최종 root 재확인, 최초 publish 승격, header 버전 우선 슬롯·즉시 clock 관측·새 transfer ID 재시도 교체, 결정적 버전 비교를 통과한 명시 Broadcast만 stale-file guard를 1회 우회하는 계약으로 각각 차단했다. 단순 clock 재승격·재전파 방식은 상충 stale 이력에서 무한 핑퐁을 재현해 채택하지 않았다.
+16. 4차 Codex 재리뷰에서 Drive가 D0에 머문 채 Broadcast D1~D9가 수락되면 8개 stale 이력에서 D0가 밀려나 파일 reload가 D0를 다시 설치하는 P1을 발견했다. 실제 디스크의 마지막 관측 지문을 capped Set 밖에서 별도 추적하고, Broadcast는 이를 바꾸지 않으며 disk stale 관측·현재 일치·새 상태 설치 성공 때만 이동하도록 보강했다. D0 보호, 실제 D1 전진 뒤 보호 이동, 미지 D19 정상 설치까지 실제 provider spy로 검증했다.
 
 ## 리스크 및 우려 사항
 
@@ -211,6 +212,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 동시 저장한 두 참가자가 상대 루트를 교차 적용해 서로 다른 상태로 고착 | 높음 | Lamport+actor 결정적 root LWW, pending/local-save clock, 패자 stale 지문 연동 |
 | 대용량 청크 헤더 교차·미완료 전송 때문에 최고 버전 또는 동일 버전 재시도가 유실 | 높음 | header 단계에서 낮은 버전만 거절하고 동일 버전의 새 transfer ID는 교체, 수신 즉시 Lamport clock 관측 |
 | 상충 stale 이력에서 고버전 Broadcast가 no-op되거나 재전파 핑퐁 | 높음 | 명시 Broadcast만 해당 stale 지문을 설치 성공 시 해제, 파일 reload guard와 실패 시 stale 보호 유지 |
+| 실제 Drive 루트가 8개 stale 이력에서 퇴출돼 파일 reload로 rollback | 높음 | 마지막 실제 디스크 관측 지문을 Set 밖에서 보호하고 disk 전진 확인 시에만 이동 |
 | 500ms 안의 후속 파일 알림이 누락돼 최신 루트가 미적용 | 중간 | leading 즉시 실행 + 최신 trailing 1회 coalescing, 실행 시 파일 경로 재검증 |
 | 저장 대기 중 Undo된 댓글의 Slack 알림이 뒤늦게 발송 | 중간 | 저장 뒤 현재 마커 null/deleted 재검증 |
 | Fabric 동시 편집에서 패자 획이 대체 | 중간 | 양쪽은 결정적 root-level last-save-wins로 수렴, 스트로크 단위 병합은 후속 범위 |
@@ -231,7 +233,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
 | 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
 | 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
-| PR 리뷰 보강 최종 | 25/25 | 1,888/1,888 | PASS |
+| PR 리뷰 보강 최종 | 25/25 | 1,890/1,890 | PASS |
 
 Task 6 TDD focused 검증:
 
@@ -254,7 +256,7 @@ npm.cmd run test:mpv
 | 스크립트 | Tests | Pass | Fail |
 |---|---:|---:|---:|
 | `test:fabric-drawing-pilot` | 327 | 327 | 0 |
-| `test:fabric-drawing-persistence` | 148 | 148 | 0 |
+| `test:fabric-drawing-persistence` | 149 | 149 | 0 |
 | `test:recent` | 18 | 18 | 0 |
 | `test:frame-grid` | 35 | 35 | 0 |
 | `test:cluster` | 43 | 43 | 0 |
@@ -262,7 +264,7 @@ npm.cmd run test:mpv
 | `test:playlist-ordering` | 17 | 17 | 0 |
 | `test:playlist-continuous` | 13 | 13 | 0 |
 | `test:playlist-comments` | 9 | 9 | 0 |
-| `test:playlist` | 258 | 258 | 0 |
+| `test:playlist` | 259 | 259 | 0 |
 | `test:cutlist` | 82 | 82 | 0 |
 | `test:drawing` | 291 | 291 | 0 |
 | `test:drawing-v3-hardening` | 174 | 174 | 0 |
@@ -278,7 +280,7 @@ npm.cmd run test:mpv
 | `test:version` | 2 | 2 | 0 |
 | `test:file-drop` | 4 | 4 | 0 |
 | `test:hybrid` | 5 | 5 | 0 |
-| **합계** | **1,888** | **1,888** | **0** |
+| **합계** | **1,890** | **1,890** | **0** |
 
 최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
 
@@ -300,4 +302,4 @@ npm.cmd run test:mpv
 | 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
 | 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
 
-수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,888건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,890건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -208,7 +208,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 19. 5차 Codex 재리뷰에서 실제 디스크 관측이 D1→D2로 전진할 때 D1이 scalar와 Set 양쪽에서 빠져 이후 Drive rollback으로 재설치되는 P1을 발견했다. scalar가 이동할 때 현재 권위 루트를 제외한 직전 관측 지문을 capped history의 최신 항목으로 승계하고, cap 압박 뒤 disk catch-up→rollback을 실제 provider spy로 검증했다.
 20. 5차 보강의 독립 검토에서 현재 내용과 지문이 같은 더 높은 Broadcast 버전은 provider 적용을 생략해 pending disk reload epoch를 무효화하지 않는 P1을 재현했다. RDM의 전용 invalidation 경로를 일반 external apply와 same-root `comparison > 0` 수락이 함께 호출하게 하고, 같은 A의 clock 10 수락 뒤 보류된 B reload가 false·A 유지인지 실제 manager/store/sync로 검증했다.
 21. 6차 Codex 재리뷰에서 Drive가 D0에 머문 동안 Broadcast D1~D10을 수락하면 아직 파일에서 관측하지 못한 D1도 8개 stale cap에서 먼저 축출돼, 뒤늦은 D1 파일이 현재 D10을 되돌리는 P1을 발견했다. full canonical 지문을 고정 길이 compact identity로 바꾸고 count eviction을 제거해 세션 동안 수락한 중간 루트를 잊지 않도록 했다. 서로 다른 `documentId`의 D1~D10 뒤 D1 reload import 0회·D10 유지, 미지 파일 루트 정상 설치, 명시 Broadcast 우회를 실제 provider로 검증했다.
-22. 같은 재리뷰에서 Ctrl/Cmd+Z/Y의 Fabric IPC가 느린 동안 새 댓글·하이라이트가 전역 스택에 들어오면, 뒤늦은 `history-empty` 폴백이 키 입력 당시 없던 새 항목을 지우는 P2를 발견했다. 모든 전역 undo/redo 스택 변경에 단조 revision을 올리고 active Fabric 단축키가 입력 시점 revision과 응답 시점 revision을 비교하도록 보강했다. 중간 변경 시 폴백 0회, 무변경 시 undo/redo 각 1회를 deferred 기능 테스트로 검증했다.
+22. 같은 재리뷰에서 Ctrl/Cmd+Z/Y의 Fabric IPC가 느린 동안 새 댓글·하이라이트가 전역 스택에 들어오면, 뒤늦은 `history-empty` 폴백이 키 입력 당시 없던 새 항목을 지우는 P2를 발견했다. 댓글·하이라이트 추가, 직접 전역 undo/redo, 파일 초기화 같은 외부 스택 변경에 단조 revision을 올리고 active Fabric 단축키가 입력 시점 revision과 응답 시점 revision을 비교하도록 보강했다. 중간 변경 시 폴백 0회, 무변경 시 undo/redo 각 1회를 deferred 기능 테스트로 검증했다. 연속 Fabric 폴백 자체의 stack 이동은 후속 #31에서 별도 provenance로 분리했다.
 23. 6차 보강의 독립 경로 감사에서 mpv 오버레이가 포커스를 가진 경우 host가 먼저 Fabric 히스토리를 비동기로 조회한 뒤 renderer에 키를 넘겨, revision 캡처가 물리 입력보다 늦고 Fabric 조회도 두 번 일어나는 P2를 확인했다. host의 로컬 히스토리 실행을 제거하고 Ctrl/Cmd+Z/Y를 즉시 renderer에 릴레이해 단일 owner가 입력 시점 revision 캡처부터 조건부 폴백까지 한 번만 수행하도록 고정했다. 메인 창의 직전 댓글 입력 포커스가 남아도 history chord는 문서 타깃을 그대로 보존해 컨트롤러에 도달시키되, Tab 등 일반 릴레이 키는 기존 활성 요소로 보내는 기능 테스트도 추가했다.
 24. 7차 Codex 재리뷰에서 10초 억제가 끝난 stale peer도 새 참가자가 들어오면 삭제 tombstone이 없는 레거시 `broadcastCurrentState()`를 실행해, 삭제된 키프레임·레이어를 `getOrCreateKeyframe()`/`restore: true`로 부활시키고 RDM 자동 저장으로 영속화하는 P1을 재현했다. 참가자 증가 자동 seed에서 레거시 호출만 제거하고 댓글·인과 버전 Fabric seed와 명시적 복구·재연결 seed는 유지했다. 소스 계약은 두 블록을 각각 잘라 과잉 제거와 재도입을 함께 막는다.
 25. 같은 HEAD의 후속 Codex 재리뷰에서 댓글 current-state seed도 삭제 tombstone 없이 살아 있는 layer·marker만 additive event로 전파하므로, 삭제 전 파일을 가진 stale peer가 신규 참가자에게 삭제된 댓글 layer와 그 marker를 부활시키고 자동 저장할 수 있는 P1을 확인했다. 참가자 증가 자동 seed는 causal tombstone/version을 가진 Fabric만 남기고 댓글·레거시 additive seed를 모두 제외했다. 교차 감사에서는 종료 취소 후 reload 없이 재접속하는 두 경로뿐 아니라, 첫 저장·충돌 병합에서 디스크 read 직후 리스너 설치 전에 발생한 원격 layer 삭제도 놓칠 수 있음을 확인했다. 따라서 공통 `seedCurrentState` 블록도 causal Fabric-only로 고정하고 종료 취소의 두 caller는 `seedCurrentState: false`로 두었다. 소스 계약은 자동·명시 블록에서 additive seed 0건, 병합 caller의 Fabric seed 옵션 true 3건, 재연결 false 2건을 함께 검증한다.
@@ -217,6 +217,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 28. 같은 검토에서 비교 불가능한 baseline을 단일 boolean으로 막으면 다른 peer의 ACK 하나가 남은 충돌까지 풀거나, 반대로 정상 same-document 수렴 뒤 저장이 영구 차단되는 P1을 확인했다. Sync가 peer actor별 unresolved Set을 소유하고, CONFLICT·PULL·ACK·targeted root의 source를 끝까지 전달해 해당 peer만 해소한다. 64개를 넘는 재연결 actor는 항목을 축출하지 않고 unattributed fail-closed latch로 승격한다. RDM은 충돌 중 실제 Fabric 변경이 없는 댓글 저장만 차단하고, 실제 Fabric 저장·인과 root·유효한 파일 전진에서 hold를 해소한다.
 29. 저장 final hook 또는 `saveReview` IPC를 기다리는 동안 새 baseline 충돌·외부 root·로컬 Fabric 변경이 생기면, 이미 수집한 구버전 payload를 저장 성공으로 승인하고 `saved` Broadcast까지 보내는 P1을 실제 manager/store 하니스로 재현했다. 권위 epoch를 수집 직전에 캡처해 IPC 뒤 다시 비교하고, 불일치한 물리 write는 observed/stale 이력으로만 기록한 뒤 최신 root를 bounded 재시도한다. 외부 apply와 selective disk reload는 입장부터 종료까지 context-owned in-flight token으로 보호해 hydration 중 구버전 저장을 막되, 파일 A의 늦은 작업은 파일 B 저장을 막지 않는다. 같은 revision·다른 documentId 외부 root, install 보류 순서, IPC 중 로컬 rev 증가, A→B 전환 저장을 각각 기능 테스트로 고정했다.
 30. 위 자동저장 재개 경로의 독립 감사에서 pending 권위 작업이 끝나면 `pauseAutoSave()` 또는 `disconnect()` 뒤에도 dirty 타이머를 다시 예약하는 P2를 재현했다. 이어 pause 뒤 새 Fabric transition이 `_markDirty()`에서 별도 타이머를 만드는 우회도 확인했다. 권위 해소 전용 재개 helper는 `isLoading`과 연결 상태를 함께 확인하고, 범용 dirty 예약·timer callback은 기존 connect-less trailing-save 계약을 보존하며 `isLoading`만 재검증하도록 좁혔다. pending reload 종료와 pause 중 실제 provider 변경 모두 write 0건·dirty/localChanges 유지, disconnect 뒤 write 0건으로 검증했다.
+31. 9차 Codex 재리뷰에서 Ctrl/Cmd+Z/Y를 빠르게 두 번 누르면 두 요청이 같은 전역 history revision을 캡처하고, 첫 `history-empty` 폴백이 revision을 올려 두 번째 정상 의도까지 폐기하는 P2를 발견했다. Fabric IPC부터 조건부 전역 폴백 완료까지 하나의 queue transaction으로 직렬화하고, Fabric이 시작한 폴백 내부의 pop/push만 외부 변경 fence에서 제외했다. 새 댓글·하이라이트·파일 전환 같은 무관 변경은 계속 fence를 올려 대기 중 폴백을 차단한다. 비동기 undo/redo 중 무관 변경이 끼면 과거 action을 반대·원래 stack에 뒤늦게 재삽입하지 않고, 실패는 toast와 revision barrier를 유지한다. 연속 undo/redo 각 2회, 첫 폴백 보류 중 두 번째 IPC 0회, 무관 변경 시 두 번째 폴백 0회, deferred 성공·실패 중 push/reset의 old action 재삽입 0건을 기능 테스트로 고정했다.
 
 ## 리스크 및 우려 사항
 
@@ -224,7 +225,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 |---|---|---|
 | getter 대입 예외가 undo 스택을 반복해서 막음 | 높음 | `colorKey`만 복원하고 실패 토스트·소스 회귀 테스트 추가 |
 | Fabric 적용 뒤 전역 undo까지 이중 실행 | 높음 | `history-empty` 결과에만 폴백, applied/duplicate·repeat 차단 |
-| 느린 Fabric 빈-히스토리 응답이 키 입력 뒤 생긴 새 댓글·하이라이트를 전역 undo | 높음 | 오버레이 history chord를 즉시 renderer 문서의 단일 경로로 릴레이, 키 입력 시점 global history revision 캡처·응답 시 재검증, 모든 스택 mutation·파일 전환에서 revision 증가 |
+| 느린/연속 Fabric 빈-히스토리 응답이 새 댓글·하이라이트를 지우거나 두 번째 정상 undo를 누락 | 높음 | 오버레이 history chord를 renderer 단일 경로로 릴레이하고 IPC→조건부 폴백 전체를 직렬화, Fabric-origin stack 변경만 fence에서 제외하며 무관 변경·파일 전환과 비동기 stack commit을 revision으로 재검증 |
 | hydration의 늦은 응답이 취소된 B 진입을 부활 | 높음 | 입력 revision + owner 재검증 |
 | 파일 A의 늦은 디스크 읽기가 파일 B에 설치 | 높음 | owner 선캡처·await 후 재검증·명시 전달 |
 | 종료된 협업 세션의 큐가 새 세션을 오염 | 높음 | `_sessionGeneration` fence와 A1/A2/A3 테스트 |
@@ -267,7 +268,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
 | 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
 | 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
-| PR 리뷰 보강 최종 | 25/25 | 1,903/1,903 | PASS |
+| PR 리뷰 보강 최종 | 25/25 | 1,904/1,904 | PASS |
 
 Task 6 TDD focused 검증:
 
@@ -289,7 +290,7 @@ npm.cmd run test:mpv
 
 | 스크립트 | Tests | Pass | Fail |
 |---|---:|---:|---:|
-| `test:fabric-drawing-pilot` | 328 | 328 | 0 |
+| `test:fabric-drawing-pilot` | 329 | 329 | 0 |
 | `test:fabric-drawing-persistence` | 155 | 155 | 0 |
 | `test:recent` | 18 | 18 | 0 |
 | `test:frame-grid` | 35 | 35 | 0 |
@@ -314,7 +315,7 @@ npm.cmd run test:mpv
 | `test:version` | 2 | 2 | 0 |
 | `test:file-drop` | 4 | 4 | 0 |
 | `test:hybrid` | 5 | 5 | 0 |
-| **합계** | **1,903** | **1,903** | **0** |
+| **합계** | **1,904** | **1,904** | **0** |
 
 최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
 
@@ -336,4 +337,4 @@ npm.cmd run test:mpv
 | 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
 | 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
 
-수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,903건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake와 안정화 재요청의 실제 다중 클라이언트 네트워크 동작, Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,904건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake와 안정화 재요청의 실제 다중 클라이언트 네트워크 동작, Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -4,7 +4,7 @@
 - 작업 브랜치: `fix/드로잉엔진-안정화`
 - 기준 스냅샷: `origin/main` `f1bd96e34d2019ddad905d21fc9f8caf608a2474` (`2.0.3-beta`)
 - 목표 버전: `2.1.0-beta`
-- 구현 기간: 2026-08-14 ~ 2026-08-16
+- 구현 기간: 2026-08-14 ~ 2026-08-21
 
 ## 요약
 
@@ -16,6 +16,7 @@
 | 작업 4 | B 입력 예약·취소와 레거시 준비 표시의 경합 안정화 | `renderer/scripts/app.js`, `renderer/scripts/modules/fabric-drawing-pilot-controller.js`, 관련 테스트 2개 | ✅ 완료 | `eeb8bb1` |
 | 작업 5 | Fabric `drawingsV3` 협업 전파·외부 반영·세션 경계 보호 | `renderer/scripts/modules/fabric-drawing-sync.js` 외 생산 코드 2개, 테스트 2개 | ✅ 완료 | `ee4dd1e` |
 | 작업 6 | mpv 자식 창의 키·마우스 입력 소비 차단과 버전 갱신 | `main/mpv-manager.js`, `scripts/tests/mpv-manager.test.js`, 버전 파일·계약 테스트 | ✅ 완료 | 마지막 커밋 |
+| PR 리뷰 보강 | 저장 대기 알림·늦은 합류 seed·외부 루트 기준 상태의 추가 경합 차단 | 생산 코드 3개, 테스트 2개, 본 문서 | ✅ 완료 | PR 리뷰 반영 커밋 |
 
 ## 배경 및 목적
 
@@ -59,6 +60,7 @@
 
 - 로컬 신규 댓글의 `ADD_COMMENT` undo 액션을 동기적으로 먼저 등록한다.
 - 그 뒤 `.bframe` 저장과 Slack 알림을 수행한다.
+- 저장 await 뒤 현재 마커를 다시 읽어, 그 사이 Undo·삭제된 댓글은 Slack 알림을 보내지 않는다.
 - 원격·복원·가져오기 댓글은 기존처럼 undo 등록과 알림을 건너뛴다.
 
 ### 예상/실제 리스크
@@ -136,8 +138,11 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 - 저장 완료 루트를 크기에 따라 인라인 또는 청크로 전송하고, 원격 루트는 순서대로 적용한다.
 - stale 지문을 최대 8개 보관해 Drive에서 늦게 되돌아온 구버전 루트의 재설치를 막는다.
 - `reloadDrawingsV3FromDisk()`는 await 전에 owner를 캡처하고, await 뒤 재검증한 같은 owner를 reconcile에 명시 전달한다.
+- 수락한 원격 루트를 opaque 저장 기준에도 즉시 반영해, Drive의 구버전 파일을 읽은 뒤 관련 없는 댓글을 저장해도 최신 `drawingsV3`가 되돌아가지 않게 한다.
+- provider 설치가 성공한 뒤에만 stale 지문·디스크 상태·opaque 기준을 확정해, 첫 설치 실패 뒤 같은 payload를 실제로 다시 설치할 수 있게 한다.
 - 연결 중 파일 감지는 comments/레거시 전체 reload를 계속 막되 `drawingsV3`만 제한적으로 다시 읽는다.
 - 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 현재 상태를 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다.
+- 신규 참가자는 Fabric 수신 리스너 설치 직후 seed를 한 번 요청하고, 10초 이상 안정된 기존 참가자만 응답한다. 방 입장 직후의 1회 seed가 구독 창에서 유실돼도 복구되며 새 참가자의 구버전 seed 억제는 유지된다.
 - stop→start를 넘은 적용 큐는 `_sessionGeneration`으로 폐기하며, 새 세션 A3는 정상 적용한다.
 
 ### 예상/실제 리스크
@@ -179,6 +184,10 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 5. 작업 5 리뷰에서 stop→start 경계를 넘은 `_applyQueue`가 같은 경로의 새 세션에 적용되는 결함을 발견했다. `_sessionGeneration` fence와 A1/A2/A3 회귀 테스트를 추가했다. reconcile에는 이미 owner epoch 검증이 있고 큐 세션 수명은 `FabricDrawingSync` 책임이므로 별도 세션 가드를 의도적으로 넣지 않았다.
 6. 작업 6 계획은 `test:mpv` 문자열을 두 테스트가 모두 완전일치로 검사하는 것처럼 설명했지만, 실제로는 `mpv-runtime-source.test.js`만 `assert.equal` 완전일치이고 `mpv-overlay-host.test.js`는 toolbar 테스트 파일 포함 여부를 `assert.match`한다. 스크립트 문자열을 바꾸지 않는 결론은 동일하며 두 테스트 모두 수정하지 않았다.
 7. 최종 preflight의 읽기 전용 `npx prettier --check renderer/scripts/lib/mpv-fabric-overlay.iife.js`가 formatting warning과 exit 1을 반환했다. 절대 수정 금지인 번들과 `mpv/`를 임시 ignore로 제외해 계획의 format 명령을 실행했으나 기존 줄바꿈 차이 때문에 범위 밖 추적 파일 300개가 기계적으로 변경됐다. 포맷 결과는 모두 원복하고 Task 6의 계획된 변경만 유지했으며, 금지 경로 변경 0건을 다시 확인했다.
+8. PR #174 Codex 리뷰에서 댓글 생성 직후 Undo가 저장 await 중 실행되면 삭제된 마커의 Slack 알림이 뒤늦게 전송되는 경합을 발견했다. 저장 뒤 현재 마커를 다시 조회하고 null/deleted를 차단했다.
+9. PR #174 Codex 리뷰에서 Liveblocks 방 입장과 Fabric 수신 리스너 설치 사이의 창에 기존 참가자의 1회 seed가 유실될 수 있음을 발견했다. post-subscription 요청/응답 handshake를 추가하되, 신규 참가자의 구버전 seed를 막는 기존 10초 조건을 응답자에도 적용했다.
+10. PR #174 Codex 리뷰에서 Broadcast로 수락한 최신 루트가 provider에만 설치되고 opaque 저장 기준에는 남지 않아, 관련 없는 저장이 구버전 디스크 루트를 다시 기록할 수 있음을 발견했다. 계획서는 이를 잔여 한계로 수용하고 수정 금지로 두었지만 실제 데이터 되돌림 P1으로 판정되어 사용자 승인 후 예외적으로 보강했다.
+11. 위 보강의 독립 검토에서 provider 설치 실패 전에 `_drawingsV3DiskState`를 갱신하면 같은 payload 재시도가 fingerprint no-op 성공으로 오인되는 P1을 추가 발견했다. 사용자에게 중단 보고하고 승인받은 뒤, provider accepted/preserved 확인 후에만 기준 상태를 확정하도록 순서를 바꿨다.
 
 ## 리스크 및 우려 사항
 
@@ -189,6 +198,10 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | hydration의 늦은 응답이 취소된 B 진입을 부활 | 높음 | 입력 revision + owner 재검증 |
 | 파일 A의 늦은 디스크 읽기가 파일 B에 설치 | 높음 | owner 선캡처·await 후 재검증·명시 전달 |
 | 종료된 협업 세션의 큐가 새 세션을 오염 | 높음 | `_sessionGeneration` fence와 A1/A2/A3 테스트 |
+| 방 입장 직후 기존 Fabric seed가 수신 구독 전에 유실 | 높음 | post-subscription seed 요청 + 안정된 peer 응답 테스트 |
+| 원격 최신 루트 적용 뒤 관련 없는 저장이 구버전 루트를 재기록 | 높음 | accepted 루트를 opaque 기준에 채택하고 Drive 지연 저장 회귀 테스트 추가 |
+| provider 설치 실패를 동일 payload 재시도에서 성공으로 오인 | 높음 | 설치 성공 후에만 기준 상태 확정, 실패→동일 payload 재시도 기능 테스트 추가 |
+| 저장 대기 중 Undo된 댓글의 Slack 알림이 뒤늦게 발송 | 중간 | 저장 뒤 현재 마커 null/deleted 재검증 |
 | Fabric 동시 편집 충돌 | 중간 | 현재는 루트 단위 last-save-wins로 수용, 후속 정교화 필요 |
 | 늦은 합류 seed가 10초 이내에는 억제됨 | 중간 | 계획된 기준 유지, 자동 경합 계약 통과; 격리 프로필의 준비 정체로 실제 원격 획 전파는 미확인 |
 | mpv 입력 차단 옵션의 실제 Windows 포커스 동작 | 중간 | 자동 인자 계약과 실제 실행 인자 확인 완료; 화면 자동화 키 주입 한계로 실제 단축키 라우팅은 미확인 |
@@ -207,6 +220,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
 | 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
 | 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
+| PR 리뷰 보강 최종 | 25/25 | 1,880/1,880 | PASS |
 
 Task 6 TDD focused 검증:
 
@@ -229,7 +243,7 @@ npm.cmd run test:mpv
 | 스크립트 | Tests | Pass | Fail |
 |---|---:|---:|---:|
 | `test:fabric-drawing-pilot` | 327 | 327 | 0 |
-| `test:fabric-drawing-persistence` | 141 | 141 | 0 |
+| `test:fabric-drawing-persistence` | 144 | 144 | 0 |
 | `test:recent` | 18 | 18 | 0 |
 | `test:frame-grid` | 35 | 35 | 0 |
 | `test:cluster` | 43 | 43 | 0 |
@@ -237,7 +251,7 @@ npm.cmd run test:mpv
 | `test:playlist-ordering` | 17 | 17 | 0 |
 | `test:playlist-continuous` | 13 | 13 | 0 |
 | `test:playlist-comments` | 9 | 9 | 0 |
-| `test:playlist` | 251 | 251 | 0 |
+| `test:playlist` | 254 | 254 | 0 |
 | `test:cutlist` | 82 | 82 | 0 |
 | `test:drawing` | 291 | 291 | 0 |
 | `test:drawing-v3-hardening` | 174 | 174 | 0 |
@@ -248,12 +262,12 @@ npm.cmd run test:mpv
 | `test:fps` | 7 | 7 | 0 |
 | `test:audio-waveform` | 2 | 2 | 0 |
 | `test:collaboration` | 5 | 5 | 0 |
-| `test:comment-input` | 18 | 18 | 0 |
+| `test:comment-input` | 19 | 19 | 0 |
 | `test:toast-stack` | 9 | 9 | 0 |
 | `test:version` | 2 | 2 | 0 |
 | `test:file-drop` | 4 | 4 | 0 |
 | `test:hybrid` | 5 | 5 | 0 |
-| **합계** | **1,873** | **1,873** | **0** |
+| **합계** | **1,880** | **1,880** | **0** |
 
 최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
 
@@ -275,4 +289,4 @@ npm.cmd run test:mpv
 | 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
 | 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
 
-수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. 동일 계약을 고정한 자동 테스트 25종 1,873건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다.
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,880건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -16,7 +16,7 @@
 | 작업 4 | B 입력 예약·취소와 레거시 준비 표시의 경합 안정화 | `renderer/scripts/app.js`, `renderer/scripts/modules/fabric-drawing-pilot-controller.js`, 관련 테스트 2개 | ✅ 완료 | `eeb8bb1` |
 | 작업 5 | Fabric `drawingsV3` 협업 전파·외부 반영·세션 경계 보호 | `renderer/scripts/modules/fabric-drawing-sync.js` 외 생산 코드 2개, 테스트 2개 | ✅ 완료 | `ee4dd1e` |
 | 작업 6 | mpv 자식 창의 키·마우스 입력 소비 차단과 버전 갱신 | `main/mpv-manager.js`, `scripts/tests/mpv-manager.test.js`, 버전 파일·계약 테스트 | ✅ 완료 | 마지막 커밋 |
-| PR 리뷰 보강 | 저장 대기 알림·늦은 합류 seed·외부 루트 기준 상태의 추가 경합 차단 | 생산 코드 3개, 테스트 2개, 본 문서 | ✅ 완료 | PR 리뷰 반영 커밋 |
+| PR 리뷰 보강 | 저장 대기 알림·늦은 합류 seed·외부 루트·전역 히스토리의 추가 경합 차단 | 생산 코드 7개, 테스트 5개, 본 문서 | ✅ 완료 | PR 리뷰 반영 커밋 |
 
 ## 배경 및 목적
 
@@ -79,20 +79,24 @@ Fabric 드로잉 히스토리가 비어 있을 때 Ctrl+Z/Y를 버리지 않고 
 - `main/mpv-overlay-host.js`
 - `renderer/scripts/app.js`
 - `renderer/scripts/modules/fabric-drawing-pilot-controller.js`
+- `renderer/scripts/modules/keyboard-shortcut-targets.js`
+- `renderer/scripts/modules/mpv-overlay-keyboard-relay.js`
 - `scripts/tests/drawing-runtime-source.test.js`
+- `scripts/tests/mpv-overlay-keyboard-relay.test.js`
 - `scripts/tests/mpv-overlay-host.test.js`
 
 ### 구현 내용
 
 - 드로잉 액션 결과의 허용 응답에 `reason`을 추가했다.
 - renderer 포커스 경로는 `history-empty`일 때만 `globalUndo()`/`globalRedo()`를 호출한다.
-- mpv 오버레이 포커스 경로도 같은 경우에만 키 입력을 renderer로 한 번 릴레이한다.
+- mpv 오버레이 포커스 경로는 물리 Ctrl/Cmd+Z/Y를 즉시 renderer 문서로 한 번 릴레이하고, renderer가 Fabric 히스토리와 조건부 전역 폴백을 단일 경로에서 처리한다. 일반 키는 기존 활성 입력 요소를 그대로 대상으로 삼는다.
 - `applied`·`duplicate` 결과와 자동 반복 입력은 폴백하지 않아 이중 실행을 막았다.
+- Fabric IPC 대기 전 전역 히스토리 revision을 캡처하고, 댓글·하이라이트 추가나 undo/redo·파일 전환으로 스택이 바뀌면 늦은 `history-empty` 폴백을 폐기한다.
 
 ### 예상/실제 리스크
 
 - 예상: Fabric 작업이 실제 적용된 뒤 전역 undo까지 중복 실행되면 안 된다.
-- 실제: 적용 성공은 로컬에 머물고 `history-empty`만 1회 전달되는 기능 테스트로 보호했다.
+- 실제: renderer가 Fabric 적용을 한 번만 요청하고 `history-empty`일 때만 전역 폴백한다. 오버레이 포커스도 입력 즉시 같은 renderer 경로로 들어가며, 느린 응답 중 전역 스택이 바뀐 경우에는 새 항목을 잘못 지우지 않고 스택이 그대로인 정상 폴백만 유지한다.
 
 ## Phase 4: B 입력 예약·복구 경합 안정화
 
@@ -136,8 +140,8 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 ### 구현 내용
 
 - 저장 완료 루트를 크기에 따라 인라인 또는 청크로 전송하고, 원격 루트는 순서대로 적용한다.
-- stale 지문은 최대 8개를 유지하고, 실제 디스크에서 마지막으로 관측한 지문은 별도 상태로 보호해 현재 디스크에 머문 지연 루트가 8개 stale 이력에서 밀려나도 되돌아오지 않게 한다.
-- 실제 디스크 관측 지문이 전진하면 직전 관측 지문을 stale 이력의 최신 항목으로 승계해, Drive가 다시 과거 상태로 돌아가도 재설치하지 않는다.
+- stale 루트는 전체 canonical JSON 대신 Broadcast wire와 같은 고정 길이 이중 해시+길이 identity로 압축해 활성 리뷰 컨텍스트 동안 누락 없이 보존한다. D0에 머문 Drive가 D1~D10 중간본을 늦게 노출해도 count eviction으로 되살아나지 않으며, 전체 루트 크기에 비례한 이력 메모리는 남기지 않는다.
+- 실제 디스크에서 마지막으로 관측한 전체 지문은 별도 scalar로 보호하고, 관측 지문이 전진하면 직전 지문도 compact stale 이력에 남겨 Drive가 다시 과거 상태로 돌아가도 재설치하지 않는다.
 - `reloadDrawingsV3FromDisk()`는 await 전에 owner를 캡처하고, await 뒤 재검증한 같은 owner를 reconcile에 명시 전달한다.
 - 수락한 원격 루트를 opaque 저장 기준에도 즉시 반영해, Drive의 구버전 파일을 읽은 뒤 관련 없는 댓글을 저장해도 최신 `drawingsV3`가 되돌아가지 않게 한다.
 - provider 설치가 성공한 뒤에만 stale 지문·디스크 상태·opaque 기준을 확정해, 첫 설치 실패 뒤 같은 payload를 실제로 다시 설치할 수 있게 한다.
@@ -201,6 +205,9 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 18. 같은 후속 코멘트에서 안정 참가자의 `.bframe`에 `drawingsV3`가 없으면 seed 응답 자체가 생략돼, 지연 복제본의 구버전 루트가 다시 방 전체에 부활하는 P2를 발견했다. 부재 tombstone과 요청자의 현재 clock을 포함하는 handshake를 추가해 revision 12 구버전보다 높은 tombstone, provider reset, 반복 seed 버전 유지와 역방향 유효 루트 보호를 검증했다.
 19. 5차 Codex 재리뷰에서 실제 디스크 관측이 D1→D2로 전진할 때 D1이 scalar와 Set 양쪽에서 빠져 이후 Drive rollback으로 재설치되는 P1을 발견했다. scalar가 이동할 때 현재 권위 루트를 제외한 직전 관측 지문을 capped history의 최신 항목으로 승계하고, cap 압박 뒤 disk catch-up→rollback을 실제 provider spy로 검증했다.
 20. 5차 보강의 독립 검토에서 현재 내용과 지문이 같은 더 높은 Broadcast 버전은 provider 적용을 생략해 pending disk reload epoch를 무효화하지 않는 P1을 재현했다. RDM의 전용 invalidation 경로를 일반 external apply와 same-root `comparison > 0` 수락이 함께 호출하게 하고, 같은 A의 clock 10 수락 뒤 보류된 B reload가 false·A 유지인지 실제 manager/store/sync로 검증했다.
+21. 6차 Codex 재리뷰에서 Drive가 D0에 머문 동안 Broadcast D1~D10을 수락하면 아직 파일에서 관측하지 못한 D1도 8개 stale cap에서 먼저 축출돼, 뒤늦은 D1 파일이 현재 D10을 되돌리는 P1을 발견했다. full canonical 지문을 고정 길이 compact identity로 바꾸고 count eviction을 제거해 세션 동안 수락한 중간 루트를 잊지 않도록 했다. 서로 다른 `documentId`의 D1~D10 뒤 D1 reload import 0회·D10 유지, 미지 파일 루트 정상 설치, 명시 Broadcast 우회를 실제 provider로 검증했다.
+22. 같은 재리뷰에서 Ctrl/Cmd+Z/Y의 Fabric IPC가 느린 동안 새 댓글·하이라이트가 전역 스택에 들어오면, 뒤늦은 `history-empty` 폴백이 키 입력 당시 없던 새 항목을 지우는 P2를 발견했다. 모든 전역 undo/redo 스택 변경에 단조 revision을 올리고 active Fabric 단축키가 입력 시점 revision과 응답 시점 revision을 비교하도록 보강했다. 중간 변경 시 폴백 0회, 무변경 시 undo/redo 각 1회를 deferred 기능 테스트로 검증했다.
+23. 6차 보강의 독립 경로 감사에서 mpv 오버레이가 포커스를 가진 경우 host가 먼저 Fabric 히스토리를 비동기로 조회한 뒤 renderer에 키를 넘겨, revision 캡처가 물리 입력보다 늦고 Fabric 조회도 두 번 일어나는 P2를 확인했다. host의 로컬 히스토리 실행을 제거하고 Ctrl/Cmd+Z/Y를 즉시 renderer에 릴레이해 단일 owner가 입력 시점 revision 캡처부터 조건부 폴백까지 한 번만 수행하도록 고정했다. 메인 창의 직전 댓글 입력 포커스가 남아도 history chord는 문서 타깃을 그대로 보존해 컨트롤러에 도달시키되, Tab 등 일반 릴레이 키는 기존 활성 요소로 보내는 기능 테스트도 추가했다.
 
 ## 리스크 및 우려 사항
 
@@ -208,6 +215,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 |---|---|---|
 | getter 대입 예외가 undo 스택을 반복해서 막음 | 높음 | `colorKey`만 복원하고 실패 토스트·소스 회귀 테스트 추가 |
 | Fabric 적용 뒤 전역 undo까지 이중 실행 | 높음 | `history-empty` 결과에만 폴백, applied/duplicate·repeat 차단 |
+| 느린 Fabric 빈-히스토리 응답이 키 입력 뒤 생긴 새 댓글·하이라이트를 전역 undo | 높음 | 오버레이 history chord를 즉시 renderer 문서의 단일 경로로 릴레이, 키 입력 시점 global history revision 캡처·응답 시 재검증, 모든 스택 mutation·파일 전환에서 revision 증가 |
 | hydration의 늦은 응답이 취소된 B 진입을 부활 | 높음 | 입력 revision + owner 재검증 |
 | 파일 A의 늦은 디스크 읽기가 파일 B에 설치 | 높음 | owner 선캡처·await 후 재검증·명시 전달 |
 | 종료된 협업 세션의 큐가 새 세션을 오염 | 높음 | `_sessionGeneration` fence와 A1/A2/A3 테스트 |
@@ -218,8 +226,8 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 동시 저장한 두 참가자가 상대 루트를 교차 적용해 서로 다른 상태로 고착 | 높음 | Lamport+actor 결정적 root LWW, pending/local-save clock, 패자 stale 지문 연동 |
 | 대용량 청크 헤더 교차·미완료 전송 때문에 최고 버전 또는 동일 버전 재시도가 유실 | 높음 | header 단계에서 낮은 버전만 거절하고 동일 버전의 새 transfer ID는 교체, 수신 즉시 Lamport clock 관측 |
 | 상충 stale 이력에서 고버전 Broadcast가 no-op되거나 재전파 핑퐁 | 높음 | 명시 Broadcast만 해당 stale 지문을 설치 성공 시 해제, 파일 reload guard와 실패 시 stale 보호 유지 |
-| 실제 Drive 루트가 8개 stale 이력에서 퇴출돼 파일 reload로 rollback | 높음 | 마지막 실제 디스크 관측 지문을 Set 밖에서 보호하고 disk 전진 확인 시에만 이동 |
-| 디스크 관측이 전진한 뒤 직전 관측 루트가 보호에서 빠져 rollback | 높음 | scalar 이동 시 직전 관측 지문을 stale 이력 최신 항목으로 승계, 현재 권위 루트는 제외 |
+| 실제 Drive 루트나 아직 미관측 중간본이 8개 stale 이력에서 퇴출돼 파일 reload로 rollback | 높음 | 전체 JSON 대신 고정 길이 compact identity를 세션 동안 count eviction 없이 보존하고, 마지막 실제 디스크 관측 지문은 별도 scalar로 보호 |
+| 디스크 관측이 전진한 뒤 직전 관측 루트가 보호에서 빠져 rollback | 높음 | scalar 이동 시 직전 관측 지문도 compact stale 이력에 보존, 현재 권위 루트는 stale 판정에서 제외 |
 | 보류 중인 파일 reload가 더 최신 Broadcast 적용 뒤 완료되어 역전 | 높음 | explicit apply와 same-root 고버전 수락 시 이전 disk reload epoch 무효화, 후속 fresh reload 정상 경로 보존 |
 | `drawingsV3` 부재 상태를 seed하지 못해 지연 복제본의 구버전 획이 부활 | 높음 | 명시 tombstone + 요청 clock causal floor + provider reset 경로 |
 | 500ms 안의 후속 파일 알림이 누락돼 최신 루트가 미적용 | 중간 | leading 즉시 실행 + 최신 trailing 1회 coalescing, 실행 시 파일 경로 재검증 |
@@ -229,6 +237,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | mpv 입력 차단 옵션의 실제 Windows 포커스 동작 | 중간 | 자동 인자 계약과 실제 실행 인자 확인 완료; 화면 자동화 키 주입 한계로 실제 단축키 라우팅은 미확인 |
 | bare format이 생성 번들·mpv 금지 범위를 오염 | 높음 | 금지 경로를 임시 ignore로 제외하고 실행, 범위 밖 기계적 변경은 전부 원복해 변경 0건 확인 |
 | 복구 테스트의 고정 PID `12345`가 종료 handle과 충돌 | 중간 | 코드 변경 없이 기록, PID 소멸 뒤 최종 컨트롤러가 재검증 |
+| compact stale identity 이력이 활성 리뷰의 고유 루트 수에 따라 증가 | 낮음 | 루트 전문 대신 약 20자 identity만 저장하고 파일 컨텍스트 전환에서 초기화; strict 고정 메모리와 file fallback을 함께 보장하려면 향후 `.bframe` causal metadata가 필요 |
 
 ## 테스트 방법
 
@@ -242,7 +251,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
 | 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
 | 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
-| PR 리뷰 보강 최종 | 25/25 | 1,896/1,896 | PASS |
+| PR 리뷰 보강 최종 | 25/25 | 1,899/1,899 | PASS |
 
 Task 6 TDD focused 검증:
 
@@ -264,8 +273,8 @@ npm.cmd run test:mpv
 
 | 스크립트 | Tests | Pass | Fail |
 |---|---:|---:|---:|
-| `test:fabric-drawing-pilot` | 327 | 327 | 0 |
-| `test:fabric-drawing-persistence` | 152 | 152 | 0 |
+| `test:fabric-drawing-pilot` | 328 | 328 | 0 |
+| `test:fabric-drawing-persistence` | 153 | 153 | 0 |
 | `test:recent` | 18 | 18 | 0 |
 | `test:frame-grid` | 35 | 35 | 0 |
 | `test:cluster` | 43 | 43 | 0 |
@@ -273,7 +282,7 @@ npm.cmd run test:mpv
 | `test:playlist-ordering` | 17 | 17 | 0 |
 | `test:playlist-continuous` | 13 | 13 | 0 |
 | `test:playlist-comments` | 9 | 9 | 0 |
-| `test:playlist` | 262 | 262 | 0 |
+| `test:playlist` | 263 | 263 | 0 |
 | `test:cutlist` | 82 | 82 | 0 |
 | `test:drawing` | 291 | 291 | 0 |
 | `test:drawing-v3-hardening` | 174 | 174 | 0 |
@@ -289,7 +298,7 @@ npm.cmd run test:mpv
 | `test:version` | 2 | 2 | 0 |
 | `test:file-drop` | 4 | 4 | 0 |
 | `test:hybrid` | 5 | 5 | 0 |
-| **합계** | **1,896** | **1,896** | **0** |
+| **합계** | **1,899** | **1,899** | **0** |
 
 최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
 
@@ -311,4 +320,4 @@ npm.cmd run test:mpv
 | 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
 | 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
 
-수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,896건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,899건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -141,15 +141,16 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 - 수락한 원격 루트를 opaque 저장 기준에도 즉시 반영해, Drive의 구버전 파일을 읽은 뒤 관련 없는 댓글을 저장해도 최신 `drawingsV3`가 되돌아가지 않게 한다.
 - provider 설치가 성공한 뒤에만 stale 지문·디스크 상태·opaque 기준을 확정해, 첫 설치 실패 뒤 같은 payload를 실제로 다시 설치할 수 있게 한다.
 - 같은 파일의 디스크 reload 요청마다 세대를 올리고 reconcile의 owner predicate까지 전달해, 느린 이전 hydration이 빠른 최신 reload 뒤에 완료돼도 설치하지 않는다.
-- 연결 중 파일 감지는 comments/레거시 전체 reload를 계속 막되 `drawingsV3`만 제한적으로 다시 읽는다.
+- 연결 중 파일 감지는 comments/레거시 전체 reload를 계속 막되 `drawingsV3`만 제한적으로 다시 읽고, 500ms 안의 후속 알림은 한 번의 trailing reload로 합쳐 최신 상태를 놓치지 않는다.
 - 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 현재 상태를 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다.
 - 신규 참가자는 Fabric 수신 리스너 설치 직후 seed를 한 번 요청하고, 10초 이상 안정된 기존 참가자만 응답한다. 방 입장 직후의 1회 seed가 구독 창에서 유실돼도 복구되며 새 참가자의 구버전 seed 억제는 유지된다.
+- 동시 저장 루트는 세션 actor와 Lamport clock으로 결정적 순서를 부여한다. 스트로크 병합 없이 한쪽 루트가 이기는 기존 정책은 유지하되, 양쪽 화면이 서로 반대 루트를 적용하는 분기는 막고 패자 지문을 stale로 기록해 Drive rollback도 차단한다.
 - stop→start를 넘은 적용 큐는 `_sessionGeneration`으로 폐기하며, 새 세션 A3는 정상 적용한다.
 
 ### 예상/실제 리스크
 
 - 예상: 큰 payload, 파일 A→B 전환, 저장 에코, 늦은 합류, 세션 재시작이 서로 영향을 줄 수 있다.
-- 실제: owner 경합, 협업 방의 잔존 인원 기준값, 이전 세션 큐 누출을 구현·리뷰 과정에서 추가 발견해 각각 fence를 넣었다. 루트 단위 동시 편집은 last-save-wins, 10초 안 동시 합류 seed 억제, 대용량 청크 수신 슬롯 1개라는 계획상 한계는 유지했다. 실제 앱 두 개로 같은 `.bframe`을 열었지만 두 번째 격리 프로필의 Fabric 진입이 준비 상태에 머물러 원격 획 전파는 끝까지 확인하지 못했다.
+- 실제: owner 경합, 협업 방의 잔존 인원 기준값, 이전 세션 큐 누출, 동시 저장의 상호 교체 분기를 구현·리뷰 과정에서 추가 발견해 각각 fence를 넣었다. 루트 단위 동시 편집은 결정적 last-save-wins로 수렴하지만 패자 획은 대체될 수 있고, 10초 안 동시 합류 seed 억제와 대용량 청크 수신 슬롯 1개라는 계획상 한계는 유지했다. 실제 앱 두 개로 같은 `.bframe`을 열었지만 두 번째 격리 프로필의 Fabric 진입이 준비 상태에 머물러 원격 획 전파는 끝까지 확인하지 못했다.
 
 ## Phase 6: mpv 입력 소비 차단과 버전 갱신
 
@@ -190,6 +191,9 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 10. PR #174 Codex 리뷰에서 Broadcast로 수락한 최신 루트가 provider에만 설치되고 opaque 저장 기준에는 남지 않아, 관련 없는 저장이 구버전 디스크 루트를 다시 기록할 수 있음을 발견했다. 계획서는 이를 잔여 한계로 수용하고 수정 금지로 두었지만 실제 데이터 되돌림 P1으로 판정되어 사용자 승인 후 예외적으로 보강했다.
 11. 위 보강의 독립 검토에서 provider 설치 실패 전에 `_drawingsV3DiskState`를 갱신하면 같은 payload 재시도가 fingerprint no-op 성공으로 오인되는 P1을 추가 발견했다. 사용자에게 중단 보고하고 승인받은 뒤, provider accepted/preserved 확인 후에만 기준 상태를 확정하도록 순서를 바꿨다.
 12. 첫 리뷰 반영 커밋의 Codex 재리뷰에서 같은 파일의 Drive 알림 B·C가 겹치면 빠른 C 적용 뒤 느린 B hydration이 완료되어 다시 B로 역전되는 P1을 발견했다. `reloadDrawingsV3FromDisk()` 요청 세대를 읽기 await 뒤와 reconcile 설치 직전에 모두 재검증해 최신 요청만 적용되도록 했다.
+13. 두 번째 Codex 재리뷰에서 두 사용자가 서로의 Broadcast를 받기 전에 각각 저장하면 A는 B, B는 A를 적용해 반대 상태로 고착되는 P1을 발견했다. 계획의 스트로크 병합 범위 외 결정은 유지하면서 root-level Lamport LWW, local-dirty 후속 저장의 clock 전진, 패자 stale 연동, seed·청크 버전 보존을 추가했다.
+14. 같은 재리뷰에서 연결 중 500ms 이내 두 번째 파일 알림이 trailing 예약 없이 버려지는 P2를 발견했다. 첫 reload는 즉시 유지하고 interval 안의 최신 알림을 남은 시간 뒤 한 번 실행하며, 파일 전환 시 이전 예약을 폐기하도록 보강했다.
+15. 3차 보강의 독립 적대 검토에서 적용 await 중 로컬 저장의 버전 강등, 동일 revision 합류 seed의 지문 의존, 대용량 청크 헤더 교차·clock 미관측·동일 버전 재시도 차단, 상충 stale 이력의 재수렴 실패를 추가 재현했다. 최종 root 재확인, 최초 publish 승격, header 버전 우선 슬롯·즉시 clock 관측·새 transfer ID 재시도 교체, 결정적 버전 비교를 통과한 명시 Broadcast만 stale-file guard를 1회 우회하는 계약으로 각각 차단했다. 단순 clock 재승격·재전파 방식은 상충 stale 이력에서 무한 핑퐁을 재현해 채택하지 않았다.
 
 ## 리스크 및 우려 사항
 
@@ -204,8 +208,12 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 원격 최신 루트 적용 뒤 관련 없는 저장이 구버전 루트를 재기록 | 높음 | accepted 루트를 opaque 기준에 채택하고 Drive 지연 저장 회귀 테스트 추가 |
 | provider 설치 실패를 동일 payload 재시도에서 성공으로 오인 | 높음 | 설치 성공 후에만 기준 상태 확정, 실패→동일 payload 재시도 기능 테스트 추가 |
 | 같은 파일의 느린 이전 reload가 빠른 최신 reload를 역전 | 높음 | RDM reload request generation fence를 reconcile owner 검사까지 전달 |
+| 동시 저장한 두 참가자가 상대 루트를 교차 적용해 서로 다른 상태로 고착 | 높음 | Lamport+actor 결정적 root LWW, pending/local-save clock, 패자 stale 지문 연동 |
+| 대용량 청크 헤더 교차·미완료 전송 때문에 최고 버전 또는 동일 버전 재시도가 유실 | 높음 | header 단계에서 낮은 버전만 거절하고 동일 버전의 새 transfer ID는 교체, 수신 즉시 Lamport clock 관측 |
+| 상충 stale 이력에서 고버전 Broadcast가 no-op되거나 재전파 핑퐁 | 높음 | 명시 Broadcast만 해당 stale 지문을 설치 성공 시 해제, 파일 reload guard와 실패 시 stale 보호 유지 |
+| 500ms 안의 후속 파일 알림이 누락돼 최신 루트가 미적용 | 중간 | leading 즉시 실행 + 최신 trailing 1회 coalescing, 실행 시 파일 경로 재검증 |
 | 저장 대기 중 Undo된 댓글의 Slack 알림이 뒤늦게 발송 | 중간 | 저장 뒤 현재 마커 null/deleted 재검증 |
-| Fabric 동시 편집 충돌 | 중간 | 현재는 루트 단위 last-save-wins로 수용, 후속 정교화 필요 |
+| Fabric 동시 편집에서 패자 획이 대체 | 중간 | 양쪽은 결정적 root-level last-save-wins로 수렴, 스트로크 단위 병합은 후속 범위 |
 | 늦은 합류 seed가 10초 이내에는 억제됨 | 중간 | 계획된 기준 유지, 자동 경합 계약 통과; 격리 프로필의 준비 정체로 실제 원격 획 전파는 미확인 |
 | mpv 입력 차단 옵션의 실제 Windows 포커스 동작 | 중간 | 자동 인자 계약과 실제 실행 인자 확인 완료; 화면 자동화 키 주입 한계로 실제 단축키 라우팅은 미확인 |
 | bare format이 생성 번들·mpv 금지 범위를 오염 | 높음 | 금지 경로를 임시 ignore로 제외하고 실행, 범위 밖 기계적 변경은 전부 원복해 변경 0건 확인 |
@@ -223,7 +231,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
 | 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
 | 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
-| PR 리뷰 보강 최종 | 25/25 | 1,882/1,882 | PASS |
+| PR 리뷰 보강 최종 | 25/25 | 1,888/1,888 | PASS |
 
 Task 6 TDD focused 검증:
 
@@ -246,7 +254,7 @@ npm.cmd run test:mpv
 | 스크립트 | Tests | Pass | Fail |
 |---|---:|---:|---:|
 | `test:fabric-drawing-pilot` | 327 | 327 | 0 |
-| `test:fabric-drawing-persistence` | 145 | 145 | 0 |
+| `test:fabric-drawing-persistence` | 148 | 148 | 0 |
 | `test:recent` | 18 | 18 | 0 |
 | `test:frame-grid` | 35 | 35 | 0 |
 | `test:cluster` | 43 | 43 | 0 |
@@ -254,7 +262,7 @@ npm.cmd run test:mpv
 | `test:playlist-ordering` | 17 | 17 | 0 |
 | `test:playlist-continuous` | 13 | 13 | 0 |
 | `test:playlist-comments` | 9 | 9 | 0 |
-| `test:playlist` | 255 | 255 | 0 |
+| `test:playlist` | 258 | 258 | 0 |
 | `test:cutlist` | 82 | 82 | 0 |
 | `test:drawing` | 291 | 291 | 0 |
 | `test:drawing-v3-hardening` | 174 | 174 | 0 |
@@ -270,7 +278,7 @@ npm.cmd run test:mpv
 | `test:version` | 2 | 2 | 0 |
 | `test:file-drop` | 4 | 4 | 0 |
 | `test:hybrid` | 5 | 5 | 0 |
-| **합계** | **1,882** | **1,882** | **0** |
+| **합계** | **1,888** | **1,888** | **0** |
 
 최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
 
@@ -292,4 +300,4 @@ npm.cmd run test:mpv
 | 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
 | 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
 
-수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,882건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,888건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -142,7 +142,7 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 - 수락한 원격 루트를 opaque 저장 기준에도 즉시 반영해, Drive의 구버전 파일을 읽은 뒤 관련 없는 댓글을 저장해도 최신 `drawingsV3`가 되돌아가지 않게 한다.
 - provider 설치가 성공한 뒤에만 stale 지문·디스크 상태·opaque 기준을 확정해, 첫 설치 실패 뒤 같은 payload를 실제로 다시 설치할 수 있게 한다.
 - 같은 파일의 디스크 reload 요청마다 세대를 올리고 reconcile의 owner predicate까지 전달해, 느린 이전 hydration이 빠른 최신 reload 뒤에 완료돼도 설치하지 않는다.
-- 명시 Broadcast 적용이 시작되면 그보다 먼저 시작한 디스크 reload 세대를 무효화해, 파일 읽기 B가 보류된 동안 협업 루트 C가 적용된 뒤 B가 C를 덮지 못하게 한다.
+- 명시 Broadcast 적용이 시작되거나 같은 내용의 더 높은 인과 버전을 수락하면 그보다 먼저 시작한 디스크 reload 세대를 무효화해, 파일 읽기 B가 보류된 동안 협업 루트 C가 확정된 뒤 B가 C를 덮지 못하게 한다.
 - 연결 중 파일 감지는 comments/레거시 전체 reload를 계속 막되 `drawingsV3`만 제한적으로 다시 읽고, 500ms 안의 후속 알림은 한 번의 trailing reload로 합쳐 최신 상태를 놓치지 않는다.
 - 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 현재 상태를 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다. 합류 요청에는 현재 인과 버전을 실어 안정 참가자가 요청자보다 높은 버전으로 응답하며, `drawingsV3` 부재도 명시 tombstone으로 전파한다.
 - 신규 참가자는 Fabric 수신 리스너 설치 직후 seed를 한 번 요청하고, 10초 이상 안정된 기존 참가자만 응답한다. 방 입장 직후의 1회 seed가 구독 창에서 유실돼도 복구되며 새 참가자의 구버전 seed 억제는 유지된다.
@@ -200,6 +200,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 17. 같은 4차 리뷰의 후속 코멘트에서 파일 B 읽기가 보류된 동안 Broadcast C가 적용돼도 기존 reload 세대가 살아 있어 B가 C를 덮는 P1을 발견했다. RDM의 explicit Broadcast 진입점에서 disk reload 세대를 먼저 올리고, B reload false·C 유지·후속 D reload 정상 적용을 실제 store로 검증했다.
 18. 같은 후속 코멘트에서 안정 참가자의 `.bframe`에 `drawingsV3`가 없으면 seed 응답 자체가 생략돼, 지연 복제본의 구버전 루트가 다시 방 전체에 부활하는 P2를 발견했다. 부재 tombstone과 요청자의 현재 clock을 포함하는 handshake를 추가해 revision 12 구버전보다 높은 tombstone, provider reset, 반복 seed 버전 유지와 역방향 유효 루트 보호를 검증했다.
 19. 5차 Codex 재리뷰에서 실제 디스크 관측이 D1→D2로 전진할 때 D1이 scalar와 Set 양쪽에서 빠져 이후 Drive rollback으로 재설치되는 P1을 발견했다. scalar가 이동할 때 현재 권위 루트를 제외한 직전 관측 지문을 capped history의 최신 항목으로 승계하고, cap 압박 뒤 disk catch-up→rollback을 실제 provider spy로 검증했다.
+20. 5차 보강의 독립 검토에서 현재 내용과 지문이 같은 더 높은 Broadcast 버전은 provider 적용을 생략해 pending disk reload epoch를 무효화하지 않는 P1을 재현했다. RDM의 전용 invalidation 경로를 일반 external apply와 same-root `comparison > 0` 수락이 함께 호출하게 하고, 같은 A의 clock 10 수락 뒤 보류된 B reload가 false·A 유지인지 실제 manager/store/sync로 검증했다.
 
 ## 리스크 및 우려 사항
 
@@ -219,7 +220,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 상충 stale 이력에서 고버전 Broadcast가 no-op되거나 재전파 핑퐁 | 높음 | 명시 Broadcast만 해당 stale 지문을 설치 성공 시 해제, 파일 reload guard와 실패 시 stale 보호 유지 |
 | 실제 Drive 루트가 8개 stale 이력에서 퇴출돼 파일 reload로 rollback | 높음 | 마지막 실제 디스크 관측 지문을 Set 밖에서 보호하고 disk 전진 확인 시에만 이동 |
 | 디스크 관측이 전진한 뒤 직전 관측 루트가 보호에서 빠져 rollback | 높음 | scalar 이동 시 직전 관측 지문을 stale 이력 최신 항목으로 승계, 현재 권위 루트는 제외 |
-| 보류 중인 파일 reload가 더 최신 Broadcast 적용 뒤 완료되어 역전 | 높음 | explicit Broadcast 진입 시 이전 disk reload epoch 무효화, 후속 fresh reload 정상 경로 보존 |
+| 보류 중인 파일 reload가 더 최신 Broadcast 적용 뒤 완료되어 역전 | 높음 | explicit apply와 same-root 고버전 수락 시 이전 disk reload epoch 무효화, 후속 fresh reload 정상 경로 보존 |
 | `drawingsV3` 부재 상태를 seed하지 못해 지연 복제본의 구버전 획이 부활 | 높음 | 명시 tombstone + 요청 clock causal floor + provider reset 경로 |
 | 500ms 안의 후속 파일 알림이 누락돼 최신 루트가 미적용 | 중간 | leading 즉시 실행 + 최신 trailing 1회 coalescing, 실행 시 파일 경로 재검증 |
 | 저장 대기 중 Undo된 댓글의 Slack 알림이 뒤늦게 발송 | 중간 | 저장 뒤 현재 마커 null/deleted 재검증 |
@@ -241,7 +242,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
 | 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
 | 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
-| PR 리뷰 보강 최종 | 25/25 | 1,894/1,894 | PASS |
+| PR 리뷰 보강 최종 | 25/25 | 1,896/1,896 | PASS |
 
 Task 6 TDD focused 검증:
 
@@ -264,7 +265,7 @@ npm.cmd run test:mpv
 | 스크립트 | Tests | Pass | Fail |
 |---|---:|---:|---:|
 | `test:fabric-drawing-pilot` | 327 | 327 | 0 |
-| `test:fabric-drawing-persistence` | 151 | 151 | 0 |
+| `test:fabric-drawing-persistence` | 152 | 152 | 0 |
 | `test:recent` | 18 | 18 | 0 |
 | `test:frame-grid` | 35 | 35 | 0 |
 | `test:cluster` | 43 | 43 | 0 |
@@ -272,7 +273,7 @@ npm.cmd run test:mpv
 | `test:playlist-ordering` | 17 | 17 | 0 |
 | `test:playlist-continuous` | 13 | 13 | 0 |
 | `test:playlist-comments` | 9 | 9 | 0 |
-| `test:playlist` | 261 | 261 | 0 |
+| `test:playlist` | 262 | 262 | 0 |
 | `test:cutlist` | 82 | 82 | 0 |
 | `test:drawing` | 291 | 291 | 0 |
 | `test:drawing-v3-hardening` | 174 | 174 | 0 |
@@ -288,7 +289,7 @@ npm.cmd run test:mpv
 | `test:version` | 2 | 2 | 0 |
 | `test:file-drop` | 4 | 4 | 0 |
 | `test:hybrid` | 5 | 5 | 0 |
-| **합계** | **1,894** | **1,894** | **0** |
+| **합계** | **1,896** | **1,896** | **0** |
 
 최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
 
@@ -310,4 +311,4 @@ npm.cmd run test:mpv
 | 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
 | 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
 
-수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,894건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,896건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -1,0 +1,278 @@
+# 드로잉 엔진 안정화 구현
+
+- 계획서: `C:\BAEframe\BAEFRAME_수정계획_드로잉엔진-안정화.md`
+- 작업 브랜치: `fix/드로잉엔진-안정화`
+- 기준 스냅샷: `origin/main` `f1bd96e34d2019ddad905d21fc9f8caf608a2474` (`2.0.3-beta`)
+- 목표 버전: `2.1.0-beta`
+- 구현 기간: 2026-08-14 ~ 2026-08-16
+
+## 요약
+
+| 작업 | 목적 | 수정 파일 | 상태 | 커밋 |
+|---|---|---|---|---|
+| 작업 1 | 하이라이트 undo/redo 실패로 전역 스택이 막히는 문제 해소 | `renderer/scripts/app.js`, `scripts/tests/drawing-runtime-source.test.js` | ✅ 완료 | `3c3f414` |
+| 작업 2 | 댓글 생성 직후에도 Ctrl+Z가 빠짐없이 등록되도록 순서 보정 | `renderer/scripts/app.js` | ✅ 완료 | `1e5d5cc` |
+| 작업 3 | Fabric 히스토리가 비었을 때 전역 undo/redo로 연결 | `main/mpv-overlay-host.js`, `renderer/scripts/app.js`, `renderer/scripts/modules/fabric-drawing-pilot-controller.js`, 관련 테스트 2개 | ✅ 완료 | `f3e26e8` |
+| 작업 4 | B 입력 예약·취소와 레거시 준비 표시의 경합 안정화 | `renderer/scripts/app.js`, `renderer/scripts/modules/fabric-drawing-pilot-controller.js`, 관련 테스트 2개 | ✅ 완료 | `eeb8bb1` |
+| 작업 5 | Fabric `drawingsV3` 협업 전파·외부 반영·세션 경계 보호 | `renderer/scripts/modules/fabric-drawing-sync.js` 외 생산 코드 2개, 테스트 2개 | ✅ 완료 | `ee4dd1e` |
+| 작업 6 | mpv 자식 창의 키·마우스 입력 소비 차단과 버전 갱신 | `main/mpv-manager.js`, `scripts/tests/mpv-manager.test.js`, 버전 파일·계약 테스트 | ✅ 완료 | 마지막 커밋 |
+
+## 배경 및 목적
+
+배포 기본 경로인 Fabric 드로잉 엔진에서 세 가지 사용 문제가 함께 보고됐다. B를 눌러도 준비 상태가 보이지 않거나 진입이 취소되는 문제, 하이라이트·댓글·Fabric 히스토리가 섞일 때 Ctrl+Z가 막히는 문제, 그리고 `drawingsV3`가 협업 사용자에게 전달되지 않는 문제다. 또한 mpv 네이티브 자식 창이 포커스를 얻으면 앱보다 먼저 키 입력을 소비할 여지가 있었다.
+
+이번 작업은 각 원인을 별도 커밋으로 분리하되, 최종적으로 입력 라우팅, 전역 undo 폴백, 비동기 복구 상태, 파일 소유권, 협업 세션 수명을 한 흐름으로 맞추는 데 목적이 있다. `.bframe` 형식, mpv 바이너리, 생성된 Fabric 오버레이 번들은 변경하지 않았다.
+
+## Phase 1: 하이라이트 undo 잼 해소
+
+### 목표
+
+하이라이트 생성 redo·삭제 undo가 getter 전용 `colorInfo`에 값을 대입하면서 던지는 예외를 없애고, undo/redo 실패를 사용자가 알 수 있게 한다.
+
+### 수정 파일
+
+- `renderer/scripts/app.js`
+- `scripts/tests/drawing-runtime-source.test.js`
+
+### 구현 내용
+
+- 하이라이트 복원 시 읽기 전용 `colorInfo` 대신 저장 가능한 `colorKey`만 복원한다.
+- `globalUndo()`와 `globalRedo()`가 실패 액션을 원래 스택에 되돌린 뒤 오류 토스트를 표시한다.
+- 회귀 테스트로 `restored.colorInfo =` 대입이 다시 생기지 않도록 고정했다.
+
+### 예상/실제 리스크
+
+- 예상: 하이라이트의 id·시간·메모·색 복원이 그대로 유지돼야 한다.
+- 실제: 자동 테스트에서 회귀는 없었고, 실패 시 스택 롤백 동작도 보존됐다.
+
+## Phase 2: 댓글 생성 undo 등록 순서 보정
+
+### 목표
+
+댓글 생성 뒤 저장과 Slack 알림을 기다리는 동안 Ctrl+Z 등록이 늦거나, 저장 실패 때문에 등록 자체가 누락되는 창을 없앤다.
+
+### 수정 파일
+
+- `renderer/scripts/app.js`
+
+### 구현 내용
+
+- 로컬 신규 댓글의 `ADD_COMMENT` undo 액션을 동기적으로 먼저 등록한다.
+- 그 뒤 `.bframe` 저장과 Slack 알림을 수행한다.
+- 원격·복원·가져오기 댓글은 기존처럼 undo 등록과 알림을 건너뛴다.
+
+### 예상/실제 리스크
+
+- 예상: 저장 실패 시에도 앱 세션의 undo는 가능해야 하며, 원격 변경을 로컬 undo에 넣어서는 안 된다.
+- 실제: 기존 분기와 알림 계약을 유지했고 25종 자동 테스트가 통과했다.
+
+## Phase 3: Fabric 빈 히스토리의 전역 undo/redo 폴백
+
+### 목표
+
+Fabric 드로잉 히스토리가 비어 있을 때 Ctrl+Z/Y를 버리지 않고 앱의 전역 하이라이트·댓글 히스토리로 넘긴다.
+
+### 수정 파일
+
+- `main/mpv-overlay-host.js`
+- `renderer/scripts/app.js`
+- `renderer/scripts/modules/fabric-drawing-pilot-controller.js`
+- `scripts/tests/drawing-runtime-source.test.js`
+- `scripts/tests/mpv-overlay-host.test.js`
+
+### 구현 내용
+
+- 드로잉 액션 결과의 허용 응답에 `reason`을 추가했다.
+- renderer 포커스 경로는 `history-empty`일 때만 `globalUndo()`/`globalRedo()`를 호출한다.
+- mpv 오버레이 포커스 경로도 같은 경우에만 키 입력을 renderer로 한 번 릴레이한다.
+- `applied`·`duplicate` 결과와 자동 반복 입력은 폴백하지 않아 이중 실행을 막았다.
+
+### 예상/실제 리스크
+
+- 예상: Fabric 작업이 실제 적용된 뒤 전역 undo까지 중복 실행되면 안 된다.
+- 실제: 적용 성공은 로컬에 머물고 `history-empty`만 1회 전달되는 기능 테스트로 보호했다.
+
+## Phase 4: B 입력 예약·복구 경합 안정화
+
+### 목표
+
+Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약하며, 사용자가 다시 B를 눌러 취소하면 늦은 hydration 응답이 드로잉 모드를 되살리지 못하게 한다. 레거시 경로도 준비 중 표시를 즉시 보여준다.
+
+### 수정 파일
+
+- `renderer/scripts/app.js`
+- `renderer/scripts/modules/fabric-drawing-pilot-controller.js`
+- `scripts/tests/fabric-drawing-pilot-shortcuts.test.js`
+- `scripts/tests/hybrid-review-engine-source.test.js`
+
+### 구현 내용
+
+- recovering·소스 갱신 중 B를 `resumeRequested` 상태로 예약·취소한다.
+- reconcile 및 persistence refresh 완료 시 캡처 값뿐 아니라 현재 예약 상태도 다시 확인한다.
+- hydration await 뒤 입력 revision과 현재 owner를 재확인해, 대기 중 들어온 최신 취소를 우선한다.
+- 레거시 mpv 진입 직후 스피너를 켜고 하이브리드 전환 예외는 freeze 준비로 연결한다.
+
+### 예상/실제 리스크
+
+- 예상: 이전 비디오/이전 입력의 늦은 완료가 현재 화면을 활성화할 수 있다.
+- 실제: 구현 중 hydration 대기 창의 B 취소 경합을 추가 발견해 계획의 `(a-4)`로 반영했다. 실제 앱에서 준비 중 B를 다시 눌러 취소한 뒤 늦게 재활성화되지 않고 passive 상태가 유지됨을 확인했다.
+
+## Phase 5: Fabric 드로잉 협업 동기화
+
+### 목표
+
+저장된 `drawingsV3` 스냅샷을 Liveblocks Broadcast로 전달하고, 늦은 합류·Drive 지연·파일 전환·협업 세션 재시작에서도 다른 파일이나 이전 세션 데이터가 설치되지 않게 한다.
+
+### 수정 파일
+
+- `renderer/scripts/modules/fabric-drawing-sync.js` (신규)
+- `renderer/scripts/modules/review-data-manager.js`
+- `renderer/scripts/app.js`
+- `scripts/tests/lazy-bframe-creation-source.test.js`
+- `scripts/tests/review-data-manager-save.test.js`
+
+### 구현 내용
+
+- 저장 완료 루트를 크기에 따라 인라인 또는 청크로 전송하고, 원격 루트는 순서대로 적용한다.
+- stale 지문을 최대 8개 보관해 Drive에서 늦게 되돌아온 구버전 루트의 재설치를 막는다.
+- `reloadDrawingsV3FromDisk()`는 await 전에 owner를 캡처하고, await 뒤 재검증한 같은 owner를 reconcile에 명시 전달한다.
+- 연결 중 파일 감지는 comments/레거시 전체 reload를 계속 막되 `drawingsV3`만 제한적으로 다시 읽는다.
+- 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 현재 상태를 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다.
+- stop→start를 넘은 적용 큐는 `_sessionGeneration`으로 폐기하며, 새 세션 A3는 정상 적용한다.
+
+### 예상/실제 리스크
+
+- 예상: 큰 payload, 파일 A→B 전환, 저장 에코, 늦은 합류, 세션 재시작이 서로 영향을 줄 수 있다.
+- 실제: owner 경합, 협업 방의 잔존 인원 기준값, 이전 세션 큐 누출을 구현·리뷰 과정에서 추가 발견해 각각 fence를 넣었다. 루트 단위 동시 편집은 last-save-wins, 10초 안 동시 합류 seed 억제, 대용량 청크 수신 슬롯 1개라는 계획상 한계는 유지했다. 실제 앱 두 개로 같은 `.bframe`을 열었지만 두 번째 격리 프로필의 Fabric 진입이 준비 상태에 머물러 원격 획 전파는 끝까지 확인하지 못했다.
+
+## Phase 6: mpv 입력 소비 차단과 버전 갱신
+
+### 목표
+
+mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 입력을 소비하지 않게 하고, 앱 버전을 `2.1.0-beta`로 올린다.
+
+### 수정 파일
+
+- `main/mpv-manager.js`
+- `scripts/tests/mpv-manager.test.js`
+- `package.json`
+- `package-lock.json`
+- `scripts/tests/runtime-profile.test.js`
+
+### 구현 내용
+
+- 모든 mpv 실행 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`를 추가했다.
+- 일반, `--wid`, headless 인자 구성에서 차단 옵션이 유지되는 회귀 테스트를 추가했다.
+- 패키지와 lockfile의 루트 버전, 런타임 버전 계약 테스트를 `2.1.0-beta`로 맞췄다.
+
+### 예상/실제 리스크
+
+- 예상: headless 메타데이터 probe나 임베드 재생에서도 IPC 제어는 유지돼야 한다.
+- 실제: focused RED에서 누락 인자를 정확히 검출했고, 인자 추가 후 32/32 GREEN을 확인했다. 실제 실행 로그에서도 세 차단 인자가 mpv에 전달되고 UI 재생 버튼이 정상 동작함을 확인했다. 다만 화면 자동화의 키 입력이 영상 영역과 렌더러 영역 모두에서 전달되지 않아 Space·화살표·Ctrl+Z 라우팅은 수동 통과로 판정하지 않았다.
+
+## 계획 대비 실제 구현·검증 차이
+
+1. 작업 4에서 hydration await 중 B로 예약을 취소해도 오래된 `shouldResume`이 활성화를 되살리는 경합을 발견했다. 입력 revision과 owner를 재검증하는 `(a-4)`를 계획에 추가해 구현했다.
+2. 작업 5에서 `reloadDrawingsV3FromDisk()`가 파일 A 읽기를 기다리는 동안 B로 전환되면 A 루트를 B에 설치할 수 있는 owner 경합을 발견했다. await 전 owner 캡처, await 후 재검증, 동일 owner 명시 전달로 막았다.
+3. 작업 5에서 새 협업 방을 시작해도 `_previousOthersCount`가 이전 방 값으로 남아 late seed를 가릴 수 있음을 발견했다. 세션 시작 시 0으로 초기화했다.
+4. 2026-08-16 계획 문구 2건을 실제 계약에 맞게 정정했다. `applyExternalDrawingsV3`는 호출 직전 await가 없어 기본 owner 캡처를 사용하고, `reloadDrawingsV3FromDisk`만 선캡처한 owner를 명시 전달한다. 경합 테스트는 freeze된 실제 store를 직접 교체하지 않고 `importRootValue`에 위임하는 spy wrapper를 쓴다.
+5. 작업 5 리뷰에서 stop→start 경계를 넘은 `_applyQueue`가 같은 경로의 새 세션에 적용되는 결함을 발견했다. `_sessionGeneration` fence와 A1/A2/A3 회귀 테스트를 추가했다. reconcile에는 이미 owner epoch 검증이 있고 큐 세션 수명은 `FabricDrawingSync` 책임이므로 별도 세션 가드를 의도적으로 넣지 않았다.
+6. 작업 6 계획은 `test:mpv` 문자열을 두 테스트가 모두 완전일치로 검사하는 것처럼 설명했지만, 실제로는 `mpv-runtime-source.test.js`만 `assert.equal` 완전일치이고 `mpv-overlay-host.test.js`는 toolbar 테스트 파일 포함 여부를 `assert.match`한다. 스크립트 문자열을 바꾸지 않는 결론은 동일하며 두 테스트 모두 수정하지 않았다.
+7. 최종 preflight의 읽기 전용 `npx prettier --check renderer/scripts/lib/mpv-fabric-overlay.iife.js`가 formatting warning과 exit 1을 반환했다. 절대 수정 금지인 번들과 `mpv/`를 임시 ignore로 제외해 계획의 format 명령을 실행했으나 기존 줄바꿈 차이 때문에 범위 밖 추적 파일 300개가 기계적으로 변경됐다. 포맷 결과는 모두 원복하고 Task 6의 계획된 변경만 유지했으며, 금지 경로 변경 0건을 다시 확인했다.
+
+## 리스크 및 우려 사항
+
+| 리스크 | 심각도 | 완화 방안/현재 상태 |
+|---|---|---|
+| getter 대입 예외가 undo 스택을 반복해서 막음 | 높음 | `colorKey`만 복원하고 실패 토스트·소스 회귀 테스트 추가 |
+| Fabric 적용 뒤 전역 undo까지 이중 실행 | 높음 | `history-empty` 결과에만 폴백, applied/duplicate·repeat 차단 |
+| hydration의 늦은 응답이 취소된 B 진입을 부활 | 높음 | 입력 revision + owner 재검증 |
+| 파일 A의 늦은 디스크 읽기가 파일 B에 설치 | 높음 | owner 선캡처·await 후 재검증·명시 전달 |
+| 종료된 협업 세션의 큐가 새 세션을 오염 | 높음 | `_sessionGeneration` fence와 A1/A2/A3 테스트 |
+| Fabric 동시 편집 충돌 | 중간 | 현재는 루트 단위 last-save-wins로 수용, 후속 정교화 필요 |
+| 늦은 합류 seed가 10초 이내에는 억제됨 | 중간 | 계획된 기준 유지, 자동 경합 계약 통과; 격리 프로필의 준비 정체로 실제 원격 획 전파는 미확인 |
+| mpv 입력 차단 옵션의 실제 Windows 포커스 동작 | 중간 | 자동 인자 계약과 실제 실행 인자 확인 완료; 화면 자동화 키 주입 한계로 실제 단축키 라우팅은 미확인 |
+| bare format이 생성 번들·mpv 금지 범위를 오염 | 높음 | 금지 경로를 임시 ignore로 제외하고 실행, 범위 밖 기계적 변경은 전부 원복해 변경 0건 확인 |
+| 복구 테스트의 고정 PID `12345`가 종료 handle과 충돌 | 중간 | 코드 변경 없이 기록, PID 소멸 뒤 최종 컨트롤러가 재검증 |
+
+## 테스트 방법
+
+### 작업별 자동 검증
+
+| 완료 시점 | package `test:*` 스크립트 | 누적 테스트 | 결과 |
+|---|---:|---:|---|
+| 작업 1 (`3c3f414`) | 25/25 | 1,860/1,860 | PASS |
+| 작업 2 (`1e5d5cc`) | 25/25 | 1,860/1,860 | PASS |
+| 작업 3 (`f3e26e8`) | 25/25 | 1,863/1,863 | PASS |
+| 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
+| 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
+| 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
+
+Task 6 TDD focused 검증:
+
+```text
+node --test scripts/tests/mpv-manager.test.js
+RED: tests 32, pass 31, fail 1
+실패 이유: --input-default-bindings=no 누락
+GREEN: tests 32, pass 32, fail 0
+```
+
+최종 자동 검증 명령:
+
+```powershell
+npm.cmd run test:mpv
+# package.json에 정의된 test:* 25종을 정의 순서대로 각각 1회 실행
+```
+
+`npm.cmd run test:mpv`는 290/290 통과했다. 25종 전체 실행의 스크립트별 수치는 다음과 같다.
+
+| 스크립트 | Tests | Pass | Fail |
+|---|---:|---:|---:|
+| `test:fabric-drawing-pilot` | 327 | 327 | 0 |
+| `test:fabric-drawing-persistence` | 141 | 141 | 0 |
+| `test:recent` | 18 | 18 | 0 |
+| `test:frame-grid` | 35 | 35 | 0 |
+| `test:cluster` | 43 | 43 | 0 |
+| `test:composition` | 60 | 60 | 0 |
+| `test:playlist-ordering` | 17 | 17 | 0 |
+| `test:playlist-continuous` | 13 | 13 | 0 |
+| `test:playlist-comments` | 9 | 9 | 0 |
+| `test:playlist` | 251 | 251 | 0 |
+| `test:cutlist` | 82 | 82 | 0 |
+| `test:drawing` | 291 | 291 | 0 |
+| `test:drawing-v3-hardening` | 174 | 174 | 0 |
+| `test:drawing-v3-adapter` | 34 | 34 | 0 |
+| `test:drawing-v3-store-observer` | 19 | 19 | 0 |
+| `test:video-pan` | 17 | 17 | 0 |
+| `test:mpv` | 290 | 290 | 0 |
+| `test:fps` | 7 | 7 | 0 |
+| `test:audio-waveform` | 2 | 2 | 0 |
+| `test:collaboration` | 5 | 5 | 0 |
+| `test:comment-input` | 18 | 18 | 0 |
+| `test:toast-stack` | 9 | 9 | 0 |
+| `test:version` | 2 | 2 | 0 |
+| `test:file-drop` | 4 | 4 | 0 |
+| `test:hybrid` | 5 | 5 | 0 |
+| **합계** | **1,873** | **1,873** | **0** |
+
+최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
+
+- `the next read restores a prepared transaction whose main is missing`
+- `a valid external version supersedes an interrupted prepared transaction`
+- `a displaced external CAS backup is restored after a helper crash`
+
+세 테스트는 같은 머신의 복구 owner PID를 `12345`로 고정한다. 최초 실행 당시 `Get-Process`에는 `C:\Program Files\Git\mingw64\bin\git.exe` PID `12345`가 남아 있었고 `process.kill(12345, 0)`도 생존으로 판정했지만, `tasklist`와 CIM에는 해당 PID가 없었다. 종료 뒤 handle만 남은 zombie-like 환경 충돌로 보이며, `review-file-store.js`는 의도대로 복구 트랜잭션을 활성 상태로 기다리다가 5초 후 실패했다. 사용자 프로세스를 종료하거나 범위 밖 테스트를 바꾸지 않았다. 해당 프로세스의 소유 세션이 끝난 뒤 `Get-Process`에서 PID가 사라지고 `process.kill(12345, 0)`이 `ESRCH`를 반환함을 확인했다. 이어 `test:fabric-drawing-persistence` 141/141과 `test:*` 25종 전체 1,873/1,873이 코드 변경 없이 통과해 환경 충돌임을 확정했다.
+
+### 실제 앱 통합 검증
+
+실제 Electron GUI 검증은 자동 테스트와 분리해 두 격리 프로필(`appendix-a-codex-20260816-2329-a`, `appendix-a-codex-20260816-2329-b`)과 20초짜리 임시 영상 두 개로 수행했다.
+
+| 부록 A 시나리오 | 결과 | 실제 확인 내용 |
+|---|---|---|
+| 1. Fabric 획 → 하이라이트 → undo 순서 | 부분 확인 | Fabric 도구 진입, 빨간 획 작성, 하이라이트 추가와 `.bframe` 저장을 확인했다. Fabric 도구의 Undo는 획만 제거하고 하이라이트를 유지했으며 Redo도 정상 동작했다. 화면 자동화의 Ctrl+Z 주입이 앱에 전달되지 않아 Fabric 히스토리 소진 뒤 전역 하이라이트 undo까지는 수동 판정하지 않았다. |
+| 2. 2-인스턴스 독립 동작 | 부분 확인 | 두 인스턴스가 같은 `.bframe`과 하이라이트를 열었다. 두 번째 격리 프로필은 Fabric 준비 상태에서 진입이 끝나지 않아 A의 새 획이 B로 실시간 전파되는지는 확인하지 못했다. |
+| 3. 영상 전환·B 예약·동기화·중복 로그 | 부분 확인 | 준비 중 B를 다시 눌러 취소한 뒤 대기해도 늦은 enable 없이 passive 상태가 유지됐다. 영상 전환 뒤 상대 화면 반영과 중복 로그 부재는 두 번째 인스턴스의 준비 정체 때문에 수동 확인하지 못했으며, owner/revision/fingerprint 자동 경합 테스트로 검증했다. |
+| 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
+| 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
+
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. 동일 계약을 고정한 자동 테스트 25종 1,873건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다.

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -149,14 +149,16 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 - 명시 Broadcast 적용이 시작되거나 같은 내용의 더 높은 인과 버전을 수락하면 그보다 먼저 시작한 디스크 reload 세대를 무효화해, 파일 읽기 B가 보류된 동안 협업 루트 C가 확정된 뒤 B가 C를 덮지 못하게 한다.
 - 연결 중 파일 감지는 comments/레거시 전체 reload를 계속 막되 `drawingsV3`만 제한적으로 다시 읽고, 500ms 안의 후속 알림은 한 번의 trailing reload로 합쳐 최신 상태를 놓치지 않는다.
 - 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 causal Fabric root만 자동 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다. 삭제 상태를 포함하지 않는 additive 댓글·레거시 드로잉 전체 상태는 자동 합류·첫 저장·충돌 병합·종료 취소 재연결 어디에서도 seed하지 않는다. 기존 `seedCurrentState` 옵션은 causal Fabric root만 전송하며, 종료 취소 재연결은 이 옵션도 false로 둔다. Fabric 합류 요청에는 현재 인과 버전을 실어 안정 참가자가 요청자보다 높은 버전으로 응답하고, `drawingsV3` 부재도 명시 tombstone으로 전파한다.
-- 신규 참가자는 Fabric 수신 리스너 설치 직후 seed를 한 번 요청하고, 10초 이상 안정된 기존 참가자만 응답한다. 방 입장 직후의 1회 seed가 구독 창에서 유실돼도 복구되며 새 참가자의 구버전 seed 억제는 유지된다.
+- 신규 참가자는 Fabric 수신 리스너 설치 직후 V2 seed를 요청한다. 다중 참가자 일부가 같은 낮은 root를 먼저 수락해도 다른 참가자의 높은 root를 발견할 수 있도록 모든 live 세션은 안정화 직후 최신 상태로 딱 한 번 재요청하며, 세션 종료·파일 전환에서 타이머를 폐기한다. 응답은 요청자에게만 전달하고 ACK에는 응답자의 버전도 실어, 제3자 root를 덮거나 같은 내용의 높은 clock을 놓치지 않는다. raw baseline 응답은 기존 버전을 그대로 재사용하고 실제 로컬 저장만 Lamport clock을 올려, 낮은 revision 참가자가 요청 순서 때문에 높은 revision을 역전하지 못하게 한다.
+- fresh baseline끼리는 실제 provider가 호환 형식으로 검증한 같은 `documentId`에서만 `revision`과 결정적 지문 순서를 사용한다. 부재·미래/opaque 형식·서로 다른 문서 ID는 권위를 추측하지 않고 peer별 충돌 hold를 건다. hold는 최대 64개 actor를 추적하고 초과 시 fail-closed latch로 승격하며, 다른 peer의 ACK 하나가 남은 충돌을 지우지 못한다. 세션 시작 baseline은 무관 저장이나 명시 seed만으로 인과 버전이 승격되지 않되, 협업 시작 전에 만든 실제 로컬 Fabric 변경은 저장 성공 시 peer 유무와 관계없이 인과 버전으로 확정해 이후 합류자에게 전파할 수 있게 한다.
+- baseline 충돌이나 외부 root·디스크 reload가 진행 중이면 댓글만 바뀐 저장을 보류한다. 저장 final hook 뒤와 IPC 완료 뒤에도 Fabric 권위 epoch를 재검증하며, IPC 중 더 최신 root가 생기면 이미 기록된 payload는 관측·stale 이력으로만 남기고 `saved` 이벤트나 현재 권위로 승인하지 않은 채 최신 root를 다시 저장한다. 진행 중 권위 상태는 리뷰 컨텍스트별 token으로 관리해 파일 A의 느린 reload가 파일 B 저장을 막지 않으며, hold 해소 뒤 dirty 자동 저장은 재예약하되 일시정지·연결 해제 상태에서는 다시 켜지 않는다.
 - 동시 저장 루트는 세션 actor와 Lamport clock으로 결정적 순서를 부여한다. 스트로크 병합 없이 한쪽 루트가 이기는 기존 정책은 유지하되, 양쪽 화면이 서로 반대 루트를 적용하는 분기는 막고 패자 지문을 stale로 기록해 Drive rollback도 차단한다.
 - stop→start를 넘은 적용 큐는 `_sessionGeneration`으로 폐기하며, 새 세션 A3는 정상 적용한다.
 
 ### 예상/실제 리스크
 
 - 예상: 큰 payload, 파일 A→B 전환, 저장 에코, 늦은 합류, 세션 재시작이 서로 영향을 줄 수 있다.
-- 실제: owner 경합, 협업 방의 잔존 인원 기준값, 이전 세션 큐 누출, 동시 저장의 상호 교체 분기를 구현·리뷰 과정에서 추가 발견해 각각 fence를 넣었다. 루트 단위 동시 편집은 결정적 last-save-wins로 수렴하지만 패자 획은 대체될 수 있고, 삭제를 표현하지 못하는 댓글·레거시 드로잉 전체 seed는 데이터 부활보다 안전한 파일 reload·후속 delta 경로를 택해 자동·명시 실행을 모두 중단했다. 이에 따라 첫 저장 전에 만든 댓글·레거시 드로잉의 다른 클라이언트 즉시 반영은 파일 재개방이나 후속 delta까지 지연될 수 있다. 10초 안 동시 합류 Fabric seed 억제와 대용량 청크 수신 슬롯 1개라는 한계는 유지했다. 실제 앱 두 개로 같은 `.bframe`을 열었지만 두 번째 격리 프로필의 Fabric 진입이 준비 상태에 머물러 원격 획 전파는 끝까지 확인하지 못했다.
+- 실제: owner 경합, 협업 방의 잔존 인원 기준값, 이전 세션 큐 누출, 동시 저장의 상호 교체 분기를 구현·리뷰 과정에서 추가 발견해 각각 fence를 넣었다. 루트 단위 동시 편집은 비교 가능한 인과 버전에서 결정적 last-save-wins로 수렴하지만 패자 획은 대체될 수 있다. 서로 다른 문서 ID·부재·opaque처럼 시작 상태의 권위를 증명할 수 없는 경우에는 임의 선택 대신 양쪽 저장을 보류하며, 파일 채널·실제 Fabric 편집·인과 root로 해소될 때까지 즉시 수렴하지 않는 가용성 tradeoff를 택했다. 삭제를 표현하지 못하는 댓글·레거시 드로잉 전체 seed는 데이터 부활보다 안전한 파일 reload·후속 delta 경로를 택해 자동·명시 실행을 모두 중단했다. 이에 따라 첫 저장 전에 만든 댓글·레거시 드로잉의 다른 클라이언트 즉시 반영은 파일 재개방이나 후속 delta까지 지연될 수 있다. 계획에서 수용했던 10초 안 동시 합류 Fabric seed 억제는 stale save rollback이 가능해 단발 재요청·targeted 응답·저장 hold로 보강했고, 대용량 청크 수신 슬롯 1개라는 한계만 유지했다. 실제 앱 두 개로 같은 `.bframe`을 열었지만 두 번째 격리 프로필의 Fabric 진입이 준비 상태에 머물러 원격 획 전파는 끝까지 확인하지 못했다.
 
 ## Phase 6: mpv 입력 소비 차단과 버전 갱신
 
@@ -209,7 +211,12 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 22. 같은 재리뷰에서 Ctrl/Cmd+Z/Y의 Fabric IPC가 느린 동안 새 댓글·하이라이트가 전역 스택에 들어오면, 뒤늦은 `history-empty` 폴백이 키 입력 당시 없던 새 항목을 지우는 P2를 발견했다. 모든 전역 undo/redo 스택 변경에 단조 revision을 올리고 active Fabric 단축키가 입력 시점 revision과 응답 시점 revision을 비교하도록 보강했다. 중간 변경 시 폴백 0회, 무변경 시 undo/redo 각 1회를 deferred 기능 테스트로 검증했다.
 23. 6차 보강의 독립 경로 감사에서 mpv 오버레이가 포커스를 가진 경우 host가 먼저 Fabric 히스토리를 비동기로 조회한 뒤 renderer에 키를 넘겨, revision 캡처가 물리 입력보다 늦고 Fabric 조회도 두 번 일어나는 P2를 확인했다. host의 로컬 히스토리 실행을 제거하고 Ctrl/Cmd+Z/Y를 즉시 renderer에 릴레이해 단일 owner가 입력 시점 revision 캡처부터 조건부 폴백까지 한 번만 수행하도록 고정했다. 메인 창의 직전 댓글 입력 포커스가 남아도 history chord는 문서 타깃을 그대로 보존해 컨트롤러에 도달시키되, Tab 등 일반 릴레이 키는 기존 활성 요소로 보내는 기능 테스트도 추가했다.
 24. 7차 Codex 재리뷰에서 10초 억제가 끝난 stale peer도 새 참가자가 들어오면 삭제 tombstone이 없는 레거시 `broadcastCurrentState()`를 실행해, 삭제된 키프레임·레이어를 `getOrCreateKeyframe()`/`restore: true`로 부활시키고 RDM 자동 저장으로 영속화하는 P1을 재현했다. 참가자 증가 자동 seed에서 레거시 호출만 제거하고 댓글·인과 버전 Fabric seed와 명시적 복구·재연결 seed는 유지했다. 소스 계약은 두 블록을 각각 잘라 과잉 제거와 재도입을 함께 막는다.
-25. 같은 HEAD의 후속 Codex 재리뷰에서 댓글 current-state seed도 삭제 marker를 보내지 않고 살아 있는 marker만 `COMMENT_MARKER_ADDED`로 전파하므로, 삭제 전 파일을 가진 stale peer가 신규 참가자에게 댓글을 부활시키고 자동 저장할 수 있는 P1을 확인했다. 참가자 증가 자동 seed는 causal tombstone/version을 가진 Fabric만 남기고 댓글·레거시 additive seed를 모두 제외했다. 교차 감사에서는 종료 취소 후 reload 없이 재접속하는 두 경로뿐 아니라, 첫 저장·충돌 병합에서 디스크 read 직후 리스너 설치 전에 발생한 원격 삭제도 놓칠 수 있음을 확인했다. 따라서 공통 `seedCurrentState` 블록도 causal Fabric-only로 고정하고 종료 취소의 두 caller는 `seedCurrentState: false`로 두었다. 소스 계약은 자동·명시 블록에서 additive seed 0건, 병합 caller의 Fabric seed 옵션 true 3건, 재연결 false 2건을 함께 검증한다.
+25. 같은 HEAD의 후속 Codex 재리뷰에서 댓글 current-state seed도 삭제 tombstone 없이 살아 있는 layer·marker만 additive event로 전파하므로, 삭제 전 파일을 가진 stale peer가 신규 참가자에게 삭제된 댓글 layer와 그 marker를 부활시키고 자동 저장할 수 있는 P1을 확인했다. 참가자 증가 자동 seed는 causal tombstone/version을 가진 Fabric만 남기고 댓글·레거시 additive seed를 모두 제외했다. 교차 감사에서는 종료 취소 후 reload 없이 재접속하는 두 경로뿐 아니라, 첫 저장·충돌 병합에서 디스크 read 직후 리스너 설치 전에 발생한 원격 layer 삭제도 놓칠 수 있음을 확인했다. 따라서 공통 `seedCurrentState` 블록도 causal Fabric-only로 고정하고 종료 취소의 두 caller는 `seedCurrentState: false`로 두었다. 소스 계약은 자동·명시 블록에서 additive seed 0건, 병합 caller의 Fabric seed 옵션 true 3건, 재연결 false 2건을 함께 검증한다.
+26. 8차 Codex 재리뷰에서 두 peer가 같은 10초 안정화 창에 합류하면 서로의 startup 요청 응답과 app의 1회 seed가 모두 억제되고 다시 평가되지 않아, 서로 다른 root로 남은 뒤 stale peer의 무관 저장이 더 높은 clock을 발급해 최신 root를 되돌리는 P1을 재현했다. 처음에는 응답을 수락한 세션의 retry를 취소했지만, 독립 감사에서 3명 중 두 명이 같은 낮은 root를 먼저 수락하면 두 retry가 모두 사라져 높은 세 번째 root를 영구히 발견하지 못하는 P1을 다시 재현했다. 따라서 모든 live 세션이 10초 뒤 한 번씩 요청하고, stop·파일 전환·이전 세션 callback만 차단하도록 정정했다. 또 `revision`은 같은 `documentId` 안에서만 순서가 있으므로, absent/미래 opaque/리셋 뒤 다른 문서 ID를 숫자로 비교해 덮는 방식도 폐기했다. request에 bounded root identity를 싣고 같은 지원 문서의 높은 revision만 응답하며 나머지는 fail-closed 보존한다. 시작 baseline의 무관 저장과 강제 seed는 0건, 실제 Fabric 편집은 정상 전파하도록 막았다. 2인·3인 same-document 수렴, absent/opaque/reset 양 시작 순서 보존, 응답 선수락 뒤에도 단발 retry 유지, stop→start 이전 callback 폐기를 fake clock/timer 기능 테스트로 고정했다.
+27. 8차 보강의 적대 검토에서 root 응답 때마다 raw baseline을 새 actor/clock으로 승격하면 3명 중 rev10 참가자가 먼저 답한 뒤 rev9 참가자가 더 높은 clock으로 답해 전원이 rev9로 rollback하는 P1을 재현했다. V2 요청·응답·청크를 공개 저장 Broadcast와 분리해 target actor만 처리하게 하고, 비교 우위 응답은 현재 버전을 그대로 재사용했다. 같은 내용의 ACK도 응답 버전을 전달하고, 낮은 쪽이 높은 쪽에 pull을 요청하도록 해 전달 순서와 제3자 topology에 독립적으로 수렴시켰다. raw snapshot clock은 관측 Lamport 최대가 아니라 자기 문서 revision으로 유지하고, 다음 실제 로컬 편집만 관측 최대보다 큰 clock을 발급하도록 분리했다.
+28. 같은 검토에서 비교 불가능한 baseline을 단일 boolean으로 막으면 다른 peer의 ACK 하나가 남은 충돌까지 풀거나, 반대로 정상 same-document 수렴 뒤 저장이 영구 차단되는 P1을 확인했다. Sync가 peer actor별 unresolved Set을 소유하고, CONFLICT·PULL·ACK·targeted root의 source를 끝까지 전달해 해당 peer만 해소한다. 64개를 넘는 재연결 actor는 항목을 축출하지 않고 unattributed fail-closed latch로 승격한다. RDM은 충돌 중 실제 Fabric 변경이 없는 댓글 저장만 차단하고, 실제 Fabric 저장·인과 root·유효한 파일 전진에서 hold를 해소한다.
+29. 저장 final hook 또는 `saveReview` IPC를 기다리는 동안 새 baseline 충돌·외부 root·로컬 Fabric 변경이 생기면, 이미 수집한 구버전 payload를 저장 성공으로 승인하고 `saved` Broadcast까지 보내는 P1을 실제 manager/store 하니스로 재현했다. 권위 epoch를 수집 직전에 캡처해 IPC 뒤 다시 비교하고, 불일치한 물리 write는 observed/stale 이력으로만 기록한 뒤 최신 root를 bounded 재시도한다. 외부 apply와 selective disk reload는 입장부터 종료까지 context-owned in-flight token으로 보호해 hydration 중 구버전 저장을 막되, 파일 A의 늦은 작업은 파일 B 저장을 막지 않는다. 같은 revision·다른 documentId 외부 root, install 보류 순서, IPC 중 로컬 rev 증가, A→B 전환 저장을 각각 기능 테스트로 고정했다.
+30. 위 자동저장 재개 경로의 독립 감사에서 pending 권위 작업이 끝나면 `pauseAutoSave()` 또는 `disconnect()` 뒤에도 dirty 타이머를 다시 예약하는 P2를 재현했다. 이어 pause 뒤 새 Fabric transition이 `_markDirty()`에서 별도 타이머를 만드는 우회도 확인했다. 권위 해소 전용 재개 helper는 `isLoading`과 연결 상태를 함께 확인하고, 범용 dirty 예약·timer callback은 기존 connect-less trailing-save 계약을 보존하며 `isLoading`만 재검증하도록 좁혔다. pending reload 종료와 pause 중 실제 provider 변경 모두 write 0건·dirty/localChanges 유지, disconnect 뒤 write 0건으로 검증했다.
 
 ## 리스크 및 우려 사항
 
@@ -233,11 +240,16 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 보류 중인 파일 reload가 더 최신 Broadcast 적용 뒤 완료되어 역전 | 높음 | explicit apply와 same-root 고버전 수락 시 이전 disk reload epoch 무효화, 후속 fresh reload 정상 경로 보존 |
 | `drawingsV3` 부재 상태를 seed하지 못해 지연 복제본의 구버전 획이 부활 | 높음 | 명시 tombstone + 요청 clock causal floor + provider reset 경로 |
 | stale peer의 additive 레거시 전체 seed가 삭제된 키프레임·레이어를 부활 | 높음 | 자동·명시 seed 모두 causal Fabric-only, 종료 취소 재연결 옵션 false |
-| stale peer의 additive 댓글 전체 seed가 삭제된 marker를 부활 | 높음 | 자동·명시 seed 모두 causal Fabric-only, 종료 취소 재연결 옵션 false |
+| stale peer의 additive 댓글 전체 seed가 삭제된 layer·marker를 부활 | 높음 | 자동·명시 seed 모두 causal Fabric-only, 종료 취소 재연결 옵션 false |
 | 500ms 안의 후속 파일 알림이 누락돼 최신 루트가 미적용 | 중간 | leading 즉시 실행 + 최신 trailing 1회 coalescing, 실행 시 파일 경로 재검증 |
 | 저장 대기 중 Undo된 댓글의 Slack 알림이 뒤늦게 발송 | 중간 | 저장 뒤 현재 마커 null/deleted 재검증 |
 | Fabric 동시 편집에서 패자 획이 대체 | 중간 | 양쪽은 결정적 root-level last-save-wins로 수렴, 스트로크 단위 병합은 후속 범위 |
-| 늦은 합류 seed가 10초 이내에는 억제됨 | 중간 | 계획된 기준 유지, 자동 경합 계약 통과; 격리 프로필의 준비 정체로 실제 원격 획 전파는 미확인 |
+| 여러 peer가 10초 안에 함께 합류해 startup seed가 모두 억제되고 stale save가 rollback | 높음 | 모든 live 세션의 안정화 후 단발 요청, 같은 문서의 revision 우위만 응답, 불명 권위 baseline fail-closed 보존, baseline 저장·force seed 억제, stop·파일 전환 timer fence |
+| root 응답 순서나 제3자 topology가 낮은 revision을 더 높은 clock으로 승격 | 높음 | V2 targeted 응답·청크, raw 버전 재사용, version ACK·PULL, raw revision과 관측 Lamport 분리 |
+| 비교 불가능한 peer 충돌을 다른 peer의 ACK가 잘못 해제하거나 정상 수렴 뒤 영구 저장 차단 | 높음 | actor별 conflict Set과 overflow fail-closed latch, source별 ACK/targeted 적용 해소 |
+| `saveReview` IPC 중 바뀐 Fabric 권위를 구버전 저장 완료로 승인·재전파 | 높음 | collect 전/IPC 후 authority epoch fence, stale physical write는 관측 이력만 기록, 최신 root bounded 재저장 |
+| 파일 A의 느린 권위 작업이 파일 B 저장을 차단 | 중간 | review context epoch별 단일 in-flight slot과 token 일치 종료 |
+| 권위 작업 종료가 일시정지·연결 해제된 자동저장을 다시 예약 | 중간 | autosave 재개 시 `isLoading`·연결 상태 재검증, pause/disconnect write 0 회귀 |
 | mpv 입력 차단 옵션의 실제 Windows 포커스 동작 | 중간 | 자동 인자 계약과 실제 실행 인자 확인 완료; 화면 자동화 키 주입 한계로 실제 단축키 라우팅은 미확인 |
 | bare format이 생성 번들·mpv 금지 범위를 오염 | 높음 | 금지 경로를 임시 ignore로 제외하고 실행, 범위 밖 기계적 변경은 전부 원복해 변경 0건 확인 |
 | 복구 테스트의 고정 PID `12345`가 종료 handle과 충돌 | 중간 | 코드 변경 없이 기록, PID 소멸 뒤 최종 컨트롤러가 재검증 |
@@ -255,7 +267,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
 | 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
 | 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
-| PR 리뷰 보강 최종 | 25/25 | 1,901/1,901 | PASS |
+| PR 리뷰 보강 최종 | 25/25 | 1,903/1,903 | PASS |
 
 Task 6 TDD focused 검증:
 
@@ -278,7 +290,7 @@ npm.cmd run test:mpv
 | 스크립트 | Tests | Pass | Fail |
 |---|---:|---:|---:|
 | `test:fabric-drawing-pilot` | 328 | 328 | 0 |
-| `test:fabric-drawing-persistence` | 154 | 154 | 0 |
+| `test:fabric-drawing-persistence` | 155 | 155 | 0 |
 | `test:recent` | 18 | 18 | 0 |
 | `test:frame-grid` | 35 | 35 | 0 |
 | `test:cluster` | 43 | 43 | 0 |
@@ -286,7 +298,7 @@ npm.cmd run test:mpv
 | `test:playlist-ordering` | 17 | 17 | 0 |
 | `test:playlist-continuous` | 13 | 13 | 0 |
 | `test:playlist-comments` | 9 | 9 | 0 |
-| `test:playlist` | 264 | 264 | 0 |
+| `test:playlist` | 265 | 265 | 0 |
 | `test:cutlist` | 82 | 82 | 0 |
 | `test:drawing` | 291 | 291 | 0 |
 | `test:drawing-v3-hardening` | 174 | 174 | 0 |
@@ -302,7 +314,7 @@ npm.cmd run test:mpv
 | `test:version` | 2 | 2 | 0 |
 | `test:file-drop` | 4 | 4 | 0 |
 | `test:hybrid` | 5 | 5 | 0 |
-| **합계** | **1,901** | **1,901** | **0** |
+| **합계** | **1,903** | **1,903** | **0** |
 
 최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
 
@@ -324,4 +336,4 @@ npm.cmd run test:mpv
 | 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
 | 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
 
-수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,901건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,903건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake와 안정화 재요청의 실제 다중 클라이언트 네트워크 동작, Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.

--- a/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
+++ b/DEVLOG/2026-08-16-드로잉엔진-안정화-구현.md
@@ -137,12 +137,14 @@ Fabric 소스 갱신·복구 중 B 입력을 침묵 거절하지 않고 예약�
 
 - 저장 완료 루트를 크기에 따라 인라인 또는 청크로 전송하고, 원격 루트는 순서대로 적용한다.
 - stale 지문은 최대 8개를 유지하고, 실제 디스크에서 마지막으로 관측한 지문은 별도 상태로 보호해 현재 디스크에 머문 지연 루트가 8개 stale 이력에서 밀려나도 되돌아오지 않게 한다.
+- 실제 디스크 관측 지문이 전진하면 직전 관측 지문을 stale 이력의 최신 항목으로 승계해, Drive가 다시 과거 상태로 돌아가도 재설치하지 않는다.
 - `reloadDrawingsV3FromDisk()`는 await 전에 owner를 캡처하고, await 뒤 재검증한 같은 owner를 reconcile에 명시 전달한다.
 - 수락한 원격 루트를 opaque 저장 기준에도 즉시 반영해, Drive의 구버전 파일을 읽은 뒤 관련 없는 댓글을 저장해도 최신 `drawingsV3`가 되돌아가지 않게 한다.
 - provider 설치가 성공한 뒤에만 stale 지문·디스크 상태·opaque 기준을 확정해, 첫 설치 실패 뒤 같은 payload를 실제로 다시 설치할 수 있게 한다.
 - 같은 파일의 디스크 reload 요청마다 세대를 올리고 reconcile의 owner predicate까지 전달해, 느린 이전 hydration이 빠른 최신 reload 뒤에 완료돼도 설치하지 않는다.
+- 명시 Broadcast 적용이 시작되면 그보다 먼저 시작한 디스크 reload 세대를 무효화해, 파일 읽기 B가 보류된 동안 협업 루트 C가 적용된 뒤 B가 C를 덮지 못하게 한다.
 - 연결 중 파일 감지는 comments/레거시 전체 reload를 계속 막되 `drawingsV3`만 제한적으로 다시 읽고, 500ms 안의 후속 알림은 한 번의 trailing reload로 합쳐 최신 상태를 놓치지 않는다.
-- 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 현재 상태를 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다.
+- 참여자 증가와 세션 시작 10초 경과를 함께 만족할 때 현재 상태를 seed하고, 새 방 시작 시 참여자 기준값을 0으로 초기화한다. 합류 요청에는 현재 인과 버전을 실어 안정 참가자가 요청자보다 높은 버전으로 응답하며, `drawingsV3` 부재도 명시 tombstone으로 전파한다.
 - 신규 참가자는 Fabric 수신 리스너 설치 직후 seed를 한 번 요청하고, 10초 이상 안정된 기존 참가자만 응답한다. 방 입장 직후의 1회 seed가 구독 창에서 유실돼도 복구되며 새 참가자의 구버전 seed 억제는 유지된다.
 - 동시 저장 루트는 세션 actor와 Lamport clock으로 결정적 순서를 부여한다. 스트로크 병합 없이 한쪽 루트가 이기는 기존 정책은 유지하되, 양쪽 화면이 서로 반대 루트를 적용하는 분기는 막고 패자 지문을 stale로 기록해 Drive rollback도 차단한다.
 - stop→start를 넘은 적용 큐는 `_sessionGeneration`으로 폐기하며, 새 세션 A3는 정상 적용한다.
@@ -195,6 +197,9 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 14. 같은 재리뷰에서 연결 중 500ms 이내 두 번째 파일 알림이 trailing 예약 없이 버려지는 P2를 발견했다. 첫 reload는 즉시 유지하고 interval 안의 최신 알림을 남은 시간 뒤 한 번 실행하며, 파일 전환 시 이전 예약을 폐기하도록 보강했다.
 15. 3차 보강의 독립 적대 검토에서 적용 await 중 로컬 저장의 버전 강등, 동일 revision 합류 seed의 지문 의존, 대용량 청크 헤더 교차·clock 미관측·동일 버전 재시도 차단, 상충 stale 이력의 재수렴 실패를 추가 재현했다. 최종 root 재확인, 최초 publish 승격, header 버전 우선 슬롯·즉시 clock 관측·새 transfer ID 재시도 교체, 결정적 버전 비교를 통과한 명시 Broadcast만 stale-file guard를 1회 우회하는 계약으로 각각 차단했다. 단순 clock 재승격·재전파 방식은 상충 stale 이력에서 무한 핑퐁을 재현해 채택하지 않았다.
 16. 4차 Codex 재리뷰에서 Drive가 D0에 머문 채 Broadcast D1~D9가 수락되면 8개 stale 이력에서 D0가 밀려나 파일 reload가 D0를 다시 설치하는 P1을 발견했다. 실제 디스크의 마지막 관측 지문을 capped Set 밖에서 별도 추적하고, Broadcast는 이를 바꾸지 않으며 disk stale 관측·현재 일치·새 상태 설치 성공 때만 이동하도록 보강했다. D0 보호, 실제 D1 전진 뒤 보호 이동, 미지 D19 정상 설치까지 실제 provider spy로 검증했다.
+17. 같은 4차 리뷰의 후속 코멘트에서 파일 B 읽기가 보류된 동안 Broadcast C가 적용돼도 기존 reload 세대가 살아 있어 B가 C를 덮는 P1을 발견했다. RDM의 explicit Broadcast 진입점에서 disk reload 세대를 먼저 올리고, B reload false·C 유지·후속 D reload 정상 적용을 실제 store로 검증했다.
+18. 같은 후속 코멘트에서 안정 참가자의 `.bframe`에 `drawingsV3`가 없으면 seed 응답 자체가 생략돼, 지연 복제본의 구버전 루트가 다시 방 전체에 부활하는 P2를 발견했다. 부재 tombstone과 요청자의 현재 clock을 포함하는 handshake를 추가해 revision 12 구버전보다 높은 tombstone, provider reset, 반복 seed 버전 유지와 역방향 유효 루트 보호를 검증했다.
+19. 5차 Codex 재리뷰에서 실제 디스크 관측이 D1→D2로 전진할 때 D1이 scalar와 Set 양쪽에서 빠져 이후 Drive rollback으로 재설치되는 P1을 발견했다. scalar가 이동할 때 현재 권위 루트를 제외한 직전 관측 지문을 capped history의 최신 항목으로 승계하고, cap 압박 뒤 disk catch-up→rollback을 실제 provider spy로 검증했다.
 
 ## 리스크 및 우려 사항
 
@@ -213,6 +218,9 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 대용량 청크 헤더 교차·미완료 전송 때문에 최고 버전 또는 동일 버전 재시도가 유실 | 높음 | header 단계에서 낮은 버전만 거절하고 동일 버전의 새 transfer ID는 교체, 수신 즉시 Lamport clock 관측 |
 | 상충 stale 이력에서 고버전 Broadcast가 no-op되거나 재전파 핑퐁 | 높음 | 명시 Broadcast만 해당 stale 지문을 설치 성공 시 해제, 파일 reload guard와 실패 시 stale 보호 유지 |
 | 실제 Drive 루트가 8개 stale 이력에서 퇴출돼 파일 reload로 rollback | 높음 | 마지막 실제 디스크 관측 지문을 Set 밖에서 보호하고 disk 전진 확인 시에만 이동 |
+| 디스크 관측이 전진한 뒤 직전 관측 루트가 보호에서 빠져 rollback | 높음 | scalar 이동 시 직전 관측 지문을 stale 이력 최신 항목으로 승계, 현재 권위 루트는 제외 |
+| 보류 중인 파일 reload가 더 최신 Broadcast 적용 뒤 완료되어 역전 | 높음 | explicit Broadcast 진입 시 이전 disk reload epoch 무효화, 후속 fresh reload 정상 경로 보존 |
+| `drawingsV3` 부재 상태를 seed하지 못해 지연 복제본의 구버전 획이 부활 | 높음 | 명시 tombstone + 요청 clock causal floor + provider reset 경로 |
 | 500ms 안의 후속 파일 알림이 누락돼 최신 루트가 미적용 | 중간 | leading 즉시 실행 + 최신 trailing 1회 coalescing, 실행 시 파일 경로 재검증 |
 | 저장 대기 중 Undo된 댓글의 Slack 알림이 뒤늦게 발송 | 중간 | 저장 뒤 현재 마커 null/deleted 재검증 |
 | Fabric 동시 편집에서 패자 획이 대체 | 중간 | 양쪽은 결정적 root-level last-save-wins로 수렴, 스트로크 단위 병합은 후속 범위 |
@@ -233,7 +241,7 @@ mpv 자식 HWND가 포커스를 얻더라도 기본 키·VO 키보드·커서 �
 | 작업 4 (`eeb8bb1`) | 25/25 | 1,866/1,866 | PASS |
 | 작업 5 (`ee4dd1e`) | 25/25 | 1,872/1,872 | PASS |
 | 작업 6 최종 | 25/25 | 1,873/1,873 | PASS |
-| PR 리뷰 보강 최종 | 25/25 | 1,890/1,890 | PASS |
+| PR 리뷰 보강 최종 | 25/25 | 1,894/1,894 | PASS |
 
 Task 6 TDD focused 검증:
 
@@ -256,7 +264,7 @@ npm.cmd run test:mpv
 | 스크립트 | Tests | Pass | Fail |
 |---|---:|---:|---:|
 | `test:fabric-drawing-pilot` | 327 | 327 | 0 |
-| `test:fabric-drawing-persistence` | 149 | 149 | 0 |
+| `test:fabric-drawing-persistence` | 151 | 151 | 0 |
 | `test:recent` | 18 | 18 | 0 |
 | `test:frame-grid` | 35 | 35 | 0 |
 | `test:cluster` | 43 | 43 | 0 |
@@ -264,7 +272,7 @@ npm.cmd run test:mpv
 | `test:playlist-ordering` | 17 | 17 | 0 |
 | `test:playlist-continuous` | 13 | 13 | 0 |
 | `test:playlist-comments` | 9 | 9 | 0 |
-| `test:playlist` | 259 | 259 | 0 |
+| `test:playlist` | 261 | 261 | 0 |
 | `test:cutlist` | 82 | 82 | 0 |
 | `test:drawing` | 291 | 291 | 0 |
 | `test:drawing-v3-hardening` | 174 | 174 | 0 |
@@ -280,7 +288,7 @@ npm.cmd run test:mpv
 | `test:version` | 2 | 2 | 0 |
 | `test:file-drop` | 4 | 4 | 0 |
 | `test:hybrid` | 5 | 5 | 0 |
-| **합계** | **1,890** | **1,890** | **0** |
+| **합계** | **1,894** | **1,894** | **0** |
 
 최초 전체 실행에서는 기존 `review-file-store-recovery.test.js`의 다음 세 건이 모두 `ERR_REVIEW_LOCK_TIMEOUT`으로 실패했다.
 
@@ -302,4 +310,4 @@ npm.cmd run test:mpv
 | 4. Fabric 킬 스위치의 레거시 경로 | PASS | `--disable-fabric-drawing-pilot`로 실행해 기존 `레이어 1`, 레거시 그리기 도구 패널과 캔버스가 열리고 선 입력이 반영됨을 확인했다. |
 | 5. mpv 입력 소비 차단 | 부분 확인 | 실제 실행 로그의 mpv 인자에 `--input-default-bindings=no`, `--input-vo-keyboard=no`, `--input-cursor=no`가 모두 포함됐고 UI 재생·일시정지는 정상 동작했다. 자동화 키 주입이 영상과 렌더러 양쪽에서 반응하지 않아 Space·화살표·Ctrl+Z의 실제 포커스 라우팅은 수동 판정하지 않았다. |
 
-수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,890건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.
+수동 검증의 미확인 항목은 코드 실패로 판정하지 않았다. PR 리뷰 보강 후 동일 계약을 고정한 자동 테스트 25종 1,894건은 모두 통과했으며, 실제 앱에서는 레거시 폴백과 준비 취소 무재활성화까지 확인했다. post-subscription handshake의 실제 다중 클라이언트 네트워크 동작과 Slack 웹훅 발송은 자동 기능·소스 계약으로만 검증했고 별도 수동 완료로 주장하지 않는다.

--- a/main/mpv-manager.js
+++ b/main/mpv-manager.js
@@ -103,6 +103,10 @@ function createMpvLaunchArgs({ ipcPath, forceWindow = true, wid = null, headless
     '--hwdec=auto',
     '--screenshot-format=png',
     '--screenshot-png-compression=1',
+    // mpv 자식 창이 키·마우스 입력을 소비하지 않도록 차단 (입력은 앱이 IPC로 전달)
+    '--input-default-bindings=no',
+    '--input-vo-keyboard=no',
+    '--input-cursor=no',
     `--input-ipc-server=${ipcPath}`
   ];
 

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -2412,7 +2412,6 @@ class MPVOverlayHost {
     this.maxProcessedActionIds = 2048;
     this.drawingActionQueue = Promise.resolve();
     this.suppressedOverlayHistoryKeys = new Set();
-    this.overlayHistoryActionSequence = 0;
     this.drawingV3ShadowEnabled = false;
     this.drawingV3ShadowConfigured = false;
     this.drawingV3ShadowLocked = false;
@@ -3267,18 +3266,6 @@ class MPVOverlayHost {
     }
   }
 
-  _makeOverlayHistoryActionRequest(action) {
-    this.overlayHistoryActionSequence += 1;
-    return {
-      hostGeneration: this.hostGeneration,
-      videoGeneration: this.currentVideoGeneration,
-      inputRevision: this.currentInputRevision,
-      sessionId: this.activeSessionId,
-      actionId: `overlay-history-${this.hostGeneration}-${this.overlayHistoryActionSequence}`,
-      action
-    };
-  }
-
   _executeFabricMethod(method, payload) {
     const argument = payload === undefined ? '' : JSON.stringify(payload);
     return this.window.webContents?.executeJavaScript?.(
@@ -3630,24 +3617,9 @@ class MPVOverlayHost {
       if (historyAction) {
         this.suppressedOverlayHistoryKeys.add(inputCode);
         event?.preventDefault?.();
-        if (input.isAutoRepeat !== true) {
-          const request = this._makeOverlayHistoryActionRequest(historyAction);
-          this.applyDrawingAction(request).then(result => {
-            if (result?.applied === true || result?.duplicate === true) return;
-            if (result?.reason !== 'history-empty') return;
-            // fabric 히스토리가 비어 있으면 renderer의 전역 undo가 처리하도록 릴레이한다
-            const fallbackInput = createForwardedKeyboardInput(input);
-            const mainWindow = this.getMainWindow();
-            if (!fallbackInput ||
-                !mainWindow ||
-                mainWindow.isDestroyed?.() ||
-                typeof mainWindow.webContents?.send !== 'function') {
-              return;
-            }
-            mainWindow.webContents.send(FORWARDED_KEYBOARD_CHANNEL, fallbackInput);
-          }).catch(() => {});
-        }
-        return;
+        if (input.isAutoRepeat === true) return;
+        // renderer가 Fabric 실행과 전역 히스토리 fallback을 한 경로에서 판정하도록
+        // 물리 키 입력을 즉시 릴레이한다.
       }
       const forwardedInput = createForwardedKeyboardInput(input);
       const mainWindow = this.getMainWindow();

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -2736,6 +2736,7 @@ class MPVOverlayHost {
         success: result?.applied === true || result?.duplicate === true,
         applied: result?.applied === true,
         duplicate: result?.duplicate === true,
+        ...(typeof result?.reason === 'string' ? { reason: result.reason } : {}),
         deletedCount: Math.max(0, Math.trunc(finiteDiagnosticNumber(result?.deletedCount)))
       };
     } catch (error) {
@@ -3631,7 +3632,20 @@ class MPVOverlayHost {
         event?.preventDefault?.();
         if (input.isAutoRepeat !== true) {
           const request = this._makeOverlayHistoryActionRequest(historyAction);
-          this.applyDrawingAction(request).catch(() => {});
+          this.applyDrawingAction(request).then(result => {
+            if (result?.applied === true || result?.duplicate === true) return;
+            if (result?.reason !== 'history-empty') return;
+            // fabric 히스토리가 비어 있으면 renderer의 전역 undo가 처리하도록 릴레이한다
+            const fallbackInput = createForwardedKeyboardInput(input);
+            const mainWindow = this.getMainWindow();
+            if (!fallbackInput ||
+                !mainWindow ||
+                mainWindow.isDestroyed?.() ||
+                typeof mainWindow.webContents?.send !== 'function') {
+              return;
+            }
+            mainWindow.webContents.send(FORWARDED_KEYBOARD_CHANNEL, fallbackInput);
+          }).catch(() => {});
         }
         return;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.0.3-beta",
+  "version": "2.1.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.0.3-beta",
+      "version": "2.1.0-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.0.3-beta",
+  "version": "2.1.0-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -10016,6 +10016,9 @@ async function initApp() {
     }
     if (enabled && isMpvPilotPlaybackActive()) {
       videoPlayer.pause();
+      // 하이브리드 스왑·freeze 준비가 끝날 때까지 준비중 표시를 즉시 켠다
+      setDrawModeReadyState(false);
+      setDrawModePreparingState(true);
       // 작업 4: 하이브리드 우선 — HTML5 직재생 가능하면 엔진 전환, 아니면 기존 freeze 준비.
       // (c-0)의 skipReviewTransition 덕에 preparationToken이 보존되어 실패 폴백이 성립한다.
       void enterHybridReviewEngineIfPossible().then((swapped) => {
@@ -10030,6 +10033,9 @@ async function initApp() {
         } else {
           void prepareMpvDrawMode(preparationToken);
         }
+      }, () => {
+        // 스왑 자체가 예외로 실패해도 준비중 표시가 고착되지 않도록 freeze 폴백으로 잇는다
+        if (state.isDrawMode) void prepareMpvDrawMode(preparationToken);
       });
     } else {
       setDrawModePreparingState(false);

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -19,6 +19,7 @@ import { ReviewDataManager, getBframePath } from './modules/review-data-manager.
 import { LiveblocksManager } from './modules/liveblocks-manager.js';
 import { CommentSync } from './modules/comment-sync.js';
 import { DrawingSync } from './modules/drawing-sync.js';
+import { FabricDrawingSync } from './modules/fabric-drawing-sync.js';
 import { createFabricDrawingPilotController } from './modules/fabric-drawing-pilot-controller.js';
 import { createFabricDrawingPersistenceStore } from './modules/fabric-drawing-persistence-store.js';
 import { HighlightManager, HIGHLIGHT_COLORS } from './modules/highlight-manager.js';
@@ -1278,6 +1279,11 @@ async function initApp() {
       remoteStrokeOverlayForMpv = overlay || null;
       scheduleMpvOverlayStateSync({ liveDrawing: true });
     }
+  });
+  // Fabric 드로잉(drawingsV3) 동기화 — 저장 스냅샷을 Broadcast로 전파
+  const fabricDrawingSync = new FabricDrawingSync({
+    liveblocksManager,
+    reviewDataManager
   });
   const playbackSync = getPlaybackSync(liveblocksManager);
 
@@ -6626,6 +6632,7 @@ async function initApp() {
     try {
       playbackSync.stop();
       drawingSync.stop();
+      fabricDrawingSync.stop();
       commentSync.stop();
       await liveblocksManager.stop();
     } catch (error) {
@@ -6678,10 +6685,16 @@ async function initApp() {
         return false;
       }
       drawingSync.start();
+      fabricDrawingSync.start();
       playbackSync.start();
+      // 새 협업 세션 기준값 초기화 — LiveblocksManager.stop()은 collaboratorsChanged([])를
+      // 발생시키지 않아 이전 방의 참여자 수가 남으면 새 방의 late seed 조건을 놓친다
+      _previousOthersCount = 0;
+      _collaborationSessionStartedAt = Date.now();
       if (seedCurrentState) {
         commentSync.broadcastCurrentState?.();
         drawingSync.broadcastCurrentState?.();
+        fabricDrawingSync.broadcastCurrentState?.();
       }
       log.info('Liveblocks 협업 세션 시작됨', { roomId, isNewRoom });
     } catch (error) {
@@ -9109,6 +9122,7 @@ async function initApp() {
           } finally {
             commentSync.stop();
             drawingSync.stop();
+            fabricDrawingSync.stop();
           }
           // 협업 UI 초기화 (이전 세션의 아바타/인원 표시 제거)
           updateCollaboratorsUI([]);
@@ -13765,6 +13779,7 @@ async function initApp() {
     // 협업 세션 종료 (presence 제거)
     commentSync.stop();
     drawingSync.stop();
+    fabricDrawingSync.stop();
     try {
       await liveblocksManager.stop();
     } catch (error) {
@@ -16742,6 +16757,7 @@ async function initApp() {
 
   // Liveblocks 협업 이벤트 리스너
   let _previousOthersCount = 0;
+  let _collaborationSessionStartedAt = 0;
   liveblocksManager.addEventListener('collaboratorsChanged', (e) => {
     // 자기 자신 + 다른 사용자 모두 표시
     const isSyncing = playbackSync.syncEnabled;
@@ -16764,6 +16780,15 @@ async function initApp() {
     if (currentOthersCount > 0 && _previousOthersCount === 0) {
       showToast('실시간 협업 세션에 참여했습니다', 'info');
       _triggerCollabRipple();
+    }
+    // 참여자가 늘어나면 현재 드로잉·댓글 상태를 재전송해 늦은 참여자를 seed한다.
+    // 단 자신이 방금 합류한 쪽이면(연결 10초 이내) 구버전 로컬 상태를 방에
+    // 뿌리지 않도록 억제한다 — 기존 멤버 측 재전송만으로 seed가 완성된다.
+    if (currentOthersCount > _previousOthersCount &&
+        Date.now() - _collaborationSessionStartedAt > 10000) {
+      commentSync.broadcastCurrentState?.();
+      drawingSync.broadcastCurrentState?.();
+      fabricDrawingSync.broadcastCurrentState?.();
     }
     _previousOthersCount = currentOthersCount;
 
@@ -17099,6 +17124,7 @@ async function initApp() {
   // ====== 파일 변경 감지 (실시간 동기화) ======
   // 다른 사용자가 저장하면 즉시 동기화
   let lastSyncTime = 0;
+  let lastDrawingsV3SyncTime = 0;
   const MIN_SYNC_INTERVAL = 500; // 최소 500ms 간격
 
   async function syncReviewFileFromDisk(filePath, options = {}) {
@@ -17112,9 +17138,16 @@ async function initApp() {
     // 현재 열린 파일이 아니면 무시
     if (!isSameFilePath(filePath, reviewDataManager.currentBframePath)) return false;
 
-    // Liveblocks 연결 중이면 Broadcast가 실시간 동기화를 담당하므로
-    // 파일 기반 동기화 건너뛰기 (구버전 파일로 덮어쓰는 것 방지)
+    // Liveblocks 연결 중이면 댓글·레거시 드로잉은 Broadcast가 담당하므로
+    // 파일 기반 동기화를 건너뛴다 (구버전 파일로 덮어쓰는 것 방지).
+    // 단 Fabric 드로잉(drawingsV3)은 Broadcast가 없던 시절 저장분·오프라인 저장분이
+    // 파일로만 도착할 수 있어, 드로잉만 선별 반영한다 (지문 비교로 no-op 보장).
     if (liveblocksManager.isConnected) {
+      const now = Date.now();
+      if (now - lastDrawingsV3SyncTime >= MIN_SYNC_INTERVAL) {
+        lastDrawingsV3SyncTime = now;
+        void reviewDataManager.reloadDrawingsV3FromDisk?.();
+      }
       return false;
     }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -299,6 +299,71 @@ function createCoalescedAsyncScheduler({
   return { schedule, cancel };
 }
 
+function createLeadingTrailingThrottle({
+  intervalMs,
+  run,
+  shouldRun = () => true,
+  now = () => Date.now(),
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+  onError = () => {}
+}) {
+  let lastRunAt = Number.NEGATIVE_INFINITY;
+  let timer = null;
+  let pendingValue;
+  let hasPending = false;
+
+  function invoke(value) {
+    if (!shouldRun(value)) return false;
+    lastRunAt = now();
+    try {
+      const result = run(value);
+      if (result && typeof result.catch === 'function') {
+        void result.catch(onError);
+      }
+    } catch (error) {
+      onError(error);
+    }
+    return true;
+  }
+
+  function schedule(value) {
+    pendingValue = value;
+    hasPending = true;
+    if (!shouldRun(value)) return;
+
+    const remaining = intervalMs - (now() - lastRunAt);
+    if (remaining <= 0) {
+      if (timer !== null) clearTimer(timer);
+      timer = null;
+      const nextValue = pendingValue;
+      pendingValue = undefined;
+      hasPending = false;
+      invoke(nextValue);
+      return;
+    }
+    if (timer !== null) return;
+
+    timer = setTimer(() => {
+      timer = null;
+      if (!hasPending) return;
+      const nextValue = pendingValue;
+      pendingValue = undefined;
+      hasPending = false;
+      invoke(nextValue);
+    }, remaining);
+  }
+
+  function cancel() {
+    if (timer !== null) clearTimer(timer);
+    timer = null;
+    pendingValue = undefined;
+    hasPending = false;
+  }
+
+  return { schedule, cancel };
+}
+
 function createSharedAsyncCaptureOwner() {
   let inFlight = null;
 
@@ -17129,8 +17194,16 @@ async function initApp() {
   // ====== 파일 변경 감지 (실시간 동기화) ======
   // 다른 사용자가 저장하면 즉시 동기화
   let lastSyncTime = 0;
-  let lastDrawingsV3SyncTime = 0;
   const MIN_SYNC_INTERVAL = 500; // 최소 500ms 간격
+  const connectedDrawingsV3ReloadThrottle = createLeadingTrailingThrottle({
+    intervalMs: MIN_SYNC_INTERVAL,
+    shouldRun: filePath => liveblocksManager.isConnected &&
+      isSameFilePath(filePath, reviewDataManager.currentBframePath),
+    run: () => reviewDataManager.reloadDrawingsV3FromDisk?.(),
+    onError: error => log.warn('drawingsV3 파일 동기화 실패', {
+      error: error?.message || String(error)
+    })
+  });
 
   async function syncReviewFileFromDisk(filePath, options = {}) {
     const {
@@ -17148,11 +17221,7 @@ async function initApp() {
     // 단 Fabric 드로잉(drawingsV3)은 Broadcast가 없던 시절 저장분·오프라인 저장분이
     // 파일로만 도착할 수 있어, 드로잉만 선별 반영한다 (지문 비교로 no-op 보장).
     if (liveblocksManager.isConnected) {
-      const now = Date.now();
-      if (now - lastDrawingsV3SyncTime >= MIN_SYNC_INTERVAL) {
-        lastDrawingsV3SyncTime = now;
-        void reviewDataManager.reloadDrawingsV3FromDisk?.();
-      }
+      connectedDrawingsV3ReloadThrottle.schedule(filePath);
       return false;
     }
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1124,6 +1124,7 @@ async function initApp() {
     } catch (err) {
       log.error('Undo 실패', err);
       undoStack.push(action); // 롤백
+      showToast('실행 취소에 실패했습니다', 'error');
       return false;
     } finally {
       _isProcessingUndo = false;
@@ -1160,6 +1161,7 @@ async function initApp() {
     } catch (err) {
       log.error('Redo 실패', err);
       redoStack.push(action); // 롤백
+      showToast('다시 실행에 실패했습니다', 'error');
       return false;
     } finally {
       _isProcessingUndo = false;
@@ -4224,12 +4226,12 @@ async function initApp() {
         reviewDataManager.save();
       },
       redo: () => {
-        // 하이라이트 복원 (같은 속성으로)
+        // 하이라이트 복원 (같은 속성으로) — colorInfo는 getter라 colorKey만 복원한다
         const restored = highlightManager.createHighlight(highlight.startTime);
         restored.id = highlight.id;
         restored.endTime = highlight.endTime;
         restored.note = highlight.note;
-        restored.colorInfo = highlight.colorInfo;
+        restored.colorKey = highlight.colorKey;
         renderHighlights();
         reviewDataManager.save();
       }
@@ -4589,13 +4591,12 @@ async function initApp() {
         type: 'highlight-delete',
         data: { highlightId: deletedId },
         undo: () => {
-          // 하이라이트 복원
+          // 하이라이트 복원 — colorInfo는 getter라 colorKey만 복원한다
           const restored = highlightManager.createHighlight(deletedHighlight.startTime);
           restored.id = deletedHighlight.id;
           restored.endTime = deletedHighlight.endTime;
           restored.note = deletedHighlight.note;
           restored.colorKey = deletedHighlight.colorKey;
-          restored.colorInfo = deletedHighlight.colorInfo;
           renderHighlights();
           reviewDataManager.save();
         },

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -16865,13 +16865,14 @@ async function initApp() {
       showToast('실시간 협업 세션에 참여했습니다', 'info');
       _triggerCollabRipple();
     }
-    // 참여자가 늘어나면 현재 드로잉·댓글 상태를 재전송해 늦은 참여자를 seed한다.
+    // 참여자가 늘어나면 댓글 상태와 causal Fabric root를 재전송해 늦은 참여자를 seed한다.
     // 단 자신이 방금 합류한 쪽이면(연결 10초 이내) 구버전 로컬 상태를 방에
     // 뿌리지 않도록 억제한다 — 기존 멤버 측 재전송만으로 seed가 완성된다.
+    // 레거시 drawing current-state seed는 삭제 tombstone이 없는 additive 전송이므로
+    // 검증되지 않은 기존 peer에서 자동 재전송하지 않는다.
     if (currentOthersCount > _previousOthersCount &&
         Date.now() - _collaborationSessionStartedAt > 10000) {
       commentSync.broadcastCurrentState?.();
-      drawingSync.broadcastCurrentState?.();
       fabricDrawingSync.broadcastCurrentState?.();
     }
     _previousOthersCount = currentOthersCount;

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -2187,11 +2187,16 @@ async function initApp() {
         return;
       }
     }
-    slackNotifier.notifyNewComment(marker, commentManager.getAuthor(), {
+    const currentMarker = commentManager.getMarker(markerData.id);
+    if (!currentMarker || currentMarker.deleted) {
+      log.info('저장 대기 중 취소된 댓글의 Slack 알림 건너뜀', { id: markerData.id });
+      return;
+    }
+    slackNotifier.notifyNewComment(currentMarker, commentManager.getAuthor(), {
       filePath: state.currentFile,
       bframePath: reviewDataManager.getBframePath() || '',
       fileName: elements.fileName?.textContent || '',
-      timecode: marker.startTimecode || ''
+      timecode: currentMarker.startTimecode || ''
     });
   });
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1153,6 +1153,11 @@ async function initApp() {
   const redoStack = [];
   const MAX_UNDO_STACK = 50;
   let _isProcessingUndo = false;
+  let globalHistoryRevision = 0;
+
+  function advanceGlobalHistoryRevision() {
+    globalHistoryRevision += 1;
+  }
 
   /**
    * Undo 스택에 작업 추가
@@ -1165,6 +1170,7 @@ async function initApp() {
       undoStack.shift();
     }
     redoStack.length = 0; // Redo 스택 초기화
+    advanceGlobalHistoryRevision();
   }
 
   /**
@@ -1175,6 +1181,7 @@ async function initApp() {
     _isProcessingUndo = true;
 
     const action = undoStack.pop();
+    advanceGlobalHistoryRevision();
     try {
       if (action && action.undo) {
         // redo를 위해 현재 상태 캡처 (DRAWING 타입인 경우)
@@ -1184,12 +1191,14 @@ async function initApp() {
         }
         await action.undo();
         redoStack.push(action);
+        advanceGlobalHistoryRevision();
         return true;
       }
       return false;
     } catch (err) {
       log.error('Undo 실패', err);
       undoStack.push(action); // 롤백
+      advanceGlobalHistoryRevision();
       showToast('실행 취소에 실패했습니다', 'error');
       return false;
     } finally {
@@ -1205,6 +1214,7 @@ async function initApp() {
     _isProcessingUndo = true;
 
     const action = redoStack.pop();
+    advanceGlobalHistoryRevision();
     try {
       if (action) {
         // DRAWING 타입의 경우 redo 콜백 대신 _redoSnapshot으로 복원
@@ -1221,12 +1231,14 @@ async function initApp() {
           await action.redo();
         }
         undoStack.push(action);
+        advanceGlobalHistoryRevision();
         return true;
       }
       return false;
     } catch (err) {
       log.error('Redo 실패', err);
       redoStack.push(action); // 롤백
+      advanceGlobalHistoryRevision();
       showToast('다시 실행에 실패했습니다', 'error');
       return false;
     } finally {
@@ -7203,6 +7215,7 @@ async function initApp() {
     matchesSelectionShortcut: event => userSettings.matchShortcut('drawingToolSelect', event),
     persistenceStore: fabricDrawingPersistenceStore,
     onStateChange: handleFabricDrawingPilotStateChange,
+    getHistoryRevision: () => globalHistoryRevision,
     // fabric 히스토리가 비어 있으면 전역 undo/redo로 폴백한다
     onHistoryFallback: (action) => {
       if (action === 'undo') {
@@ -9237,6 +9250,7 @@ async function initApp() {
         // Undo/Redo 스택 초기화 (파일 전환 시 크로스파일 오염 방지)
         undoStack.length = 0;
         redoStack.length = 0;
+        advanceGlobalHistoryRevision();
         // 그리기 매니저 초기화
         drawingManager.reset();
         // 하이라이트 매니저 초기화

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1176,12 +1176,16 @@ async function initApp() {
   /**
    * 글로벌 Undo 실행 (통합 타임라인)
    */
-  async function globalUndo() {
+  async function globalUndo({ fromFabricFallback = false } = {}) {
     if (_isProcessingUndo || undoStack.length === 0) return false;
     _isProcessingUndo = true;
+    const advanceHistoryRevision = () => {
+      if (!fromFabricFallback) advanceGlobalHistoryRevision();
+    };
 
     const action = undoStack.pop();
-    advanceGlobalHistoryRevision();
+    advanceHistoryRevision();
+    const historyMutationRevision = globalHistoryRevision;
     try {
       if (action && action.undo) {
         // redo를 위해 현재 상태 캡처 (DRAWING 타입인 경우)
@@ -1190,15 +1194,20 @@ async function initApp() {
           action._redoSnapshot = currentSnapshot;
         }
         await action.undo();
+        // 비동기 undo 중 새 작업·파일 전환이 끼면 과거 action을 새 redo 스택에 되살리지 않는다.
+        if (historyMutationRevision !== globalHistoryRevision) return true;
         redoStack.push(action);
-        advanceGlobalHistoryRevision();
+        advanceHistoryRevision();
         return true;
       }
       return false;
     } catch (err) {
       log.error('Undo 실패', err);
-      undoStack.push(action); // 롤백
-      advanceGlobalHistoryRevision();
+      if (historyMutationRevision === globalHistoryRevision) {
+        undoStack.push(action); // 롤백
+        // 실패한 Fabric 폴백도 같은 키 입력 묶음의 후속 재실행을 막는 barrier가 된다.
+        advanceGlobalHistoryRevision();
+      }
       showToast('실행 취소에 실패했습니다', 'error');
       return false;
     } finally {
@@ -1209,12 +1218,16 @@ async function initApp() {
   /**
    * 글로벌 Redo 실행 (통합 타임라인)
    */
-  async function globalRedo() {
+  async function globalRedo({ fromFabricFallback = false } = {}) {
     if (_isProcessingUndo || redoStack.length === 0) return false;
     _isProcessingUndo = true;
+    const advanceHistoryRevision = () => {
+      if (!fromFabricFallback) advanceGlobalHistoryRevision();
+    };
 
     const action = redoStack.pop();
-    advanceGlobalHistoryRevision();
+    advanceHistoryRevision();
+    const historyMutationRevision = globalHistoryRevision;
     try {
       if (action) {
         // DRAWING 타입의 경우 redo 콜백 대신 _redoSnapshot으로 복원
@@ -1230,15 +1243,20 @@ async function initApp() {
         } else if (action.redo) {
           await action.redo();
         }
+        // 비동기 redo 중 새 작업·파일 전환이 끼면 과거 action을 새 undo 스택에 되살리지 않는다.
+        if (historyMutationRevision !== globalHistoryRevision) return true;
         undoStack.push(action);
-        advanceGlobalHistoryRevision();
+        advanceHistoryRevision();
         return true;
       }
       return false;
     } catch (err) {
       log.error('Redo 실패', err);
-      redoStack.push(action); // 롤백
-      advanceGlobalHistoryRevision();
+      if (historyMutationRevision === globalHistoryRevision) {
+        redoStack.push(action); // 롤백
+        // 실패한 Fabric 폴백도 같은 키 입력 묶음의 후속 재실행을 막는 barrier가 된다.
+        advanceGlobalHistoryRevision();
+      }
       showToast('다시 실행에 실패했습니다', 'error');
       return false;
     } finally {
@@ -7218,14 +7236,17 @@ async function initApp() {
     // fabric 히스토리가 비어 있으면 전역 undo/redo로 폴백한다
     onHistoryFallback: (action) => {
       if (action === 'undo') {
-        void globalUndo().then(done => {
+        return globalUndo({ fromFabricFallback: true }).then(done => {
           if (done) showToast('실행 취소됨', 'info');
+          return done;
         });
       } else if (action === 'redo') {
-        void globalRedo().then(done => {
+        return globalRedo({ fromFabricFallback: true }).then(done => {
           if (done) showToast('다시 실행됨', 'info');
+          return done;
         });
       }
+      return Promise.resolve(false);
     }
   });
   reviewDataManager.setFabricDrawingSourceRefreshHandler(

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -7119,7 +7119,19 @@ async function initApp() {
     matchesDrawingToggleShortcut: event => userSettings.matchShortcut('drawMode', event),
     matchesSelectionShortcut: event => userSettings.matchShortcut('drawingToolSelect', event),
     persistenceStore: fabricDrawingPersistenceStore,
-    onStateChange: handleFabricDrawingPilotStateChange
+    onStateChange: handleFabricDrawingPilotStateChange,
+    // fabric 히스토리가 비어 있으면 전역 undo/redo로 폴백한다
+    onHistoryFallback: (action) => {
+      if (action === 'undo') {
+        void globalUndo().then(done => {
+          if (done) showToast('실행 취소됨', 'info');
+        });
+      } else if (action === 'redo') {
+        void globalRedo().then(done => {
+          if (done) showToast('다시 실행됨', 'info');
+        });
+      }
+    }
   });
   reviewDataManager.setFabricDrawingSourceRefreshHandler(
     ({ installSource }) =>

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -2152,22 +2152,7 @@ async function initApp() {
     // 원격 변경, Redo 복원, 가져온 피드백은 알림/Undo 스킵
     if (remote || restored || imported) return;
 
-    // Slack 알림: @멘션 대상에게 웹훅 전송 (딥링크 전에 저장하여 최신 상태 보장)
-    if (reviewDataManager.getBframePath()) {
-      const saved = await reviewDataManager.save();
-      if (!saved) {
-        log.warn('bframe 저장 실패, Slack 알림 건너뜀');
-        return;
-      }
-    }
-    slackNotifier.notifyNewComment(marker, commentManager.getAuthor(), {
-      filePath: state.currentFile,
-      bframePath: reviewDataManager.getBframePath() || '',
-      fileName: elements.fileName?.textContent || '',
-      timecode: marker.startTimecode || ''
-    });
-
-    // Undo 스택에 추가
+    // Undo 스택에 추가 — 저장·알림보다 먼저 동기 등록해 생성 직후 Ctrl+Z를 보장한다
     const markerData = marker.toJSON();
     pushUndo({
       type: 'ADD_COMMENT',
@@ -2186,6 +2171,21 @@ async function initApp() {
         updateVideoMarkers();
         await reviewDataManager.save();
       }
+    });
+
+    // Slack 알림: @멘션 대상에게 웹훅 전송 (딥링크 전에 저장하여 최신 상태 보장)
+    if (reviewDataManager.getBframePath()) {
+      const saved = await reviewDataManager.save();
+      if (!saved) {
+        log.warn('bframe 저장 실패, Slack 알림 건너뜀');
+        return;
+      }
+    }
+    slackNotifier.notifyNewComment(marker, commentManager.getAuthor(), {
+      filePath: state.currentFile,
+      bframePath: reviewDataManager.getBframePath() || '',
+      fileName: elements.fileName?.textContent || '',
+      timecode: marker.startTimecode || ''
     });
   });
 

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6774,8 +6774,7 @@ async function initApp() {
       _previousOthersCount = 0;
       _collaborationSessionStartedAt = Date.now();
       if (seedCurrentState) {
-        commentSync.broadcastCurrentState?.();
-        drawingSync.broadcastCurrentState?.();
+        // 댓글·레거시 drawing seed는 삭제 경합을 수렴시킬 causal 정보가 없어 제외한다.
         fabricDrawingSync.broadcastCurrentState?.();
       }
       log.info('Liveblocks 협업 세션 시작됨', { roomId, isNewRoom });
@@ -13901,7 +13900,7 @@ async function initApp() {
           await startCollaborationForVideoLoad(
             latestVideoLoadToken,
             reviewDataManager.currentBframePath,
-            { persistNewRoom: false, seedCurrentState: true }
+            { persistNewRoom: false, seedCurrentState: false }
           );
           saveBeforeQuitInProgress = false;
         }
@@ -13921,7 +13920,7 @@ async function initApp() {
         await startCollaborationForVideoLoad(
           latestVideoLoadToken,
           reviewDataManager.currentBframePath,
-          { persistNewRoom: false, seedCurrentState: true }
+          { persistNewRoom: false, seedCurrentState: false }
         );
         saveBeforeQuitInProgress = false;
       }
@@ -16865,14 +16864,13 @@ async function initApp() {
       showToast('실시간 협업 세션에 참여했습니다', 'info');
       _triggerCollabRipple();
     }
-    // 참여자가 늘어나면 댓글 상태와 causal Fabric root를 재전송해 늦은 참여자를 seed한다.
+    // 참여자가 늘어나면 causal Fabric root를 재전송해 늦은 참여자를 seed한다.
     // 단 자신이 방금 합류한 쪽이면(연결 10초 이내) 구버전 로컬 상태를 방에
     // 뿌리지 않도록 억제한다 — 기존 멤버 측 재전송만으로 seed가 완성된다.
-    // 레거시 drawing current-state seed는 삭제 tombstone이 없는 additive 전송이므로
-    // 검증되지 않은 기존 peer에서 자동 재전송하지 않는다.
+    // 댓글·레거시 drawing current-state seed는 삭제 상태를 전파하지 않는 additive
+    // 전송이므로 검증되지 않은 기존 peer에서 자동 재전송하지 않는다.
     if (currentOthersCount > _previousOthersCount &&
         Date.now() - _collaborationSessionStartedAt > 10000) {
-      commentSync.broadcastCurrentState?.();
       fabricDrawingSync.broadcastCurrentState?.();
     }
     _previousOthersCount = currentOthersCount;

--- a/renderer/scripts/modules/fabric-drawing-pilot-controller.js
+++ b/renderer/scripts/modules/fabric-drawing-pilot-controller.js
@@ -1064,7 +1064,7 @@ export function createFabricDrawingPilotController(options = {}) {
         setState('recovering');
         return true;
       }
-      if (shouldResume) {
+      if (resumeRequested) {
         return startEnable(
           persistenceVideoContext,
           () => ownsPersistenceOwner(refreshOwner)
@@ -1241,13 +1241,14 @@ export function createFabricDrawingPilotController(options = {}) {
         enableContext,
         isStillCurrent
       );
-      if (!isStillCurrent()) return false;
+      // 수화 대기 중 B 취소(disable)로 입력 revision이 넘어갔으면 재개하지 않는다
+      if (!isCurrentInputRequest(request) || !isStillCurrent()) return false;
       if (!hydrated) {
         setState('passive');
         return false;
       }
     }
-    if (shouldResume) return startEnable(enableContext, isStillCurrent);
+    if (shouldResume || resumeRequested) return startEnable(enableContext, isStillCurrent);
     if (!isStillCurrent()) return false;
     setState(settledState);
     return true;
@@ -1520,15 +1521,24 @@ export function createFabricDrawingPilotController(options = {}) {
 
   function toggle() {
     if (!shouldOwnDrawingShortcut()) return Promise.resolve(false);
-    if (persistenceSourceRefreshInProgress ||
-        persistenceQuitSuspension !== null) {
-      return Promise.resolve(false);
-    }
+    if (persistenceQuitSuspension !== null) return Promise.resolve(false);
     const context = contextSnapshot();
     if (!validPilotContext(context)) return Promise.resolve(false);
+    if (persistenceSourceRefreshInProgress) {
+      // 저장 소스 갱신 중: B를 버리지 않고 갱신 완료 후 자동 진입/취소 예약으로 처리한다
+      resumeRequested = !resumeRequested;
+      notifyStateChange();
+      return Promise.resolve(true);
+    }
     if (state === 'active' || state === 'preparing' ||
         (state === 'recovering' && resumeRequested)) {
       return disable();
+    }
+    if (state === 'recovering') {
+      // 복구가 끝나면 자동으로 드로잉 모드에 진입하도록 예약한다
+      resumeRequested = true;
+      notifyStateChange();
+      return Promise.resolve(true);
     }
     if (state !== 'passive' && state !== 'failed') return Promise.resolve(false);
     if (!hostGeneration || !videoGeneration || !videoReady) {

--- a/renderer/scripts/modules/fabric-drawing-pilot-controller.js
+++ b/renderer/scripts/modules/fabric-drawing-pilot-controller.js
@@ -68,6 +68,9 @@ export function createFabricDrawingPilotController(options = {}) {
   const electronAPI = options.electronAPI || {};
   const getContext = typeof options.getContext === 'function' ? options.getContext : () => ({});
   const onStateChange = typeof options.onStateChange === 'function' ? options.onStateChange : () => {};
+  const onHistoryFallback = typeof options.onHistoryFallback === 'function'
+    ? options.onHistoryFallback
+    : () => {};
   const configuredDrawingToggleMatcher =
     typeof options.matchesDrawingToggleShortcut === 'function'
       ? options.matchesDrawingToggleShortcut
@@ -514,9 +517,11 @@ export function createFabricDrawingPilotController(options = {}) {
   async function sendDrawingActionRequest(request) {
     try {
       const response = await electronAPI.mpvApplyOverlayDrawingAction(request);
-      return response?.success === true;
+      return response && typeof response === 'object'
+        ? response
+        : { success: false, applied: false };
     } catch {
-      return false;
+      return { success: false, applied: false };
     }
   }
 
@@ -524,7 +529,17 @@ export function createFabricDrawingPilotController(options = {}) {
     const request = makeDrawingActionRequest(action);
     if (!request) return Promise.resolve(false);
     const operation = drawingActionQueue.then(() => sendDrawingActionRequest(request));
-    drawingActionQueue = operation.catch(() => false);
+    drawingActionQueue = operation.then(r => r?.success === true, () => false);
+    return operation.then(r => r?.success === true);
+  }
+
+  function applyHistoryAction(action) {
+    const request = makeDrawingActionRequest(action);
+    if (!request) {
+      return Promise.resolve({ success: false, applied: false });
+    }
+    const operation = drawingActionQueue.then(() => sendDrawingActionRequest(request));
+    drawingActionQueue = operation.then(r => r?.success === true, () => false);
     return operation;
   }
 
@@ -1533,11 +1548,20 @@ export function createFabricDrawingPilotController(options = {}) {
 
     const historyAction = drawingHistoryActionFromKeyEvent(event);
     if (historyAction) {
-      if (state !== 'preparing' && state !== 'active') return false;
-      consumeKeyEvent(event);
-      if (event.repeat !== true && state === 'active') {
-        runDetached(applyDrawingAction(historyAction));
+      if (state !== 'preparing' && state !== 'active' && state !== 'recovering') {
+        return false;
       }
+      consumeKeyEvent(event);
+      if (event.repeat === true) return true;
+      if (state !== 'active') {
+        // 세션 준비·복구 중에는 fabric 히스토리를 쓸 수 없다 — 전역 undo로 폴백
+        onHistoryFallback(historyAction);
+        return true;
+      }
+      runDetached(applyHistoryAction(historyAction).then(result => {
+        if (result?.applied === true || result?.duplicate === true) return;
+        if (result?.reason === 'history-empty') onHistoryFallback(historyAction);
+      }));
       return true;
     }
     const isDrawingToggleShortcut = matchesDrawingToggleShortcut(event);

--- a/renderer/scripts/modules/fabric-drawing-pilot-controller.js
+++ b/renderer/scripts/modules/fabric-drawing-pilot-controller.js
@@ -71,6 +71,9 @@ export function createFabricDrawingPilotController(options = {}) {
   const onHistoryFallback = typeof options.onHistoryFallback === 'function'
     ? options.onHistoryFallback
     : () => {};
+  const getHistoryRevision = typeof options.getHistoryRevision === 'function'
+    ? options.getHistoryRevision
+    : null;
   const configuredDrawingToggleMatcher =
     typeof options.matchesDrawingToggleShortcut === 'function'
       ? options.matchesDrawingToggleShortcut
@@ -141,6 +144,16 @@ export function createFabricDrawingPilotController(options = {}) {
     return overrides && typeof overrides === 'object'
       ? { ...current, ...overrides }
       : { ...current };
+  }
+
+  function readHistoryRevision() {
+    if (!getHistoryRevision) return null;
+    try {
+      return getHistoryRevision();
+    } catch {
+      // 설정된 fence를 읽지 못하면 서로 다른 객체를 반환해 fallback을 fail-close한다.
+      return {};
+    }
   }
 
   function localSnapshot() {
@@ -1568,9 +1581,13 @@ export function createFabricDrawingPilotController(options = {}) {
         onHistoryFallback(historyAction);
         return true;
       }
+      const historyRevision = readHistoryRevision();
       runDetached(applyHistoryAction(historyAction).then(result => {
         if (result?.applied === true || result?.duplicate === true) return;
-        if (result?.reason === 'history-empty') onHistoryFallback(historyAction);
+        if (result?.reason === 'history-empty' &&
+            historyRevision === readHistoryRevision()) {
+          onHistoryFallback(historyAction);
+        }
       }));
       return true;
     }

--- a/renderer/scripts/modules/fabric-drawing-pilot-controller.js
+++ b/renderer/scripts/modules/fabric-drawing-pilot-controller.js
@@ -546,12 +546,29 @@ export function createFabricDrawingPilotController(options = {}) {
     return operation.then(r => r?.success === true);
   }
 
-  function applyHistoryAction(action) {
-    const request = makeDrawingActionRequest(action);
+  function enqueueHistoryFallback(historyAction, historyRevision) {
+    const operation = drawingActionQueue.then(async () => {
+      if (historyRevision !== readHistoryRevision()) return false;
+      return onHistoryFallback(historyAction);
+    });
+    drawingActionQueue = operation.then(result => result === true, () => false);
+    return operation;
+  }
+
+  function applyHistoryAction(historyAction, historyRevision) {
+    const request = makeDrawingActionRequest(historyAction);
     if (!request) {
       return Promise.resolve({ success: false, applied: false });
     }
-    const operation = drawingActionQueue.then(() => sendDrawingActionRequest(request));
+    const operation = drawingActionQueue.then(async () => {
+      const result = await sendDrawingActionRequest(request);
+      if (result?.applied === true || result?.duplicate === true) return result;
+      if (result?.reason === 'history-empty' &&
+          historyRevision === readHistoryRevision()) {
+        await onHistoryFallback(historyAction);
+      }
+      return result;
+    });
     drawingActionQueue = operation.then(r => r?.success === true, () => false);
     return operation;
   }
@@ -1576,19 +1593,13 @@ export function createFabricDrawingPilotController(options = {}) {
       }
       consumeKeyEvent(event);
       if (event.repeat === true) return true;
+      const historyRevision = readHistoryRevision();
       if (state !== 'active') {
         // 세션 준비·복구 중에는 fabric 히스토리를 쓸 수 없다 — 전역 undo로 폴백
-        onHistoryFallback(historyAction);
+        runDetached(enqueueHistoryFallback(historyAction, historyRevision));
         return true;
       }
-      const historyRevision = readHistoryRevision();
-      runDetached(applyHistoryAction(historyAction).then(result => {
-        if (result?.applied === true || result?.duplicate === true) return;
-        if (result?.reason === 'history-empty' &&
-            historyRevision === readHistoryRevision()) {
-          onHistoryFallback(historyAction);
-        }
-      }));
+      runDetached(applyHistoryAction(historyAction, historyRevision));
       return true;
     }
     const isDrawingToggleShortcut = matchesDrawingToggleShortcut(event);

--- a/renderer/scripts/modules/fabric-drawing-sync.js
+++ b/renderer/scripts/modules/fabric-drawing-sync.js
@@ -21,6 +21,7 @@ const MAX_ROOT_TRANSFER_BYTES = 32 * 1024 * 1024;
 const MAX_ROOT_CHUNKS = Math.ceil(MAX_ROOT_TRANSFER_BYTES / ROOT_CHUNK_RAW_SIZE);
 // 이 크기 미만이면 청크 없이 인라인 전송 (봉투 오버헤드 포함 Liveblocks 1MB 제한 준수)
 const INLINE_ROOT_MAX_BYTES = 700 * 1024;
+const ROOT_REQUEST_STABILIZATION_MS = 10000;
 
 // drawingsV3 지문(review-data-manager의 captureDrawingsV3DiskState)은 해시가 아니라
 // 'present:' + 전체 canonical JSON 문자열이다 — 와이어에 그대로 실으면 payload가
@@ -53,13 +54,15 @@ function base64ToBytes(value) {
 }
 
 export class FabricDrawingSync {
-  constructor({ liveblocksManager, reviewDataManager }) {
+  constructor({ liveblocksManager, reviewDataManager, now = () => Date.now() }) {
     this._lm = liveblocksManager;
     this._rdm = reviewDataManager;
+    this._now = now;
     this._started = false;
     // stop()마다 증가하는 세션 세대 — stop→start 경계를 넘어 살아남은
     // 이전 세션의 적용 큐 항목을 무효화하는 fence다
     this._sessionGeneration = 0;
+    this._sessionStartedAt = 0;
     this._lastSentFingerprint = null;
     this._transfer = null;
     this._applyQueue = Promise.resolve();
@@ -72,7 +75,13 @@ export class FabricDrawingSync {
     if (this._started) return;
     this._rdm.addEventListener('saved', this._onSaved);
     this._lm.addEventListener('broadcastReceived', this._onBroadcast);
+    this._sessionStartedAt = this._now();
     this._started = true;
+    try {
+      this._lm.broadcastEvent({ type: 'FABRIC_DRAWING_ROOT_REQUEST' });
+    } catch (error) {
+      log.warn('drawingsV3 seed 요청 실패', { error: error?.message || String(error) });
+    }
     log.info('Fabric 드로잉 동기화 시작됨');
   }
 
@@ -83,6 +92,7 @@ export class FabricDrawingSync {
     this._clearTransfer();
     this._lastSentFingerprint = null;
     this._started = false;
+    this._sessionStartedAt = 0;
     // 이 세션에서 큐잉된 적용을 전부 무효화한다 (stop→start 재시작 후 실행 방지).
     // 리스너는 이미 해제되어 정지 중 새 큐잉은 없으므로 stop 시점 증가로 충분하다.
     this._sessionGeneration += 1;
@@ -98,8 +108,8 @@ export class FabricDrawingSync {
     this._broadcastRoot({ force: false });
   }
 
-  _broadcastRoot({ force }) {
-    if (!this._started || !this._lm.hasOtherCollaborators()) return;
+  _broadcastRoot({ force, peerConfirmed = false }) {
+    if (!this._started || (!peerConfirmed && !this._lm.hasOtherCollaborators())) return;
     const snapshot = this._rdm.getDrawingsV3RootSnapshot?.();
     if (!snapshot?.present) return;
     // 구버전 디스크 상태(Broadcast 적용 이전)를 재전파하지 않는다
@@ -153,6 +163,13 @@ export class FabricDrawingSync {
   _onBroadcast(e) {
     const event = e.detail?.event || e.detail;
     if (!event?.type) return;
+
+    if (event.type === 'FABRIC_DRAWING_ROOT_REQUEST') {
+      if (this._now() - this._sessionStartedAt > ROOT_REQUEST_STABILIZATION_MS) {
+        this._broadcastRoot({ force: true, peerConfirmed: true });
+      }
+      return;
+    }
 
     if (event.type === 'FABRIC_DRAWING_ROOT') {
       if (event.root !== undefined) {

--- a/renderer/scripts/modules/fabric-drawing-sync.js
+++ b/renderer/scripts/modules/fabric-drawing-sync.js
@@ -22,6 +22,29 @@ const MAX_ROOT_CHUNKS = Math.ceil(MAX_ROOT_TRANSFER_BYTES / ROOT_CHUNK_RAW_SIZE)
 // 이 크기 미만이면 청크 없이 인라인 전송 (봉투 오버헤드 포함 Liveblocks 1MB 제한 준수)
 const INLINE_ROOT_MAX_BYTES = 700 * 1024;
 const ROOT_REQUEST_STABILIZATION_MS = 10000;
+const ROOT_EVENT_TYPE = 'FABRIC_DRAWING_ROOT';
+const ROOT_CHUNK_EVENT_TYPE = 'FABRIC_DRAWING_ROOT_CHUNK';
+const ROOT_REQUEST_EVENT_TYPE = 'FABRIC_DRAWING_ROOT_REQUEST_V2';
+const ROOT_RESPONSE_EVENT_TYPE = 'FABRIC_DRAWING_ROOT_RESPONSE';
+const ROOT_RESPONSE_CHUNK_EVENT_TYPE = 'FABRIC_DRAWING_ROOT_RESPONSE_CHUNK';
+const MAX_BASELINE_CONFLICT_ACTORS = 64;
+const FABRIC_STORAGE_SCHEMA = 'baeframe-fabric-scenes';
+const FABRIC_STORAGE_VERSION = '1.0.0';
+const FABRIC_STORAGE_ENGINE = 'fabric-7';
+const ROOT_IDENTITY_KIND = Object.freeze({
+  ABSENT: 'absent',
+  OPAQUE: 'opaque',
+  REVISIONED: 'revisioned'
+});
+const ROOT_REQUEST_DECISION = Object.freeze({
+  CONFLICT: 'conflict',
+  EQUAL: 'equal',
+  IGNORE: 'ignore',
+  PULL: 'pull',
+  PULL_WITH_PROMOTION: 'pull-with-promotion',
+  RESPOND: 'respond',
+  RESPOND_WITH_PROMOTION: 'respond-with-promotion'
+});
 
 // drawingsV3 지문(review-data-manager의 captureDrawingsV3DiskState)은 해시가 아니라
 // 'present:' + 전체 canonical JSON 문자열이다 — 와이어에 그대로 실으면 payload가
@@ -51,6 +74,101 @@ function createSyncActorId() {
 function getRootRevision(rootValue) {
   const revision = Number(rootValue?.revision);
   return Number.isSafeInteger(revision) && revision >= 0 ? revision : 0;
+}
+
+function describeRootIdentity(snapshot) {
+  if (!snapshot || typeof snapshot.present !== 'boolean') return null;
+  if (!snapshot.present) return { kind: ROOT_IDENTITY_KIND.ABSENT };
+  const rootValue = snapshot.value;
+  const documentId = rootValue?.documentId;
+  const revision = Number(rootValue?.revision);
+  if (snapshot.compatible === true &&
+      rootValue?.storageSchema === FABRIC_STORAGE_SCHEMA &&
+      rootValue?.storageVersion === FABRIC_STORAGE_VERSION &&
+      rootValue?.engine === FABRIC_STORAGE_ENGINE &&
+      typeof documentId === 'string' && documentId.length > 0 &&
+      documentId.length <= 512 &&
+      Number.isSafeInteger(revision) && revision >= 0) {
+    return {
+      kind: ROOT_IDENTITY_KIND.REVISIONED,
+      documentId,
+      revision
+    };
+  }
+  return { kind: ROOT_IDENTITY_KIND.OPAQUE };
+}
+
+function normalizeRootIdentity(value, present) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  if (present === false && value.kind === ROOT_IDENTITY_KIND.ABSENT) {
+    return { kind: ROOT_IDENTITY_KIND.ABSENT };
+  }
+  if (present !== true) return null;
+  if (value.kind === ROOT_IDENTITY_KIND.OPAQUE) {
+    return { kind: ROOT_IDENTITY_KIND.OPAQUE };
+  }
+  const revision = Number(value.revision);
+  if (value.kind !== ROOT_IDENTITY_KIND.REVISIONED ||
+      typeof value.documentId !== 'string' || value.documentId.length < 1 ||
+      value.documentId.length > 512 ||
+      !Number.isSafeInteger(revision) || revision < 0) {
+    return null;
+  }
+  return {
+    kind: ROOT_IDENTITY_KIND.REVISIONED,
+    documentId: value.documentId,
+    revision
+  };
+}
+
+function decideRootRequest(
+  current,
+  requestVersion,
+  requestIdentity
+) {
+  if (!current?.version || !requestVersion || !requestIdentity) {
+    return ROOT_REQUEST_DECISION.IGNORE;
+  }
+  if (current.fingerprint && current.fingerprint === requestVersion.fingerprint) {
+    return ROOT_REQUEST_DECISION.EQUAL;
+  }
+  const currentIdentity = describeRootIdentity(current.snapshot);
+  if (!currentIdentity) return ROOT_REQUEST_DECISION.IGNORE;
+
+  const currentHasCausalActor = current.version.actorId.length > 0;
+  const requesterHasCausalActor = requestVersion.actorId.length > 0;
+  if (currentHasCausalActor !== requesterHasCausalActor) {
+    return currentHasCausalActor
+      ? ROOT_REQUEST_DECISION.RESPOND_WITH_PROMOTION
+      : ROOT_REQUEST_DECISION.PULL_WITH_PROMOTION;
+  }
+
+  const comparison = compareSyncVersions(current.version, requestVersion);
+  if (currentHasCausalActor && requesterHasCausalActor) {
+    if (comparison > 0) return ROOT_REQUEST_DECISION.RESPOND;
+    if (comparison < 0) return ROOT_REQUEST_DECISION.PULL;
+    return ROOT_REQUEST_DECISION.EQUAL;
+  }
+
+  const sameRevisionedDocument =
+    currentIdentity.kind === ROOT_IDENTITY_KIND.REVISIONED &&
+    requestIdentity.kind === ROOT_IDENTITY_KIND.REVISIONED &&
+    currentIdentity.documentId === requestIdentity.documentId;
+  if (sameRevisionedDocument) {
+    if (comparison > 0) return ROOT_REQUEST_DECISION.RESPOND;
+    if (comparison < 0) return ROOT_REQUEST_DECISION.PULL;
+    return ROOT_REQUEST_DECISION.EQUAL;
+  }
+
+  // fresh baseline끼리 삭제/opaque/서로 다른 documentId가 충돌하면
+  // 권위를 추론하지 않고 양쪽 저장을 fail-closed로 보류한다.
+  return ROOT_REQUEST_DECISION.CONFLICT;
+}
+
+function normalizeRequestActorId(value) {
+  return typeof value === 'string' && value.length > 0 && value.length <= 512
+    ? value
+    : null;
 }
 
 function normalizeSyncVersion(value, fingerprint) {
@@ -97,7 +215,9 @@ export class FabricDrawingSync {
     liveblocksManager,
     reviewDataManager,
     now = () => Date.now(),
-    actorId = null
+    actorId = null,
+    scheduleSeedRetry = (callback, delay) => setTimeout(callback, delay),
+    cancelSeedRetry = timer => clearTimeout(timer)
   }) {
     this._lm = liveblocksManager;
     this._rdm = reviewDataManager;
@@ -105,6 +225,8 @@ export class FabricDrawingSync {
     this._explicitActorId = typeof actorId === 'string' && actorId.length > 0
       ? actorId
       : null;
+    this._scheduleSeedRetryCallback = scheduleSeedRetry;
+    this._cancelSeedRetryCallback = cancelSeedRetry;
     this._actorId = null;
     this._rootClock = 0;
     this._currentRootVersion = null;
@@ -114,6 +236,11 @@ export class FabricDrawingSync {
     // 이전 세션의 적용 큐 항목을 무효화하는 fence다
     this._sessionGeneration = 0;
     this._sessionStartedAt = 0;
+    this._seedRetryTimer = null;
+    this._sessionBaselineFingerprint = null;
+    this._sessionBaselineHadLocalChanges = false;
+    this._baselineConflictActors = new Set();
+    this._hasUnattributedBaselineConflict = false;
     this._lastSentFingerprint = null;
     this._transfer = null;
     this._applyQueue = Promise.resolve();
@@ -133,23 +260,21 @@ export class FabricDrawingSync {
     this._currentRootVersion = null;
     this._pendingExternalRoot = null;
     const current = this._ensureCurrentRootVersion();
+    // 협업 시작 시 이미 존재하던 baseline은 저장 이벤트나 명시 seed만으로
+    // publish하지 않는다. 실제 Fabric 변경으로 지문이 달라질 때만 전송한다.
+    this._lastSentFingerprint = current.snapshot?.localChanges === true
+      ? null
+      : current.fingerprint;
+    this._sessionBaselineFingerprint = current.fingerprint;
+    this._sessionBaselineHadLocalChanges = current.snapshot?.localChanges === true;
+    this._baselineConflictActors.clear();
+    this._hasUnattributedBaselineConflict = current.snapshot?.baselineConflict === true;
     this._rdm.addEventListener('saved', this._onSaved);
     this._lm.addEventListener('broadcastReceived', this._onBroadcast);
     this._sessionStartedAt = this._now();
     this._started = true;
-    try {
-      const requestEvent = { type: 'FABRIC_DRAWING_ROOT_REQUEST' };
-      if (current.version) {
-        requestEvent.fingerprint = current.fingerprint;
-        requestEvent.syncVersion = {
-          clock: current.version.clock,
-          actorId: current.version.actorId
-        };
-      }
-      this._lm.broadcastEvent(requestEvent);
-    } catch (error) {
-      log.warn('drawingsV3 seed 요청 실패', { error: error?.message || String(error) });
-    }
+    this._scheduleRootRequestRetry();
+    this._broadcastRootRequest();
     log.info('Fabric 드로잉 동기화 시작됨');
   }
 
@@ -158,6 +283,9 @@ export class FabricDrawingSync {
     this._rdm.removeEventListener('saved', this._onSaved);
     this._lm.removeEventListener('broadcastReceived', this._onBroadcast);
     this._clearTransfer();
+    this._clearRootRequestRetry();
+    this._sessionBaselineFingerprint = null;
+    this._sessionBaselineHadLocalChanges = false;
     this._lastSentFingerprint = null;
     this._started = false;
     this._sessionStartedAt = 0;
@@ -165,15 +293,145 @@ export class FabricDrawingSync {
     this._rootClock = 0;
     this._currentRootVersion = null;
     this._pendingExternalRoot = null;
+    this._baselineConflictActors.clear();
+    this._hasUnattributedBaselineConflict = false;
     // 이 세션에서 큐잉된 적용을 전부 무효화한다 (stop→start 재시작 후 실행 방지).
     // 리스너는 이미 해제되어 정지 중 새 큐잉은 없으므로 stop 시점 증가로 충분하다.
     this._sessionGeneration += 1;
     log.info('Fabric 드로잉 동기화 중지됨');
   }
 
-  /** 늦게 참여한 협업자 seed용 — 지문 중복 검사 없이 현재 상태를 전송한다 */
+  _broadcastRootRequest({ stabilizationRetry = false } = {}) {
+    if (!this._started) return false;
+    const current = this._ensureCurrentRootVersion();
+    const requestEvent = { type: ROOT_REQUEST_EVENT_TYPE };
+    if (stabilizationRetry) requestEvent.stabilizationRetry = true;
+    if (typeof current.snapshot?.present === 'boolean') {
+      requestEvent.present = current.snapshot.present;
+    }
+    const rootIdentity = describeRootIdentity(current.snapshot);
+    if (rootIdentity) requestEvent.rootIdentity = rootIdentity;
+    if (this._actorId) requestEvent.requestActorId = this._actorId;
+    if (current.version) {
+      requestEvent.fingerprint = current.fingerprint;
+      requestEvent.syncVersion = {
+        clock: current.version.clock,
+        actorId: current.version.actorId
+      };
+    }
+    try {
+      this._lm.broadcastEvent(requestEvent);
+      return true;
+    } catch (error) {
+      log.warn('drawingsV3 seed 요청 실패', { error: error?.message || String(error) });
+      return false;
+    }
+  }
+
+  _scheduleRootRequestRetry() {
+    this._clearRootRequestRetry();
+    const sessionGeneration = this._sessionGeneration;
+    const expectedBframePath = this._rdm.currentBframePath || null;
+    let timer = null;
+    let invoked = false;
+    const retry = () => {
+      if (invoked) return;
+      invoked = true;
+      if (this._seedRetryTimer === timer) this._seedRetryTimer = null;
+      if (!this._started || sessionGeneration !== this._sessionGeneration ||
+          (this._rdm.currentBframePath || null) !== expectedBframePath) {
+        return;
+      }
+      this._broadcastRootRequest({ stabilizationRetry: true });
+    };
+    timer = this._scheduleSeedRetryCallback(
+      retry,
+      ROOT_REQUEST_STABILIZATION_MS + 1
+    );
+    this._seedRetryTimer = timer;
+    timer?.unref?.();
+  }
+
+  _clearRootRequestRetry() {
+    if (this._seedRetryTimer === null) return;
+    this._cancelSeedRetryCallback(this._seedRetryTimer);
+    this._seedRetryTimer = null;
+  }
+
+  _markBaselineConflict(actorId = null) {
+    const normalizedActorId = normalizeRequestActorId(actorId);
+    if (normalizedActorId) {
+      if (!this._baselineConflictActors.has(normalizedActorId)) {
+        if (this._baselineConflictActors.size < MAX_BASELINE_CONFLICT_ACTORS) {
+          this._baselineConflictActors.add(normalizedActorId);
+        } else {
+          // reconnect actor가 무한히 쌓이면 메모리 대신 fail-closed latch로 승격한다.
+          this._hasUnattributedBaselineConflict = true;
+        }
+      }
+    } else {
+      this._hasUnattributedBaselineConflict = true;
+    }
+    this._rdm.markDrawingsV3BaselineConflict?.();
+  }
+
+  _resolveBaselineConflict(actorId) {
+    const normalizedActorId = normalizeRequestActorId(actorId);
+    if (!normalizedActorId) return;
+    this._baselineConflictActors.delete(normalizedActorId);
+    if (this._baselineConflictActors.size === 0 &&
+        !this._hasUnattributedBaselineConflict) {
+      this._rdm.clearDrawingsV3BaselineConflict?.();
+    }
+  }
+
+  _clearAllBaselineConflicts() {
+    this._baselineConflictActors.clear();
+    this._hasUnattributedBaselineConflict = false;
+    this._rdm.clearDrawingsV3BaselineConflict?.();
+  }
+
+  _broadcastControlEvent(event, label) {
+    try {
+      this._lm.broadcastEvent(event);
+      return true;
+    } catch (error) {
+      log.warn(label, { error: error?.message || String(error) });
+      return false;
+    }
+  }
+
+  _sendRootAcknowledgement(
+    targetActorId,
+    fingerprint,
+    syncVersion = this._currentRootVersion
+  ) {
+    const normalizedTargetActorId = normalizeRequestActorId(targetActorId);
+    if (!normalizedTargetActorId || !this._actorId) return false;
+    const normalizedVersion = normalizeSyncVersion(syncVersion, fingerprint);
+    return this._broadcastControlEvent({
+      type: 'FABRIC_DRAWING_ROOT_ACK',
+      targetActorId: normalizedTargetActorId,
+      sourceActorId: this._actorId,
+      fingerprint,
+      ...(normalizedVersion
+        ? {
+          syncVersion: {
+            clock: normalizedVersion.clock,
+            actorId: normalizedVersion.actorId
+          }
+        }
+        : {})
+    }, 'drawingsV3 seed 확인 전송 실패');
+  }
+
+  /** 늦게 참여한 협업자 seed용 — 세션 baseline이 아닌 현재 상태만 전송한다 */
   broadcastCurrentState() {
-    this._broadcastRoot({ force: true });
+    const current = this._ensureCurrentRootVersion();
+    // 세션 시작 당시의 unverified baseline은 force seed로도 권위 승격하지 않는다.
+    // 합류자는 ROOT_REQUEST/단발 stabilization retry로 안전하게 동기화한다.
+    if (current.fingerprint === this._sessionBaselineFingerprint) return false;
+    return this._broadcastRoot({ force: true });
   }
 
   _onSaved() {
@@ -183,6 +441,8 @@ export class FabricDrawingSync {
       peerConfirmed: Boolean(this._pendingExternalRoot)
     });
     if (published?.createdVersion) {
+      this._sessionBaselineHadLocalChanges = false;
+      this._clearAllBaselineConflicts();
       this._discardPendingExternalRootAtOrBelow(
         published.version,
         published.version.fingerprint
@@ -194,24 +454,53 @@ export class FabricDrawingSync {
     force,
     peerConfirmed = false,
     localSave = false,
-    causalFloor = null
+    causalFloor = null,
+    preserveCurrentVersion = false,
+    targetActorId = null
   }) {
-    if (!this._started || (!peerConfirmed && !this._lm.hasOtherCollaborators())) return;
+    if (!this._started) return;
     const snapshot = this._rdm.getDrawingsV3RootSnapshot?.();
     if (!snapshot || typeof snapshot.present !== 'boolean') return;
     // 구버전 디스크 상태(Broadcast 적용 이전)를 재전파하지 않는다
     if (snapshot.stale === true) return;
     const wireFingerprint = hashFingerprint(snapshot.fingerprint);
-    if (!force && wireFingerprint === this._lastSentFingerprint) return;
+    const mustConfirmRawLocalSave = Boolean(
+      localSave &&
+      this._sessionBaselineHadLocalChanges &&
+      this._currentRootVersion?.fingerprint === wireFingerprint &&
+      this._currentRootVersion.actorId === ''
+    );
+    if (!force && wireFingerprint === this._lastSentFingerprint &&
+        !mustConfirmRawLocalSave) {
+      return;
+    }
     const preparedVersion = this._prepareOutgoingRootVersion(
       snapshot.value,
       wireFingerprint,
-      { localSave, causalFloor }
+      { localSave, causalFloor, preserveCurrentVersion }
     );
+    if (!peerConfirmed && !this._lm.hasOtherCollaborators()) {
+      return preparedVersion;
+    }
     const syncVersion = {
       clock: preparedVersion.version.clock,
       actorId: preparedVersion.version.actorId
     };
+    const normalizedTargetActorId = normalizeRequestActorId(targetActorId);
+    const rootEventType = normalizedTargetActorId
+      ? ROOT_RESPONSE_EVENT_TYPE
+      : ROOT_EVENT_TYPE;
+    const chunkEventType = normalizedTargetActorId
+      ? ROOT_RESPONSE_CHUNK_EVENT_TYPE
+      : ROOT_CHUNK_EVENT_TYPE;
+    const routing = this._actorId
+      ? {
+        sourceActorId: this._actorId,
+        ...(normalizedTargetActorId
+          ? { targetActorId: normalizedTargetActorId }
+          : {})
+      }
+      : {};
     try {
       const payloadBytes = snapshot.present
         ? new TextEncoder().encode(JSON.stringify(snapshot.value))
@@ -223,19 +512,21 @@ export class FabricDrawingSync {
       const transferId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
       if (!snapshot.present) {
         this._lm.broadcastEvent({
-          type: 'FABRIC_DRAWING_ROOT',
+          type: rootEventType,
           transferId,
           present: false,
           fingerprint: wireFingerprint,
-          syncVersion
+          syncVersion,
+          ...routing
         });
       } else if (payloadBytes.length < INLINE_ROOT_MAX_BYTES) {
         this._lm.broadcastEvent({
-          type: 'FABRIC_DRAWING_ROOT',
+          type: rootEventType,
           transferId,
           present: true,
           fingerprint: wireFingerprint,
           syncVersion,
+          ...routing,
           root: snapshot.value
         });
       } else {
@@ -245,17 +536,18 @@ export class FabricDrawingSync {
           return;
         }
         this._lm.broadcastEvent({
-          type: 'FABRIC_DRAWING_ROOT',
+          type: rootEventType,
           transferId,
           present: true,
           fingerprint: wireFingerprint,
           syncVersion,
+          ...routing,
           chunkCount: count
         });
         for (let index = 0; index < count; index++) {
           const start = index * ROOT_CHUNK_RAW_SIZE;
           this._lm.broadcastEvent({
-            type: 'FABRIC_DRAWING_ROOT_CHUNK',
+            type: chunkEventType,
             transferId,
             index,
             count,
@@ -274,6 +566,12 @@ export class FabricDrawingSync {
 
   _ensureCurrentRootVersion() {
     const snapshot = this._rdm.getDrawingsV3RootSnapshot?.();
+    if (snapshot?.baselineConflict === false &&
+        (this._baselineConflictActors.size > 0 ||
+         this._hasUnattributedBaselineConflict)) {
+      this._baselineConflictActors.clear();
+      this._hasUnattributedBaselineConflict = false;
+    }
     if (!snapshot || typeof snapshot.present !== 'boolean' ||
         typeof snapshot.fingerprint !== 'string') {
       this._currentRootVersion = null;
@@ -284,7 +582,9 @@ export class FabricDrawingSync {
       return { snapshot, fingerprint, version: this._currentRootVersion };
     }
     const version = {
-      clock: Math.max(this._rootClock, getRootRevision(snapshot.value)),
+      // raw/unverified baseline의 순서는 문서 revision으로만 비교한다.
+      // 관측한 Lamport max는 _rootClock에 별도 보존해 다음 실제 로컬 저장만 넘는다.
+      clock: getRootRevision(snapshot.value),
       actorId: '',
       fingerprint: fingerprint || ''
     };
@@ -293,7 +593,11 @@ export class FabricDrawingSync {
     return { snapshot, fingerprint, version };
   }
 
-  _prepareOutgoingRootVersion(rootValue, fingerprint, { localSave, causalFloor = null }) {
+  _prepareOutgoingRootVersion(
+    rootValue,
+    fingerprint,
+    { localSave, causalFloor = null, preserveCurrentVersion = false }
+  ) {
     const currentMatches = this._currentRootVersion?.fingerprint === fingerprint;
     if (causalFloor) {
       this._rootClock = Math.max(this._rootClock, causalFloor.clock);
@@ -303,7 +607,15 @@ export class FabricDrawingSync {
       causalFloor.fingerprint !== fingerprint &&
       compareSyncVersions(this._currentRootVersion, causalFloor) <= 0
     );
+    const createsLocalCausalWinner = Boolean(
+      localSave &&
+      (!currentMatches || this._currentRootVersion?.actorId === '' ||
+       requiresCausalPromotion)
+    );
     let createdVersion = false;
+    if (preserveCurrentVersion && currentMatches && this._currentRootVersion) {
+      return { version: this._currentRootVersion, createdVersion: false };
+    }
     if (!currentMatches || this._currentRootVersion.actorId === '' ||
         requiresCausalPromotion) {
       const rootRevision = getRootRevision(rootValue);
@@ -315,7 +627,7 @@ export class FabricDrawingSync {
         actorId: this._actorId || '',
         fingerprint: fingerprint || ''
       };
-      createdVersion = localSave && !currentMatches;
+      createdVersion = createsLocalCausalWinner;
     }
     this._rootClock = Math.max(this._rootClock, this._currentRootVersion.clock);
     return { version: this._currentRootVersion, createdVersion };
@@ -372,36 +684,153 @@ export class FabricDrawingSync {
     const event = e.detail?.event || e.detail;
     if (!event?.type) return;
 
-    if (event.type === 'FABRIC_DRAWING_ROOT_REQUEST') {
+    if (event.type === ROOT_REQUEST_EVENT_TYPE ||
+        event.type === 'FABRIC_DRAWING_ROOT_REQUEST') {
       const requestVersion = normalizeSyncVersion(
         event.syncVersion,
         event.fingerprint
       );
+      const requestIdentity = normalizeRootIdentity(event.rootIdentity, event.present);
+      const requestActorId = normalizeRequestActorId(event.requestActorId);
       if (requestVersion) {
         this._rootClock = Math.max(this._rootClock, requestVersion.clock);
       }
-      if (this._now() - this._sessionStartedAt > ROOT_REQUEST_STABILIZATION_MS) {
+      const current = this._ensureCurrentRootVersion();
+      const decision = decideRootRequest(current, requestVersion, requestIdentity);
+      if (decision === ROOT_REQUEST_DECISION.EQUAL) {
+        if (compareSyncVersions(requestVersion, current.version) > 0) {
+          // 내용이 같은 더 높은 인과 버전도 수락해야, 그 요청보다 먼저 시작한
+          // disk reload가 뒤늦게 같은 root를 구버전으로 되돌리지 못한다.
+          this._rdm.invalidatePendingDrawingsV3DiskReloadsForExternalSync?.();
+          this._currentRootVersion = requestVersion;
+        }
+        if (requestVersion?.actorId.length > 0) {
+          this._clearAllBaselineConflicts();
+        } else {
+          this._resolveBaselineConflict(requestActorId);
+        }
+        this._sendRootAcknowledgement(requestActorId, current.fingerprint);
+        return;
+      }
+      if (decision !== ROOT_REQUEST_DECISION.IGNORE && requestActorId) {
+        // 서로 다른 baseline을 확인한 즉시 양쪽 저장을 hold한다. 실제 root 전송은
+        // 안정화 시간이 지난 뒤에만 수행해 fresh stale peer의 seed는 계속 막는다.
+        this._markBaselineConflict(requestActorId);
+        this._broadcastControlEvent({
+          type: 'FABRIC_DRAWING_ROOT_CONFLICT',
+          targetActorId: requestActorId,
+          sourceActorId: this._actorId,
+          requestFingerprint: requestVersion?.fingerprint || null
+        }, 'drawingsV3 baseline 충돌 알림 실패');
+      }
+      if (this._now() - this._sessionStartedAt < ROOT_REQUEST_STABILIZATION_MS) {
+        return;
+      }
+      if (decision === ROOT_REQUEST_DECISION.CONFLICT) {
+        return;
+      }
+      if (decision === ROOT_REQUEST_DECISION.PULL ||
+          decision === ROOT_REQUEST_DECISION.PULL_WITH_PROMOTION) {
+        if (!requestActorId) return;
+        this._broadcastControlEvent({
+          type: 'FABRIC_DRAWING_ROOT_PULL',
+          targetActorId: requestActorId,
+          sourceActorId: this._actorId,
+          requestFingerprint: requestVersion?.fingerprint || null,
+          causalFloor: current.version,
+          promote: decision === ROOT_REQUEST_DECISION.PULL_WITH_PROMOTION
+        }, 'drawingsV3 pull 요청 실패');
+        return;
+      }
+      if (decision === ROOT_REQUEST_DECISION.RESPOND ||
+          decision === ROOT_REQUEST_DECISION.RESPOND_WITH_PROMOTION) {
         this._broadcastRoot({
           force: true,
           peerConfirmed: true,
-          causalFloor: requestVersion
+          causalFloor: requestVersion,
+          preserveCurrentVersion: decision === ROOT_REQUEST_DECISION.RESPOND,
+          targetActorId: requestActorId
         });
       }
       return;
     }
 
-    if (event.type === 'FABRIC_DRAWING_ROOT') {
+    if (event.type === 'FABRIC_DRAWING_ROOT_CONFLICT') {
+      if (normalizeRequestActorId(event.targetActorId) !== this._actorId) return;
+      const current = this._ensureCurrentRootVersion();
+      if (event.requestFingerprint !== current.fingerprint) return;
+      this._markBaselineConflict(event.sourceActorId);
+      return;
+    }
+
+    if (event.type === 'FABRIC_DRAWING_ROOT_PULL') {
+      if (normalizeRequestActorId(event.targetActorId) !== this._actorId) return;
+      const sourceActorId = normalizeRequestActorId(event.sourceActorId);
+      if (!sourceActorId) return;
+      const current = this._ensureCurrentRootVersion();
+      if (event.requestFingerprint !== current.fingerprint) return;
+      const causalFloor = normalizeSyncVersion(
+        event.causalFloor,
+        event.causalFloor?.fingerprint
+      );
+      this._broadcastRoot({
+        force: true,
+        peerConfirmed: true,
+        causalFloor,
+        preserveCurrentVersion: event.promote !== true,
+        targetActorId: sourceActorId
+      });
+      return;
+    }
+
+    if (event.type === 'FABRIC_DRAWING_ROOT_ACK') {
+      if (normalizeRequestActorId(event.targetActorId) !== this._actorId) return;
+      const sourceActorId = normalizeRequestActorId(event.sourceActorId);
+      if (!sourceActorId) return;
+      const current = this._ensureCurrentRootVersion();
+      if (event.fingerprint !== current.fingerprint) return;
+      const acknowledgedVersion = normalizeSyncVersion(
+        event.syncVersion,
+        event.fingerprint
+      );
+      if (acknowledgedVersion) {
+        this._rootClock = Math.max(this._rootClock, acknowledgedVersion.clock);
+        if (compareSyncVersions(acknowledgedVersion, current.version) > 0) {
+          this._rdm.invalidatePendingDrawingsV3DiskReloadsForExternalSync?.();
+          this._currentRootVersion = acknowledgedVersion;
+        }
+      }
+      this._resolveBaselineConflict(sourceActorId);
+      return;
+    }
+
+    if (event.type === ROOT_EVENT_TYPE ||
+        event.type === ROOT_RESPONSE_EVENT_TYPE) {
+      const isTargetedResponse = event.type === ROOT_RESPONSE_EVENT_TYPE;
+      const targetActorId = normalizeRequestActorId(event.targetActorId);
+      if ((isTargetedResponse || event.targetActorId !== undefined) &&
+          targetActorId !== this._actorId) {
+        return;
+      }
+      const sourceActorId = normalizeRequestActorId(event.sourceActorId);
       if (event.present === false) {
         this._enqueueApply(
           undefined,
           event.fingerprint,
           event.syncVersion,
-          false
+          false,
+          sourceActorId
         );
         return;
       }
       if (event.root !== undefined) {
-        this._enqueueApply(event.root, event.fingerprint, event.syncVersion, true);
+        this._enqueueApply(
+          event.root,
+          event.fingerprint,
+          event.syncVersion,
+          true,
+          sourceActorId
+        );
         return;
       }
       const count = Math.trunc(Number(event.chunkCount));
@@ -436,6 +865,10 @@ export class FabricDrawingSync {
         transferId: event.transferId,
         fingerprint,
         syncVersion: event.syncVersion,
+        sourceActorId,
+        chunkEventType: isTargetedResponse
+          ? ROOT_RESPONSE_CHUNK_EVENT_TYPE
+          : ROOT_CHUNK_EVENT_TYPE,
         orderingVersion,
         chunks: new Array(count),
         received: 0,
@@ -445,9 +878,11 @@ export class FabricDrawingSync {
       return;
     }
 
-    if (event.type === 'FABRIC_DRAWING_ROOT_CHUNK') {
+    if (event.type === ROOT_CHUNK_EVENT_TYPE ||
+        event.type === ROOT_RESPONSE_CHUNK_EVENT_TYPE) {
       const transfer = this._transfer;
-      if (!transfer || transfer.transferId !== event.transferId) return;
+      if (!transfer || transfer.transferId !== event.transferId ||
+          transfer.chunkEventType !== event.type) return;
       const index = Math.trunc(Number(event.index));
       if (!Number.isFinite(index) || index < 0 || index >= transfer.count ||
           typeof event.data !== 'string' || transfer.chunks[index] !== undefined) {
@@ -460,6 +895,7 @@ export class FabricDrawingSync {
       let rootValue;
       const fingerprint = transfer.fingerprint;
       const syncVersion = transfer.syncVersion;
+      const sourceActorId = transfer.sourceActorId;
       try {
         const chunkBytes = transfer.chunks.map(chunk => base64ToBytes(chunk));
         const totalLength = chunkBytes.reduce((sum, bytes) => sum + bytes.length, 0);
@@ -479,11 +915,17 @@ export class FabricDrawingSync {
         return;
       }
       this._clearTransfer();
-      this._enqueueApply(rootValue, fingerprint, syncVersion, true);
+      this._enqueueApply(rootValue, fingerprint, syncVersion, true, sourceActorId);
     }
   }
 
-  _enqueueApply(rootValue, fingerprint, syncVersionValue, present = true) {
+  _enqueueApply(
+    rootValue,
+    fingerprint,
+    syncVersionValue,
+    present = true,
+    sourceActorId = null
+  ) {
     const syncVersion = this._normalizeIncomingRootVersion(
       rootValue,
       fingerprint,
@@ -528,6 +970,12 @@ export class FabricDrawingSync {
           fingerprint
         );
         this._lastSentFingerprint = fingerprint;
+        if (syncVersion.actorId.length > 0) {
+          this._clearAllBaselineConflicts();
+        } else {
+          this._resolveBaselineConflict(sourceActorId);
+        }
+        this._sendRootAcknowledgement(sourceActorId, fingerprint);
         return;
       }
       if (comparison <= 0) {
@@ -560,6 +1008,12 @@ export class FabricDrawingSync {
           this._currentRootVersion,
           fingerprint
         );
+        if (syncVersion.actorId.length > 0) {
+          this._clearAllBaselineConflicts();
+        } else {
+          this._resolveBaselineConflict(sourceActorId);
+        }
+        this._sendRootAcknowledgement(sourceActorId, fingerprint);
         log.info('원격 drawingsV3 반영됨');
       } else if (postApplyComparison <= 0) {
         this._markExternalRootSuperseded(rootValue, present);

--- a/renderer/scripts/modules/fabric-drawing-sync.js
+++ b/renderer/scripts/modules/fabric-drawing-sync.js
@@ -1,0 +1,250 @@
+/**
+ * BAEFRAME - Fabric Drawing Sync (Broadcast 기반)
+ * Fabric 드로잉(drawingsV3) 루트 스냅샷 ↔ Liveblocks Broadcast 동기화
+ *
+ * 배경: Fabric 정식 승격 이후 드로잉은 .bframe의 drawingsV3에만 저장되고
+ * 실시간 채널이 없었다. 이 모듈은 저장 완료 시점의 drawingsV3 루트 스냅샷을
+ * Broadcast로 전파하고, 수신측은 ReviewDataManager의 디스크 반영 파이프라인
+ * (applyExternalDrawingsV3)을 재사용해 오버레이를 재수화한다.
+ * 충돌 정책: 수신측에 미저장 로컬 드로잉 변경이 있으면 적용하지 않는다
+ * (fail-closed — 기존 fabric-drawing-conflict 정책과 동일).
+ */
+
+import { createLogger } from '../logger.js';
+
+const log = createLogger('FabricDrawingSync');
+
+// Broadcast 메시지 사이즈 제한 (drawing-sync.js와 동일 기준)
+const ROOT_CHUNK_RAW_SIZE = 384 * 1024;
+const ROOT_CHUNK_TIMEOUT_MS = 30000;
+const MAX_ROOT_TRANSFER_BYTES = 32 * 1024 * 1024;
+const MAX_ROOT_CHUNKS = Math.ceil(MAX_ROOT_TRANSFER_BYTES / ROOT_CHUNK_RAW_SIZE);
+// 이 크기 미만이면 청크 없이 인라인 전송 (봉투 오버헤드 포함 Liveblocks 1MB 제한 준수)
+const INLINE_ROOT_MAX_BYTES = 700 * 1024;
+
+// drawingsV3 지문(review-data-manager의 captureDrawingsV3DiskState)은 해시가 아니라
+// 'present:' + 전체 canonical JSON 문자열이다 — 와이어에 그대로 실으면 payload가
+// 2배가 되어 1MB 한도를 깨뜨린다. 이벤트에는 반드시 이 짧은 해시만 싣는다.
+function hashFingerprint(fingerprint) {
+  if (typeof fingerprint !== 'string') return null;
+  let h1 = 0x811c9dc5;
+  let h2 = 0xcbf29ce4;
+  for (let index = 0; index < fingerprint.length; index++) {
+    const code = fingerprint.charCodeAt(index);
+    h1 = Math.imul(h1 ^ code, 0x01000193) >>> 0;
+    h2 = Math.imul(h2 ^ code, 0x01000197) >>> 0;
+  }
+  return `${h1.toString(36)}-${h2.toString(36)}-${fingerprint.length.toString(36)}`;
+}
+
+function bytesToBase64(bytes) {
+  let binary = '';
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(value) {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) bytes[index] = binary.charCodeAt(index);
+  return bytes;
+}
+
+export class FabricDrawingSync {
+  constructor({ liveblocksManager, reviewDataManager }) {
+    this._lm = liveblocksManager;
+    this._rdm = reviewDataManager;
+    this._started = false;
+    // stop()마다 증가하는 세션 세대 — stop→start 경계를 넘어 살아남은
+    // 이전 세션의 적용 큐 항목을 무효화하는 fence다
+    this._sessionGeneration = 0;
+    this._lastSentFingerprint = null;
+    this._transfer = null;
+    this._applyQueue = Promise.resolve();
+    this._onSaved = this._onSaved.bind(this);
+    this._onBroadcast = this._onBroadcast.bind(this);
+    log.info('FabricDrawingSync 초기화됨 (Broadcast 모드)');
+  }
+
+  start() {
+    if (this._started) return;
+    this._rdm.addEventListener('saved', this._onSaved);
+    this._lm.addEventListener('broadcastReceived', this._onBroadcast);
+    this._started = true;
+    log.info('Fabric 드로잉 동기화 시작됨');
+  }
+
+  stop() {
+    if (!this._started) return;
+    this._rdm.removeEventListener('saved', this._onSaved);
+    this._lm.removeEventListener('broadcastReceived', this._onBroadcast);
+    this._clearTransfer();
+    this._lastSentFingerprint = null;
+    this._started = false;
+    // 이 세션에서 큐잉된 적용을 전부 무효화한다 (stop→start 재시작 후 실행 방지).
+    // 리스너는 이미 해제되어 정지 중 새 큐잉은 없으므로 stop 시점 증가로 충분하다.
+    this._sessionGeneration += 1;
+    log.info('Fabric 드로잉 동기화 중지됨');
+  }
+
+  /** 늦게 참여한 협업자 seed용 — 지문 중복 검사 없이 현재 상태를 전송한다 */
+  broadcastCurrentState() {
+    this._broadcastRoot({ force: true });
+  }
+
+  _onSaved() {
+    this._broadcastRoot({ force: false });
+  }
+
+  _broadcastRoot({ force }) {
+    if (!this._started || !this._lm.hasOtherCollaborators()) return;
+    const snapshot = this._rdm.getDrawingsV3RootSnapshot?.();
+    if (!snapshot?.present) return;
+    // 구버전 디스크 상태(Broadcast 적용 이전)를 재전파하지 않는다
+    if (snapshot.stale === true) return;
+    const wireFingerprint = hashFingerprint(snapshot.fingerprint);
+    if (!force && wireFingerprint === this._lastSentFingerprint) return;
+    try {
+      const payloadBytes = new TextEncoder().encode(JSON.stringify(snapshot.value));
+      if (payloadBytes.length > MAX_ROOT_TRANSFER_BYTES) {
+        log.warn('drawingsV3 스냅샷이 너무 커 브로드캐스트 생략', { bytes: payloadBytes.length });
+        return;
+      }
+      const transferId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      if (payloadBytes.length < INLINE_ROOT_MAX_BYTES) {
+        this._lm.broadcastEvent({
+          type: 'FABRIC_DRAWING_ROOT',
+          transferId,
+          fingerprint: wireFingerprint,
+          root: snapshot.value
+        });
+      } else {
+        const count = Math.ceil(payloadBytes.length / ROOT_CHUNK_RAW_SIZE);
+        if (count > MAX_ROOT_CHUNKS) {
+          log.warn('drawingsV3 청크 수 초과로 브로드캐스트 생략', { count });
+          return;
+        }
+        this._lm.broadcastEvent({
+          type: 'FABRIC_DRAWING_ROOT',
+          transferId,
+          fingerprint: wireFingerprint,
+          chunkCount: count
+        });
+        for (let index = 0; index < count; index++) {
+          const start = index * ROOT_CHUNK_RAW_SIZE;
+          this._lm.broadcastEvent({
+            type: 'FABRIC_DRAWING_ROOT_CHUNK',
+            transferId,
+            index,
+            count,
+            data: bytesToBase64(payloadBytes.subarray(start, start + ROOT_CHUNK_RAW_SIZE))
+          });
+        }
+      }
+      this._lastSentFingerprint = wireFingerprint;
+      log.info('drawingsV3 브로드캐스트 전송', { transferId, bytes: payloadBytes.length });
+    } catch (error) {
+      log.error('drawingsV3 브로드캐스트 실패', { error: error?.message || String(error) });
+    }
+  }
+
+  _onBroadcast(e) {
+    const event = e.detail?.event || e.detail;
+    if (!event?.type) return;
+
+    if (event.type === 'FABRIC_DRAWING_ROOT') {
+      if (event.root !== undefined) {
+        this._enqueueApply(event.root, event.fingerprint);
+        return;
+      }
+      const count = Math.trunc(Number(event.chunkCount));
+      if (typeof event.transferId !== 'string' ||
+          !Number.isFinite(count) || count < 1 || count > MAX_ROOT_CHUNKS) {
+        return;
+      }
+      this._clearTransfer();
+      this._transfer = {
+        transferId: event.transferId,
+        fingerprint: typeof event.fingerprint === 'string' ? event.fingerprint : null,
+        chunks: new Array(count),
+        received: 0,
+        count,
+        timer: setTimeout(() => this._clearTransfer(), ROOT_CHUNK_TIMEOUT_MS)
+      };
+      return;
+    }
+
+    if (event.type === 'FABRIC_DRAWING_ROOT_CHUNK') {
+      const transfer = this._transfer;
+      if (!transfer || transfer.transferId !== event.transferId) return;
+      const index = Math.trunc(Number(event.index));
+      if (!Number.isFinite(index) || index < 0 || index >= transfer.count ||
+          typeof event.data !== 'string' || transfer.chunks[index] !== undefined) {
+        return;
+      }
+      transfer.chunks[index] = event.data;
+      transfer.received += 1;
+      if (transfer.received < transfer.count) return;
+
+      let rootValue;
+      const fingerprint = transfer.fingerprint;
+      try {
+        const chunkBytes = transfer.chunks.map(chunk => base64ToBytes(chunk));
+        const totalLength = chunkBytes.reduce((sum, bytes) => sum + bytes.length, 0);
+        if (totalLength > MAX_ROOT_TRANSFER_BYTES) {
+          this._clearTransfer();
+          return;
+        }
+        const merged = new Uint8Array(totalLength);
+        let offset = 0;
+        for (const bytes of chunkBytes) {
+          merged.set(bytes, offset);
+          offset += bytes.length;
+        }
+        rootValue = JSON.parse(new TextDecoder().decode(merged));
+      } catch (_error) {
+        this._clearTransfer();
+        return;
+      }
+      this._clearTransfer();
+      this._enqueueApply(rootValue, fingerprint);
+    }
+  }
+
+  _enqueueApply(rootValue, fingerprint) {
+    // 자기 전송분 에코 방지 (Liveblocks Broadcast는 자기에게 안 오지만 방어)
+    if (fingerprint && fingerprint === this._lastSentFingerprint) return;
+    // 수신 시점의 세션 세대·리뷰 파일 경로를 캡처해, 큐 대기 중 세션이 끝나거나
+    // (stop→start 재시작 포함) 영상이 전환되면 폐기한다 — 파일 경로만으로는
+    // 같은 .bframe 재접속(A→B→A) 시 이전 세션의 잔존 큐를 구분하지 못한다
+    const sessionGeneration = this._sessionGeneration;
+    const expectedBframePath = this._rdm.currentBframePath || null;
+    this._applyQueue = this._applyQueue.then(async () => {
+      if (!this._started || sessionGeneration !== this._sessionGeneration) {
+        log.debug('원격 drawingsV3 폐기 (협업 세션 종료·재시작)');
+        return;
+      }
+      if ((this._rdm.currentBframePath || null) !== expectedBframePath) {
+        log.debug('원격 drawingsV3 폐기 (리뷰 파일 전환됨)');
+        return;
+      }
+      const applied = await this._rdm.applyExternalDrawingsV3?.(rootValue);
+      if (applied) {
+        // 수신 상태를 그대로 재브로드캐스트하지 않도록 지문을 기록한다
+        if (typeof fingerprint === 'string') this._lastSentFingerprint = fingerprint;
+        log.info('원격 drawingsV3 반영됨');
+      } else {
+        log.debug('원격 drawingsV3 반영 생략 (로컬 변경 보호 또는 동일 상태)');
+      }
+    }).catch(error => {
+      log.warn('원격 drawingsV3 반영 실패', { error: error?.message || String(error) });
+    });
+  }
+
+  _clearTransfer() {
+    if (this._transfer?.timer) clearTimeout(this._transfer.timer);
+    this._transfer = null;
+  }
+}

--- a/renderer/scripts/modules/fabric-drawing-sync.js
+++ b/renderer/scripts/modules/fabric-drawing-sync.js
@@ -517,7 +517,12 @@ export class FabricDrawingSync {
       );
       const comparison = compareSyncVersions(syncVersion, current.version);
       if (sameRoot) {
-        if (comparison > 0) this._currentRootVersion = syncVersion;
+        if (comparison > 0) {
+          // 내용이 같아 provider 적용을 생략해도 더 높은 외부 인과 버전을
+          // 수락했으므로, 그보다 먼저 시작한 disk reload는 함께 무효화한다.
+          this._rdm.invalidatePendingDrawingsV3DiskReloadsForExternalSync?.();
+          this._currentRootVersion = syncVersion;
+        }
         this._discardPendingExternalRootAtOrBelow(
           this._currentRootVersion,
           fingerprint

--- a/renderer/scripts/modules/fabric-drawing-sync.js
+++ b/renderer/scripts/modules/fabric-drawing-sync.js
@@ -38,6 +38,45 @@ function hashFingerprint(fingerprint) {
   return `${h1.toString(36)}-${h2.toString(36)}-${fingerprint.length.toString(36)}`;
 }
 
+function createSyncActorId() {
+  try {
+    const randomId = globalThis.crypto?.randomUUID?.();
+    if (typeof randomId === 'string' && randomId.length > 0) return randomId;
+  } catch (_error) {
+    // 보안 난수 API가 없는 구형 런타임은 아래 세션 한정 식별자로 폴백한다.
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 14)}`;
+}
+
+function getRootRevision(rootValue) {
+  const revision = Number(rootValue?.revision);
+  return Number.isSafeInteger(revision) && revision >= 0 ? revision : 0;
+}
+
+function normalizeSyncVersion(value, fingerprint) {
+  const clock = Number(value?.clock);
+  const actorId = value?.actorId;
+  if (!Number.isSafeInteger(clock) || clock < 0 ||
+      typeof actorId !== 'string' || actorId.length > 512) {
+    return null;
+  }
+  return {
+    clock,
+    actorId,
+    fingerprint: typeof fingerprint === 'string' ? fingerprint : ''
+  };
+}
+
+function compareSyncVersions(left, right) {
+  if (!left && !right) return 0;
+  if (!left) return -1;
+  if (!right) return 1;
+  if (left.clock !== right.clock) return left.clock > right.clock ? 1 : -1;
+  if (left.actorId !== right.actorId) return left.actorId > right.actorId ? 1 : -1;
+  if (left.fingerprint === right.fingerprint) return 0;
+  return left.fingerprint > right.fingerprint ? 1 : -1;
+}
+
 function bytesToBase64(bytes) {
   let binary = '';
   for (let offset = 0; offset < bytes.length; offset += 0x8000) {
@@ -54,10 +93,22 @@ function base64ToBytes(value) {
 }
 
 export class FabricDrawingSync {
-  constructor({ liveblocksManager, reviewDataManager, now = () => Date.now() }) {
+  constructor({
+    liveblocksManager,
+    reviewDataManager,
+    now = () => Date.now(),
+    actorId = null
+  }) {
     this._lm = liveblocksManager;
     this._rdm = reviewDataManager;
     this._now = now;
+    this._explicitActorId = typeof actorId === 'string' && actorId.length > 0
+      ? actorId
+      : null;
+    this._actorId = null;
+    this._rootClock = 0;
+    this._currentRootVersion = null;
+    this._pendingExternalRoot = null;
     this._started = false;
     // stop()마다 증가하는 세션 세대 — stop→start 경계를 넘어 살아남은
     // 이전 세션의 적용 큐 항목을 무효화하는 fence다
@@ -73,6 +124,15 @@ export class FabricDrawingSync {
 
   start() {
     if (this._started) return;
+    const connectionId = this._lm.getSelf?.()?.connectionId;
+    this._actorId = this._explicitActorId ||
+      (connectionId !== null && connectionId !== undefined
+        ? String(connectionId)
+        : createSyncActorId());
+    this._rootClock = 0;
+    this._currentRootVersion = null;
+    this._pendingExternalRoot = null;
+    this._ensureCurrentRootVersion();
     this._rdm.addEventListener('saved', this._onSaved);
     this._lm.addEventListener('broadcastReceived', this._onBroadcast);
     this._sessionStartedAt = this._now();
@@ -93,6 +153,10 @@ export class FabricDrawingSync {
     this._lastSentFingerprint = null;
     this._started = false;
     this._sessionStartedAt = 0;
+    this._actorId = null;
+    this._rootClock = 0;
+    this._currentRootVersion = null;
+    this._pendingExternalRoot = null;
     // 이 세션에서 큐잉된 적용을 전부 무효화한다 (stop→start 재시작 후 실행 방지).
     // 리스너는 이미 해제되어 정지 중 새 큐잉은 없으므로 stop 시점 증가로 충분하다.
     this._sessionGeneration += 1;
@@ -105,10 +169,20 @@ export class FabricDrawingSync {
   }
 
   _onSaved() {
-    this._broadcastRoot({ force: false });
+    const published = this._broadcastRoot({
+      force: false,
+      localSave: true,
+      peerConfirmed: Boolean(this._pendingExternalRoot)
+    });
+    if (published?.createdVersion) {
+      this._discardPendingExternalRootAtOrBelow(
+        published.version,
+        published.version.fingerprint
+      );
+    }
   }
 
-  _broadcastRoot({ force, peerConfirmed = false }) {
+  _broadcastRoot({ force, peerConfirmed = false, localSave = false }) {
     if (!this._started || (!peerConfirmed && !this._lm.hasOtherCollaborators())) return;
     const snapshot = this._rdm.getDrawingsV3RootSnapshot?.();
     if (!snapshot?.present) return;
@@ -116,6 +190,15 @@ export class FabricDrawingSync {
     if (snapshot.stale === true) return;
     const wireFingerprint = hashFingerprint(snapshot.fingerprint);
     if (!force && wireFingerprint === this._lastSentFingerprint) return;
+    const preparedVersion = this._prepareOutgoingRootVersion(
+      snapshot.value,
+      wireFingerprint,
+      { localSave }
+    );
+    const syncVersion = {
+      clock: preparedVersion.version.clock,
+      actorId: preparedVersion.version.actorId
+    };
     try {
       const payloadBytes = new TextEncoder().encode(JSON.stringify(snapshot.value));
       if (payloadBytes.length > MAX_ROOT_TRANSFER_BYTES) {
@@ -128,6 +211,7 @@ export class FabricDrawingSync {
           type: 'FABRIC_DRAWING_ROOT',
           transferId,
           fingerprint: wireFingerprint,
+          syncVersion,
           root: snapshot.value
         });
       } else {
@@ -140,6 +224,7 @@ export class FabricDrawingSync {
           type: 'FABRIC_DRAWING_ROOT',
           transferId,
           fingerprint: wireFingerprint,
+          syncVersion,
           chunkCount: count
         });
         for (let index = 0; index < count; index++) {
@@ -155,9 +240,95 @@ export class FabricDrawingSync {
       }
       this._lastSentFingerprint = wireFingerprint;
       log.info('drawingsV3 브로드캐스트 전송', { transferId, bytes: payloadBytes.length });
+      return preparedVersion;
     } catch (error) {
       log.error('drawingsV3 브로드캐스트 실패', { error: error?.message || String(error) });
+      return preparedVersion;
     }
+  }
+
+  _ensureCurrentRootVersion() {
+    const snapshot = this._rdm.getDrawingsV3RootSnapshot?.();
+    if (!snapshot?.present) {
+      this._currentRootVersion = null;
+      return { snapshot, fingerprint: null, version: null };
+    }
+    const fingerprint = hashFingerprint(snapshot.fingerprint);
+    if (this._currentRootVersion?.fingerprint === fingerprint) {
+      return { snapshot, fingerprint, version: this._currentRootVersion };
+    }
+    const version = {
+      clock: Math.max(this._rootClock, getRootRevision(snapshot.value)),
+      actorId: '',
+      fingerprint: fingerprint || ''
+    };
+    this._rootClock = Math.max(this._rootClock, version.clock);
+    this._currentRootVersion = version;
+    return { snapshot, fingerprint, version };
+  }
+
+  _prepareOutgoingRootVersion(rootValue, fingerprint, { localSave }) {
+    const currentMatches = this._currentRootVersion?.fingerprint === fingerprint;
+    let createdVersion = false;
+    if (!currentMatches || this._currentRootVersion.actorId === '') {
+      const rootRevision = getRootRevision(rootValue);
+      const nextClock = this._rootClock < Number.MAX_SAFE_INTEGER
+        ? this._rootClock + 1
+        : Number.MAX_SAFE_INTEGER;
+      this._currentRootVersion = {
+        clock: Math.max(nextClock, rootRevision),
+        actorId: this._actorId || '',
+        fingerprint: fingerprint || ''
+      };
+      createdVersion = localSave && !currentMatches;
+    }
+    this._rootClock = Math.max(this._rootClock, this._currentRootVersion.clock);
+    return { version: this._currentRootVersion, createdVersion };
+  }
+
+  _normalizeIncomingRootVersion(rootValue, fingerprint, value) {
+    return normalizeSyncVersion(value, fingerprint) || {
+      clock: getRootRevision(rootValue),
+      actorId: '',
+      fingerprint: typeof fingerprint === 'string' ? fingerprint : ''
+    };
+  }
+
+  _markExternalRootSuperseded(rootValue) {
+    try {
+      this._rdm.markExternalDrawingsV3Superseded?.(rootValue);
+    } catch (error) {
+      log.warn('패자 drawingsV3 지문 기록 실패', {
+        error: error?.message || String(error)
+      });
+    }
+  }
+
+  _compareIncomingAgainstPending(candidate) {
+    const pending = this._pendingExternalRoot;
+    if (!pending) return 1;
+    const comparison = compareSyncVersions(candidate.version, pending.version);
+    if (comparison < 0) {
+      this._markExternalRootSuperseded(candidate.rootValue);
+      return -1;
+    }
+    if (comparison > 0) {
+      this._markExternalRootSuperseded(pending.rootValue);
+      this._pendingExternalRoot = null;
+    }
+    return comparison;
+  }
+
+  _discardPendingExternalRootAtOrBelow(winnerVersion, winnerFingerprint) {
+    const pending = this._pendingExternalRoot;
+    if (!pending) return;
+    const comparison = compareSyncVersions(pending.version, winnerVersion);
+    if (comparison > 0 ||
+        (comparison === 0 && pending.fingerprint !== winnerFingerprint)) {
+      return;
+    }
+    if (comparison < 0) this._markExternalRootSuperseded(pending.rootValue);
+    this._pendingExternalRoot = null;
   }
 
   _onBroadcast(e) {
@@ -173,7 +344,7 @@ export class FabricDrawingSync {
 
     if (event.type === 'FABRIC_DRAWING_ROOT') {
       if (event.root !== undefined) {
-        this._enqueueApply(event.root, event.fingerprint);
+        this._enqueueApply(event.root, event.fingerprint, event.syncVersion);
         return;
       }
       const count = Math.trunc(Number(event.chunkCount));
@@ -181,10 +352,34 @@ export class FabricDrawingSync {
           !Number.isFinite(count) || count < 1 || count > MAX_ROOT_CHUNKS) {
         return;
       }
+      const fingerprint = typeof event.fingerprint === 'string'
+        ? event.fingerprint
+        : null;
+      const orderingVersion = this._normalizeIncomingRootVersion(
+        undefined,
+        fingerprint,
+        event.syncVersion
+      );
+      // 청크 본문이 늦게 도착하더라도 header 수신 자체는 causal observation이다.
+      // 그 사이의 로컬 저장은 반드시 이 전송보다 높은 clock을 발급해야 한다.
+      this._rootClock = Math.max(this._rootClock, orderingVersion.clock);
+      if (this._transfer) {
+        const transferComparison = compareSyncVersions(
+          orderingVersion,
+          this._transfer.orderingVersion
+        );
+        if (transferComparison < 0 ||
+            (transferComparison === 0 &&
+             event.transferId === this._transfer.transferId)) {
+          return;
+        }
+      }
       this._clearTransfer();
       this._transfer = {
         transferId: event.transferId,
-        fingerprint: typeof event.fingerprint === 'string' ? event.fingerprint : null,
+        fingerprint,
+        syncVersion: event.syncVersion,
+        orderingVersion,
         chunks: new Array(count),
         received: 0,
         count,
@@ -207,6 +402,7 @@ export class FabricDrawingSync {
 
       let rootValue;
       const fingerprint = transfer.fingerprint;
+      const syncVersion = transfer.syncVersion;
       try {
         const chunkBytes = transfer.chunks.map(chunk => base64ToBytes(chunk));
         const totalLength = chunkBytes.reduce((sum, bytes) => sum + bytes.length, 0);
@@ -226,13 +422,19 @@ export class FabricDrawingSync {
         return;
       }
       this._clearTransfer();
-      this._enqueueApply(rootValue, fingerprint);
+      this._enqueueApply(rootValue, fingerprint, syncVersion);
     }
   }
 
-  _enqueueApply(rootValue, fingerprint) {
-    // 자기 전송분 에코 방지 (Liveblocks Broadcast는 자기에게 안 오지만 방어)
-    if (fingerprint && fingerprint === this._lastSentFingerprint) return;
+  _enqueueApply(rootValue, fingerprint, syncVersionValue) {
+    const syncVersion = this._normalizeIncomingRootVersion(
+      rootValue,
+      fingerprint,
+      syncVersionValue
+    );
+    // 적용 성공 여부와 무관하게 수신 시점에 Lamport clock을 관측해야,
+    // local-dirty로 거절한 뒤의 로컬 저장이 수신 루트보다 새 버전을 발급한다.
+    this._rootClock = Math.max(this._rootClock, syncVersion.clock);
     // 수신 시점의 세션 세대·리뷰 파일 경로를 캡처해, 큐 대기 중 세션이 끝나거나
     // (stop→start 재시작 포함) 영상이 전환되면 폐기한다 — 파일 경로만으로는
     // 같은 .bframe 재접속(A→B→A) 시 이전 세션의 잔존 큐를 구분하지 못한다
@@ -247,12 +449,65 @@ export class FabricDrawingSync {
         log.debug('원격 drawingsV3 폐기 (리뷰 파일 전환됨)');
         return;
       }
+      const candidate = { rootValue, fingerprint, version: syncVersion };
+      if (this._compareIncomingAgainstPending(candidate) < 0) {
+        log.debug('원격 drawingsV3 폐기 (더 최신인 대기 루트 존재)');
+        return;
+      }
+      const current = this._ensureCurrentRootVersion();
+      const sameRoot = Boolean(
+        fingerprint && current.fingerprint && fingerprint === current.fingerprint
+      );
+      const comparison = compareSyncVersions(syncVersion, current.version);
+      if (sameRoot) {
+        if (comparison > 0) this._currentRootVersion = syncVersion;
+        this._discardPendingExternalRootAtOrBelow(
+          this._currentRootVersion,
+          fingerprint
+        );
+        this._lastSentFingerprint = fingerprint;
+        return;
+      }
+      if (comparison <= 0) {
+        this._markExternalRootSuperseded(rootValue);
+        log.debug('원격 drawingsV3 폐기 (결정적 버전 패자)');
+        return;
+      }
       const applied = await this._rdm.applyExternalDrawingsV3?.(rootValue);
-      if (applied) {
+      if (!this._started || sessionGeneration !== this._sessionGeneration ||
+          (this._rdm.currentBframePath || null) !== expectedBframePath) {
+        return;
+      }
+      const postApply = this._ensureCurrentRootVersion();
+      const finalRootIsIncoming = !fingerprint || fingerprint === postApply.fingerprint;
+      const postApplyComparison = compareSyncVersions(syncVersion, postApply.version);
+      if (applied && !finalRootIsIncoming) {
+        if (this._pendingExternalRoot && compareSyncVersions(
+          this._pendingExternalRoot.version,
+          syncVersion
+        ) === 0) {
+          this._pendingExternalRoot = null;
+        }
+        this._markExternalRootSuperseded(rootValue);
+        log.debug('원격 drawingsV3 반영 뒤 폐기 (현재 루트 불일치)');
+      } else if (applied) {
         // 수신 상태를 그대로 재브로드캐스트하지 않도록 지문을 기록한다
         if (typeof fingerprint === 'string') this._lastSentFingerprint = fingerprint;
+        if (postApplyComparison > 0) this._currentRootVersion = syncVersion;
+        this._discardPendingExternalRootAtOrBelow(
+          this._currentRootVersion,
+          fingerprint
+        );
         log.info('원격 drawingsV3 반영됨');
+      } else if (postApplyComparison <= 0) {
+        this._markExternalRootSuperseded(rootValue);
+        this._discardPendingExternalRootAtOrBelow(
+          postApply.version,
+          postApply.fingerprint
+        );
+        log.debug('원격 drawingsV3 반영 뒤 폐기 (await 중 최신 루트 확정)');
       } else {
+        this._pendingExternalRoot = candidate;
         log.debug('원격 drawingsV3 반영 생략 (로컬 변경 보호 또는 동일 상태)');
       }
     }).catch(error => {

--- a/renderer/scripts/modules/fabric-drawing-sync.js
+++ b/renderer/scripts/modules/fabric-drawing-sync.js
@@ -132,13 +132,21 @@ export class FabricDrawingSync {
     this._rootClock = 0;
     this._currentRootVersion = null;
     this._pendingExternalRoot = null;
-    this._ensureCurrentRootVersion();
+    const current = this._ensureCurrentRootVersion();
     this._rdm.addEventListener('saved', this._onSaved);
     this._lm.addEventListener('broadcastReceived', this._onBroadcast);
     this._sessionStartedAt = this._now();
     this._started = true;
     try {
-      this._lm.broadcastEvent({ type: 'FABRIC_DRAWING_ROOT_REQUEST' });
+      const requestEvent = { type: 'FABRIC_DRAWING_ROOT_REQUEST' };
+      if (current.version) {
+        requestEvent.fingerprint = current.fingerprint;
+        requestEvent.syncVersion = {
+          clock: current.version.clock,
+          actorId: current.version.actorId
+        };
+      }
+      this._lm.broadcastEvent(requestEvent);
     } catch (error) {
       log.warn('drawingsV3 seed 요청 실패', { error: error?.message || String(error) });
     }
@@ -182,10 +190,15 @@ export class FabricDrawingSync {
     }
   }
 
-  _broadcastRoot({ force, peerConfirmed = false, localSave = false }) {
+  _broadcastRoot({
+    force,
+    peerConfirmed = false,
+    localSave = false,
+    causalFloor = null
+  }) {
     if (!this._started || (!peerConfirmed && !this._lm.hasOtherCollaborators())) return;
     const snapshot = this._rdm.getDrawingsV3RootSnapshot?.();
-    if (!snapshot?.present) return;
+    if (!snapshot || typeof snapshot.present !== 'boolean') return;
     // 구버전 디스크 상태(Broadcast 적용 이전)를 재전파하지 않는다
     if (snapshot.stale === true) return;
     const wireFingerprint = hashFingerprint(snapshot.fingerprint);
@@ -193,23 +206,34 @@ export class FabricDrawingSync {
     const preparedVersion = this._prepareOutgoingRootVersion(
       snapshot.value,
       wireFingerprint,
-      { localSave }
+      { localSave, causalFloor }
     );
     const syncVersion = {
       clock: preparedVersion.version.clock,
       actorId: preparedVersion.version.actorId
     };
     try {
-      const payloadBytes = new TextEncoder().encode(JSON.stringify(snapshot.value));
-      if (payloadBytes.length > MAX_ROOT_TRANSFER_BYTES) {
+      const payloadBytes = snapshot.present
+        ? new TextEncoder().encode(JSON.stringify(snapshot.value))
+        : new Uint8Array(0);
+      if (snapshot.present && payloadBytes.length > MAX_ROOT_TRANSFER_BYTES) {
         log.warn('drawingsV3 스냅샷이 너무 커 브로드캐스트 생략', { bytes: payloadBytes.length });
         return;
       }
       const transferId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-      if (payloadBytes.length < INLINE_ROOT_MAX_BYTES) {
+      if (!snapshot.present) {
         this._lm.broadcastEvent({
           type: 'FABRIC_DRAWING_ROOT',
           transferId,
+          present: false,
+          fingerprint: wireFingerprint,
+          syncVersion
+        });
+      } else if (payloadBytes.length < INLINE_ROOT_MAX_BYTES) {
+        this._lm.broadcastEvent({
+          type: 'FABRIC_DRAWING_ROOT',
+          transferId,
+          present: true,
           fingerprint: wireFingerprint,
           syncVersion,
           root: snapshot.value
@@ -223,6 +247,7 @@ export class FabricDrawingSync {
         this._lm.broadcastEvent({
           type: 'FABRIC_DRAWING_ROOT',
           transferId,
+          present: true,
           fingerprint: wireFingerprint,
           syncVersion,
           chunkCount: count
@@ -249,7 +274,8 @@ export class FabricDrawingSync {
 
   _ensureCurrentRootVersion() {
     const snapshot = this._rdm.getDrawingsV3RootSnapshot?.();
-    if (!snapshot?.present) {
+    if (!snapshot || typeof snapshot.present !== 'boolean' ||
+        typeof snapshot.fingerprint !== 'string') {
       this._currentRootVersion = null;
       return { snapshot, fingerprint: null, version: null };
     }
@@ -267,10 +293,19 @@ export class FabricDrawingSync {
     return { snapshot, fingerprint, version };
   }
 
-  _prepareOutgoingRootVersion(rootValue, fingerprint, { localSave }) {
+  _prepareOutgoingRootVersion(rootValue, fingerprint, { localSave, causalFloor = null }) {
     const currentMatches = this._currentRootVersion?.fingerprint === fingerprint;
+    if (causalFloor) {
+      this._rootClock = Math.max(this._rootClock, causalFloor.clock);
+    }
+    const requiresCausalPromotion = Boolean(
+      causalFloor &&
+      causalFloor.fingerprint !== fingerprint &&
+      compareSyncVersions(this._currentRootVersion, causalFloor) <= 0
+    );
     let createdVersion = false;
-    if (!currentMatches || this._currentRootVersion.actorId === '') {
+    if (!currentMatches || this._currentRootVersion.actorId === '' ||
+        requiresCausalPromotion) {
       const rootRevision = getRootRevision(rootValue);
       const nextClock = this._rootClock < Number.MAX_SAFE_INTEGER
         ? this._rootClock + 1
@@ -294,9 +329,9 @@ export class FabricDrawingSync {
     };
   }
 
-  _markExternalRootSuperseded(rootValue) {
+  _markExternalRootSuperseded(rootValue, present = true) {
     try {
-      this._rdm.markExternalDrawingsV3Superseded?.(rootValue);
+      this._rdm.markExternalDrawingsV3Superseded?.(rootValue, { present });
     } catch (error) {
       log.warn('패자 drawingsV3 지문 기록 실패', {
         error: error?.message || String(error)
@@ -309,11 +344,11 @@ export class FabricDrawingSync {
     if (!pending) return 1;
     const comparison = compareSyncVersions(candidate.version, pending.version);
     if (comparison < 0) {
-      this._markExternalRootSuperseded(candidate.rootValue);
+      this._markExternalRootSuperseded(candidate.rootValue, candidate.present);
       return -1;
     }
     if (comparison > 0) {
-      this._markExternalRootSuperseded(pending.rootValue);
+      this._markExternalRootSuperseded(pending.rootValue, pending.present);
       this._pendingExternalRoot = null;
     }
     return comparison;
@@ -327,7 +362,9 @@ export class FabricDrawingSync {
         (comparison === 0 && pending.fingerprint !== winnerFingerprint)) {
       return;
     }
-    if (comparison < 0) this._markExternalRootSuperseded(pending.rootValue);
+    if (comparison < 0) {
+      this._markExternalRootSuperseded(pending.rootValue, pending.present);
+    }
     this._pendingExternalRoot = null;
   }
 
@@ -336,15 +373,35 @@ export class FabricDrawingSync {
     if (!event?.type) return;
 
     if (event.type === 'FABRIC_DRAWING_ROOT_REQUEST') {
+      const requestVersion = normalizeSyncVersion(
+        event.syncVersion,
+        event.fingerprint
+      );
+      if (requestVersion) {
+        this._rootClock = Math.max(this._rootClock, requestVersion.clock);
+      }
       if (this._now() - this._sessionStartedAt > ROOT_REQUEST_STABILIZATION_MS) {
-        this._broadcastRoot({ force: true, peerConfirmed: true });
+        this._broadcastRoot({
+          force: true,
+          peerConfirmed: true,
+          causalFloor: requestVersion
+        });
       }
       return;
     }
 
     if (event.type === 'FABRIC_DRAWING_ROOT') {
+      if (event.present === false) {
+        this._enqueueApply(
+          undefined,
+          event.fingerprint,
+          event.syncVersion,
+          false
+        );
+        return;
+      }
       if (event.root !== undefined) {
-        this._enqueueApply(event.root, event.fingerprint, event.syncVersion);
+        this._enqueueApply(event.root, event.fingerprint, event.syncVersion, true);
         return;
       }
       const count = Math.trunc(Number(event.chunkCount));
@@ -422,11 +479,11 @@ export class FabricDrawingSync {
         return;
       }
       this._clearTransfer();
-      this._enqueueApply(rootValue, fingerprint, syncVersion);
+      this._enqueueApply(rootValue, fingerprint, syncVersion, true);
     }
   }
 
-  _enqueueApply(rootValue, fingerprint, syncVersionValue) {
+  _enqueueApply(rootValue, fingerprint, syncVersionValue, present = true) {
     const syncVersion = this._normalizeIncomingRootVersion(
       rootValue,
       fingerprint,
@@ -449,7 +506,7 @@ export class FabricDrawingSync {
         log.debug('원격 drawingsV3 폐기 (리뷰 파일 전환됨)');
         return;
       }
-      const candidate = { rootValue, fingerprint, version: syncVersion };
+      const candidate = { rootValue, present, fingerprint, version: syncVersion };
       if (this._compareIncomingAgainstPending(candidate) < 0) {
         log.debug('원격 drawingsV3 폐기 (더 최신인 대기 루트 존재)');
         return;
@@ -469,11 +526,11 @@ export class FabricDrawingSync {
         return;
       }
       if (comparison <= 0) {
-        this._markExternalRootSuperseded(rootValue);
+        this._markExternalRootSuperseded(rootValue, present);
         log.debug('원격 drawingsV3 폐기 (결정적 버전 패자)');
         return;
       }
-      const applied = await this._rdm.applyExternalDrawingsV3?.(rootValue);
+      const applied = await this._rdm.applyExternalDrawingsV3?.(rootValue, { present });
       if (!this._started || sessionGeneration !== this._sessionGeneration ||
           (this._rdm.currentBframePath || null) !== expectedBframePath) {
         return;
@@ -488,7 +545,7 @@ export class FabricDrawingSync {
         ) === 0) {
           this._pendingExternalRoot = null;
         }
-        this._markExternalRootSuperseded(rootValue);
+        this._markExternalRootSuperseded(rootValue, present);
         log.debug('원격 drawingsV3 반영 뒤 폐기 (현재 루트 불일치)');
       } else if (applied) {
         // 수신 상태를 그대로 재브로드캐스트하지 않도록 지문을 기록한다
@@ -500,7 +557,7 @@ export class FabricDrawingSync {
         );
         log.info('원격 drawingsV3 반영됨');
       } else if (postApplyComparison <= 0) {
-        this._markExternalRootSuperseded(rootValue);
+        this._markExternalRootSuperseded(rootValue, present);
         this._discardPendingExternalRootAtOrBelow(
           postApply.version,
           postApply.fingerprint

--- a/renderer/scripts/modules/keyboard-shortcut-targets.js
+++ b/renderer/scripts/modules/keyboard-shortcut-targets.js
@@ -55,6 +55,7 @@ export function isTextEntryShortcutTarget(target) {
 
 export function getEffectiveKeyboardShortcutTarget(event, ownerDocument = globalThis.document) {
   const target = event?.target || null;
+  if (target && target === ownerDocument) return target;
   const tagName = getTagName(target);
   if (target && tagName !== 'BODY' && tagName !== 'HTML' && tagName !== '') {
     return target;

--- a/renderer/scripts/modules/mpv-overlay-keyboard-relay.js
+++ b/renderer/scripts/modules/mpv-overlay-keyboard-relay.js
@@ -64,6 +64,14 @@ function normalizeKeyboardInput(value) {
   }
 }
 
+function isOverlayHistoryShortcut(input) {
+  if (input.type !== 'keyDown' || input.altKey === true) return false;
+  const exactlyOnePrimaryModifier = input.ctrlKey !== input.metaKey;
+  if (!exactlyOnePrimaryModifier) return false;
+  if (input.code === 'KeyZ') return true;
+  return input.code === 'KeyY' && input.shiftKey !== true;
+}
+
 export function dispatchMpvOverlayKeyboardInput(
   value,
   {
@@ -94,7 +102,8 @@ export function dispatchMpvOverlayKeyboardInput(
         composed: false
       }
     );
-    const dispatchTarget = typeof ownerDocument.activeElement?.dispatchEvent === 'function'
+    const dispatchTarget = !isOverlayHistoryShortcut(input) &&
+        typeof ownerDocument.activeElement?.dispatchEvent === 'function'
       ? ownerDocument.activeElement
       : ownerDocument;
     dispatchTarget.dispatchEvent(event);

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -1912,9 +1912,18 @@ export class ReviewDataManager extends EventTarget {
 
   _recordDrawingsV3DiskObservation(fingerprint) {
     if (typeof fingerprint !== 'string') return;
+    const previousObservedFingerprint = this._drawingsV3LastObservedDiskFingerprint;
     this._drawingsV3LastObservedDiskFingerprint = fingerprint;
     // 현재 실제 파일 지문은 cap 밖의 scalar가 보호하므로 중복 슬롯을 비운다.
     this._drawingsV3ExternalStaleFingerprints.delete(fingerprint);
+    if (typeof previousObservedFingerprint === 'string' &&
+        previousObservedFingerprint !== fingerprint &&
+        previousObservedFingerprint !== this._drawingsV3DiskState?.fingerprint) {
+      // scalar 보호가 새 실제 파일 지문으로 이동하면 직전 관측 지문을 capped
+      // history의 최신 항목으로 승계해, 이후 Drive rollback에도 재설치되지 않게 한다.
+      this._drawingsV3ExternalStaleFingerprints.delete(previousObservedFingerprint);
+      this._rememberDrawingsV3StaleFingerprint(previousObservedFingerprint);
+    }
   }
 
   _recordDrawingsV3DiskState(data) {
@@ -2094,9 +2103,12 @@ export class ReviewDataManager extends EventTarget {
   }
 
   /** 결정적 협업 버전 비교에서 패한 루트가 파일 채널로 되돌아오지 않게 기록한다. */
-  markExternalDrawingsV3Superseded(rootValue) {
-    if (rootValue === undefined) return false;
-    const state = captureDrawingsV3DiskState({ drawingsV3: rootValue });
+  markExternalDrawingsV3Superseded(rootValue, options = {}) {
+    const present = options.present !== false;
+    if (present && rootValue === undefined) return false;
+    const state = captureDrawingsV3DiskState(
+      present ? { drawingsV3: rootValue } : {}
+    );
     if (state.fingerprint === this._drawingsV3DiskState?.fingerprint) return false;
     this._rememberDrawingsV3StaleFingerprint(state.fingerprint);
     return true;
@@ -2110,12 +2122,17 @@ export class ReviewDataManager extends EventTarget {
    * 교체되는 직전 지문의 스테일 기록은 (a-0-2)의 설치 지점 마킹이 담당하므로
    * 여기서는 반영만 위임한다.
    */
-  async applyExternalDrawingsV3(rootValue) {
-    if (rootValue === undefined) return false;
+  async applyExternalDrawingsV3(rootValue, options = {}) {
+    const present = options.present !== false;
+    if (present && rootValue === undefined) return false;
     try {
-      const externalState = captureDrawingsV3DiskState({ drawingsV3: rootValue });
+      const externalData = present ? { drawingsV3: rootValue } : {};
+      const externalState = captureDrawingsV3DiskState(externalData);
+      // 이 explicit Broadcast보다 먼저 시작한 disk snapshot은 causal winner를
+      // 뒤늦게 덮을 수 없도록 reconcile 진입 전에 reload 세대를 무효화한다.
+      this._drawingsV3DiskReloadRequestEpoch += 1;
       return (await this._reconcileDrawingsV3DiskState(
-        { drawingsV3: rootValue },
+        externalData,
         undefined,
         undefined,
         {

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -1894,7 +1894,12 @@ export class ReviewDataManager extends EventTarget {
         previous.fingerprint === nextFingerprint) {
       return;
     }
-    this._drawingsV3ExternalStaleFingerprints.add(previous.fingerprint);
+    this._rememberDrawingsV3StaleFingerprint(previous.fingerprint);
+  }
+
+  _rememberDrawingsV3StaleFingerprint(fingerprint) {
+    if (typeof fingerprint !== 'string') return;
+    this._drawingsV3ExternalStaleFingerprints.add(fingerprint);
     while (this._drawingsV3ExternalStaleFingerprints.size > 8) {
       const oldest =
         this._drawingsV3ExternalStaleFingerprints.values().next().value;
@@ -1981,16 +1986,25 @@ export class ReviewDataManager extends EventTarget {
   async _reconcileDrawingsV3DiskState(
     data,
     owner = this._captureReviewContextOwner(),
-    ownsOwner = candidate => this._ownsReviewContext(candidate)
+    ownsOwner = candidate => this._ownsReviewContext(candidate),
+    options = {}
   ) {
+    const allowSupersededFingerprint =
+      typeof options.allowSupersededFingerprint === 'string'
+        ? options.allowSupersededFingerprint
+        : null;
     const latestState = captureDrawingsV3DiskState(data);
     if (this._drawingsV3DiskState.known &&
         latestState.fingerprint === this._drawingsV3DiskState.fingerprint) {
+      if (latestState.fingerprint === allowSupersededFingerprint) {
+        this._drawingsV3ExternalStaleFingerprints.delete(latestState.fingerprint);
+      }
       return true;
     }
     // Broadcast로 이미 더 새로운 drawingsV3를 적용했고 디스크(Drive 복제 지연)가
     // 아직 따라오지 못한 상태면, 구버전 디스크 상태를 재설치하지 않는다
-    if (this._drawingsV3ExternalStaleFingerprints.has(latestState.fingerprint)) {
+    if (this._drawingsV3ExternalStaleFingerprints.has(latestState.fingerprint) &&
+        latestState.fingerprint !== allowSupersededFingerprint) {
       this._adoptDrawingsV3OpaqueRootState(this._drawingsV3DiskState);
       return true;
     }
@@ -2001,6 +2015,9 @@ export class ReviewDataManager extends EventTarget {
       }
       if (this._drawingsV3DiskState.known &&
           latestState.fingerprint === this._drawingsV3DiskState.fingerprint) {
+        if (latestState.fingerprint === allowSupersededFingerprint) {
+          this._drawingsV3ExternalStaleFingerprints.delete(latestState.fingerprint);
+        }
         return true;
       }
       if (this._fabricDrawingHasLocalChanges) {
@@ -2023,6 +2040,9 @@ export class ReviewDataManager extends EventTarget {
       this._drawingsV3DiskState = latestState;
       this._hasCompletedReviewLoad = true;
       this._adoptDrawingsV3OpaqueRootState(latestState);
+      if (latestState.fingerprint === allowSupersededFingerprint) {
+        this._drawingsV3ExternalStaleFingerprints.delete(latestState.fingerprint);
+      }
       return true;
     }, {
       reason: 'external-drawings-v3-changed',
@@ -2046,16 +2066,33 @@ export class ReviewDataManager extends EventTarget {
     };
   }
 
+  /** 결정적 협업 버전 비교에서 패한 루트가 파일 채널로 되돌아오지 않게 기록한다. */
+  markExternalDrawingsV3Superseded(rootValue) {
+    if (rootValue === undefined) return false;
+    const state = captureDrawingsV3DiskState({ drawingsV3: rootValue });
+    if (state.fingerprint === this._drawingsV3DiskState?.fingerprint) return false;
+    this._rememberDrawingsV3StaleFingerprint(state.fingerprint);
+    return true;
+  }
+
   /**
    * 원격(Broadcast)에서 받은 drawingsV3 루트를 디스크 반영 파이프라인으로 적용한다.
    * 로컬 미저장 fabric 변경이 있으면 기존 fail-closed 가드가 적용을 거른다.
+   * 결정적 버전 비교를 통과한 명시 Broadcast만 같은 지문의 file-stale guard를
+   * 한 번 우회하며, 실제 설치 성공 뒤에만 해당 stale 표시를 해제한다.
    * 교체되는 직전 지문의 스테일 기록은 (a-0-2)의 설치 지점 마킹이 담당하므로
    * 여기서는 반영만 위임한다.
    */
   async applyExternalDrawingsV3(rootValue) {
     if (rootValue === undefined) return false;
     try {
-      return (await this._reconcileDrawingsV3DiskState({ drawingsV3: rootValue })) === true;
+      const externalState = captureDrawingsV3DiskState({ drawingsV3: rootValue });
+      return (await this._reconcileDrawingsV3DiskState(
+        { drawingsV3: rootValue },
+        undefined,
+        undefined,
+        { allowSupersededFingerprint: externalState.fingerprint }
+      )) === true;
     } catch (error) {
       log.warn('원격 drawingsV3 반영 실패', { error: error.message });
       return false;

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -855,6 +855,7 @@ export class ReviewDataManager extends EventTarget {
     this._fabricDrawingProviderUnsubscribe = null;
     this._drawingsV3DiskState = createUnknownDrawingsV3DiskState();
     this._drawingsV3ExternalStaleFingerprints = new Set();
+    this._drawingsV3DiskReloadRequestEpoch = 0;
     this._reviewMergeBase = createEmptyReviewMergeBase();
     this._hasCompletedReviewLoad = false;
     this._isConnected = false;
@@ -2070,16 +2071,24 @@ export class ReviewDataManager extends EventTarget {
    * 새 리뷰에 설치된다 (load()의 캡처→재검증 관용구(1135-1139)와 동일 패턴).
    */
   async reloadDrawingsV3FromDisk() {
+    const reloadRequestEpoch = ++this._drawingsV3DiskReloadRequestEpoch;
     const owner = this._captureReviewContextOwner();
+    const ownsReload = candidate =>
+      reloadRequestEpoch === this._drawingsV3DiskReloadRequestEpoch &&
+      this._ownsReviewContext(candidate);
     if (!owner.bframePath) return false;
     try {
       const snapshot = await this._readReviewSnapshot(owner.bframePath);
-      if (!this._ownsReviewContext(owner)) return false;
+      if (!ownsReload(owner)) return false;
       const remoteData = snapshot?.data;
       if (!remoteData || typeof remoteData !== 'object' || Array.isArray(remoteData)) {
         return false;
       }
-      return (await this._reconcileDrawingsV3DiskState(remoteData, owner)) === true;
+      return (await this._reconcileDrawingsV3DiskState(
+        remoteData,
+        owner,
+        ownsReload
+      )) === true;
     } catch (error) {
       log.warn('drawingsV3 파일 동기화 실패', { error: error.message });
       return false;

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -1908,6 +1908,16 @@ export class ReviewDataManager extends EventTarget {
     this._hasCompletedReviewLoad = true;
   }
 
+  _adoptDrawingsV3OpaqueRootState(state) {
+    const opaqueRootFields = { ...this._opaqueRootFields };
+    if (state.present) {
+      opaqueRootFields.drawingsV3 = cloneJson(state.value);
+    } else {
+      delete opaqueRootFields.drawingsV3;
+    }
+    this._opaqueRootFields = opaqueRootFields;
+  }
+
   async _readReviewSnapshot(filePath) {
     if (typeof window.electronAPI.loadReviewSnapshot === 'function') {
       const snapshot = await window.electronAPI.loadReviewSnapshot(filePath);
@@ -1980,6 +1990,7 @@ export class ReviewDataManager extends EventTarget {
     // Broadcast로 이미 더 새로운 drawingsV3를 적용했고 디스크(Drive 복제 지연)가
     // 아직 따라오지 못한 상태면, 구버전 디스크 상태를 재설치하지 않는다
     if (this._drawingsV3ExternalStaleFingerprints.has(latestState.fingerprint)) {
+      this._adoptDrawingsV3OpaqueRootState(this._drawingsV3DiskState);
       return true;
     }
 
@@ -1996,10 +2007,7 @@ export class ReviewDataManager extends EventTarget {
         return false;
       }
 
-      this._markReplacedDrawingsV3Stale(latestState.fingerprint);
-      this._drawingsV3DiskState = latestState;
-      this._hasCompletedReviewLoad = true;
-      const installed = this._installRecordedDiskStateInProvider({
+      const installed = this._installFabricDrawingRootInProvider(latestState, {
         clearLocalChanges: true,
         failureReason: 'disk-reconcile-failed'
       });
@@ -2010,6 +2018,10 @@ export class ReviewDataManager extends EventTarget {
         this._writeBlockedReason = 'fabric-drawing-source-refresh-failed';
         return false;
       }
+      this._markReplacedDrawingsV3Stale(latestState.fingerprint);
+      this._drawingsV3DiskState = latestState;
+      this._hasCompletedReviewLoad = true;
+      this._adoptDrawingsV3OpaqueRootState(latestState);
       return true;
     }, {
       reason: 'external-drawings-v3-changed',

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -855,6 +855,7 @@ export class ReviewDataManager extends EventTarget {
     this._fabricDrawingProviderUnsubscribe = null;
     this._drawingsV3DiskState = createUnknownDrawingsV3DiskState();
     this._drawingsV3ExternalStaleFingerprints = new Set();
+    this._drawingsV3LastObservedDiskFingerprint = null;
     this._drawingsV3DiskReloadRequestEpoch = 0;
     this._reviewMergeBase = createEmptyReviewMergeBase();
     this._hasCompletedReviewLoad = false;
@@ -1108,6 +1109,7 @@ export class ReviewDataManager extends EventTarget {
     this._invalidateFabricDrawingPersistenceProvider('video-load-started');
     this._drawingsV3DiskState = createUnknownDrawingsV3DiskState();
     this._drawingsV3ExternalStaleFingerprints.clear();
+    this._drawingsV3LastObservedDiskFingerprint = null;
     this._reviewMergeBase = createEmptyReviewMergeBase();
     this._hasCompletedReviewLoad = false;
     this.currentVideoPath = videoPath;
@@ -1556,6 +1558,7 @@ export class ReviewDataManager extends EventTarget {
       this._hasCompletedReviewLoad = false;
       this._drawingsV3DiskState = createUnknownDrawingsV3DiskState();
       this._drawingsV3ExternalStaleFingerprints.clear();
+      this._drawingsV3LastObservedDiskFingerprint = null;
       this._reviewMergeBase = createEmptyReviewMergeBase();
       this._invalidateFabricDrawingPersistenceProvider('review-load-failed');
       this.isLoading = false;
@@ -1907,8 +1910,16 @@ export class ReviewDataManager extends EventTarget {
     }
   }
 
+  _recordDrawingsV3DiskObservation(fingerprint) {
+    if (typeof fingerprint !== 'string') return;
+    this._drawingsV3LastObservedDiskFingerprint = fingerprint;
+    // 현재 실제 파일 지문은 cap 밖의 scalar가 보호하므로 중복 슬롯을 비운다.
+    this._drawingsV3ExternalStaleFingerprints.delete(fingerprint);
+  }
+
   _recordDrawingsV3DiskState(data) {
     const nextState = captureDrawingsV3DiskState(data);
+    this._recordDrawingsV3DiskObservation(nextState.fingerprint);
     this._markReplacedDrawingsV3Stale(nextState.fingerprint);
     this._drawingsV3DiskState = nextState;
     this._hasCompletedReviewLoad = true;
@@ -1993,9 +2004,13 @@ export class ReviewDataManager extends EventTarget {
       typeof options.allowSupersededFingerprint === 'string'
         ? options.allowSupersededFingerprint
         : null;
+    const confirmDiskObservation = options.confirmDiskObservation !== false;
     const latestState = captureDrawingsV3DiskState(data);
     if (this._drawingsV3DiskState.known &&
         latestState.fingerprint === this._drawingsV3DiskState.fingerprint) {
+      if (confirmDiskObservation) {
+        this._recordDrawingsV3DiskObservation(latestState.fingerprint);
+      }
       if (latestState.fingerprint === allowSupersededFingerprint) {
         this._drawingsV3ExternalStaleFingerprints.delete(latestState.fingerprint);
       }
@@ -2003,8 +2018,14 @@ export class ReviewDataManager extends EventTarget {
     }
     // Broadcast로 이미 더 새로운 drawingsV3를 적용했고 디스크(Drive 복제 지연)가
     // 아직 따라오지 못한 상태면, 구버전 디스크 상태를 재설치하지 않는다
-    if (this._drawingsV3ExternalStaleFingerprints.has(latestState.fingerprint) &&
+    const matchesObservedDisk = confirmDiskObservation &&
+      latestState.fingerprint === this._drawingsV3LastObservedDiskFingerprint;
+    if ((matchesObservedDisk ||
+         this._drawingsV3ExternalStaleFingerprints.has(latestState.fingerprint)) &&
         latestState.fingerprint !== allowSupersededFingerprint) {
+      if (confirmDiskObservation) {
+        this._recordDrawingsV3DiskObservation(latestState.fingerprint);
+      }
       this._adoptDrawingsV3OpaqueRootState(this._drawingsV3DiskState);
       return true;
     }
@@ -2015,6 +2036,9 @@ export class ReviewDataManager extends EventTarget {
       }
       if (this._drawingsV3DiskState.known &&
           latestState.fingerprint === this._drawingsV3DiskState.fingerprint) {
+        if (confirmDiskObservation) {
+          this._recordDrawingsV3DiskObservation(latestState.fingerprint);
+        }
         if (latestState.fingerprint === allowSupersededFingerprint) {
           this._drawingsV3ExternalStaleFingerprints.delete(latestState.fingerprint);
         }
@@ -2035,6 +2059,9 @@ export class ReviewDataManager extends EventTarget {
       if (!accepted) {
         this._writeBlockedReason = 'fabric-drawing-source-refresh-failed';
         return false;
+      }
+      if (confirmDiskObservation) {
+        this._recordDrawingsV3DiskObservation(latestState.fingerprint);
       }
       this._markReplacedDrawingsV3Stale(latestState.fingerprint);
       this._drawingsV3DiskState = latestState;
@@ -2091,7 +2118,10 @@ export class ReviewDataManager extends EventTarget {
         { drawingsV3: rootValue },
         undefined,
         undefined,
-        { allowSupersededFingerprint: externalState.fingerprint }
+        {
+          allowSupersededFingerprint: externalState.fingerprint,
+          confirmDiskObservation: false
+        }
       )) === true;
     } catch (error) {
       log.warn('원격 drawingsV3 반영 실패', { error: error.message });

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -128,6 +128,21 @@ function canonicalizeJson(value) {
   return result;
 }
 
+// stale history는 활성 리뷰 컨텍스트 동안 과거 루트를 잊으면 안 된다. 전체
+// canonical JSON 대신 Broadcast wire와 같은 고정 길이 이중 해시+길이를 보관해,
+// 지연 복제 안전성을 유지하면서 루트 크기에 비례한 메모리 누적을 피한다.
+function compactDrawingsV3Fingerprint(fingerprint) {
+  if (typeof fingerprint !== 'string') return null;
+  let h1 = 0x811c9dc5;
+  let h2 = 0xcbf29ce4;
+  for (let index = 0; index < fingerprint.length; index++) {
+    const code = fingerprint.charCodeAt(index);
+    h1 = Math.imul(h1 ^ code, 0x01000193) >>> 0;
+    h2 = Math.imul(h2 ^ code, 0x01000197) >>> 0;
+  }
+  return `${h1.toString(36)}-${h2.toString(36)}-${fingerprint.length.toString(36)}`;
+}
+
 function captureDrawingsV3DiskState(data) {
   const present = Boolean(
     data &&
@@ -1901,27 +1916,25 @@ export class ReviewDataManager extends EventTarget {
   }
 
   _rememberDrawingsV3StaleFingerprint(fingerprint) {
-    if (typeof fingerprint !== 'string') return;
-    this._drawingsV3ExternalStaleFingerprints.add(fingerprint);
-    while (this._drawingsV3ExternalStaleFingerprints.size > 8) {
-      const oldest =
-        this._drawingsV3ExternalStaleFingerprints.values().next().value;
-      this._drawingsV3ExternalStaleFingerprints.delete(oldest);
-    }
+    const identity = compactDrawingsV3Fingerprint(fingerprint);
+    if (identity === null) return;
+    this._drawingsV3ExternalStaleFingerprints.add(identity);
+  }
+
+  _isDrawingsV3FingerprintStale(fingerprint) {
+    const identity = compactDrawingsV3Fingerprint(fingerprint);
+    return identity !== null && this._drawingsV3ExternalStaleFingerprints.has(identity);
   }
 
   _recordDrawingsV3DiskObservation(fingerprint) {
     if (typeof fingerprint !== 'string') return;
     const previousObservedFingerprint = this._drawingsV3LastObservedDiskFingerprint;
     this._drawingsV3LastObservedDiskFingerprint = fingerprint;
-    // 현재 실제 파일 지문은 cap 밖의 scalar가 보호하므로 중복 슬롯을 비운다.
-    this._drawingsV3ExternalStaleFingerprints.delete(fingerprint);
     if (typeof previousObservedFingerprint === 'string' &&
         previousObservedFingerprint !== fingerprint &&
         previousObservedFingerprint !== this._drawingsV3DiskState?.fingerprint) {
-      // scalar 보호가 새 실제 파일 지문으로 이동하면 직전 관측 지문을 capped
-      // history의 최신 항목으로 승계해, 이후 Drive rollback에도 재설치되지 않게 한다.
-      this._drawingsV3ExternalStaleFingerprints.delete(previousObservedFingerprint);
+      // scalar 보호가 새 실제 파일 지문으로 이동하면 직전 관측 지문도 compact
+      // history에 남겨, 이후 Drive rollback에도 재설치되지 않게 한다.
       this._rememberDrawingsV3StaleFingerprint(previousObservedFingerprint);
     }
   }
@@ -2020,9 +2033,6 @@ export class ReviewDataManager extends EventTarget {
       if (confirmDiskObservation) {
         this._recordDrawingsV3DiskObservation(latestState.fingerprint);
       }
-      if (latestState.fingerprint === allowSupersededFingerprint) {
-        this._drawingsV3ExternalStaleFingerprints.delete(latestState.fingerprint);
-      }
       return true;
     }
     // Broadcast로 이미 더 새로운 drawingsV3를 적용했고 디스크(Drive 복제 지연)가
@@ -2030,7 +2040,7 @@ export class ReviewDataManager extends EventTarget {
     const matchesObservedDisk = confirmDiskObservation &&
       latestState.fingerprint === this._drawingsV3LastObservedDiskFingerprint;
     if ((matchesObservedDisk ||
-         this._drawingsV3ExternalStaleFingerprints.has(latestState.fingerprint)) &&
+         this._isDrawingsV3FingerprintStale(latestState.fingerprint)) &&
         latestState.fingerprint !== allowSupersededFingerprint) {
       if (confirmDiskObservation) {
         this._recordDrawingsV3DiskObservation(latestState.fingerprint);
@@ -2047,9 +2057,6 @@ export class ReviewDataManager extends EventTarget {
           latestState.fingerprint === this._drawingsV3DiskState.fingerprint) {
         if (confirmDiskObservation) {
           this._recordDrawingsV3DiskObservation(latestState.fingerprint);
-        }
-        if (latestState.fingerprint === allowSupersededFingerprint) {
-          this._drawingsV3ExternalStaleFingerprints.delete(latestState.fingerprint);
         }
         return true;
       }
@@ -2076,9 +2083,6 @@ export class ReviewDataManager extends EventTarget {
       this._drawingsV3DiskState = latestState;
       this._hasCompletedReviewLoad = true;
       this._adoptDrawingsV3OpaqueRootState(latestState);
-      if (latestState.fingerprint === allowSupersededFingerprint) {
-        this._drawingsV3ExternalStaleFingerprints.delete(latestState.fingerprint);
-      }
       return true;
     }, {
       reason: 'external-drawings-v3-changed',
@@ -2094,11 +2098,14 @@ export class ReviewDataManager extends EventTarget {
    */
   getDrawingsV3RootSnapshot() {
     const state = captureDrawingsV3DiskState(this._opaqueRootFields || {});
+    const isCurrentAuthoritativeRoot =
+      state.fingerprint === this._drawingsV3DiskState?.fingerprint;
     return {
       present: state.present,
       value: state.value,
       fingerprint: state.fingerprint,
-      stale: this._drawingsV3ExternalStaleFingerprints.has(state.fingerprint)
+      stale: !isCurrentAuthoritativeRoot &&
+        this._isDrawingsV3FingerprintStale(state.fingerprint)
     };
   }
 

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -2114,6 +2114,11 @@ export class ReviewDataManager extends EventTarget {
     return true;
   }
 
+  /** 수락한 외부 인과 버전보다 먼저 시작한 drawingsV3 disk reload를 무효화한다. */
+  invalidatePendingDrawingsV3DiskReloadsForExternalSync() {
+    this._drawingsV3DiskReloadRequestEpoch += 1;
+  }
+
   /**
    * 원격(Broadcast)에서 받은 drawingsV3 루트를 디스크 반영 파이프라인으로 적용한다.
    * 로컬 미저장 fabric 변경이 있으면 기존 fail-closed 가드가 적용을 거른다.
@@ -2130,7 +2135,7 @@ export class ReviewDataManager extends EventTarget {
       const externalState = captureDrawingsV3DiskState(externalData);
       // 이 explicit Broadcast보다 먼저 시작한 disk snapshot은 causal winner를
       // 뒤늦게 덮을 수 없도록 reconcile 진입 전에 reload 세대를 무효화한다.
-      this._drawingsV3DiskReloadRequestEpoch += 1;
+      this.invalidatePendingDrawingsV3DiskReloadsForExternalSync();
       return (await this._reconcileDrawingsV3DiskState(
         externalData,
         undefined,

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -854,6 +854,7 @@ export class ReviewDataManager extends EventTarget {
     this._fabricDrawingCollectedRevision = null;
     this._fabricDrawingProviderUnsubscribe = null;
     this._drawingsV3DiskState = createUnknownDrawingsV3DiskState();
+    this._drawingsV3ExternalStaleFingerprints = new Set();
     this._reviewMergeBase = createEmptyReviewMergeBase();
     this._hasCompletedReviewLoad = false;
     this._isConnected = false;
@@ -1105,6 +1106,7 @@ export class ReviewDataManager extends EventTarget {
     this._reviewFileVersionToken = null;
     this._invalidateFabricDrawingPersistenceProvider('video-load-started');
     this._drawingsV3DiskState = createUnknownDrawingsV3DiskState();
+    this._drawingsV3ExternalStaleFingerprints.clear();
     this._reviewMergeBase = createEmptyReviewMergeBase();
     this._hasCompletedReviewLoad = false;
     this.currentVideoPath = videoPath;
@@ -1552,6 +1554,7 @@ export class ReviewDataManager extends EventTarget {
       log.error('.bframe 로드 실패', error);
       this._hasCompletedReviewLoad = false;
       this._drawingsV3DiskState = createUnknownDrawingsV3DiskState();
+      this._drawingsV3ExternalStaleFingerprints.clear();
       this._reviewMergeBase = createEmptyReviewMergeBase();
       this._invalidateFabricDrawingPersistenceProvider('review-load-failed');
       this.isLoading = false;
@@ -1883,8 +1886,25 @@ export class ReviewDataManager extends EventTarget {
     }
   }
 
+  _markReplacedDrawingsV3Stale(nextFingerprint) {
+    const previous = this._drawingsV3DiskState;
+    if (!previous?.known ||
+        typeof previous.fingerprint !== 'string' ||
+        previous.fingerprint === nextFingerprint) {
+      return;
+    }
+    this._drawingsV3ExternalStaleFingerprints.add(previous.fingerprint);
+    while (this._drawingsV3ExternalStaleFingerprints.size > 8) {
+      const oldest =
+        this._drawingsV3ExternalStaleFingerprints.values().next().value;
+      this._drawingsV3ExternalStaleFingerprints.delete(oldest);
+    }
+  }
+
   _recordDrawingsV3DiskState(data) {
-    this._drawingsV3DiskState = captureDrawingsV3DiskState(data);
+    const nextState = captureDrawingsV3DiskState(data);
+    this._markReplacedDrawingsV3Stale(nextState.fingerprint);
+    this._drawingsV3DiskState = nextState;
     this._hasCompletedReviewLoad = true;
   }
 
@@ -1957,6 +1977,11 @@ export class ReviewDataManager extends EventTarget {
         latestState.fingerprint === this._drawingsV3DiskState.fingerprint) {
       return true;
     }
+    // Broadcast로 이미 더 새로운 drawingsV3를 적용했고 디스크(Drive 복제 지연)가
+    // 아직 따라오지 못한 상태면, 구버전 디스크 상태를 재설치하지 않는다
+    if (this._drawingsV3ExternalStaleFingerprints.has(latestState.fingerprint)) {
+      return true;
+    }
 
     return this._runFabricDrawingSourceRefresh(async () => {
       if (!ownsOwner(owner)) {
@@ -1971,6 +1996,7 @@ export class ReviewDataManager extends EventTarget {
         return false;
       }
 
+      this._markReplacedDrawingsV3Stale(latestState.fingerprint);
       this._drawingsV3DiskState = latestState;
       this._hasCompletedReviewLoad = true;
       const installed = this._installRecordedDiskStateInProvider({
@@ -1989,6 +2015,63 @@ export class ReviewDataManager extends EventTarget {
       reason: 'external-drawings-v3-changed',
       fingerprint: latestState.fingerprint
     }, () => ownsOwner(owner));
+  }
+
+  /**
+   * 현재 메모리의 drawingsV3 루트 스냅샷(지문 포함)을 반환한다.
+   * FabricDrawingSync가 저장 완료 시점의 브로드캐스트 payload로 사용한다.
+   * stale=true면 이 루트는 Broadcast 적용 이전의 구버전 디스크 상태이므로
+   * 브로드캐스트하면 안 된다.
+   */
+  getDrawingsV3RootSnapshot() {
+    const state = captureDrawingsV3DiskState(this._opaqueRootFields || {});
+    return {
+      present: state.present,
+      value: state.value,
+      fingerprint: state.fingerprint,
+      stale: this._drawingsV3ExternalStaleFingerprints.has(state.fingerprint)
+    };
+  }
+
+  /**
+   * 원격(Broadcast)에서 받은 drawingsV3 루트를 디스크 반영 파이프라인으로 적용한다.
+   * 로컬 미저장 fabric 변경이 있으면 기존 fail-closed 가드가 적용을 거른다.
+   * 교체되는 직전 지문의 스테일 기록은 (a-0-2)의 설치 지점 마킹이 담당하므로
+   * 여기서는 반영만 위임한다.
+   */
+  async applyExternalDrawingsV3(rootValue) {
+    if (rootValue === undefined) return false;
+    try {
+      return (await this._reconcileDrawingsV3DiskState({ drawingsV3: rootValue })) === true;
+    } catch (error) {
+      log.warn('원격 drawingsV3 반영 실패', { error: error.message });
+      return false;
+    }
+  }
+
+  /**
+   * .bframe 파일에서 drawingsV3만 다시 읽어 반영한다.
+   * Liveblocks 연결 중에도 파일 채널로 드로잉을 동기화하기 위한 선별 경로다.
+   * 읽기 await 중 영상이 전환될 수 있으므로 owner를 먼저 캡처해 await 후
+   * 재검증하고, reconcile에도 같은 owner를 명시 전달한다 — 그러지 않으면
+   * reconcile이 전환된 새 컨텍스트를 기본 캡처해 이전 파일의 drawingsV3가
+   * 새 리뷰에 설치된다 (load()의 캡처→재검증 관용구(1135-1139)와 동일 패턴).
+   */
+  async reloadDrawingsV3FromDisk() {
+    const owner = this._captureReviewContextOwner();
+    if (!owner.bframePath) return false;
+    try {
+      const snapshot = await this._readReviewSnapshot(owner.bframePath);
+      if (!this._ownsReviewContext(owner)) return false;
+      const remoteData = snapshot?.data;
+      if (!remoteData || typeof remoteData !== 'object' || Array.isArray(remoteData)) {
+        return false;
+      }
+      return (await this._reconcileDrawingsV3DiskState(remoteData, owner)) === true;
+    } catch (error) {
+      log.warn('drawingsV3 파일 동기화 실패', { error: error.message });
+      return false;
+    }
   }
 
   _captureRootEnvelope(data, options = {}) {

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -866,6 +866,10 @@ export class ReviewDataManager extends EventTarget {
     this._fabricDrawingPersistenceContext = {};
     this._fabricDrawingProviderLoadedForCurrentReview = false;
     this._fabricDrawingHasLocalChanges = false;
+    this._fabricDrawingBaselineConflict = false;
+    this._fabricDrawingAuthorityEpoch = 0;
+    this._fabricDrawingAuthorityChangeContextEpoch = null;
+    this._fabricDrawingAuthorityChangeInFlight = 0;
     this._fabricDrawingCollectedRevision = null;
     this._fabricDrawingProviderUnsubscribe = null;
     this._drawingsV3DiskState = createUnknownDrawingsV3DiskState();
@@ -1297,6 +1301,8 @@ export class ReviewDataManager extends EventTarget {
           });
         }
         this._assertSaveOwner(saveOwner);
+        this._assertRootEnvelopeWritable();
+        const attemptFabricDrawingAuthorityEpoch = this._fabricDrawingAuthorityEpoch;
         const localData = this._collectData();
         const attemptReviewMergeBase = captureReviewMergeBase(localData);
         const data = this._mergeBeforeSave(localData, latestRoot);
@@ -1385,6 +1391,37 @@ export class ReviewDataManager extends EventTarget {
         }
         this._hasPersistedFile = true;
         this._reviewDocumentIdPersisted = true;
+        if (attemptFabricDrawingAuthorityEpoch !== this._fabricDrawingAuthorityEpoch) {
+          // IPC write는 이미 끝났지만, collect 이후 더 최신 Fabric 권위가 생겼다.
+          // 방금 쓴 payload를 current로 승인하거나 saved로 전파하지 않고 다시 저장한다.
+          const writtenState = captureDrawingsV3DiskState(data);
+          this._recordDrawingsV3DiskObservation(writtenState.fingerprint);
+          if (writtenState.fingerprint !== this._drawingsV3DiskState?.fingerprint) {
+            this._rememberDrawingsV3StaleFingerprint(writtenState.fingerprint);
+          }
+          this.isDirty = true;
+          log.warn('.bframe 저장 중 Fabric 권위 변경 감지, 최신 상태로 재시도', {
+            path: saveOwner.bframePath
+          });
+          if ((this._fabricDrawingBaselineConflict &&
+               !this._fabricDrawingHasLocalChanges) ||
+              this._hasFabricDrawingAuthorityChangeInFlight(saveOwner)) {
+            this._emit('saveDeferred', {
+              path: saveOwner.bframePath,
+              reason: 'fabric-drawing-authority-changed'
+            });
+            return false;
+          }
+          if (attempt < maxAttempts - 1) {
+            continue;
+          }
+          if (this.autoSaveEnabled) this._scheduleAutoSave();
+          this._emit('saveDeferred', {
+            path: saveOwner.bframePath,
+            reason: 'fabric-drawing-authority-changed'
+          });
+          return false;
+        }
         savedData = data;
         savedChangeRevision = attemptChangeRevision;
         savedFabricDrawingRevision = attemptFabricDrawingRevision;
@@ -1803,6 +1840,7 @@ export class ReviewDataManager extends EventTarget {
     this._writeBlockedVersion = null;
     this._writeBlockedVersionDetected = false;
     this._writeBlockedReason = null;
+    this._fabricDrawingBaselineConflict = false;
   }
 
   _resetFabricDrawingPersistenceProvider() {
@@ -2031,7 +2069,11 @@ export class ReviewDataManager extends EventTarget {
     if (this._drawingsV3DiskState.known &&
         latestState.fingerprint === this._drawingsV3DiskState.fingerprint) {
       if (confirmDiskObservation) {
+        const diskAdvanced =
+          typeof this._drawingsV3LastObservedDiskFingerprint === 'string' &&
+          this._drawingsV3LastObservedDiskFingerprint !== latestState.fingerprint;
         this._recordDrawingsV3DiskObservation(latestState.fingerprint);
+        if (diskAdvanced) this.clearDrawingsV3BaselineConflict();
       }
       return true;
     }
@@ -2056,7 +2098,11 @@ export class ReviewDataManager extends EventTarget {
       if (this._drawingsV3DiskState.known &&
           latestState.fingerprint === this._drawingsV3DiskState.fingerprint) {
         if (confirmDiskObservation) {
+          const diskAdvanced =
+            typeof this._drawingsV3LastObservedDiskFingerprint === 'string' &&
+            this._drawingsV3LastObservedDiskFingerprint !== latestState.fingerprint;
           this._recordDrawingsV3DiskObservation(latestState.fingerprint);
+          if (diskAdvanced) this.clearDrawingsV3BaselineConflict();
         }
         return true;
       }
@@ -2076,8 +2122,10 @@ export class ReviewDataManager extends EventTarget {
         this._writeBlockedReason = 'fabric-drawing-source-refresh-failed';
         return false;
       }
+      this._fabricDrawingAuthorityEpoch += 1;
       if (confirmDiskObservation) {
         this._recordDrawingsV3DiskObservation(latestState.fingerprint);
+        this.clearDrawingsV3BaselineConflict();
       }
       this._markReplacedDrawingsV3Stale(latestState.fingerprint);
       this._drawingsV3DiskState = latestState;
@@ -2100,10 +2148,22 @@ export class ReviewDataManager extends EventTarget {
     const state = captureDrawingsV3DiskState(this._opaqueRootFields || {});
     const isCurrentAuthoritativeRoot =
       state.fingerprint === this._drawingsV3DiskState?.fingerprint;
+    let compatible = null;
+    if (state.present) {
+      try {
+        compatible = this.fabricDrawingPersistenceProvider?.getStatus?.()
+          ?.compatible === true;
+      } catch (_error) {
+        compatible = false;
+      }
+    }
     return {
       present: state.present,
       value: state.value,
       fingerprint: state.fingerprint,
+      compatible,
+      localChanges: this._fabricDrawingHasLocalChanges === true,
+      baselineConflict: this._fabricDrawingBaselineConflict === true,
       stale: !isCurrentAuthoritativeRoot &&
         this._isDrawingsV3FingerprintStale(state.fingerprint)
     };
@@ -2121,9 +2181,79 @@ export class ReviewDataManager extends EventTarget {
     return true;
   }
 
+  /** 권위를 비교할 수 없는 협업 baseline 충돌 동안 comment-only 저장을 막는다. */
+  markDrawingsV3BaselineConflict() {
+    const changed = !this._fabricDrawingBaselineConflict;
+    this._fabricDrawingBaselineConflict = true;
+    if (changed) {
+      this._fabricDrawingAuthorityEpoch += 1;
+      this._cancelAutoSave();
+    }
+    return changed;
+  }
+
+  /** 인과 root 적용·실제 Fabric 저장·파일 확인으로 baseline 충돌이 해소됐다. */
+  clearDrawingsV3BaselineConflict() {
+    const changed = this._fabricDrawingBaselineConflict;
+    this._fabricDrawingBaselineConflict = false;
+    if (changed) this._resumeAutoSaveAfterBaselineConflict();
+    return changed;
+  }
+
+  _resumeAutoSaveAfterBaselineConflict() {
+    const scheduleIfNeeded = () => {
+      if (this.isLoading || !this._isConnected ||
+          this._fabricDrawingBaselineConflict ||
+          this._hasFabricDrawingAuthorityChangeInFlight() || !this.isDirty ||
+          !this.autoSaveEnabled || this._savePromise) {
+        return;
+      }
+      this._scheduleAutoSave();
+    };
+    if (!this._savePromise) {
+      scheduleIfNeeded();
+      return;
+    }
+    Promise.resolve(this._savePromise).finally(() => {
+      queueMicrotask(scheduleIfNeeded);
+    }).catch(() => {});
+  }
+
+  _beginFabricDrawingAuthorityChange(
+    owner = this._captureReviewContextOwner()
+  ) {
+    const contextEpoch = owner?.contextEpoch;
+    if (!Number.isSafeInteger(contextEpoch)) return null;
+    if (this._fabricDrawingAuthorityChangeContextEpoch !== contextEpoch) {
+      this._fabricDrawingAuthorityChangeContextEpoch = contextEpoch;
+      this._fabricDrawingAuthorityChangeInFlight = 0;
+    }
+    this._fabricDrawingAuthorityChangeInFlight += 1;
+    this._fabricDrawingAuthorityEpoch += 1;
+    return contextEpoch;
+  }
+
+  _endFabricDrawingAuthorityChange(contextEpoch) {
+    if (!Number.isSafeInteger(contextEpoch) ||
+        contextEpoch !== this._fabricDrawingAuthorityChangeContextEpoch) return;
+    this._fabricDrawingAuthorityChangeInFlight = Math.max(
+      0,
+      this._fabricDrawingAuthorityChangeInFlight - 1
+    );
+    this._resumeAutoSaveAfterBaselineConflict();
+  }
+
+  _hasFabricDrawingAuthorityChangeInFlight(
+    owner = this._captureSaveOwner()
+  ) {
+    return owner?.contextEpoch === this._fabricDrawingAuthorityChangeContextEpoch &&
+      this._fabricDrawingAuthorityChangeInFlight > 0;
+  }
+
   /** 수락한 외부 인과 버전보다 먼저 시작한 drawingsV3 disk reload를 무효화한다. */
   invalidatePendingDrawingsV3DiskReloadsForExternalSync() {
     this._drawingsV3DiskReloadRequestEpoch += 1;
+    this._fabricDrawingAuthorityEpoch += 1;
   }
 
   /**
@@ -2137,9 +2267,11 @@ export class ReviewDataManager extends EventTarget {
   async applyExternalDrawingsV3(rootValue, options = {}) {
     const present = options.present !== false;
     if (present && rootValue === undefined) return false;
+    let authorityChangeContextEpoch = null;
     try {
       const externalData = present ? { drawingsV3: rootValue } : {};
       const externalState = captureDrawingsV3DiskState(externalData);
+      authorityChangeContextEpoch = this._beginFabricDrawingAuthorityChange();
       // 이 explicit Broadcast보다 먼저 시작한 disk snapshot은 causal winner를
       // 뒤늦게 덮을 수 없도록 reconcile 진입 전에 reload 세대를 무효화한다.
       this.invalidatePendingDrawingsV3DiskReloadsForExternalSync();
@@ -2155,6 +2287,8 @@ export class ReviewDataManager extends EventTarget {
     } catch (error) {
       log.warn('원격 drawingsV3 반영 실패', { error: error.message });
       return false;
+    } finally {
+      this._endFabricDrawingAuthorityChange(authorityChangeContextEpoch);
     }
   }
 
@@ -2173,6 +2307,8 @@ export class ReviewDataManager extends EventTarget {
       reloadRequestEpoch === this._drawingsV3DiskReloadRequestEpoch &&
       this._ownsReviewContext(candidate);
     if (!owner.bframePath) return false;
+    const authorityChangeContextEpoch =
+      this._beginFabricDrawingAuthorityChange(owner);
     try {
       const snapshot = await this._readReviewSnapshot(owner.bframePath);
       if (!ownsReload(owner)) return false;
@@ -2188,6 +2324,8 @@ export class ReviewDataManager extends EventTarget {
     } catch (error) {
       log.warn('drawingsV3 파일 동기화 실패', { error: error.message });
       return false;
+    } finally {
+      this._endFabricDrawingAuthorityChange(authorityChangeContextEpoch);
     }
   }
 
@@ -2290,6 +2428,20 @@ export class ReviewDataManager extends EventTarget {
 
     if (this._writeBlockedReason === 'fabric-drawing-conflict') {
       throw new Error('다른 변경과 로컬 Fabric 드로잉이 충돌해 원본 보호를 위해 저장을 중단했습니다.');
+    }
+
+    if (this._fabricDrawingBaselineConflict &&
+        !this._fabricDrawingHasLocalChanges) {
+      throw new Error(
+        '협업 드로잉 기준이 서로 달라 원본 보호를 위해 저장을 중단했습니다.'
+      );
+    }
+
+    if (this._hasFabricDrawingAuthorityChangeInFlight() &&
+        !this._fabricDrawingHasLocalChanges) {
+      throw new Error(
+        '협업 드로잉 권위 상태가 바뀌는 중이라 원본 보호를 위해 저장을 중단했습니다.'
+      );
     }
 
     if (this._writeBlockedReason === 'fabric-drawing-source-refresh-stale') {
@@ -2422,6 +2574,7 @@ export class ReviewDataManager extends EventTarget {
     const currentRevision = this.fabricDrawingPersistenceProvider?.getRevision?.();
     if (currentRevision === savedRevision) {
       this._fabricDrawingHasLocalChanges = false;
+      this._fabricDrawingBaselineConflict = false;
     }
   }
 
@@ -2572,13 +2725,15 @@ export class ReviewDataManager extends EventTarget {
     if (eventType) {
       this._emit('dataChanged', { event: eventType, data: event });
     }
-    if (scheduleAutoSave && this.autoSaveEnabled && !this._savePromise) {
+    if (scheduleAutoSave && !this.isLoading &&
+        this.autoSaveEnabled && !this._savePromise) {
       this._scheduleAutoSave();
     }
   }
 
   _onFabricDrawingPersistenceChanged(change) {
     if (!this._fabricDrawingProviderLoadedForCurrentReview) return;
+    this._fabricDrawingAuthorityEpoch += 1;
     this._fabricDrawingHasLocalChanges = true;
     this._markDirty({
       eventType: 'fabricDrawingChanged',
@@ -2609,6 +2764,7 @@ export class ReviewDataManager extends EventTarget {
 
     this.autoSaveTimer = setTimeout(async () => {
       if (this.hasUnsavedChanges()) {
+        if (this.isLoading) return;
         log.info('자동 저장 실행');
         await this.save();
       }

--- a/scripts/tests/comment-input-focus-source.test.js
+++ b/scripts/tests/comment-input-focus-source.test.js
@@ -145,6 +145,23 @@ test('loading review comments refreshes the right sidebar comment list', () => {
   assert.match(loadedHandlerSource, /updateCommentList\(\);/);
 });
 
+test('comment notifications are cancelled when creation is undone while save is pending', () => {
+  const handlerStart = appSource.indexOf("  commentManager.addEventListener('markerAdded', async (e) => {");
+  const handlerEnd = appSource.indexOf('  // 마커 삭제됨', handlerStart);
+  assert.ok(handlerStart >= 0 && handlerEnd > handlerStart, 'markerAdded handler should be bounded');
+  const markerAddedHandler = appSource.slice(handlerStart, handlerEnd);
+
+  const saveIndex = markerAddedHandler.indexOf('const saved = await reviewDataManager.save();');
+  const currentMarkerIndex = markerAddedHandler.indexOf('const currentMarker = commentManager.getMarker(markerData.id);');
+  const deletedGuardIndex = markerAddedHandler.indexOf('if (!currentMarker || currentMarker.deleted)');
+  const notifyIndex = markerAddedHandler.indexOf('slackNotifier.notifyNewComment(currentMarker');
+
+  assert.ok(saveIndex >= 0, 'new comments should be saved before Slack notification');
+  assert.ok(currentMarkerIndex > saveIndex, 'the marker must be re-read after the pending save');
+  assert.ok(deletedGuardIndex > currentMarkerIndex, 'deleted comments must stop notification delivery');
+  assert.ok(notifyIndex > deletedGuardIndex, 'only the still-active marker may be notified');
+});
+
 test('right sidebar reply editors grow with long replies', () => {
   assert.match(appSource, /function resizeReplyEditorToContent\(editor\) \{/);
   assert.match(appSource, /replyInput\?\.addEventListener\('input', \(\) => resizeReplyEditorToContent\(replyInput\)\);/);

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -350,3 +350,8 @@ test('피드백 35 v2: 획 선택 벡터 커밋·다중 선택·hover가 배선�
   assert.match(drawingManagerSource, /strokesInRect\(readRecords, rect\)/);
   assert.match(drawingStrokeRecordsSource, /export function strokesInRect\(strokes, rect\)/);
 });
+
+test('하이라이트 undo/redo 콜백은 getter 전용 colorInfo에 대입하지 않는다', () => {
+  assert.doesNotMatch(appSource, /restored\.colorInfo\s*=/);
+  assert.match(appSource, /restored\.colorKey = highlight\.colorKey;/);
+});

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -356,15 +356,21 @@ test('하이라이트 undo/redo 콜백은 getter 전용 colorInfo에 대입하�
   assert.match(appSource, /restored\.colorKey = highlight\.colorKey;/);
 });
 
-test('fabric 히스토리가 비면 전역 undo로 폴백한다', () => {
+test('fabric 히스토리 폴백은 renderer 단일 경로에서 처리한다', () => {
   const controllerSource = fs.readFileSync(
     path.join(rootDir, 'renderer/scripts/modules/fabric-drawing-pilot-controller.js'), 'utf8'
   );
   assert.match(controllerSource, /onHistoryFallback\(historyAction\)/);
   assert.match(controllerSource, /reason === 'history-empty'/);
+  assert.match(controllerSource, /getHistoryRevision/);
+  assert.match(controllerSource, /historyRevision === readHistoryRevision\(\)/);
+  assert.match(appSource, /let globalHistoryRevision = 0;/);
+  assert.match(appSource, /getHistoryRevision: \(\) => globalHistoryRevision/);
+  assert.match(appSource, /advanceGlobalHistoryRevision\(\);/);
   const hostSource = fs.readFileSync(
     path.join(rootDir, 'main/mpv-overlay-host.js'), 'utf8'
   );
-  assert.match(hostSource, /reason !== 'history-empty'/);
-  assert.match(hostSource, /typeof result\?\.reason === 'string'/);
+  assert.match(hostSource, /const historyAction = overlayHistoryActionFromInput\(input\);/);
+  assert.match(hostSource, /mainWindow\.webContents\.send\(FORWARDED_KEYBOARD_CHANNEL, forwardedInput\);/);
+  assert.doesNotMatch(hostSource, /this\.applyDrawingAction\(request\)\.then/);
 });

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -355,3 +355,16 @@ test('하이라이트 undo/redo 콜백은 getter 전용 colorInfo에 대입하�
   assert.doesNotMatch(appSource, /restored\.colorInfo\s*=/);
   assert.match(appSource, /restored\.colorKey = highlight\.colorKey;/);
 });
+
+test('fabric 히스토리가 비면 전역 undo로 폴백한다', () => {
+  const controllerSource = fs.readFileSync(
+    path.join(rootDir, 'renderer/scripts/modules/fabric-drawing-pilot-controller.js'), 'utf8'
+  );
+  assert.match(controllerSource, /onHistoryFallback\(historyAction\)/);
+  assert.match(controllerSource, /reason === 'history-empty'/);
+  const hostSource = fs.readFileSync(
+    path.join(rootDir, 'main/mpv-overlay-host.js'), 'utf8'
+  );
+  assert.match(hostSource, /reason !== 'history-empty'/);
+  assert.match(hostSource, /typeof result\?\.reason === 'string'/);
+});

--- a/scripts/tests/drawing-runtime-source.test.js
+++ b/scripts/tests/drawing-runtime-source.test.js
@@ -356,7 +356,7 @@ test('하이라이트 undo/redo 콜백은 getter 전용 colorInfo에 대입하�
   assert.match(appSource, /restored\.colorKey = highlight\.colorKey;/);
 });
 
-test('fabric 히스토리 폴백은 renderer 단일 경로에서 처리한다', () => {
+test('fabric 히스토리 폴백은 renderer 단일 경로에서 처리한다', async () => {
   const controllerSource = fs.readFileSync(
     path.join(rootDir, 'renderer/scripts/modules/fabric-drawing-pilot-controller.js'), 'utf8'
   );
@@ -367,6 +367,145 @@ test('fabric 히스토리 폴백은 renderer 단일 경로에서 처리한다', 
   assert.match(appSource, /let globalHistoryRevision = 0;/);
   assert.match(appSource, /getHistoryRevision: \(\) => globalHistoryRevision/);
   assert.match(appSource, /advanceGlobalHistoryRevision\(\);/);
+  assert.match(appSource, /async function globalUndo\(\{ fromFabricFallback = false \} = \{\}\)/);
+  assert.match(appSource, /async function globalRedo\(\{ fromFabricFallback = false \} = \{\}\)/);
+  assert.match(appSource, /if \(!fromFabricFallback\) advanceGlobalHistoryRevision\(\);/);
+  assert.match(appSource, /return globalUndo\(\{ fromFabricFallback: true \}\)\.then/);
+  assert.match(appSource, /return globalRedo\(\{ fromFabricFallback: true \}\)\.then/);
+  assert.equal(
+    (appSource.match(/const historyMutationRevision = globalHistoryRevision;/g) || []).length,
+    2
+  );
+  assert.equal(
+    (appSource.match(/historyMutationRevision !== globalHistoryRevision/g) || []).length,
+    2
+  );
+  assert.equal(
+    (appSource.match(/historyMutationRevision === globalHistoryRevision/g) || []).length,
+    2
+  );
+
+  const historyBlock = appSource.match(
+    /  \/\/ ====== 글로벌 Undo\/Redo 시스템 ======\n([\s\S]*?)\n  \/\/ 마커 컨테이너 생성/
+  )?.[1];
+  assert.ok(historyBlock, 'global history block should be extractable for behavior checks');
+  const createHistoryHarness = new Function(
+    'drawingManager',
+    'log',
+    'showToast',
+    `${historyBlock}\nreturn {
+      pushUndo,
+      globalUndo,
+      globalRedo,
+      getUndoStack: () => [...undoStack],
+      getRedoStack: () => [...redoStack],
+      getHistoryRevision: () => globalHistoryRevision,
+      resetForFile: () => {
+        undoStack.length = 0;
+        redoStack.length = 0;
+        advanceGlobalHistoryRevision();
+      }
+    };`
+  );
+  const newHarness = (toasts = []) => createHistoryHarness(
+    { _createSnapshot() {}, _restoreSnapshot() {}, _emit() {} },
+    { error() {} },
+    (message, type) => toasts.push({ message, type })
+  );
+  const makeDeferred = () => {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  };
+
+  const normal = newHarness();
+  const normalAction = {
+    type: 'TEST',
+    undo: async () => {},
+    redo: async () => {}
+  };
+  normal.pushUndo(normalAction);
+  assert.equal(await normal.globalUndo({ fromFabricFallback: true }), true);
+  assert.deepEqual(normal.getUndoStack(), []);
+  assert.deepEqual(normal.getRedoStack(), [normalAction]);
+  assert.equal(await normal.globalRedo({ fromFabricFallback: true }), true);
+  assert.deepEqual(normal.getUndoStack(), [normalAction]);
+  assert.deepEqual(normal.getRedoStack(), []);
+
+  const failedUndoToasts = [];
+  const failedUndo = newHarness(failedUndoToasts);
+  const failedUndoAction = {
+    type: 'TEST',
+    undo: async () => { throw new Error('expected undo failure'); },
+    redo: async () => {}
+  };
+  failedUndo.pushUndo(failedUndoAction);
+  const failedUndoRevision = failedUndo.getHistoryRevision();
+  assert.equal(await failedUndo.globalUndo({ fromFabricFallback: true }), false);
+  assert.equal(failedUndo.getHistoryRevision(), failedUndoRevision + 1);
+  assert.deepEqual(failedUndo.getUndoStack(), [failedUndoAction]);
+  assert.deepEqual(failedUndo.getRedoStack(), []);
+  assert.deepEqual(failedUndoToasts, [{ message: '실행 취소에 실패했습니다', type: 'error' }]);
+
+  const failedRedoToasts = [];
+  const failedRedo = newHarness(failedRedoToasts);
+  const failedRedoAction = {
+    type: 'TEST',
+    undo: async () => {},
+    redo: async () => { throw new Error('expected redo failure'); }
+  };
+  failedRedo.pushUndo(failedRedoAction);
+  assert.equal(await failedRedo.globalUndo({ fromFabricFallback: true }), true);
+  const failedRedoRevision = failedRedo.getHistoryRevision();
+  assert.equal(await failedRedo.globalRedo({ fromFabricFallback: true }), false);
+  assert.equal(failedRedo.getHistoryRevision(), failedRedoRevision + 1);
+  assert.deepEqual(failedRedo.getUndoStack(), []);
+  assert.deepEqual(failedRedo.getRedoStack(), [failedRedoAction]);
+  assert.deepEqual(failedRedoToasts, [{ message: '다시 실행에 실패했습니다', type: 'error' }]);
+
+  for (const direction of ['undo', 'redo']) {
+    for (const outcome of ['resolve', 'reject']) {
+      for (const interference of ['push', 'reset']) {
+        const harness = newHarness();
+        const gate = makeDeferred();
+        const oldAction = {
+          type: 'TEST',
+          undo: async () => {},
+          redo: async () => {}
+        };
+        harness.pushUndo(oldAction);
+        if (direction === 'redo') {
+          assert.equal(await harness.globalUndo({ fromFabricFallback: true }), true);
+        }
+        oldAction[direction] = () => gate.promise;
+
+        const operation = direction === 'undo'
+          ? harness.globalUndo({ fromFabricFallback: true })
+          : harness.globalRedo({ fromFabricFallback: true });
+        const newAction = { type: 'TEST', undo: async () => {}, redo: async () => {} };
+        if (interference === 'push') harness.pushUndo(newAction);
+        else harness.resetForFile();
+        if (outcome === 'resolve') gate.resolve();
+        else gate.reject(new Error('expected history failure'));
+        await operation;
+
+        assert.deepEqual(
+          harness.getUndoStack(),
+          interference === 'push' ? [newAction] : [],
+          `${direction} ${outcome} must not restore an old action after ${interference}`
+        );
+        assert.deepEqual(
+          harness.getRedoStack(),
+          [],
+          `${direction} ${outcome} must not commit an old action after ${interference}`
+        );
+      }
+    }
+  }
   const hostSource = fs.readFileSync(
     path.join(rootDir, 'main/mpv-overlay-host.js'), 'utf8'
   );

--- a/scripts/tests/fabric-drawing-pilot-shortcuts.test.js
+++ b/scripts/tests/fabric-drawing-pilot-shortcuts.test.js
@@ -75,7 +75,8 @@ function createHarness(options = {}) {
     async mpvGetOverlayDrawingDiagnostics(request) {
       calls.diagnostics.push(request);
       return { success: true, state: 'passive' };
-    }
+    },
+    ...(options.electronMethods || {})
   };
   const electronAPI = new Proxy(methods, {
     get(target, property) {
@@ -89,6 +90,8 @@ function createHarness(options = {}) {
     onStateChange: (state, snapshot) => states.push({ state, snapshot }),
     matchesDrawingToggleShortcut: options.matchesDrawingToggleShortcut,
     matchesSelectionShortcut: options.matchesSelectionShortcut,
+    persistenceStore: options.persistenceStore,
+    persistenceSessionIdFactory: options.persistenceSessionIdFactory,
     uuid: () => `uuid-${++id}`
   });
 
@@ -208,7 +211,7 @@ test('capability adoption validates passive readiness and never creates a video 
   assert.equal((await harness.controller.diagnostics()).videoGeneration, 0);
 });
 
-test('initial video confirmation sends an accepted disable before B can enable', async () => {
+test('initial video confirmation queues B and auto-enables after the disable settles', async () => {
   const firstDisable = deferred();
   const harness = createHarness({
     onInput(request, index) {
@@ -223,17 +226,19 @@ test('initial video confirmation sends an accepted disable before B can enable',
   assert.equal(harness.calls.input.length, 1);
   assert.equal(harness.calls.input[0].enabled, false);
   assert.equal(harness.controller.getState(), 'recovering');
-  assert.equal(await harness.controller.toggle(), false);
+  assert.equal(await harness.controller.toggle(), true);
   assert.equal(harness.calls.input.filter(request => request.enabled).length, 0);
 
   firstDisable.resolve({ success: true, accepted: true, enabled: false });
   assert.equal(await ready, true);
-  assert.equal(harness.controller.getState(), 'passive');
-
-  assert.equal(await harness.controller.toggle(), true);
+  assert.equal(harness.controller.getState(), 'active');
   assert.equal(harness.calls.input[1].enabled, true);
   assertEnvelope(harness.calls.input[0]);
   assertEnvelope(harness.calls.input[1]);
+
+  assert.equal(await harness.controller.toggle(), true);
+  assert.equal(harness.calls.input.at(-1).enabled, false);
+  assert.equal(harness.controller.getState(), 'passive');
 });
 
 test('100 direct B toggles issue exactly 50 enables and 50 disables after setup', async () => {
@@ -1609,4 +1614,88 @@ test('all dependencies and request envelopes stay inside the Task 3 pilot bridge
 
   const source = fs.readFileSync(controllerPath, 'utf8');
   assert.doesNotMatch(source, /DrawingManager|ReviewDataManager|save|videoPlayer|loadVideo|pause|hybrid|freeze/);
+});
+
+test('B cancellation during deferred hydration prevents a queued recovery from enabling', async () => {
+  const storePath = path.join(
+    __dirname,
+    '..',
+    '..',
+    'renderer',
+    'scripts',
+    'modules',
+    'fabric-drawing-persistence-store.js'
+  );
+  const { createFabricDrawingPersistenceStore } = await import(pathToFileURL(storePath).href);
+  const store = createFabricDrawingPersistenceStore({
+    createId: prefix => `${prefix}-test`
+  });
+  assert.equal(store.reset({
+    fps: 24,
+    totalFrames: 240,
+    stableVideoIdentity: 'video-a'
+  }).accepted, true);
+
+  const pendingHydration = deferred();
+  const hydrationCalls = [];
+  const harness = createHarness({
+    context: { fps: 24, totalFrames: 240 },
+    persistenceStore: store,
+    persistenceSessionIdFactory: () => 'persistence-session-1',
+    electronMethods: {
+      onFabricDrawingPersistenceEvent() {
+        return () => {};
+      },
+      async mpvHydrateOverlayDrawingVideo(request) {
+        hydrationCalls.push(request);
+        return pendingHydration.promise;
+      },
+      async mpvExportOverlayDrawingVideo(request) {
+        return {
+          success: true,
+          accepted: true,
+          snapshot: {
+            hostGeneration: request.hostGeneration,
+            videoGeneration: request.videoGeneration,
+            persistenceSessionId: request.persistenceSessionId,
+            stableVideoIdentity: request.stableVideoIdentity,
+            fps: request.fps,
+            totalFrames: request.totalFrames,
+            scenes: []
+          }
+        };
+      }
+    }
+  });
+  assert.equal(await harness.controller.initialize(), true);
+  assert.equal(await harness.controller.adoptOverlayCapability({
+    passiveReady: true,
+    hostGeneration: 1
+  }), true);
+
+  assert.equal(await harness.controller.toggle(), true);
+  assert.equal((await harness.controller.diagnostics()).resumeRequested, true);
+
+  const ready = harness.controller.afterVideoReady({
+    loadToken: 'load-a',
+    stableVideoIdentity: 'video-a',
+    fps: 24,
+    totalFrames: 240
+  });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(hydrationCalls.length, 1);
+  assert.equal(harness.controller.getState(), 'recovering');
+
+  assert.equal(await harness.controller.toggle(), true);
+  assert.equal(harness.controller.getState(), 'passive');
+
+  pendingHydration.resolve({
+    success: true,
+    accepted: true,
+    sceneCount: 0,
+    objectCount: 0
+  });
+  assert.equal(await ready, false);
+  assert.equal(harness.calls.input.filter(request => request.enabled).length, 0);
+  assert.equal(harness.controller.getState(), 'passive');
 });

--- a/scripts/tests/fabric-drawing-pilot-shortcuts.test.js
+++ b/scripts/tests/fabric-drawing-pilot-shortcuts.test.js
@@ -92,6 +92,8 @@ function createHarness(options = {}) {
     matchesSelectionShortcut: options.matchesSelectionShortcut,
     persistenceStore: options.persistenceStore,
     persistenceSessionIdFactory: options.persistenceSessionIdFactory,
+    getHistoryRevision: options.getHistoryRevision,
+    onHistoryFallback: options.onHistoryFallback,
     uuid: () => `uuid-${++id}`
   });
 
@@ -619,6 +621,63 @@ test('active Ctrl or Cmd history shortcuts send exactly one semantic action', as
     assert.equal(request.inputRevision, 2);
     assert.equal(request.sessionId, harness.calls.input.at(-1).session.sessionId);
     assertEnvelope(request);
+  }
+});
+
+test('delayed empty Fabric history falls back only while global history is unchanged', async () => {
+  const cases = [
+    ['z', { code: 'KeyZ', ctrlKey: true }, 'undo'],
+    ['y', { code: 'KeyY', ctrlKey: true }, 'redo']
+  ];
+
+  for (const [key, modifiers, action] of cases) {
+    let historyRevision = 7;
+    const changedFallbacks = [];
+    const changedResponse = deferred();
+    const changed = createHarness({
+      getHistoryRevision: () => historyRevision,
+      onHistoryFallback: fallbackAction => changedFallbacks.push(fallbackAction),
+      onAction: () => changedResponse.promise
+    });
+    await preparePassive(changed);
+    await changed.controller.toggle();
+
+    assert.equal(changed.controller.routeKeydown(createKeyEvent(key, modifiers)), true);
+    await new Promise(resolve => setImmediate(resolve));
+    historyRevision += 1;
+    changedResponse.resolve({
+      success: true,
+      applied: false,
+      duplicate: false,
+      reason: 'history-empty'
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(
+      changedFallbacks,
+      [],
+      `${action} must not target a global item created after keydown`
+    );
+
+    const unchangedFallbacks = [];
+    const unchangedResponse = deferred();
+    const unchanged = createHarness({
+      getHistoryRevision: () => 11,
+      onHistoryFallback: fallbackAction => unchangedFallbacks.push(fallbackAction),
+      onAction: () => unchangedResponse.promise
+    });
+    await preparePassive(unchanged);
+    await unchanged.controller.toggle();
+
+    assert.equal(unchanged.controller.routeKeydown(createKeyEvent(key, modifiers)), true);
+    await new Promise(resolve => setImmediate(resolve));
+    unchangedResponse.resolve({
+      success: true,
+      applied: false,
+      duplicate: false,
+      reason: 'history-empty'
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(unchangedFallbacks, [action]);
   }
 });
 

--- a/scripts/tests/fabric-drawing-pilot-shortcuts.test.js
+++ b/scripts/tests/fabric-drawing-pilot-shortcuts.test.js
@@ -681,6 +681,73 @@ test('delayed empty Fabric history falls back only while global history is uncha
   }
 });
 
+test('queued empty Fabric history preserves each shortcut but still fences unrelated changes', async () => {
+  const cases = [
+    ['z', { code: 'KeyZ', ctrlKey: true }, 'undo'],
+    ['y', { code: 'KeyY', ctrlKey: true }, 'redo']
+  ];
+
+  for (const [key, modifiers, action] of cases) {
+    for (const mutateHistory of [false, true]) {
+      let historyRevision = 23;
+      let fallbackInFlight = false;
+      let concurrentFallbacks = 0;
+      const fallbacks = [];
+      const firstFallbackStarted = deferred();
+      const firstFallbackGate = deferred();
+      const harness = createHarness({
+        getHistoryRevision: () => historyRevision,
+        onAction: () => ({
+          success: true,
+          applied: false,
+          duplicate: false,
+          reason: 'history-empty'
+        }),
+        onHistoryFallback: async fallbackAction => {
+          if (fallbackInFlight) {
+            concurrentFallbacks += 1;
+            return false;
+          }
+          fallbackInFlight = true;
+          fallbacks.push(fallbackAction);
+          if (fallbacks.length === 1) {
+            firstFallbackStarted.resolve();
+            await firstFallbackGate.promise;
+          }
+          fallbackInFlight = false;
+          return true;
+        }
+      });
+      await preparePassive(harness);
+      await harness.controller.toggle();
+
+      assert.equal(harness.controller.routeKeydown(createKeyEvent(key, modifiers)), true);
+      assert.equal(harness.controller.routeKeydown(createKeyEvent(key, modifiers)), true);
+      await firstFallbackStarted.promise;
+      await new Promise(resolve => setImmediate(resolve));
+      assert.equal(
+        harness.calls.action.length,
+        1,
+        'the second Fabric history request must wait for the first fallback'
+      );
+      if (mutateHistory) historyRevision += 1;
+      firstFallbackGate.resolve();
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      assert.equal(harness.calls.action.length, 2);
+      assert.equal(concurrentFallbacks, 0);
+      assert.deepEqual(
+        fallbacks,
+        mutateHistory ? [action] : [action, action],
+        mutateHistory
+          ? 'a new global-history mutation must discard the queued fallback'
+          : 'an earlier queued fallback must not discard the next shortcut intent'
+      );
+    }
+  }
+});
+
 test('preparing and auto-repeat history shortcuts are consumed without actions', async () => {
   const pendingEnable = deferred();
   const harness = createHarness({

--- a/scripts/tests/hybrid-review-engine-source.test.js
+++ b/scripts/tests/hybrid-review-engine-source.test.js
@@ -40,3 +40,15 @@ test('모드 종료 시 mpv 복귀 정리가 배선되어 있다 (작업 4)', ()
   // 다른 파일 로드 시작 시 복귀 대상 정리(경합 방지)
   assert.match(appSource, /hybridReviewResumeMpvFile = null;/);
 });
+
+test('B 토글은 복구·소스 갱신 중에 침묵 폐기되지 않고 예약된다', () => {
+  const controllerSource = fs.readFileSync(
+    path.join(rootDir, 'renderer/scripts/modules/fabric-drawing-pilot-controller.js'), 'utf8'
+  );
+  assert.match(controllerSource, /if \(state === 'recovering'\) \{\s*\n\s*\/\/ 복구가 끝나면 자동으로/);
+  assert.match(controllerSource, /resumeRequested = !resumeRequested;/);
+});
+
+test('레거시 드로잉 준비는 진입 즉시 준비중 표시를 켠다', () => {
+  assert.match(appSource, /videoPlayer\.pause\(\);\s*\n\s*\/\/ 하이브리드 스왑·freeze 준비가 끝날 때까지 준비중 표시를 즉시 켠다\s*\n\s*setDrawModeReadyState\(false\);\s*\n\s*setDrawModePreparingState\(true\);/);
+});

--- a/scripts/tests/lazy-bframe-creation-source.test.js
+++ b/scripts/tests/lazy-bframe-creation-source.test.js
@@ -21,6 +21,31 @@ const reviewFileStoreSource = normalizeNewlines(
 const commentSyncSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/comment-sync.js'), 'utf8'));
 const drawingSyncSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/drawing-sync.js'), 'utf8'));
 
+function extractNamedFunction(source, functionName) {
+  const functionStart = source.indexOf(`function ${functionName}`);
+  assert.ok(functionStart >= 0, `${functionName} should exist`);
+  const signatureEnd = /\)\s*\{/.exec(source.slice(functionStart));
+  const bodyStart = signatureEnd
+    ? functionStart + signatureEnd.index + signatureEnd[0].lastIndexOf('{')
+    : -1;
+  assert.ok(bodyStart > functionStart, `${functionName} should have a body`);
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    if (source[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(functionStart, index + 1);
+    }
+  }
+  assert.fail(`${functionName} body should be balanced`);
+}
+
+function loadNamedFunction(source, functionName) {
+  const functionSource = extractNamedFunction(source, functionName);
+  return Function(`"use strict"; return (${functionSource});`)();
+}
+
 test('missing .bframe loads enter deferred discovery instead of immediate collaboration save', () => {
   assert.match(appSource, /function startDeferredReviewFileDiscovery\(loadToken, bframePath\)/);
   assert.match(appSource, /async function stopDeferredReviewFileDiscovery\(bframePath = null\)/);
@@ -188,4 +213,71 @@ test('Fabric 드로잉(drawingsV3) 동기화가 배선되어 있다', () => {
   );
   assert.match(syncSource, /FABRIC_DRAWING_ROOT_CHUNK/);
   assert.match(syncSource, /applyExternalDrawingsV3/);
+});
+
+test('connected drawingsV3 file notifications keep one latest trailing reload', () => {
+  const createLeadingTrailingThrottle = loadNamedFunction(
+    appSource,
+    'createLeadingTrailingThrottle'
+  );
+  let now = 10000;
+  let currentPath = 'C:/reviews/a.bframe';
+  const timers = [];
+  const reloads = [];
+  const throttle = createLeadingTrailingThrottle({
+    intervalMs: 500,
+    now: () => now,
+    run: filePath => reloads.push(filePath),
+    shouldRun: filePath => filePath === currentPath,
+    setTimer: (callback, delay) => {
+      const timer = { callback, delay };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimer: timer => {
+      const index = timers.indexOf(timer);
+      if (index >= 0) timers.splice(index, 1);
+    }
+  });
+
+  throttle.schedule('C:/reviews/a.bframe');
+  assert.deepEqual(reloads, ['C:/reviews/a.bframe']);
+
+  now = 10350;
+  throttle.schedule('C:/reviews/a.bframe');
+  throttle.schedule('C:/reviews/a.bframe');
+  assert.equal(reloads.length, 1);
+  assert.equal(timers.length, 1);
+  assert.equal(timers[0].delay, 150);
+
+  now = 10500;
+  timers.shift().callback();
+  assert.deepEqual(reloads, [
+    'C:/reviews/a.bframe',
+    'C:/reviews/a.bframe'
+  ]);
+
+  now = 10600;
+  throttle.schedule('C:/reviews/a.bframe');
+  assert.equal(timers.length, 1);
+  currentPath = 'C:/reviews/b.bframe';
+  now = 11000;
+  timers.shift().callback();
+  assert.equal(reloads.length, 2, 'a trailing reload for the previous file must be discarded');
+
+  currentPath = 'C:/reviews/b.bframe';
+  throttle.schedule('C:/reviews/b.bframe');
+  assert.deepEqual(reloads.at(-1), 'C:/reviews/b.bframe');
+  now = 11100;
+  throttle.schedule('C:/reviews/b.bframe');
+  assert.equal(timers.length, 1);
+  now = 11600;
+  throttle.schedule('C:/reviews/b.bframe');
+  assert.equal(timers.length, 0, 'an overdue timer must be cleared by the new leading run');
+  assert.equal(reloads.length, 4);
+
+  assert.match(
+    appSource,
+    /if \(liveblocksManager\.isConnected\) \{[\s\S]*connectedDrawingsV3ReloadThrottle\.schedule\(filePath\);[\s\S]*return false;/
+  );
 });

--- a/scripts/tests/lazy-bframe-creation-source.test.js
+++ b/scripts/tests/lazy-bframe-creation-source.test.js
@@ -80,6 +80,31 @@ test('new review room can be attached to first save without recursively saving a
   assert.match(newRoomBranch[1], /await reviewDataManager\.save\(\{ skipMerge: true \}\);/);
 });
 
+test('late collaborator seed excludes additive legacy drawings while preserving explicit recovery seed', () => {
+  const handlerStart = appSource.indexOf(
+    "liveblocksManager.addEventListener('collaboratorsChanged'"
+  );
+  const handlerEnd = appSource.indexOf(
+    "liveblocksManager.addEventListener('collaborationStarted'",
+    handlerStart
+  );
+  assert.ok(handlerStart >= 0 && handlerEnd > handlerStart);
+  const collaboratorsChangedHandler = appSource.slice(handlerStart, handlerEnd);
+  const lateSeedBlock = collaboratorsChangedHandler.match(
+    /if \(currentOthersCount > _previousOthersCount &&[\s\S]*?\) \{([\s\S]*?)\n\s*\}/
+  );
+  assert.ok(lateSeedBlock, 'collaborator increase seed block should exist');
+  assert.match(lateSeedBlock[1], /commentSync\.broadcastCurrentState\?\.\(\);/);
+  assert.doesNotMatch(lateSeedBlock[1], /drawingSync\.broadcastCurrentState\?\.\(\);/);
+  assert.match(lateSeedBlock[1], /fabricDrawingSync\.broadcastCurrentState\?\.\(\);/);
+
+  const explicitSeedBlock = appSource.match(
+    /if \(seedCurrentState\) \{([\s\S]*?)\n\s*\}/
+  );
+  assert.ok(explicitSeedBlock, 'explicit recovery seed block should exist');
+  assert.match(explicitSeedBlock[1], /drawingSync\.broadcastCurrentState\?\.\(\);/);
+});
+
 test('first .bframe save is protected against another user creating the file first', () => {
   assert.match(reviewDataManagerSource, /setBeforeSaveHandler\(handler\)/);
   assert.match(reviewDataManagerSource, /setInitialSaveConflictHandler\(handler\)/);

--- a/scripts/tests/lazy-bframe-creation-source.test.js
+++ b/scripts/tests/lazy-bframe-creation-source.test.js
@@ -176,3 +176,16 @@ test('playlist aggregate direct save protects identity and uses a version token 
     'review identity must be prepared before direct save'
   );
 });
+
+test('Fabric 드로잉(drawingsV3) 동기화가 배선되어 있다', () => {
+  assert.match(appSource, /new FabricDrawingSync\(\{/);
+  assert.match(appSource, /fabricDrawingSync\.broadcastCurrentState\?\.\(\);/);
+  assert.match(appSource, /reloadDrawingsV3FromDisk/);
+  assert.match(appSource, /_previousOthersCount = 0;\s*\n\s*_collaborationSessionStartedAt = Date\.now\(\);/);
+  assert.match(appSource, /currentOthersCount > _previousOthersCount &&\s*\n\s*Date\.now\(\) - _collaborationSessionStartedAt > 10000/);
+  const syncSource = fs.readFileSync(
+    path.join(rootDir, 'renderer/scripts/modules/fabric-drawing-sync.js'), 'utf8'
+  );
+  assert.match(syncSource, /FABRIC_DRAWING_ROOT_CHUNK/);
+  assert.match(syncSource, /applyExternalDrawingsV3/);
+});

--- a/scripts/tests/lazy-bframe-creation-source.test.js
+++ b/scripts/tests/lazy-bframe-creation-source.test.js
@@ -71,7 +71,7 @@ test('new review room can be attached to first save without recursively saving a
   assert.match(appSource, /async function startCollaborationForVideoLoad\(loadToken, bframePath, options = \{\}\)/);
   assert.match(appSource, /persistNewRoom = true,/);
   assert.match(appSource, /seedCurrentState = false/);
-  assert.match(appSource, /if \(seedCurrentState\) \{[\s\S]*commentSync\.broadcastCurrentState\?\.\(\);[\s\S]*drawingSync\.broadcastCurrentState\?\.\(\);/);
+  assert.match(appSource, /if \(seedCurrentState\) \{[\s\S]*fabricDrawingSync\.broadcastCurrentState\?\.\(\);/);
 
   const newRoomBranch = appSource.match(/if \(isNewRoom && isCurrentReviewPath\(bframePath\)\) \{([\s\S]*?)\n      \}/);
   assert.ok(newRoomBranch, 'startCollaborationForVideoLoad should handle newly-created rooms explicitly');
@@ -80,7 +80,7 @@ test('new review room can be attached to first save without recursively saving a
   assert.match(newRoomBranch[1], /await reviewDataManager\.save\(\{ skipMerge: true \}\);/);
 });
 
-test('late collaborator seed excludes additive legacy drawings while preserving explicit recovery seed', () => {
+test('all collaboration seeds exclude additive legacy snapshots while preserving causal Fabric seed', () => {
   const handlerStart = appSource.indexOf(
     "liveblocksManager.addEventListener('collaboratorsChanged'"
   );
@@ -94,7 +94,7 @@ test('late collaborator seed excludes additive legacy drawings while preserving 
     /if \(currentOthersCount > _previousOthersCount &&[\s\S]*?\) \{([\s\S]*?)\n\s*\}/
   );
   assert.ok(lateSeedBlock, 'collaborator increase seed block should exist');
-  assert.match(lateSeedBlock[1], /commentSync\.broadcastCurrentState\?\.\(\);/);
+  assert.doesNotMatch(lateSeedBlock[1], /commentSync\.broadcastCurrentState\?\.\(\);/);
   assert.doesNotMatch(lateSeedBlock[1], /drawingSync\.broadcastCurrentState\?\.\(\);/);
   assert.match(lateSeedBlock[1], /fabricDrawingSync\.broadcastCurrentState\?\.\(\);/);
 
@@ -102,7 +102,22 @@ test('late collaborator seed excludes additive legacy drawings while preserving 
     /if \(seedCurrentState\) \{([\s\S]*?)\n\s*\}/
   );
   assert.ok(explicitSeedBlock, 'explicit recovery seed block should exist');
-  assert.match(explicitSeedBlock[1], /drawingSync\.broadcastCurrentState\?\.\(\);/);
+  assert.doesNotMatch(explicitSeedBlock[1], /commentSync\.broadcastCurrentState\?\.\(\);/);
+  assert.doesNotMatch(explicitSeedBlock[1], /drawingSync\.broadcastCurrentState\?\.\(\);/);
+  assert.match(explicitSeedBlock[1], /fabricDrawingSync\.broadcastCurrentState\?\.\(\);/);
+
+  const mergeSeedStart = appSource.indexOf('async function prepareReviewFileBeforeSave');
+  const mergeSeedEnd = appSource.indexOf('async function prepareCompositionLayerMedia', mergeSeedStart);
+  assert.ok(mergeSeedStart >= 0 && mergeSeedEnd > mergeSeedStart);
+  const mergeSeedHandlers = appSource.slice(mergeSeedStart, mergeSeedEnd);
+  assert.equal((mergeSeedHandlers.match(/seedCurrentState:\s*true/g) || []).length, 3);
+
+  const quitHandlerStart = appSource.indexOf('window.electronAPI.onRequestSaveBeforeQuit');
+  const quitHandlerEnd = appSource.indexOf('// ====== 사용자 이름 초기화', quitHandlerStart);
+  assert.ok(quitHandlerStart >= 0 && quitHandlerEnd > quitHandlerStart);
+  const quitHandler = appSource.slice(quitHandlerStart, quitHandlerEnd);
+  assert.doesNotMatch(quitHandler, /seedCurrentState:\s*true/);
+  assert.equal((quitHandler.match(/seedCurrentState:\s*false/g) || []).length, 2);
 });
 
 test('first .bframe save is protected against another user creating the file first', () => {

--- a/scripts/tests/mpv-manager.test.js
+++ b/scripts/tests/mpv-manager.test.js
@@ -777,3 +777,14 @@ test('launch args pin png screenshot format', () => {
   const args = createMpvLaunchArgs({ ipcPath: '\\\\.\\pipe\\x' });
   assert.ok(args.includes('--screenshot-format=png'));
 });
+
+test('mpv 실행 인자는 자식 창 입력 소비를 차단한다', () => {
+  const args = createMpvLaunchArgs({ ipcPath: '\\\\.\\pipe\\test-mpv' });
+  assert.ok(args.includes('--input-default-bindings=no'));
+  assert.ok(args.includes('--input-vo-keyboard=no'));
+  assert.ok(args.includes('--input-cursor=no'));
+  const widArgs = createMpvLaunchArgs({ ipcPath: '\\\\.\\pipe\\test-mpv', wid: 4242 });
+  assert.ok(widArgs.includes('--input-default-bindings=no'));
+  const headlessArgs = createMpvLaunchArgs({ ipcPath: '\\\\.\\pipe\\test-mpv', headless: true });
+  assert.ok(headlessArgs.includes('--input-vo-keyboard=no'));
+});

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -2732,6 +2732,72 @@ test('deduplicates drawing actions and allowlists lightweight host responses', a
     /fabricJSON|objects|scene\s*:|deletedIds|undoBytes|undoState|command/i);
 });
 
+test('drawing action response forwards history-empty reason', async () => {
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (!script.includes('.applyDrawingAction(')) return undefined;
+      return { applied: false, reason: 'history-empty' };
+    }
+  });
+  const tokens = await activateDrawingHost(harness, {
+    videoGeneration: 8,
+    sessionId: 'session-history-empty-response'
+  });
+  const result = await harness.host.applyDrawingAction({
+    ...tokens,
+    action: 'undo',
+    actionId: 'history-empty-response-1'
+  });
+
+  assert.equal(result.reason, 'history-empty');
+  assert.equal(result.success, false);
+});
+
+test('overlay history-empty relays to renderer while applied history stays local', async () => {
+  const runHistoryShortcut = async (drawingResult, sessionId) => {
+    const harness = createDrawingHostHarness({
+      executeDrawing(script) {
+        if (!script.includes('.applyDrawingAction(')) return undefined;
+        return drawingResult;
+      }
+    });
+    await activateDrawingHost(harness, {
+      videoGeneration: 8,
+      sessionId
+    });
+    harness.events.length = 0;
+    harness.windows[0].webContents.emit('before-input-event', {
+      preventDefault() {}
+    }, {
+      type: 'keyDown',
+      key: 'z',
+      code: 'KeyZ',
+      shift: false,
+      control: true,
+      alt: false,
+      meta: false,
+      isAutoRepeat: false
+    });
+    await waitForAsyncReposition();
+    await waitForAsyncReposition();
+    return harness.events.filter(([name, channel]) =>
+      name === 'mainWindow.send' && channel === 'mpv-overlay:keyboard-input');
+  };
+
+  const fallbackSends = await runHistoryShortcut(
+    { applied: false, reason: 'history-empty' },
+    'session-history-empty-fallback'
+  );
+  assert.equal(fallbackSends.length, 1);
+  assert.equal(fallbackSends[0][2].code, 'KeyZ');
+
+  const appliedSends = await runHistoryShortcut(
+    { applied: true },
+    'session-history-applied'
+  );
+  assert.equal(appliedSends.length, 0);
+});
+
 test('allowlists undo and redo while rejecting unknown drawing actions', async () => {
   const harness = createDrawingHostHarness();
   const tokens = await activateDrawingHost(harness, {

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -2245,7 +2245,7 @@ test('overlay physical key relay rejects malformed and composing input without f
   assert.equal(harness.events.some(([name]) => name === 'mainWindow.focus'), false);
 });
 
-test('overlay history shortcuts execute once without relaying to the main window', async () => {
+test('overlay history shortcuts relay once to the main renderer without host-side history execution', async () => {
   const harness = createDrawingHostHarness();
   await activateDrawingHost(harness, {
     videoGeneration: 12,
@@ -2275,6 +2275,10 @@ test('overlay history shortcuts execute once without relaying to the main window
   };
 
   assert.equal(emit({ control: true }), true);
+  assert.deepEqual(harness.events.filter(([name, channel]) =>
+    name === 'mainWindow.send' && channel === 'mpv-overlay:keyboard-input')
+    .map(([, , input]) => input.code), ['KeyZ'],
+  'the physical history key must relay synchronously to the renderer');
   assert.equal(emit({
     control: false,
     isAutoRepeat: true
@@ -2287,15 +2291,13 @@ test('overlay history shortcuts execute once without relaying to the main window
   assert.equal(emit({ key: 'y', code: 'KeyY', control: true }), true);
   assert.equal(emit({ control: true, shift: true }), true);
   assert.equal(emit({ control: true, isAutoRepeat: true }), true);
-  await waitForAsyncReposition();
-  await waitForAsyncReposition();
-
-  const actionPayloads = harness.events
-    .filter(([name, script]) => name === 'executeJavaScript' && script.includes?.('.applyDrawingAction('))
-    .map(([, script]) => readFabricMethodPayload(script, 'applyDrawingAction'));
-  assert.deepEqual(actionPayloads.map(request => request.action), ['undo', 'undo', 'redo', 'redo']);
-  assert.equal(new Set(actionPayloads.map(request => request.actionId)).size, 4);
-  assert.equal(harness.events.some(([name]) => name === 'mainWindow.send'), false);
+  const relayedInputs = harness.events
+    .filter(([name, channel]) =>
+      name === 'mainWindow.send' && channel === 'mpv-overlay:keyboard-input')
+    .map(([, , input]) => input);
+  assert.deepEqual(relayedInputs.map(input => input.code), ['KeyZ', 'KeyZ', 'KeyY', 'KeyZ']);
+  assert.equal(harness.events.some(([name, script]) =>
+    name === 'executeJavaScript' && script.includes?.('.applyDrawingAction(')), false);
   assert.equal(harness.events.some(([name]) => name === 'mainWindow.sendInputEvent'), false);
   assert.equal(harness.events.some(([name]) => name === 'mainWindow.focus'), false);
 });
@@ -2352,7 +2354,7 @@ test('overlay history routing leaves invalid combinations and Electron IME input
   assert.equal(harness.events.filter(([name]) => name === 'mainWindow.send').length, 7);
 });
 
-test('controller-origin and overlay-origin actions share one serialized host queue', async () => {
+test('overlay history relay bypasses an in-flight controller-origin host queue', async () => {
   const firstAttempt = createDeferred();
   const actionOrder = [];
   const harness = createDrawingHostHarness({
@@ -2390,14 +2392,17 @@ test('controller-origin and overlay-origin actions share one serialized host que
     isAutoRepeat: false
   });
   assert.equal(overlayPrevented, true);
+  assert.deepEqual(harness.events
+    .filter(([name, channel]) =>
+      name === 'mainWindow.send' && channel === 'mpv-overlay:keyboard-input')
+    .map(([, , input]) => input.code), ['KeyY']);
   await waitForAsyncReposition();
   assert.deepEqual(actionOrder, ['undo']);
 
   firstAttempt.resolve({ applied: true, deletedCount: 0 });
   assert.equal((await controllerAction).success, true);
   await waitForAsyncReposition();
-  await waitForAsyncReposition();
-  assert.deepEqual(actionOrder, ['undo', 'redo']);
+  assert.deepEqual(actionOrder, ['undo']);
 });
 
 test('overlay keeps forwarding B V Delete and Space through the main renderer route', async () => {
@@ -2753,49 +2758,41 @@ test('drawing action response forwards history-empty reason', async () => {
   assert.equal(result.success, false);
 });
 
-test('overlay history-empty relays to renderer while applied history stays local', async () => {
-  const runHistoryShortcut = async (drawingResult, sessionId) => {
-    const harness = createDrawingHostHarness({
-      executeDrawing(script) {
-        if (!script.includes('.applyDrawingAction(')) return undefined;
-        return drawingResult;
-      }
-    });
-    await activateDrawingHost(harness, {
-      videoGeneration: 8,
-      sessionId
-    });
-    harness.events.length = 0;
-    harness.windows[0].webContents.emit('before-input-event', {
-      preventDefault() {}
-    }, {
-      type: 'keyDown',
-      key: 'z',
-      code: 'KeyZ',
-      shift: false,
-      control: true,
-      alt: false,
-      meta: false,
-      isAutoRepeat: false
-    });
-    await waitForAsyncReposition();
-    await waitForAsyncReposition();
-    return harness.events.filter(([name, channel]) =>
-      name === 'mainWindow.send' && channel === 'mpv-overlay:keyboard-input');
-  };
+test('overlay history relay does not await or invoke host Fabric history', async () => {
+  const delayedHistory = createDeferred();
+  let hostHistoryCallCount = 0;
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (!script.includes('.applyDrawingAction(')) return undefined;
+      hostHistoryCallCount += 1;
+      return delayedHistory.promise;
+    }
+  });
+  await activateDrawingHost(harness, {
+    videoGeneration: 8,
+    sessionId: 'session-history-single-owner'
+  });
+  harness.events.length = 0;
 
-  const fallbackSends = await runHistoryShortcut(
-    { applied: false, reason: 'history-empty' },
-    'session-history-empty-fallback'
-  );
-  assert.equal(fallbackSends.length, 1);
-  assert.equal(fallbackSends[0][2].code, 'KeyZ');
+  harness.windows[0].webContents.emit('before-input-event', {
+    preventDefault() {}
+  }, {
+    type: 'keyDown',
+    key: 'z',
+    code: 'KeyZ',
+    shift: false,
+    control: true,
+    alt: false,
+    meta: false,
+    isAutoRepeat: false
+  });
 
-  const appliedSends = await runHistoryShortcut(
-    { applied: true },
-    'session-history-applied'
-  );
-  assert.equal(appliedSends.length, 0);
+  const relayedInputs = harness.events.filter(([name, channel]) =>
+    name === 'mainWindow.send' && channel === 'mpv-overlay:keyboard-input');
+  assert.equal(relayedInputs.length, 1);
+  assert.equal(relayedInputs[0][2].code, 'KeyZ');
+  assert.equal(hostHistoryCallCount, 0);
+  delayedHistory.resolve({ applied: true });
 });
 
 test('allowlists undo and redo while rejecting unknown drawing actions', async () => {

--- a/scripts/tests/mpv-overlay-keyboard-relay.test.js
+++ b/scripts/tests/mpv-overlay-keyboard-relay.test.js
@@ -11,6 +11,10 @@ const relayModulePath = path.join(
   rootDir,
   'renderer/scripts/modules/mpv-overlay-keyboard-relay.js'
 );
+const shortcutTargetsModulePath = path.join(
+  rootDir,
+  'renderer/scripts/modules/keyboard-shortcut-targets.js'
+);
 const appPath = path.join(rootDir, 'renderer/scripts/app.js');
 
 function loadMainPreload() {
@@ -329,16 +333,23 @@ test('renderer relay rejects malformed payloads before DOM dispatch', async () =
   assert.equal(dispatched.length, 0);
 });
 
-test('renderer relay targets the remembered active element so editable input guards still apply', async () => {
+test('renderer relay keeps ordinary keys on the remembered editor but sends overlay history to the document', async () => {
   assert.equal(fs.existsSync(relayModulePath), true);
   const { dispatchMpvOverlayKeyboardInput } = await import(
     `${pathToFileURL(relayModulePath).href}?editable=${Date.now()}`
+  );
+  const {
+    getEffectiveKeyboardShortcutTarget,
+    shouldIgnoreGlobalShortcutTarget
+  } = await import(
+    `${pathToFileURL(shortcutTargetsModulePath).href}?overlay-history=${Date.now()}`
   );
   const activeEvents = [];
   const documentEvents = [];
   const activeElement = {
     tagName: 'TEXTAREA',
     dispatchEvent(event) {
+      event.target = this;
       activeEvents.push(event);
       return true;
     }
@@ -346,6 +357,7 @@ test('renderer relay targets the remembered active element so editable input gua
   const ownerDocument = {
     activeElement,
     dispatchEvent(event) {
+      event.target = this;
       documentEvents.push(event);
       return true;
     }
@@ -363,6 +375,20 @@ test('renderer relay targets the remembered active element so editable input gua
   ), true);
   assert.equal(activeEvents.length, 1);
   assert.equal(documentEvents.length, 0);
+
+  assert.equal(dispatchMpvOverlayKeyboardInput(
+    validInput({ key: 'z', code: 'KeyZ', ctrlKey: true }),
+    { ownerDocument, KeyboardEventConstructor: FakeKeyboardEvent }
+  ), true);
+  assert.equal(activeEvents.length, 1);
+  assert.equal(documentEvents.length, 1);
+  assert.equal(documentEvents[0].code, 'KeyZ');
+  const shortcutTarget = getEffectiveKeyboardShortcutTarget(
+    documentEvents[0],
+    ownerDocument
+  );
+  assert.equal(shortcutTarget, ownerDocument);
+  assert.equal(shouldIgnoreGlobalShortcutTarget(shortcutTarget), false);
 });
 
 test('app subscribes once and dispatches overlay keyboard payloads through the guarded relay', () => {

--- a/scripts/tests/review-data-manager-save.test.js
+++ b/scripts/tests/review-data-manager-save.test.js
@@ -3711,3 +3711,189 @@ test('scalar metadata uses three-way merge and keeps remote on concurrent confli
     );
   }
 });
+
+test('drawingsV3 disk reload cannot install video A after switching to video B', async () => {
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const fabricStore = await createFabricStore();
+  const originalImportRootValue = fabricStore.importRootValue;
+  let importRootValueCalls = 0;
+  const fabricStoreSpy = {
+    ...fabricStore,
+    importRootValue(...args) {
+      importRootValueCalls += 1;
+      return originalImportRootValue(...args);
+    }
+  };
+  const videoA = 'C:/reviews/drawings-v3-disk-owner-a.mp4';
+  const videoB = 'C:/reviews/drawings-v3-disk-owner-b.mp4';
+  const pathA = 'C:/reviews/drawings-v3-disk-owner-a.bframe';
+  const pathB = 'C:/reviews/drawings-v3-disk-owner-b.bframe';
+  const initialFabricA = createFabricRoot({
+    documentId: 'fabric-document-disk-owner-a'
+  });
+  const externalFabricA = createFabricRoot({
+    documentId: 'fabric-document-disk-owner-a-external',
+    revision: 8,
+    keyframes: [{
+      id: 'drawings-v3-disk-owner-a-external-frame',
+      frame: 12,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      mutationSequence: 1,
+      objects: [createFabricRecord('drawings-v3-disk-owner-a-external-stroke')]
+    }]
+  });
+  const fabricB = createFabricRoot({
+    documentId: 'fabric-document-disk-owner-b',
+    revision: 3,
+    keyframes: [{
+      id: 'drawings-v3-disk-owner-b-frame',
+      frame: 24,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      mutationSequence: 1,
+      objects: [createFabricRecord('drawings-v3-disk-owner-b-stroke')]
+    }]
+  });
+  const roots = new Map([
+    [pathA, createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      videoFile: 'drawings-v3-disk-owner-a.mp4',
+      videoPath: videoA,
+      drawingsV3: initialFabricA
+    })],
+    [pathB, createReviewRoot({
+      reviewDocumentId: REVIEW_ID_REMOTE,
+      videoFile: 'drawings-v3-disk-owner-b.mp4',
+      videoPath: videoB,
+      drawingsV3: fabricB
+    })]
+  ]);
+  const reloadReadStarted = createDeferred();
+  const reloadReadA = createDeferred();
+  window.electronAPI = {
+    loadReview: async path => structuredClone(roots.get(path) || null),
+    loadReviewSnapshot: async path => {
+      assert.equal(path, pathA);
+      reloadReadStarted.resolve();
+      return reloadReadA.promise;
+    }
+  };
+  const manager = new ReviewDataManager({
+    autoSave: false,
+    fabricDrawingPersistenceProvider: fabricStoreSpy
+  });
+  manager.connect();
+  assert.equal(await manager.setVideoFile(videoA, {
+    fabricDrawingPersistenceContext: {
+      ...FABRIC_CONTEXT,
+      stableVideoIdentity: videoA
+    }
+  }), true);
+
+  const reloadingA = manager.reloadDrawingsV3FromDisk();
+  await reloadReadStarted.promise;
+  assert.equal(await manager.setVideoFile(videoB, {
+    skipSave: true,
+    fabricDrawingPersistenceContext: {
+      ...FABRIC_CONTEXT,
+      stableVideoIdentity: videoB
+    }
+  }), true);
+  assert.deepEqual(fabricStore.exportRootValue(), fabricB);
+  importRootValueCalls = 0;
+
+  reloadReadA.resolve({
+    data: createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      videoFile: 'drawings-v3-disk-owner-a.mp4',
+      videoPath: videoA,
+      drawingsV3: externalFabricA
+    }),
+    versionToken: 'drawings-v3-disk-owner-a-late'
+  });
+
+  assert.equal(await reloadingA, false);
+  assert.equal(importRootValueCalls, 0);
+  assert.deepEqual(fabricStore.exportRootValue(), fabricB);
+  manager.disconnect();
+});
+
+test('Fabric drawing sync drops queued roots from a stopped session after restart', async () => {
+  const { FabricDrawingSync } = await import(
+    '../../renderer/scripts/modules/fabric-drawing-sync.js'
+  );
+  const firstApply = createDeferred();
+
+  class StubLiveblocksManager extends EventTarget {
+    hasOtherCollaborators() {
+      return false;
+    }
+
+    broadcastEvent() {}
+
+    receive(event) {
+      this.dispatchEvent(new CustomEvent('broadcastReceived', {
+        detail: { event }
+      }));
+    }
+  }
+
+  class StubReviewDataManager extends EventTarget {
+    constructor() {
+      super();
+      this.currentBframePath = 'C:/reviews/session-generation-a.bframe';
+      this.appliedRoots = [];
+    }
+
+    async applyExternalDrawingsV3(rootValue) {
+      this.appliedRoots.push(structuredClone(rootValue));
+      if (this.appliedRoots.length === 1) {
+        return firstApply.promise;
+      }
+      return true;
+    }
+  }
+
+  const liveblocksManager = new StubLiveblocksManager();
+  const reviewDataManager = new StubReviewDataManager();
+  const sync = new FabricDrawingSync({
+    liveblocksManager,
+    reviewDataManager
+  });
+  const receiveRoot = id => {
+    liveblocksManager.receive({
+      type: 'FABRIC_DRAWING_ROOT',
+      root: { id },
+      fingerprint: `fingerprint-${id}`
+    });
+  };
+
+  sync.start();
+  receiveRoot('A1');
+  await Promise.resolve();
+  assert.deepEqual(reviewDataManager.appliedRoots.map(root => root.id), ['A1']);
+
+  receiveRoot('A2');
+  sync.stop();
+  reviewDataManager.currentBframePath = 'C:/reviews/session-generation-b.bframe';
+  reviewDataManager.currentBframePath = 'C:/reviews/session-generation-a.bframe';
+  sync.start();
+
+  firstApply.resolve(true);
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(
+    reviewDataManager.appliedRoots.map(root => root.id),
+    ['A1'],
+    'A2 queued by the stopped session must be discarded after restart'
+  );
+
+  receiveRoot('A3');
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(
+    reviewDataManager.appliedRoots.map(root => root.id),
+    ['A1', 'A3'],
+    'the restarted session must still apply new roots'
+  );
+  sync.stop();
+});

--- a/scripts/tests/review-data-manager-save.test.js
+++ b/scripts/tests/review-data-manager-save.test.js
@@ -480,7 +480,10 @@ test('save preflight waits for Fabric source refresh and rechecks local dirty be
   const saving = manager.save();
   await refreshEntered.promise;
   assert.equal(saveCount, 0);
-  assert.deepEqual(fabricStore.exportRootValue(), initialFabric);
+  assert.deepEqual(
+    fabricStore.exportRootValue(),
+    initialFabric
+  );
   releaseOldSnapshotPull.resolve();
   assert.equal(await saving, false);
 
@@ -2533,10 +2536,11 @@ test('failed external drawingsV3 installation retries the same payload instead o
       return originalImportRootValue(rootValue, context);
     }
   };
+  let diskFabric = initialFabric;
   window.electronAPI = {
     loadReview: async () => createReviewRoot({
       reviewDocumentId: REVIEW_ID_EXISTING,
-      drawingsV3: initialFabric
+      drawingsV3: diskFabric
     })
   };
   const manager = new ReviewDataManager({
@@ -2547,8 +2551,21 @@ test('failed external drawingsV3 installation retries the same payload instead o
     fabricDrawingPersistenceContext: FABRIC_CONTEXT
   });
 
+  diskFabric = externalFabric;
+  assert.equal(manager.markExternalDrawingsV3Superseded(externalFabric), true);
   assert.equal(await manager.applyExternalDrawingsV3(externalFabric), false);
   assert.equal(externalImportAttempts, 1);
+  const providerAfterFailedExternalInstall = fabricStore.exportRootValue();
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.equal(
+    externalImportAttempts,
+    1,
+    'a failed explicit install must keep the stale-file guard for disk reloads'
+  );
+  assert.deepEqual(
+    fabricStore.exportRootValue(),
+    providerAfterFailedExternalInstall
+  );
   assert.equal(await manager.applyExternalDrawingsV3(externalFabric), true);
   assert.equal(externalImportAttempts, 2, 'the rejected payload must reach the provider again');
   assert.deepEqual(fabricStore.exportRootValue(), externalFabric);
@@ -4124,7 +4141,9 @@ test('Fabric drawing sync requests a stable peer seed after an earlier join broa
   });
   const staleRoot = createFabricRoot({
     documentId: 'fabric-document-joining-peer',
-    revision: 2
+    // 같은 revision이어도 안정 peer의 첫 publish 버전이 newcomer baseline보다 높아야 한다.
+    // 이 두 root의 wire fingerprint 순서는 stable < joining이라 단순 hash tie-break면 실패한다.
+    revision: 12
   });
   const liveblocksA = new LinkedLiveblocksManager();
   const liveblocksB = new LinkedLiveblocksManager();
@@ -4166,6 +4185,20 @@ test('Fabric drawing sync requests a stable peer seed after an earlier join broa
     'the stable peer must answer once even before its Others view catches up'
   );
   assert.deepEqual(reviewB.appliedRoots, [latestRoot]);
+  const firstSeedVersion = structuredClone(
+    liveblocksA.sentEvents.find(event => event.type === 'FABRIC_DRAWING_ROOT').syncVersion
+  );
+  now = 10002;
+  liveblocksB.broadcastEvent({ type: 'FABRIC_DRAWING_ROOT_REQUEST' });
+  const repeatedSeeds = liveblocksA.sentEvents.filter(
+    event => event.type === 'FABRIC_DRAWING_ROOT'
+  );
+  assert.equal(repeatedSeeds.length, 2);
+  assert.deepEqual(
+    repeatedSeeds[1].syncVersion,
+    firstSeedVersion,
+    'repeated seed responses must reuse the same causal version'
+  );
 
   liveblocksA.sentEvents.length = 0;
   liveblocksB.sentEvents.length = 0;
@@ -4179,4 +4212,410 @@ test('Fabric drawing sync requests a stable peer seed after an earlier join broa
 
   syncB.stop();
   syncA.stop();
+});
+
+test('Fabric drawing sync causally converges concurrent and dirty-overlap saves', async () => {
+  const { FabricDrawingSync } = await import(
+    '../../renderer/scripts/modules/fabric-drawing-sync.js'
+  );
+
+  class BufferedLiveblocksManager extends EventTarget {
+    constructor() {
+      super();
+      this.sentEvents = [];
+    }
+
+    hasOtherCollaborators() {
+      return true;
+    }
+
+    broadcastEvent(event) {
+      this.sentEvents.push(structuredClone(event));
+    }
+
+    receive(event) {
+      this.dispatchEvent(new CustomEvent('broadcastReceived', {
+        detail: { event: structuredClone(event) }
+      }));
+    }
+  }
+
+  class StubReviewDataManager extends EventTarget {
+    constructor(rootValue, pathSuffix) {
+      super();
+      this.currentBframePath = `C:/reviews/causal-${pathSuffix}.bframe`;
+      this.rootValue = structuredClone(rootValue);
+      this.rejectNextApply = false;
+      this.deferNextApply = null;
+      this.appliedRoots = [];
+      this.supersededRoots = [];
+      this.staleOwners = new Set();
+    }
+
+    getDrawingsV3RootSnapshot() {
+      return {
+        present: true,
+        value: structuredClone(this.rootValue),
+        fingerprint: `present:${JSON.stringify(this.rootValue)}`,
+        stale: false
+      };
+    }
+
+    async applyExternalDrawingsV3(rootValue) {
+      this.appliedRoots.push(structuredClone(rootValue));
+      if (this.rejectNextApply) {
+        this.rejectNextApply = false;
+        return false;
+      }
+      this.staleOwners.delete(rootValue?.owner);
+      this.rootValue = structuredClone(rootValue);
+      if (this.deferNextApply) {
+        const gate = this.deferNextApply;
+        this.deferNextApply = null;
+        await gate.promise;
+      }
+      return true;
+    }
+
+    markExternalDrawingsV3Superseded(rootValue) {
+      this.supersededRoots.push(structuredClone(rootValue));
+      this.staleOwners.add(rootValue?.owner);
+      return true;
+    }
+
+    saveRoot(rootValue) {
+      this.rootValue = structuredClone(rootValue);
+      this.dispatchEvent(new CustomEvent('saved', {
+        detail: { path: this.currentBframePath }
+      }));
+    }
+  }
+
+  const initialRoot = {
+    schemaVersion: '3.0.0',
+    documentId: 'fabric-causal-shared',
+    revision: 0,
+    owner: 'initial'
+  };
+  const rootA = { ...initialRoot, revision: 1, owner: 'A' };
+  const rootB = { ...initialRoot, revision: 1, owner: 'B' };
+  const flush = () => new Promise(resolve => setImmediate(resolve));
+  const createPair = (suffix, roots = {}) => {
+    const liveblocksA = new BufferedLiveblocksManager();
+    const liveblocksB = new BufferedLiveblocksManager();
+    const reviewA = new StubReviewDataManager(
+      roots.rootA || initialRoot,
+      `${suffix}-a`
+    );
+    const reviewB = new StubReviewDataManager(
+      roots.rootB || initialRoot,
+      `${suffix}-b`
+    );
+    const syncA = new FabricDrawingSync({
+      liveblocksManager: liveblocksA,
+      reviewDataManager: reviewA,
+      actorId: 'actor-a'
+    });
+    const syncB = new FabricDrawingSync({
+      liveblocksManager: liveblocksB,
+      reviewDataManager: reviewB,
+      actorId: 'actor-b'
+    });
+    syncA.start();
+    syncB.start();
+    liveblocksA.sentEvents.length = 0;
+    liveblocksB.sentEvents.length = 0;
+    return { liveblocksA, liveblocksB, reviewA, reviewB, syncA, syncB };
+  };
+  const rootEvent = manager => manager.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT'
+  );
+
+  const concurrent = createPair('concurrent');
+  concurrent.reviewA.saveRoot(rootA);
+  concurrent.reviewB.saveRoot(rootB);
+  const concurrentEventA = rootEvent(concurrent.liveblocksA);
+  const concurrentEventB = rootEvent(concurrent.liveblocksB);
+  assert.ok(concurrentEventA?.syncVersion);
+  assert.ok(concurrentEventB?.syncVersion);
+  concurrent.liveblocksA.receive(concurrentEventB);
+  concurrent.liveblocksB.receive(concurrentEventA);
+  await flush();
+  await flush();
+  assert.deepEqual(concurrent.reviewA.rootValue, rootB);
+  assert.deepEqual(concurrent.reviewB.rootValue, rootB);
+  assert.deepEqual(concurrent.reviewB.supersededRoots, [rootA]);
+  concurrent.syncA.stop();
+  concurrent.syncB.stop();
+
+  const overlap = createPair('dirty-overlap');
+  overlap.reviewA.saveRoot(rootA);
+  const earlierEventA = rootEvent(overlap.liveblocksA);
+  overlap.reviewB.rejectNextApply = true;
+  overlap.liveblocksB.receive(earlierEventA);
+  await flush();
+  assert.deepEqual(overlap.reviewB.rootValue, initialRoot);
+
+  overlap.reviewB.saveRoot(rootB);
+  const laterEventB = rootEvent(overlap.liveblocksB);
+  assert.ok(
+    laterEventB.syncVersion.clock > earlierEventA.syncVersion.clock,
+    'a local save after observing a rejected root must advance the causal clock'
+  );
+  overlap.liveblocksA.receive(laterEventB);
+  await flush();
+  await flush();
+  assert.deepEqual(overlap.reviewA.rootValue, rootB);
+  assert.deepEqual(overlap.reviewB.rootValue, rootB);
+  assert.deepEqual(overlap.reviewB.supersededRoots, [rootA]);
+  overlap.syncA.stop();
+  overlap.syncB.stop();
+
+  const applyRace = createPair('apply-await-race');
+  const applyGate = createDeferred();
+  applyRace.reviewA.saveRoot(rootA);
+  const incomingBeforeLocalSave = rootEvent(applyRace.liveblocksA);
+  applyRace.reviewB.deferNextApply = applyGate;
+  applyRace.liveblocksB.receive(incomingBeforeLocalSave);
+  await Promise.resolve();
+  assert.deepEqual(applyRace.reviewB.rootValue, rootA);
+
+  const newerLocalRoot = { ...initialRoot, revision: 2, owner: 'B-newer' };
+  applyRace.reviewB.saveRoot(newerLocalRoot);
+  const newerLocalEvent = rootEvent(applyRace.liveblocksB);
+  applyGate.resolve();
+  await flush();
+  await flush();
+  assert.deepEqual(applyRace.reviewB.rootValue, newerLocalRoot);
+
+  applyRace.liveblocksB.sentEvents.length = 0;
+  applyRace.syncB.broadcastCurrentState();
+  const postApplySeed = rootEvent(applyRace.liveblocksB);
+  assert.deepEqual(postApplySeed.root, newerLocalRoot);
+  assert.deepEqual(
+    postApplySeed.syncVersion,
+    newerLocalEvent.syncVersion,
+    'a completed older apply must not downgrade the version created during its await'
+  );
+  assert.deepEqual(applyRace.reviewB.supersededRoots, [rootA]);
+  applyRace.syncA.stop();
+  applyRace.syncB.stop();
+
+  const staleWinnerRoot = {
+    ...initialRoot,
+    revision: 5,
+    owner: 'stale-winner-a'
+  };
+  const causalWinnerRoot = {
+    ...initialRoot,
+    revision: 100,
+    owner: 'causal-winner-b'
+  };
+  const conflictingStale = createPair('conflicting-stale', {
+    rootA: staleWinnerRoot,
+    rootB: causalWinnerRoot
+  });
+  conflictingStale.reviewA.staleOwners.add(causalWinnerRoot.owner);
+  conflictingStale.reviewB.staleOwners.add(staleWinnerRoot.owner);
+  conflictingStale.syncA.broadcastCurrentState();
+  conflictingStale.syncB.broadcastCurrentState();
+  const staleWinnerEvent = rootEvent(conflictingStale.liveblocksA);
+  const causalWinnerEvent = rootEvent(conflictingStale.liveblocksB);
+  conflictingStale.liveblocksB.receive(staleWinnerEvent);
+  conflictingStale.liveblocksA.receive(causalWinnerEvent);
+  await flush();
+  await flush();
+  assert.deepEqual(conflictingStale.reviewA.rootValue, causalWinnerRoot);
+  assert.deepEqual(conflictingStale.reviewB.rootValue, causalWinnerRoot);
+  assert.equal(conflictingStale.reviewA.staleOwners.has(causalWinnerRoot.owner), false);
+  assert.equal(
+    conflictingStale.liveblocksA.sentEvents.filter(
+      event => event.type === 'FABRIC_DRAWING_ROOT'
+    ).length + conflictingStale.liveblocksB.sentEvents.filter(
+      event => event.type === 'FABRIC_DRAWING_ROOT'
+    ).length,
+    2,
+    'conflicting stale histories must converge without causal reassert ping-pong'
+  );
+  conflictingStale.syncA.stop();
+  conflictingStale.syncB.stop();
+
+  const chunked = createPair('chunked-version');
+  const largeRoot = {
+    ...rootA,
+    revision: 5,
+    payload: 'x'.repeat(720 * 1024)
+  };
+  chunked.reviewA.saveRoot(largeRoot);
+  const chunkHeader = rootEvent(chunked.liveblocksA);
+  const chunkEvents = chunked.liveblocksA.sentEvents.filter(
+    event => event.type === 'FABRIC_DRAWING_ROOT_CHUNK'
+  );
+  assert.ok(chunkHeader?.syncVersion);
+  assert.ok(chunkEvents.length > 1);
+  chunked.liveblocksB.receive(chunkHeader);
+  const retryTransferId = `${chunkHeader.transferId}-retry`;
+  chunked.liveblocksB.receive({
+    ...chunkHeader,
+    transferId: retryTransferId
+  });
+  for (const event of chunkEvents) {
+    chunked.liveblocksB.receive({
+      ...event,
+      transferId: retryTransferId
+    });
+  }
+  await flush();
+  await flush();
+  assert.deepEqual(chunked.reviewB.rootValue, largeRoot);
+  assert.deepEqual(
+    chunked.reviewB.appliedRoots,
+    [largeRoot],
+    'a same-version chunk retry with a new transferId must replace an incomplete transfer'
+  );
+
+  chunked.liveblocksB.sentEvents.length = 0;
+  chunked.syncB.broadcastCurrentState();
+  const echoedChunkHeader = rootEvent(chunked.liveblocksB);
+  assert.deepEqual(
+    echoedChunkHeader.syncVersion,
+    chunkHeader.syncVersion,
+    'chunk hydration and force seed must preserve the accepted causal version'
+  );
+  chunked.syncA.stop();
+  chunked.syncB.stop();
+
+  const headerClock = createPair('chunk-header-clock');
+  headerClock.reviewA.saveRoot(largeRoot);
+  const delayedHeader = structuredClone(rootEvent(headerClock.liveblocksA));
+  delayedHeader.syncVersion = { clock: 100, actorId: 'actor-z' };
+  const delayedChunks = headerClock.liveblocksA.sentEvents.filter(
+    event => event.type === 'FABRIC_DRAWING_ROOT_CHUNK'
+  );
+  headerClock.liveblocksB.receive(delayedHeader);
+  const localAfterHeader = {
+    ...rootB,
+    revision: 6,
+    owner: 'B-after-header'
+  };
+  headerClock.reviewB.saveRoot(localAfterHeader);
+  const localAfterHeaderEvent = rootEvent(headerClock.liveblocksB);
+  assert.ok(
+    localAfterHeaderEvent.syncVersion.clock > delayedHeader.syncVersion.clock,
+    'a chunk header must advance the observed clock before a later local save'
+  );
+  for (const event of delayedChunks) headerClock.liveblocksB.receive(event);
+  await flush();
+  await flush();
+  assert.deepEqual(headerClock.reviewB.rootValue, localAfterHeader);
+  headerClock.syncA.stop();
+  headerClock.syncB.stop();
+
+  const chunkManagers = ['a', 'b', 'c'].map(actor => {
+    const liveblocksManager = new BufferedLiveblocksManager();
+    const reviewDataManager = new StubReviewDataManager(
+      initialRoot,
+      `chunk-interleave-${actor}`
+    );
+    const sync = new FabricDrawingSync({
+      liveblocksManager,
+      reviewDataManager,
+      actorId: `actor-${actor}`
+    });
+    sync.start();
+    liveblocksManager.sentEvents.length = 0;
+    return { actor, liveblocksManager, reviewDataManager, sync };
+  });
+  const chunkRoots = chunkManagers.map(({ actor }) => ({
+    ...initialRoot,
+    revision: 9,
+    owner: actor.toUpperCase(),
+    payload: actor.repeat(720 * 1024)
+  }));
+  chunkManagers.forEach((participant, index) => {
+    participant.reviewDataManager.saveRoot(chunkRoots[index]);
+  });
+  const transfers = chunkManagers.map(({ liveblocksManager }) => ({
+    header: rootEvent(liveblocksManager),
+    chunks: liveblocksManager.sentEvents.filter(
+      event => event.type === 'FABRIC_DRAWING_ROOT_CHUNK'
+    )
+  }));
+  const deliverInterleavedTransfers = (recipientIndex, firstIndex, secondIndex) => {
+    const recipient = chunkManagers[recipientIndex].liveblocksManager;
+    recipient.receive(transfers[firstIndex].header);
+    recipient.receive(transfers[secondIndex].header);
+    for (const event of transfers[firstIndex].chunks) recipient.receive(event);
+    for (const event of transfers[secondIndex].chunks) recipient.receive(event);
+  };
+  deliverInterleavedTransfers(0, 1, 2);
+  deliverInterleavedTransfers(1, 2, 0);
+  deliverInterleavedTransfers(2, 0, 1);
+  await flush();
+  await flush();
+  for (const participant of chunkManagers) {
+    assert.deepEqual(
+      participant.reviewDataManager.rootValue,
+      chunkRoots[2],
+      'interleaved chunk headers must preserve the highest causal transfer'
+    );
+    participant.sync.stop();
+  }
+});
+
+test('a causally superseded Fabric root cannot return through disk reload', async () => {
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const fabricStore = await createFabricStore();
+  const winnerRoot = createFabricRoot({
+    documentId: 'fabric-causal-disk-winner',
+    revision: 8
+  });
+  const loserRoot = createFabricRoot({
+    documentId: 'fabric-causal-disk-loser',
+    revision: 7
+  });
+  let diskFabric = loserRoot;
+  window.electronAPI = {
+    loadReview: async () => createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: winnerRoot
+    }),
+    loadReviewSnapshot: async () => ({
+      data: createReviewRoot({
+        reviewDocumentId: REVIEW_ID_EXISTING,
+        drawingsV3: diskFabric
+      }),
+      versionToken: 'causal-loser-disk-token'
+    })
+  };
+  const manager = new ReviewDataManager({
+    autoSave: false,
+    fabricDrawingPersistenceProvider: fabricStore
+  });
+  manager.connect();
+  assert.equal(await manager.setVideoFile('C:/reviews/causal-disk-winner.mp4', {
+    fabricDrawingPersistenceContext: FABRIC_CONTEXT
+  }), true);
+
+  assert.equal(manager.markExternalDrawingsV3Superseded(loserRoot), true);
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.deepEqual(fabricStore.exportRootValue(), winnerRoot);
+  assert.equal(manager.getDrawingsV3RootSnapshot().stale, false);
+
+  assert.equal(await manager.applyExternalDrawingsV3(loserRoot), true);
+  assert.deepEqual(
+    fabricStore.exportRootValue(),
+    loserRoot,
+    'an explicit causal winner must bypass its stale-file fingerprint once'
+  );
+  assert.equal(manager.getDrawingsV3RootSnapshot().stale, false);
+
+  diskFabric = winnerRoot;
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.deepEqual(
+    fabricStore.exportRootValue(),
+    loserRoot,
+    'the root replaced by the explicit winner must remain blocked on disk reload'
+  );
+  manager.disconnect();
 });

--- a/scripts/tests/review-data-manager-save.test.js
+++ b/scripts/tests/review-data-manager-save.test.js
@@ -3922,6 +3922,73 @@ test('drawingsV3 disk reload cannot install video A after switching to video B',
   manager.disconnect();
 });
 
+test('newer same-file drawingsV3 reload wins when an older hydration finishes later', async () => {
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const fabricStore = await createFabricStore();
+  const initialFabric = createFabricRoot({
+    documentId: 'fabric-document-same-file-initial'
+  });
+  const olderFabric = createFabricRoot({
+    documentId: 'fabric-document-same-file-older',
+    revision: 5
+  });
+  const newerFabric = createFabricRoot({
+    documentId: 'fabric-document-same-file-newer',
+    revision: 6
+  });
+  const reviewPath = 'C:/reviews/same-file-reload-order.bframe';
+  window.electronAPI = {
+    loadReview: async () => createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: initialFabric
+    })
+  };
+  const manager = new ReviewDataManager({
+    autoSave: false,
+    fabricDrawingPersistenceProvider: fabricStore
+  });
+  manager.connect();
+  assert.equal(await manager.setVideoFile('C:/reviews/same-file-reload-order.mp4', {
+    fabricDrawingPersistenceContext: FABRIC_CONTEXT
+  }), true);
+  assert.equal(manager.currentBframePath, reviewPath);
+
+  const snapshots = [olderFabric, newerFabric];
+  window.electronAPI.loadReviewSnapshot = async _path => ({
+    data: createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: snapshots.shift()
+    }),
+    versionToken: `same-file-reload-${snapshots.length}`
+  });
+  const olderRefreshEntered = createDeferred();
+  const releaseOlderRefresh = createDeferred();
+  let refreshCount = 0;
+  manager.setFabricDrawingSourceRefreshHandler(async ({ installSource }) => {
+    refreshCount += 1;
+    if (refreshCount === 1) {
+      olderRefreshEntered.resolve();
+      await releaseOlderRefresh.promise;
+    }
+    return installSource();
+  });
+
+  const olderReload = manager.reloadDrawingsV3FromDisk();
+  await olderRefreshEntered.promise;
+  const newerReload = manager.reloadDrawingsV3FromDisk();
+  assert.equal(await newerReload, true);
+  assert.deepEqual(fabricStore.exportRootValue(), newerFabric);
+
+  releaseOlderRefresh.resolve();
+  assert.equal(await olderReload, false);
+  assert.equal(refreshCount, 2);
+  assert.deepEqual(fabricStore.exportRootValue(), newerFabric);
+  const finalSnapshot = manager.getDrawingsV3RootSnapshot();
+  assert.equal(finalSnapshot.stale, false);
+  assert.deepEqual(finalSnapshot.value, newerFabric);
+  manager.disconnect();
+});
+
 test('Fabric drawing sync drops queued roots from a stopped session after restart', async () => {
   const { FabricDrawingSync } = await import(
     '../../renderer/scripts/modules/fabric-drawing-sync.js'

--- a/scripts/tests/review-data-manager-save.test.js
+++ b/scripts/tests/review-data-manager-save.test.js
@@ -2571,10 +2571,11 @@ test('failed external drawingsV3 installation retries the same payload instead o
   assert.deepEqual(fabricStore.exportRootValue(), externalFabric);
   const acceptedSnapshot = manager.getDrawingsV3RootSnapshot();
   assert.equal(acceptedSnapshot.stale, false);
+  assert.equal(acceptedSnapshot.compatible, true);
   assert.deepEqual(acceptedSnapshot.value, externalFabric);
 });
 
-test('external future and missing drawingsV3 are adopted opaquely when local Fabric is clean', async () => {
+test('external future, malformed, and missing drawingsV3 are adopted opaquely when local Fabric is clean', async () => {
   const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
 
   for (const [label, externalDrawing, expectedState] of [
@@ -2583,6 +2584,13 @@ test('external future and missing drawingsV3 are adopted opaquely when local Fab
       storageVersion: '8.0.0',
       engine: 'future-engine',
       futurePayload: { preserve: ['exactly'] }
+    }, 'incompatible'],
+    ['malformed', {
+      ...createFabricRoot({
+        documentId: 'fabric-external-malformed',
+        revision: 100
+      }),
+      keyframes: 'invalid-opaque'
     }, 'incompatible'],
     ['missing', undefined, 'ready']
   ]) {
@@ -2629,6 +2637,10 @@ test('external future and missing drawingsV3 are adopted opaquely when local Fab
       assert.equal(fabricStore.exportRootValue().keyframes.length, 0);
     }
     assert.equal(fabricStore.getStatus().state, expectedState);
+    assert.equal(
+      manager.getDrawingsV3RootSnapshot().compatible,
+      externalDrawing === undefined ? null : false
+    );
     manager.disconnect();
   }
 });
@@ -3891,12 +3903,28 @@ test('drawingsV3 disk reload cannot install video A after switching to video B',
   ]);
   const reloadReadStarted = createDeferred();
   const reloadReadA = createDeferred();
+  const savedVideoBRoots = [];
   window.electronAPI = {
     loadReview: async path => structuredClone(roots.get(path) || null),
     loadReviewSnapshot: async path => {
-      assert.equal(path, pathA);
-      reloadReadStarted.resolve();
-      return reloadReadA.promise;
+      if (path === pathA) {
+        reloadReadStarted.resolve();
+        return reloadReadA.promise;
+      }
+      assert.equal(path, pathB);
+      return {
+        data: structuredClone(roots.get(pathB)),
+        versionToken: 'drawings-v3-disk-owner-b-current'
+      };
+    },
+    saveReview: async (path, data) => {
+      assert.equal(path, pathB);
+      savedVideoBRoots.push(structuredClone(data));
+      roots.set(pathB, structuredClone(data));
+      return {
+        success: true,
+        versionToken: 'drawings-v3-disk-owner-b-saved'
+      };
     }
   };
   const manager = new ReviewDataManager({
@@ -3921,6 +3949,14 @@ test('drawingsV3 disk reload cannot install video A after switching to video B',
     }
   }), true);
   assert.deepEqual(fabricStore.exportRootValue(), fabricB);
+  manager.setVersionInfo({ fileName: 'video-b-save-before-a-reload-finishes.mp4' });
+  assert.equal(
+    await manager.save(),
+    true,
+    'an old video A reload must not block a current video B save'
+  );
+  assert.equal(savedVideoBRoots.length, 1);
+  assert.deepEqual(savedVideoBRoots[0].drawingsV3, fabricB);
   importRootValueCalls = 0;
 
   reloadReadA.resolve({
@@ -4149,18 +4185,20 @@ test('a higher-version same-root Broadcast invalidates an older pending disk rel
     actorId: 'same-root-local'
   });
   sync.start();
-  liveblocksManager.sentEvents.length = 0;
-  sync.broadcastCurrentState();
-  const currentRootEvent = liveblocksManager.sentEvents.find(
-    event => event.type === 'FABRIC_DRAWING_ROOT'
+  const currentRootRequest = liveblocksManager.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST_V2'
   );
-  assert.ok(currentRootEvent?.fingerprint);
+  liveblocksManager.sentEvents.length = 0;
+  assert.ok(currentRootRequest?.fingerprint);
 
   const olderReload = manager.reloadDrawingsV3FromDisk();
   await diskReadStarted.promise;
   liveblocksManager.receive({
-    ...currentRootEvent,
+    type: 'FABRIC_DRAWING_ROOT',
     transferId: 'same-root-remote-higher-version',
+    present: true,
+    root: structuredClone(currentFabric),
+    fingerprint: currentRootRequest.fingerprint,
     syncVersion: { clock: 10, actorId: 'same-root-remote' }
   });
   await new Promise(resolve => setImmediate(resolve));
@@ -4296,6 +4334,8 @@ test('Fabric drawing sync requests a stable peer seed after an earlier join broa
         present: true,
         value: structuredClone(this.rootValue),
         fingerprint: `present:${JSON.stringify(this.rootValue)}`,
+        compatible: true,
+        localChanges: false,
         stale: false
       };
     }
@@ -4308,14 +4348,12 @@ test('Fabric drawing sync requests a stable peer seed after an earlier join broa
   }
 
   const latestRoot = createFabricRoot({
-    documentId: 'fabric-document-stable-peer',
+    documentId: 'fabric-document-handshake-shared',
     revision: 12
   });
   const staleRoot = createFabricRoot({
-    documentId: 'fabric-document-joining-peer',
-    // 같은 revision이어도 안정 peer의 첫 publish 버전이 newcomer baseline보다 높아야 한다.
-    // 이 두 root의 wire fingerprint 순서는 stable < joining이라 단순 hash tie-break면 실패한다.
-    revision: 12
+    documentId: 'fabric-document-handshake-shared',
+    revision: 11
   });
   const liveblocksA = new LinkedLiveblocksManager();
   const liveblocksB = new LinkedLiveblocksManager();
@@ -4347,23 +4385,32 @@ test('Fabric drawing sync requests a stable peer seed after an earlier join broa
   await new Promise(resolve => setImmediate(resolve));
 
   assert.equal(
-    liveblocksB.sentEvents.filter(event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST').length,
+    liveblocksB.sentEvents.filter(
+      event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST_V2'
+    ).length,
     1,
     'the joining peer must request one post-subscription seed'
   );
   assert.equal(
-    liveblocksA.sentEvents.filter(event => event.type === 'FABRIC_DRAWING_ROOT').length,
+    liveblocksA.sentEvents.filter(
+      event => event.type === 'FABRIC_DRAWING_ROOT_RESPONSE'
+    ).length,
     1,
     'the stable peer must answer once even before its Others view catches up'
   );
   assert.deepEqual(reviewB.appliedRoots, [latestRoot]);
+  const joiningRequest = structuredClone(
+    liveblocksB.sentEvents.find(event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST_V2')
+  );
   const firstSeedVersion = structuredClone(
-    liveblocksA.sentEvents.find(event => event.type === 'FABRIC_DRAWING_ROOT').syncVersion
+    liveblocksA.sentEvents.find(
+      event => event.type === 'FABRIC_DRAWING_ROOT_RESPONSE'
+    ).syncVersion
   );
   now = 10002;
-  liveblocksB.broadcastEvent({ type: 'FABRIC_DRAWING_ROOT_REQUEST' });
+  liveblocksB.broadcastEvent(joiningRequest);
   const repeatedSeeds = liveblocksA.sentEvents.filter(
-    event => event.type === 'FABRIC_DRAWING_ROOT'
+    event => event.type === 'FABRIC_DRAWING_ROOT_RESPONSE'
   );
   assert.equal(repeatedSeeds.length, 2);
   assert.deepEqual(
@@ -4377,13 +4424,1252 @@ test('Fabric drawing sync requests a stable peer seed after an earlier join broa
   liveblocksA.broadcastEvent({ type: 'FABRIC_DRAWING_ROOT_REQUEST' });
   await new Promise(resolve => setImmediate(resolve));
   assert.equal(
-    liveblocksB.sentEvents.filter(event => event.type === 'FABRIC_DRAWING_ROOT').length,
+    liveblocksB.sentEvents.filter(
+      event => event.type === 'FABRIC_DRAWING_ROOT_RESPONSE'
+    ).length,
     0,
     'a newly joined peer must not seed its potentially stale root during stabilization'
   );
 
   syncB.stop();
   syncA.stop();
+});
+
+test('Fabric drawing sync retries once after simultaneous fresh joins and fences stale retry timers', async () => {
+  const { FabricDrawingSync } = await import(
+    '../../renderer/scripts/modules/fabric-drawing-sync.js'
+  );
+  let now = 0;
+
+  class FakeSeedRetryScheduler {
+    constructor() {
+      this.tasks = [];
+    }
+
+    schedule(callback, delay) {
+      const task = { callback, delay, cancelled: false };
+      this.tasks.push(task);
+      return task;
+    }
+
+    cancel(task) {
+      if (task) task.cancelled = true;
+    }
+  }
+
+  class LinkedLiveblocksManager extends EventTarget {
+    constructor(connectionId) {
+      super();
+      this.connectionId = connectionId;
+      this.peer = null;
+      this.sentEvents = [];
+    }
+
+    getSelf() {
+      return { connectionId: this.connectionId };
+    }
+
+    hasOtherCollaborators() {
+      return Boolean(this.peer);
+    }
+
+    broadcastEvent(event) {
+      this.sentEvents.push(structuredClone(event));
+      this.peer?.dispatchEvent(new CustomEvent('broadcastReceived', {
+        detail: { event: structuredClone(event) }
+      }));
+    }
+  }
+
+  class StubReviewDataManager extends EventTarget {
+    constructor(rootValue, path, {
+      present = rootValue !== undefined,
+      compatible = present,
+      localChanges = false
+    } = {}) {
+      super();
+      this.currentBframePath = path;
+      this.present = present;
+      this.compatible = present ? compatible : null;
+      this.localChanges = localChanges;
+      this.baselineConflict = false;
+      this.rootValue = present ? structuredClone(rootValue) : undefined;
+      this.appliedRoots = [];
+      this.invalidatedReloads = 0;
+    }
+
+    getDrawingsV3RootSnapshot() {
+      return {
+        present: this.present,
+        value: this.present ? structuredClone(this.rootValue) : undefined,
+        fingerprint: this.present
+          ? `present:${JSON.stringify(this.rootValue)}`
+          : 'missing',
+        compatible: this.compatible,
+        localChanges: this.localChanges,
+        baselineConflict: this.baselineConflict,
+        stale: false
+      };
+    }
+
+    markDrawingsV3BaselineConflict() {
+      this.baselineConflict = true;
+      return true;
+    }
+
+    clearDrawingsV3BaselineConflict() {
+      const changed = this.baselineConflict;
+      this.baselineConflict = false;
+      return changed;
+    }
+
+    invalidatePendingDrawingsV3DiskReloadsForExternalSync() {
+      this.invalidatedReloads += 1;
+    }
+
+    async applyExternalDrawingsV3(rootValue, { present = true } = {}) {
+      this.appliedRoots.push(present ? structuredClone(rootValue) : undefined);
+      if (this.localChanges) return false;
+      this.present = present;
+      this.compatible = present;
+      this.rootValue = present ? structuredClone(rootValue) : undefined;
+      return true;
+    }
+  }
+
+  const createSync = ({ liveblocksManager, reviewDataManager, scheduler, actorId }) =>
+    new FabricDrawingSync({
+      liveblocksManager,
+      reviewDataManager,
+      actorId,
+      now: () => now,
+      scheduleSeedRetry: (callback, delay) => scheduler.schedule(callback, delay),
+      cancelSeedRetry: timer => scheduler.cancel(timer)
+    });
+  const requestCount = manager => manager.sentEvents.filter(
+    event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST_V2'
+  ).length;
+  const rootCount = manager => manager.sentEvents.filter(
+    event => event.type === 'FABRIC_DRAWING_ROOT' ||
+      event.type === 'FABRIC_DRAWING_ROOT_RESPONSE'
+  ).length;
+  const flushApplyQueue = async () => {
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+  };
+
+  const latestRoot = createFabricRoot({
+    documentId: 'fabric-simultaneous-shared',
+    revision: 2
+  });
+  const staleRoot = createFabricRoot({
+    documentId: 'fabric-simultaneous-shared',
+    revision: 1
+  });
+  const simultaneousScheduler = new FakeSeedRetryScheduler();
+  const liveblocksA = new LinkedLiveblocksManager('actor-a');
+  const liveblocksB = new LinkedLiveblocksManager('actor-b');
+  liveblocksA.peer = liveblocksB;
+  liveblocksB.peer = liveblocksA;
+  const reviewA = new StubReviewDataManager(latestRoot, 'C:/reviews/simultaneous.bframe');
+  const reviewB = new StubReviewDataManager(staleRoot, 'C:/reviews/simultaneous.bframe');
+  const syncA = createSync({
+    liveblocksManager: liveblocksA,
+    reviewDataManager: reviewA,
+    scheduler: simultaneousScheduler,
+    actorId: 'actor-a'
+  });
+  const syncB = createSync({
+    liveblocksManager: liveblocksB,
+    reviewDataManager: reviewB,
+    scheduler: simultaneousScheduler,
+    actorId: 'actor-b'
+  });
+
+  syncA.start();
+  syncB.start();
+  await flushApplyQueue();
+  assert.equal(requestCount(liveblocksA), 1);
+  assert.equal(requestCount(liveblocksB), 1);
+  assert.equal(rootCount(liveblocksA) + rootCount(liveblocksB), 0);
+  assert.notDeepEqual(reviewA.rootValue, reviewB.rootValue);
+  assert.equal(reviewA.baselineConflict, true);
+  assert.equal(reviewB.baselineConflict, true);
+  assert.equal(simultaneousScheduler.tasks.length, 2);
+  assert.deepEqual(
+    simultaneousScheduler.tasks.map(task => task.delay),
+    [10001, 10001]
+  );
+
+  reviewB.dispatchEvent(new CustomEvent('saved', {
+    detail: { path: reviewB.currentBframePath }
+  }));
+  await flushApplyQueue();
+  assert.equal(
+    rootCount(liveblocksA) + rootCount(liveblocksB),
+    0,
+    'an unrelated save before stabilization must not publish the unchanged stale baseline'
+  );
+  assert.deepEqual(reviewA.rootValue, latestRoot);
+
+  now = 10001;
+  simultaneousScheduler.tasks[0].callback();
+  await flushApplyQueue();
+  simultaneousScheduler.tasks[1].callback();
+  await flushApplyQueue();
+
+  assert.equal(requestCount(liveblocksA), 2, 'A must retry only once after stabilization');
+  assert.equal(requestCount(liveblocksB), 2, 'B must retry only once after stabilization');
+  assert.equal(liveblocksA.sentEvents.filter(
+    event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST_V2'
+  ).at(-1).stabilizationRetry, true);
+  assert.equal(liveblocksB.sentEvents.filter(
+    event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST_V2'
+  ).at(-1).stabilizationRetry, true);
+  assert.deepEqual(reviewA.rootValue, latestRoot);
+  assert.deepEqual(reviewB.rootValue, latestRoot);
+  assert.deepEqual(syncA._currentRootVersion, syncB._currentRootVersion);
+  assert.equal(reviewA.baselineConflict, false);
+  assert.equal(reviewB.baselineConflict, false);
+  const requestsAfterConvergence = requestCount(liveblocksA) + requestCount(liveblocksB);
+  simultaneousScheduler.tasks.forEach(task => task.callback());
+  await flushApplyQueue();
+  assert.equal(requestCount(liveblocksA) + requestCount(liveblocksB), requestsAfterConvergence);
+  reviewB.dispatchEvent(new CustomEvent('saved', {
+    detail: { path: reviewB.currentBframePath }
+  }));
+  await flushApplyQueue();
+  assert.deepEqual(reviewA.rootValue, latestRoot, 'a later save must not restore the stale baseline');
+  syncB.stop();
+  syncA.stop();
+
+  const preserveMissingAgainstUnverifiedPresentRoot = async ({ missingStartsFirst }) => {
+    const scheduler = new FakeSeedRetryScheduler();
+    const liveblocksMissing = new LinkedLiveblocksManager('actor-missing');
+    const liveblocksPresent = new LinkedLiveblocksManager('actor-present');
+    liveblocksMissing.peer = liveblocksPresent;
+    liveblocksPresent.peer = liveblocksMissing;
+    const reviewMissing = new StubReviewDataManager(
+      undefined,
+      'C:/reviews/simultaneous-tombstone.bframe',
+      { present: false }
+    );
+    const reviewPresent = new StubReviewDataManager(
+      createFabricRoot({
+        documentId: 'fabric-simultaneous-stale-present',
+        revision: 12
+      }),
+      'C:/reviews/simultaneous-tombstone.bframe'
+    );
+    const syncMissing = createSync({
+      liveblocksManager: liveblocksMissing,
+      reviewDataManager: reviewMissing,
+      scheduler,
+      actorId: 'actor-missing'
+    });
+    const syncPresent = createSync({
+      liveblocksManager: liveblocksPresent,
+      reviewDataManager: reviewPresent,
+      scheduler,
+      actorId: 'actor-present'
+    });
+
+    now = 0;
+    if (missingStartsFirst) {
+      syncMissing.start();
+      syncPresent.start();
+    } else {
+      syncPresent.start();
+      syncMissing.start();
+    }
+    await flushApplyQueue();
+    assert.equal(rootCount(liveblocksMissing) + rootCount(liveblocksPresent), 0);
+    assert.equal(reviewMissing.baselineConflict, true);
+    assert.equal(reviewPresent.baselineConflict, true);
+    now = 10001;
+    for (const task of scheduler.tasks) {
+      task.callback();
+      await flushApplyQueue();
+    }
+    assert.equal(reviewMissing.getDrawingsV3RootSnapshot().present, false);
+    assert.equal(reviewPresent.getDrawingsV3RootSnapshot().present, true);
+    assert.equal(rootCount(liveblocksMissing) + rootCount(liveblocksPresent), 0);
+    syncPresent.stop();
+    syncMissing.stop();
+  };
+  await preserveMissingAgainstUnverifiedPresentRoot({ missingStartsFirst: true });
+  await preserveMissingAgainstUnverifiedPresentRoot({ missingStartsFirst: false });
+
+  const preserveOpaqueAgainstUnverifiedSupportedRoot = async ({ opaqueStartsFirst }) => {
+    const scheduler = new FakeSeedRetryScheduler();
+    const liveblocksOpaque = new LinkedLiveblocksManager('actor-opaque');
+    const liveblocksSupported = new LinkedLiveblocksManager('actor-supported');
+    liveblocksOpaque.peer = liveblocksSupported;
+    liveblocksSupported.peer = liveblocksOpaque;
+    const opaqueRoot = {
+      storageSchema: 'baeframe-fabric-scenes',
+      storageVersion: '8.0.0',
+      engine: 'fabric-future',
+      futurePayload: { preserve: 'byte-exact' }
+    };
+    const reviewOpaque = new StubReviewDataManager(
+      opaqueRoot,
+      'C:/reviews/simultaneous-opaque.bframe',
+      { compatible: false }
+    );
+    const reviewSupported = new StubReviewDataManager(
+      createFabricRoot({
+        documentId: 'fabric-simultaneous-stale-supported',
+        revision: 12
+      }),
+      'C:/reviews/simultaneous-opaque.bframe'
+    );
+    const syncOpaque = createSync({
+      liveblocksManager: liveblocksOpaque,
+      reviewDataManager: reviewOpaque,
+      scheduler,
+      actorId: 'actor-opaque'
+    });
+    const syncSupported = createSync({
+      liveblocksManager: liveblocksSupported,
+      reviewDataManager: reviewSupported,
+      scheduler,
+      actorId: 'actor-supported'
+    });
+
+    now = 0;
+    if (opaqueStartsFirst) {
+      syncOpaque.start();
+      syncSupported.start();
+    } else {
+      syncSupported.start();
+      syncOpaque.start();
+    }
+    await flushApplyQueue();
+    assert.equal(rootCount(liveblocksOpaque) + rootCount(liveblocksSupported), 0);
+    now = 10001;
+    for (const task of scheduler.tasks) {
+      task.callback();
+      await flushApplyQueue();
+    }
+    assert.deepEqual(reviewOpaque.rootValue, opaqueRoot);
+    assert.equal(reviewSupported.rootValue.documentId, 'fabric-simultaneous-stale-supported');
+    assert.equal(rootCount(liveblocksOpaque) + rootCount(liveblocksSupported), 0);
+    syncSupported.stop();
+    syncOpaque.stop();
+  };
+  await preserveOpaqueAgainstUnverifiedSupportedRoot({ opaqueStartsFirst: true });
+  await preserveOpaqueAgainstUnverifiedSupportedRoot({ opaqueStartsFirst: false });
+
+  const preserveMalformedOpaqueAgainstSupportedRoot = async ({ opaqueStartsFirst }) => {
+    const scheduler = new FakeSeedRetryScheduler();
+    const liveblocksOpaque = new LinkedLiveblocksManager('actor-malformed-opaque');
+    const liveblocksSupported = new LinkedLiveblocksManager('actor-valid-supported');
+    liveblocksOpaque.peer = liveblocksSupported;
+    liveblocksSupported.peer = liveblocksOpaque;
+    const malformedOpaqueRoot = {
+      ...createFabricRoot({
+        documentId: 'fabric-malformed-shared',
+        revision: 100
+      }),
+      keyframes: 'invalid-opaque'
+    };
+    const supportedRoot = createFabricRoot({
+      documentId: 'fabric-malformed-shared',
+      revision: 1
+    });
+    const reviewOpaque = new StubReviewDataManager(
+      malformedOpaqueRoot,
+      'C:/reviews/simultaneous-malformed.bframe',
+      { compatible: false }
+    );
+    const reviewSupported = new StubReviewDataManager(
+      supportedRoot,
+      'C:/reviews/simultaneous-malformed.bframe'
+    );
+    const syncOpaque = createSync({
+      liveblocksManager: liveblocksOpaque,
+      reviewDataManager: reviewOpaque,
+      scheduler,
+      actorId: 'actor-malformed-opaque'
+    });
+    const syncSupported = createSync({
+      liveblocksManager: liveblocksSupported,
+      reviewDataManager: reviewSupported,
+      scheduler,
+      actorId: 'actor-valid-supported'
+    });
+
+    now = 0;
+    if (opaqueStartsFirst) {
+      syncOpaque.start();
+      syncSupported.start();
+    } else {
+      syncSupported.start();
+      syncOpaque.start();
+    }
+    await flushApplyQueue();
+    now = 10001;
+    for (const task of scheduler.tasks) {
+      task.callback();
+      await flushApplyQueue();
+    }
+    assert.deepEqual(reviewOpaque.rootValue, malformedOpaqueRoot);
+    assert.deepEqual(reviewSupported.rootValue, supportedRoot);
+    assert.equal(rootCount(liveblocksOpaque) + rootCount(liveblocksSupported), 0);
+    syncSupported.stop();
+    syncOpaque.stop();
+  };
+  await preserveMalformedOpaqueAgainstSupportedRoot({ opaqueStartsFirst: true });
+  await preserveMalformedOpaqueAgainstSupportedRoot({ opaqueStartsFirst: false });
+
+  const convergeSameDocumentAfterEarlyEdit = async ({ reverseRetryOrder }) => {
+    const scheduler = new FakeSeedRetryScheduler();
+    const liveblocksHigh = new LinkedLiveblocksManager('actor-high-baseline');
+    const liveblocksEdited = new LinkedLiveblocksManager('actor-early-edit');
+    liveblocksHigh.peer = liveblocksEdited;
+    liveblocksEdited.peer = liveblocksHigh;
+    const highRoot = createFabricRoot({
+      documentId: 'fabric-early-edit-shared',
+      revision: 10
+    });
+    const lowRoot = createFabricRoot({
+      documentId: 'fabric-early-edit-shared',
+      revision: 1
+    });
+    const editedRoot = createFabricRoot({
+      documentId: 'fabric-early-edit-shared',
+      revision: 2
+    });
+    const reviewHigh = new StubReviewDataManager(
+      highRoot,
+      'C:/reviews/simultaneous-early-edit.bframe'
+    );
+    const reviewEdited = new StubReviewDataManager(
+      lowRoot,
+      'C:/reviews/simultaneous-early-edit.bframe'
+    );
+    const syncHigh = createSync({
+      liveblocksManager: liveblocksHigh,
+      reviewDataManager: reviewHigh,
+      scheduler,
+      actorId: 'actor-high-baseline'
+    });
+    const syncEdited = createSync({
+      liveblocksManager: liveblocksEdited,
+      reviewDataManager: reviewEdited,
+      scheduler,
+      actorId: 'actor-early-edit'
+    });
+
+    now = 0;
+    syncHigh.start();
+    syncEdited.start();
+    reviewEdited.rootValue = structuredClone(editedRoot);
+    reviewEdited.dispatchEvent(new CustomEvent('saved', {
+      detail: { path: reviewEdited.currentBframePath }
+    }));
+    await flushApplyQueue();
+    assert.deepEqual(reviewHigh.rootValue, highRoot);
+    assert.deepEqual(reviewEdited.rootValue, editedRoot);
+
+    now = 10001;
+    const retryTasks = reverseRetryOrder
+      ? [...scheduler.tasks].reverse()
+      : scheduler.tasks;
+    for (const task of retryTasks) {
+      task.callback();
+      await flushApplyQueue();
+    }
+    assert.deepEqual(reviewHigh.rootValue, editedRoot);
+    assert.deepEqual(reviewEdited.rootValue, editedRoot);
+    syncEdited.stop();
+    syncHigh.stop();
+  };
+  await convergeSameDocumentAfterEarlyEdit({ reverseRetryOrder: false });
+  await convergeSameDocumentAfterEarlyEdit({ reverseRetryOrder: true });
+
+  const dirtyScheduler = new FakeSeedRetryScheduler();
+  const liveblocksStableDirty = new LinkedLiveblocksManager('actor-stable-dirty');
+  const liveblocksLocalDirty = new LinkedLiveblocksManager('actor-local-dirty');
+  liveblocksStableDirty.peer = liveblocksLocalDirty;
+  liveblocksLocalDirty.peer = liveblocksStableDirty;
+  const stableDirtyRoot = createFabricRoot({
+    documentId: 'fabric-startup-local-dirty',
+    revision: 10
+  });
+  const localDirtyRoot = createFabricRoot({
+    documentId: 'fabric-startup-local-dirty',
+    revision: 2
+  });
+  const reviewStableDirty = new StubReviewDataManager(
+    stableDirtyRoot,
+    'C:/reviews/startup-local-dirty.bframe'
+  );
+  const reviewLocalDirty = new StubReviewDataManager(
+    localDirtyRoot,
+    'C:/reviews/startup-local-dirty.bframe',
+    { localChanges: true }
+  );
+  const syncStableDirty = createSync({
+    liveblocksManager: liveblocksStableDirty,
+    reviewDataManager: reviewStableDirty,
+    scheduler: dirtyScheduler,
+    actorId: 'actor-stable-dirty'
+  });
+  const syncLocalDirty = createSync({
+    liveblocksManager: liveblocksLocalDirty,
+    reviewDataManager: reviewLocalDirty,
+    scheduler: dirtyScheduler,
+    actorId: 'actor-local-dirty'
+  });
+  now = 0;
+  syncStableDirty.start();
+  now = 10001;
+  syncLocalDirty.start();
+  await flushApplyQueue();
+  assert.deepEqual(reviewLocalDirty.rootValue, localDirtyRoot);
+  assert.ok(syncLocalDirty._pendingExternalRoot);
+  assert.equal(syncLocalDirty.broadcastCurrentState(), false);
+  reviewLocalDirty.localChanges = false;
+  reviewLocalDirty.dispatchEvent(new CustomEvent('saved', {
+    detail: { path: reviewLocalDirty.currentBframePath }
+  }));
+  await flushApplyQueue();
+  assert.equal(rootCount(liveblocksLocalDirty), 1);
+  assert.deepEqual(reviewStableDirty.rootValue, localDirtyRoot);
+  assert.deepEqual(reviewLocalDirty.rootValue, localDirtyRoot);
+  assert.equal(syncLocalDirty._pendingExternalRoot, null);
+  syncLocalDirty.stop();
+  syncStableDirty.stop();
+
+  const dirtyResponseScheduler = new FakeSeedRetryScheduler();
+  const liveblocksDirtyResponder = new LinkedLiveblocksManager('dirty-responder');
+  const liveblocksDirtyRequester = new LinkedLiveblocksManager('dirty-requester');
+  liveblocksDirtyResponder.peer = liveblocksDirtyRequester;
+  liveblocksDirtyRequester.peer = liveblocksDirtyResponder;
+  const dirtyResponseRoot = createFabricRoot({
+    documentId: 'fabric-dirty-response',
+    revision: 2
+  });
+  const dirtyRequestRoot = createFabricRoot({
+    documentId: 'fabric-dirty-response',
+    revision: 1
+  });
+  const reviewDirtyResponder = new StubReviewDataManager(
+    dirtyResponseRoot,
+    'C:/reviews/dirty-response.bframe',
+    { localChanges: true }
+  );
+  const reviewDirtyRequester = new StubReviewDataManager(
+    dirtyRequestRoot,
+    'C:/reviews/dirty-response.bframe'
+  );
+  const syncDirtyResponder = createSync({
+    liveblocksManager: liveblocksDirtyResponder,
+    reviewDataManager: reviewDirtyResponder,
+    scheduler: dirtyResponseScheduler,
+    actorId: 'dirty-responder'
+  });
+  const syncDirtyRequester = createSync({
+    liveblocksManager: liveblocksDirtyRequester,
+    reviewDataManager: reviewDirtyRequester,
+    scheduler: dirtyResponseScheduler,
+    actorId: 'dirty-requester'
+  });
+  now = 0;
+  syncDirtyResponder.start();
+  syncDirtyRequester.start();
+  now = 10001;
+  dirtyResponseScheduler.tasks[1].callback();
+  await flushApplyQueue();
+  assert.equal(liveblocksDirtyResponder.sentEvents.filter(
+    event => event.type === 'FABRIC_DRAWING_ROOT_RESPONSE'
+  ).length, 1);
+  reviewDirtyResponder.localChanges = false;
+  reviewDirtyResponder.dispatchEvent(new CustomEvent('saved', {
+    detail: { path: reviewDirtyResponder.currentBframePath }
+  }));
+  await flushApplyQueue();
+  const confirmedDirtySave = liveblocksDirtyResponder.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT'
+  );
+  assert.equal(confirmedDirtySave.syncVersion.actorId, 'dirty-responder');
+  assert.ok(confirmedDirtySave.syncVersion.clock > 2);
+  syncDirtyRequester.stop();
+  syncDirtyResponder.stop();
+
+  const observedClockScheduler = new FakeSeedRetryScheduler();
+  const liveblocksObservedClock = new LinkedLiveblocksManager('observed-clock-peer');
+  const liveblocksRawLatest = new LinkedLiveblocksManager('raw-latest-peer');
+  liveblocksObservedClock.peer = liveblocksRawLatest;
+  liveblocksRawLatest.peer = liveblocksObservedClock;
+  const observedInitialRoot = createFabricRoot({
+    documentId: 'fabric-observed-clock-shared',
+    revision: 10
+  });
+  const observedLowerRoot = createFabricRoot({
+    documentId: 'fabric-observed-clock-shared',
+    revision: 8
+  });
+  const observedLocalEdit = createFabricRoot({
+    documentId: 'fabric-observed-clock-shared',
+    revision: 11
+  });
+  const reviewObservedClock = new StubReviewDataManager(
+    observedInitialRoot,
+    'C:/reviews/observed-clock-raw-version.bframe'
+  );
+  const reviewRawLatest = new StubReviewDataManager(
+    observedInitialRoot,
+    'C:/reviews/observed-clock-raw-version.bframe'
+  );
+  const syncObservedClock = createSync({
+    liveblocksManager: liveblocksObservedClock,
+    reviewDataManager: reviewObservedClock,
+    scheduler: observedClockScheduler,
+    actorId: 'observed-clock-peer'
+  });
+  const syncRawLatest = createSync({
+    liveblocksManager: liveblocksRawLatest,
+    reviewDataManager: reviewRawLatest,
+    scheduler: observedClockScheduler,
+    actorId: 'raw-latest-peer'
+  });
+  now = 0;
+  syncObservedClock.start();
+  liveblocksObservedClock.dispatchEvent(new CustomEvent('broadcastReceived', {
+    detail: {
+      event: {
+        type: 'FABRIC_DRAWING_ROOT',
+        transferId: 'observed-clock-header',
+        present: true,
+        fingerprint: 'observed-clock-only',
+        syncVersion: { clock: 100, actorId: 'remote-clock-peer' },
+        chunkCount: 1
+      }
+    }
+  }));
+  reviewObservedClock.rootValue = structuredClone(observedLowerRoot);
+  now = 10001;
+  syncRawLatest.start();
+  await flushApplyQueue();
+  assert.deepEqual(
+    reviewObservedClock.rootValue,
+    observedInitialRoot,
+    'an observed Lamport clock must not make a lower raw revision win'
+  );
+  assert.deepEqual(reviewRawLatest.rootValue, observedInitialRoot);
+  reviewObservedClock.rootValue = structuredClone(observedLocalEdit);
+  reviewObservedClock.dispatchEvent(new CustomEvent('saved', {
+    detail: { path: reviewObservedClock.currentBframePath }
+  }));
+  await flushApplyQueue();
+  const localAfterObservedClock = liveblocksObservedClock.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT'
+  );
+  assert.ok(localAfterObservedClock.syncVersion.clock > 100);
+  assert.equal(localAfterObservedClock.syncVersion.actorId, 'observed-clock-peer');
+  assert.deepEqual(reviewRawLatest.rootValue, observedLocalEdit);
+  syncRawLatest.stop();
+  syncObservedClock.stop();
+
+  const preserveDifferentDocumentBaselines = async ({ newDocumentStartsFirst }) => {
+    const scheduler = new FakeSeedRetryScheduler();
+    const liveblocksNew = new LinkedLiveblocksManager('actor-new-document');
+    const liveblocksOld = new LinkedLiveblocksManager('actor-old-document');
+    liveblocksNew.peer = liveblocksOld;
+    liveblocksOld.peer = liveblocksNew;
+    const newDocumentRoot = createFabricRoot({
+      documentId: 'fabric-after-reset',
+      revision: 1
+    });
+    const oldDocumentRoot = createFabricRoot({
+      documentId: 'fabric-before-reset',
+      revision: 12
+    });
+    const reviewNew = new StubReviewDataManager(
+      newDocumentRoot,
+      'C:/reviews/simultaneous-reset.bframe'
+    );
+    const reviewOld = new StubReviewDataManager(
+      oldDocumentRoot,
+      'C:/reviews/simultaneous-reset.bframe'
+    );
+    const syncNew = createSync({
+      liveblocksManager: liveblocksNew,
+      reviewDataManager: reviewNew,
+      scheduler,
+      actorId: 'actor-new-document'
+    });
+    const syncOld = createSync({
+      liveblocksManager: liveblocksOld,
+      reviewDataManager: reviewOld,
+      scheduler,
+      actorId: 'actor-old-document'
+    });
+
+    now = 0;
+    if (newDocumentStartsFirst) {
+      syncNew.start();
+      syncOld.start();
+    } else {
+      syncOld.start();
+      syncNew.start();
+    }
+    await flushApplyQueue();
+    syncOld.broadcastCurrentState();
+    await flushApplyQueue();
+    assert.equal(
+      rootCount(liveblocksOld),
+      0,
+      'an explicit force seed must not publish the unverified startup baseline'
+    );
+    now = 10001;
+    for (const task of scheduler.tasks) {
+      task.callback();
+      await flushApplyQueue();
+    }
+    assert.deepEqual(reviewNew.rootValue, newDocumentRoot);
+    assert.deepEqual(reviewOld.rootValue, oldDocumentRoot);
+    assert.equal(rootCount(liveblocksNew) + rootCount(liveblocksOld), 0);
+
+    reviewOld.dispatchEvent(new CustomEvent('saved', {
+      detail: { path: reviewOld.currentBframePath }
+    }));
+    await flushApplyQueue();
+    assert.equal(
+      rootCount(liveblocksOld),
+      0,
+      'an unrelated save must not promote an incomparable pre-reset baseline'
+    );
+    assert.deepEqual(reviewNew.rootValue, newDocumentRoot);
+
+    const editedNewDocumentRoot = createFabricRoot({
+      documentId: 'fabric-after-reset',
+      revision: 2
+    });
+    reviewNew.rootValue = structuredClone(editedNewDocumentRoot);
+    reviewNew.dispatchEvent(new CustomEvent('saved', {
+      detail: { path: reviewNew.currentBframePath }
+    }));
+    await flushApplyQueue();
+    assert.equal(rootCount(liveblocksNew), 1);
+    assert.deepEqual(
+      reviewOld.rootValue,
+      editedNewDocumentRoot,
+      'a real Fabric edit after startup must still publish and converge'
+    );
+    syncOld.stop();
+    syncNew.stop();
+  };
+  await preserveDifferentDocumentBaselines({ newDocumentStartsFirst: true });
+  await preserveDifferentDocumentBaselines({ newDocumentStartsFirst: false });
+
+  const acceptedScheduler = new FakeSeedRetryScheduler();
+  const liveblocksStable = new LinkedLiveblocksManager('actor-stable');
+  const liveblocksJoining = new LinkedLiveblocksManager('actor-joining');
+  liveblocksStable.peer = liveblocksJoining;
+  liveblocksJoining.peer = liveblocksStable;
+  const reviewStable = new StubReviewDataManager(latestRoot, 'C:/reviews/accepted.bframe');
+  const reviewJoining = new StubReviewDataManager(staleRoot, 'C:/reviews/accepted.bframe');
+  const syncStable = createSync({
+    liveblocksManager: liveblocksStable,
+    reviewDataManager: reviewStable,
+    scheduler: acceptedScheduler,
+    actorId: 'actor-stable'
+  });
+  const syncJoining = createSync({
+    liveblocksManager: liveblocksJoining,
+    reviewDataManager: reviewJoining,
+    scheduler: acceptedScheduler,
+    actorId: 'actor-joining'
+  });
+  now = 0;
+  syncStable.start();
+  now = 10001;
+  syncJoining.start();
+  await flushApplyQueue();
+  assert.deepEqual(reviewJoining.rootValue, latestRoot);
+  const joiningRetry = acceptedScheduler.tasks[1];
+  assert.equal(
+    joiningRetry.cancelled,
+    false,
+    'every live session must retain its one stabilization retry for multiparty convergence'
+  );
+  const joiningRequests = requestCount(liveblocksJoining);
+  const stableRoots = rootCount(liveblocksStable);
+  joiningRetry.callback();
+  await flushApplyQueue();
+  assert.equal(requestCount(liveblocksJoining), joiningRequests + 1);
+  assert.equal(
+    rootCount(liveblocksStable),
+    stableRoots,
+    'an equal accepted root must not trigger a redundant retry response'
+  );
+  joiningRetry.callback();
+  assert.equal(requestCount(liveblocksJoining), joiningRequests + 1);
+  syncJoining.stop();
+  syncStable.stop();
+
+  class MeshLiveblocksManager extends EventTarget {
+    constructor(connectionId) {
+      super();
+      this.connectionId = connectionId;
+      this.peers = [];
+      this.sentEvents = [];
+    }
+
+    getSelf() {
+      return { connectionId: this.connectionId };
+    }
+
+    hasOtherCollaborators() {
+      return this.peers.length > 0;
+    }
+
+    broadcastEvent(event) {
+      this.sentEvents.push(structuredClone(event));
+      for (const peer of this.peers) {
+        peer.receive(event);
+      }
+    }
+
+    receive(event) {
+      this.dispatchEvent(new CustomEvent('broadcastReceived', {
+        detail: { event: structuredClone(event) }
+      }));
+    }
+  }
+
+  const meshScheduler = new FakeSeedRetryScheduler();
+  const meshLiveblocksA = new MeshLiveblocksManager('mesh-a');
+  const meshLiveblocksB = new MeshLiveblocksManager('mesh-b');
+  const meshLiveblocksC = new MeshLiveblocksManager('mesh-c');
+  meshLiveblocksA.peers = [meshLiveblocksB, meshLiveblocksC];
+  meshLiveblocksB.peers = [meshLiveblocksA, meshLiveblocksC];
+  meshLiveblocksC.peers = [meshLiveblocksA, meshLiveblocksB];
+  const meshHighRoot = createFabricRoot({
+    documentId: 'fabric-mesh-shared',
+    revision: 10
+  });
+  const meshLowRoot = createFabricRoot({
+    documentId: 'fabric-mesh-shared',
+    revision: 1
+  });
+  const meshReviewA = new StubReviewDataManager(
+    meshHighRoot,
+    'C:/reviews/simultaneous-mesh.bframe'
+  );
+  const meshReviewB = new StubReviewDataManager(
+    meshLowRoot,
+    'C:/reviews/simultaneous-mesh.bframe'
+  );
+  const meshReviewC = new StubReviewDataManager(
+    meshLowRoot,
+    'C:/reviews/simultaneous-mesh.bframe'
+  );
+  const meshSyncA = createSync({
+    liveblocksManager: meshLiveblocksA,
+    reviewDataManager: meshReviewA,
+    scheduler: meshScheduler,
+    actorId: 'mesh-a'
+  });
+  const meshSyncB = createSync({
+    liveblocksManager: meshLiveblocksB,
+    reviewDataManager: meshReviewB,
+    scheduler: meshScheduler,
+    actorId: 'mesh-b'
+  });
+  const meshSyncC = createSync({
+    liveblocksManager: meshLiveblocksC,
+    reviewDataManager: meshReviewC,
+    scheduler: meshScheduler,
+    actorId: 'mesh-c'
+  });
+  now = 0;
+  meshSyncA.start();
+  meshSyncB.start();
+  meshSyncC.start();
+  await flushApplyQueue();
+  const meshLowRequest = meshLiveblocksB.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST_V2'
+  );
+  const meshLowSeed = {
+    type: 'FABRIC_DRAWING_ROOT',
+    transferId: 'mesh-low-seed',
+    present: true,
+    root: structuredClone(meshLowRoot),
+    fingerprint: meshLowRequest.fingerprint,
+    syncVersion: structuredClone(meshLowRequest.syncVersion)
+  };
+  meshLiveblocksB.receive(meshLowSeed);
+  meshLiveblocksC.receive(meshLowSeed);
+  await flushApplyQueue();
+
+  now = 10001;
+  for (const task of meshScheduler.tasks) {
+    task.callback();
+    await flushApplyQueue();
+  }
+  assert.deepEqual(meshReviewA.rootValue, meshHighRoot);
+  assert.deepEqual(meshReviewB.rootValue, meshHighRoot);
+  assert.deepEqual(meshReviewC.rootValue, meshHighRoot);
+  assert.deepEqual(
+    [meshLiveblocksA, meshLiveblocksB, meshLiveblocksC].map(requestCount),
+    [2, 2, 2],
+    'an accepted same-root seed must not cancel another peer\'s stabilization request'
+  );
+  const meshRequestsAfterRetry = [meshLiveblocksA, meshLiveblocksB, meshLiveblocksC]
+    .map(requestCount);
+  meshScheduler.tasks.forEach(task => task.callback());
+  assert.deepEqual(
+    [meshLiveblocksA, meshLiveblocksB, meshLiveblocksC].map(requestCount),
+    meshRequestsAfterRetry
+  );
+  meshSyncC.stop();
+  meshSyncB.stop();
+  meshSyncA.stop();
+
+  const convergeComparablePairWithoutOverwritingThird = async ({ reverseRetryOrder }) => {
+    const scheduler = new FakeSeedRetryScheduler();
+    const liveblocksHigh = new MeshLiveblocksManager('target-high');
+    const liveblocksLow = new MeshLiveblocksManager('target-low');
+    const liveblocksOther = new MeshLiveblocksManager('target-other');
+    liveblocksHigh.peers = [liveblocksLow, liveblocksOther];
+    liveblocksLow.peers = [liveblocksHigh, liveblocksOther];
+    liveblocksOther.peers = [liveblocksHigh, liveblocksLow];
+    const highRoot = createFabricRoot({
+      documentId: 'fabric-target-shared',
+      revision: 10
+    });
+    const lowRoot = createFabricRoot({
+      documentId: 'fabric-target-shared',
+      revision: 9
+    });
+    const otherRoot = createFabricRoot({
+      documentId: 'fabric-target-incomparable',
+      revision: 1
+    });
+    const reviewHigh = new StubReviewDataManager(
+      highRoot,
+      'C:/reviews/targeted-handshake.bframe'
+    );
+    const reviewLow = new StubReviewDataManager(
+      lowRoot,
+      'C:/reviews/targeted-handshake.bframe'
+    );
+    const reviewOther = new StubReviewDataManager(
+      otherRoot,
+      'C:/reviews/targeted-handshake.bframe'
+    );
+    const syncHigh = createSync({
+      liveblocksManager: liveblocksHigh,
+      reviewDataManager: reviewHigh,
+      scheduler,
+      actorId: 'target-high'
+    });
+    const syncLow = createSync({
+      liveblocksManager: liveblocksLow,
+      reviewDataManager: reviewLow,
+      scheduler,
+      actorId: 'target-low'
+    });
+    const syncOther = createSync({
+      liveblocksManager: liveblocksOther,
+      reviewDataManager: reviewOther,
+      scheduler,
+      actorId: 'target-other'
+    });
+
+    now = 0;
+    syncHigh.start();
+    syncLow.start();
+    syncOther.start();
+    await flushApplyQueue();
+    assert.equal(reviewHigh.baselineConflict, true);
+    assert.equal(reviewLow.baselineConflict, true);
+    assert.equal(reviewOther.baselineConflict, true);
+
+    now = 10001;
+    const retryTasks = reverseRetryOrder
+      ? [...scheduler.tasks].reverse()
+      : scheduler.tasks;
+    for (const task of retryTasks) {
+      task.callback();
+      await flushApplyQueue();
+    }
+
+    assert.deepEqual(reviewHigh.rootValue, highRoot);
+    assert.deepEqual(reviewLow.rootValue, highRoot);
+    assert.deepEqual(
+      reviewOther.rootValue,
+      otherRoot,
+      'a root response for a comparable peer must not overwrite an incomparable third peer'
+    );
+    const responseRoots = [liveblocksHigh, liveblocksLow, liveblocksOther]
+      .flatMap(manager => manager.sentEvents)
+      .filter(event => event.type === 'FABRIC_DRAWING_ROOT_RESPONSE');
+    assert.ok(responseRoots.length > 0);
+    assert.ok(responseRoots.every(event => typeof event.targetActorId === 'string'));
+    assert.ok(responseRoots.every(event => event.syncVersion.clock <= 10));
+    assert.equal(reviewHigh.baselineConflict, true);
+    assert.equal(reviewLow.baselineConflict, true);
+    assert.equal(reviewOther.baselineConflict, true);
+
+    const editedOtherRoot = createFabricRoot({
+      documentId: 'fabric-target-incomparable',
+      revision: 2
+    });
+    reviewOther.rootValue = structuredClone(editedOtherRoot);
+    reviewOther.dispatchEvent(new CustomEvent('saved', {
+      detail: { path: reviewOther.currentBframePath }
+    }));
+    await flushApplyQueue();
+    assert.deepEqual(reviewHigh.rootValue, editedOtherRoot);
+    assert.deepEqual(reviewLow.rootValue, editedOtherRoot);
+    assert.deepEqual(reviewOther.rootValue, editedOtherRoot);
+    assert.equal(reviewHigh.baselineConflict, false);
+    assert.equal(reviewLow.baselineConflict, false);
+    assert.equal(reviewOther.baselineConflict, false);
+    syncOther.stop();
+    syncLow.stop();
+    syncHigh.stop();
+  };
+  await convergeComparablePairWithoutOverwritingThird({ reverseRetryOrder: false });
+  await convergeComparablePairWithoutOverwritingThird({ reverseRetryOrder: true });
+
+  const soloDirtyScheduler = new FakeSeedRetryScheduler();
+  const liveblocksSolo = new LinkedLiveblocksManager('actor-solo-dirty');
+  const soloDirtyRoot = createFabricRoot({
+    documentId: 'fabric-solo-dirty',
+    revision: 2
+  });
+  const reviewSolo = new StubReviewDataManager(
+    soloDirtyRoot,
+    'C:/reviews/solo-dirty.bframe',
+    { localChanges: true }
+  );
+  const syncSolo = createSync({
+    liveblocksManager: liveblocksSolo,
+    reviewDataManager: reviewSolo,
+    scheduler: soloDirtyScheduler,
+    actorId: 'actor-solo-dirty'
+  });
+  now = 0;
+  syncSolo.start();
+  reviewSolo.localChanges = false;
+  reviewSolo.dispatchEvent(new CustomEvent('saved', {
+    detail: { path: reviewSolo.currentBframePath }
+  }));
+  await flushApplyQueue();
+  assert.equal(rootCount(liveblocksSolo), 0);
+  assert.equal(syncSolo._currentRootVersion.actorId, 'actor-solo-dirty');
+
+  const liveblocksSoloJoiner = new LinkedLiveblocksManager('actor-solo-joiner');
+  const soloJoinerScheduler = new FakeSeedRetryScheduler();
+  const reviewSoloJoiner = new StubReviewDataManager(
+    undefined,
+    'C:/reviews/solo-dirty.bframe',
+    { present: false }
+  );
+  const syncSoloJoiner = createSync({
+    liveblocksManager: liveblocksSoloJoiner,
+    reviewDataManager: reviewSoloJoiner,
+    scheduler: soloJoinerScheduler,
+    actorId: 'actor-solo-joiner'
+  });
+  liveblocksSolo.peer = liveblocksSoloJoiner;
+  liveblocksSoloJoiner.peer = liveblocksSolo;
+  now = 20000;
+  syncSoloJoiner.start();
+  await flushApplyQueue();
+  assert.deepEqual(reviewSoloJoiner.rootValue, soloDirtyRoot);
+  assert.equal(reviewSoloJoiner.present, true);
+  syncSoloJoiner.stop();
+  syncSolo.stop();
+
+  const sameRootScheduler = new FakeSeedRetryScheduler();
+  const liveblocksSameRoot = new LinkedLiveblocksManager('actor-same-root');
+  const reviewSameRoot = new StubReviewDataManager(
+    latestRoot,
+    'C:/reviews/same-root-request.bframe'
+  );
+  const syncSameRoot = createSync({
+    liveblocksManager: liveblocksSameRoot,
+    reviewDataManager: reviewSameRoot,
+    scheduler: sameRootScheduler,
+    actorId: 'actor-same-root'
+  });
+  now = 0;
+  syncSameRoot.start();
+  const sameRootRequest = liveblocksSameRoot.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST_V2'
+  );
+  liveblocksSameRoot.dispatchEvent(new CustomEvent('broadcastReceived', {
+    detail: {
+      event: {
+        ...sameRootRequest,
+        requestActorId: 'actor-causal-peer',
+        syncVersion: { clock: 20, actorId: 'actor-causal-peer' }
+      }
+    }
+  }));
+  assert.equal(reviewSameRoot.invalidatedReloads, 1);
+  assert.deepEqual(syncSameRoot._currentRootVersion, {
+    clock: 20,
+    actorId: 'actor-causal-peer',
+    fingerprint: sameRootRequest.fingerprint
+  });
+  for (let index = 0; index < 65; index++) {
+    syncSameRoot._markBaselineConflict(`overflow-peer-${index}`);
+  }
+  assert.equal(syncSameRoot._baselineConflictActors.size, 64);
+  assert.equal(syncSameRoot._hasUnattributedBaselineConflict, true);
+  syncSameRoot._clearAllBaselineConflicts();
+  syncSameRoot.stop();
+
+  const sameRootAckScheduler = new FakeSeedRetryScheduler();
+  const liveblocksSameRootStable = new LinkedLiveblocksManager('ack-stable');
+  const liveblocksSameRootJoining = new LinkedLiveblocksManager('ack-joining');
+  liveblocksSameRootStable.peer = liveblocksSameRootJoining;
+  liveblocksSameRootJoining.peer = liveblocksSameRootStable;
+  const sharedAckRoot = createFabricRoot({
+    documentId: 'fabric-same-root-ack',
+    revision: 1
+  });
+  const reviewSameRootStable = new StubReviewDataManager(
+    sharedAckRoot,
+    'C:/reviews/same-root-ack.bframe'
+  );
+  const reviewSameRootJoining = new StubReviewDataManager(
+    sharedAckRoot,
+    'C:/reviews/same-root-ack.bframe'
+  );
+  const syncSameRootStable = createSync({
+    liveblocksManager: liveblocksSameRootStable,
+    reviewDataManager: reviewSameRootStable,
+    scheduler: sameRootAckScheduler,
+    actorId: 'ack-stable'
+  });
+  const syncSameRootJoining = createSync({
+    liveblocksManager: liveblocksSameRootJoining,
+    reviewDataManager: reviewSameRootJoining,
+    scheduler: sameRootAckScheduler,
+    actorId: 'ack-joining'
+  });
+  now = 0;
+  syncSameRootStable.start();
+  syncSameRootStable._currentRootVersion = {
+    clock: 100,
+    actorId: 'ack-stable',
+    fingerprint: syncSameRootStable._currentRootVersion.fingerprint
+  };
+  syncSameRootStable._rootClock = 100;
+  now = 20000;
+  syncSameRootJoining.start();
+  await flushApplyQueue();
+  assert.deepEqual(syncSameRootJoining._currentRootVersion, {
+    clock: 100,
+    actorId: 'ack-stable',
+    fingerprint: syncSameRootStable._currentRootVersion.fingerprint
+  });
+  const editedAckRoot = createFabricRoot({
+    documentId: 'fabric-same-root-ack',
+    revision: 2
+  });
+  reviewSameRootJoining.rootValue = structuredClone(editedAckRoot);
+  reviewSameRootJoining.dispatchEvent(new CustomEvent('saved', {
+    detail: { path: reviewSameRootJoining.currentBframePath }
+  }));
+  await flushApplyQueue();
+  const editedAckEvent = liveblocksSameRootJoining.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT'
+  );
+  assert.ok(editedAckEvent.syncVersion.clock > 100);
+  assert.deepEqual(reviewSameRootStable.rootValue, editedAckRoot);
+  syncSameRootJoining.stop();
+  syncSameRootStable.stop();
+
+  const responseWireScheduler = new FakeSeedRetryScheduler();
+  const responseWireLiveblocks = new LinkedLiveblocksManager('response-wire');
+  const responseWireReview = new StubReviewDataManager(
+    undefined,
+    'C:/reviews/response-wire.bframe',
+    { present: false }
+  );
+  const responseWireSync = createSync({
+    liveblocksManager: responseWireLiveblocks,
+    reviewDataManager: responseWireReview,
+    scheduler: responseWireScheduler,
+    actorId: 'response-wire'
+  });
+  responseWireSync.start();
+  responseWireLiveblocks.sentEvents.length = 0;
+  responseWireSync._broadcastRoot({
+    force: true,
+    peerConfirmed: true,
+    targetActorId: 'response-target'
+  });
+  assert.equal(responseWireLiveblocks.sentEvents.length, 1);
+  assert.equal(
+    responseWireLiveblocks.sentEvents[0].type,
+    'FABRIC_DRAWING_ROOT_RESPONSE'
+  );
+  assert.equal(responseWireLiveblocks.sentEvents[0].present, false);
+
+  responseWireReview.present = true;
+  responseWireReview.compatible = true;
+  responseWireReview.rootValue = {
+    ...createFabricRoot({
+      documentId: 'fabric-response-wire-large',
+      revision: 1
+    }),
+    padding: 'x'.repeat(720 * 1024)
+  };
+  responseWireLiveblocks.sentEvents.length = 0;
+  responseWireSync._broadcastRoot({
+    force: true,
+    peerConfirmed: true,
+    targetActorId: 'response-target'
+  });
+  assert.equal(
+    responseWireLiveblocks.sentEvents[0].type,
+    'FABRIC_DRAWING_ROOT_RESPONSE'
+  );
+  assert.ok(responseWireLiveblocks.sentEvents.slice(1).every(
+    event => event.type === 'FABRIC_DRAWING_ROOT_RESPONSE_CHUNK'
+  ));
+  assert.equal(responseWireLiveblocks.sentEvents.some(
+    event => event.type === 'FABRIC_DRAWING_ROOT' ||
+      event.type === 'FABRIC_DRAWING_ROOT_CHUNK'
+  ), false);
+  responseWireSync.stop();
+
+  const restartScheduler = new FakeSeedRetryScheduler();
+  const liveblocksRestart = new LinkedLiveblocksManager('actor-restart');
+  const reviewRestart = new StubReviewDataManager(latestRoot, 'C:/reviews/restart.bframe');
+  const syncRestart = createSync({
+    liveblocksManager: liveblocksRestart,
+    reviewDataManager: reviewRestart,
+    scheduler: restartScheduler,
+    actorId: 'actor-restart'
+  });
+  now = 0;
+  syncRestart.start();
+  const oldSessionRetry = restartScheduler.tasks[0];
+  syncRestart.stop();
+  syncRestart.start();
+  const newSessionRetry = restartScheduler.tasks[1];
+  const requestsBeforeCallbacks = requestCount(liveblocksRestart);
+  now = 10001;
+  oldSessionRetry.callback();
+  assert.equal(requestCount(liveblocksRestart), requestsBeforeCallbacks);
+  newSessionRetry.callback();
+  assert.equal(requestCount(liveblocksRestart), requestsBeforeCallbacks + 1);
+  syncRestart.stop();
+  newSessionRetry.callback();
+  assert.equal(requestCount(liveblocksRestart), requestsBeforeCallbacks + 1);
 });
 
 test('Fabric drawing sync causally converges concurrent and dirty-overlap saves', async () => {
@@ -4583,14 +5869,11 @@ test('Fabric drawing sync causally converges concurrent and dirty-overlap saves'
     revision: 100,
     owner: 'causal-winner-b'
   };
-  const conflictingStale = createPair('conflicting-stale', {
-    rootA: staleWinnerRoot,
-    rootB: causalWinnerRoot
-  });
+  const conflictingStale = createPair('conflicting-stale');
   conflictingStale.reviewA.staleOwners.add(causalWinnerRoot.owner);
   conflictingStale.reviewB.staleOwners.add(staleWinnerRoot.owner);
-  conflictingStale.syncA.broadcastCurrentState();
-  conflictingStale.syncB.broadcastCurrentState();
+  conflictingStale.reviewA.saveRoot(staleWinnerRoot);
+  conflictingStale.reviewB.saveRoot(causalWinnerRoot);
   const staleWinnerEvent = rootEvent(conflictingStale.liveblocksA);
   const causalWinnerEvent = rootEvent(conflictingStale.liveblocksB);
   conflictingStale.liveblocksB.receive(staleWinnerEvent);
@@ -4993,7 +6276,7 @@ test('an accepted intermediate root stays blocked when Drive exposes it after la
   manager.disconnect();
 });
 
-test('Fabric drawing sync propagates an absent drawingsV3 tombstone without resurrecting a delayed root', async () => {
+test('Fabric drawing sync propagates causal tombstones without trusting incomparable startup baselines', async () => {
   const { FabricDrawingSync } = await import(
     '../../renderer/scripts/modules/fabric-drawing-sync.js'
   );
@@ -5021,10 +6304,23 @@ test('Fabric drawing sync propagates an absent drawingsV3 tombstone without resu
     })],
     ['C:/reviews/fabric-tombstone-joining-missing.bframe', createReviewRoot({
       reviewDocumentId: REVIEW_ID_REMOTE
+    })],
+    ['C:/reviews/baseline-conflict-await.bframe', createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: oldRoot
+    })],
+    ['C:/reviews/baseline-conflict-autosave.bframe', createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: oldRoot
     })]
   ]);
+  let saveReviewCalls = 0;
   window.electronAPI = {
-    loadReview: async path => structuredClone(reviewRoots.get(path) || null)
+    loadReview: async path => structuredClone(reviewRoots.get(path) || null),
+    saveReview: async () => {
+      saveReviewCalls += 1;
+      return { success: true };
+    }
   };
 
   class LinkedLiveblocksManager extends EventTarget {
@@ -5122,12 +6418,44 @@ test('Fabric drawing sync propagates an absent drawingsV3 tombstone without resu
     suffix: 'tombstone-missing'
   });
   const joinRequest = missingPair.joiningLiveblocks.sentEvents.find(
-    event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST'
-  );
-  const tombstoneEvent = missingPair.stableLiveblocks.sentEvents.find(
-    event => event.type === 'FABRIC_DRAWING_ROOT'
+    event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST_V2'
   );
   assert.ok(joinRequest?.syncVersion);
+  assert.equal(
+    missingPair.stableLiveblocks.sentEvents.filter(
+      event => event.type === 'FABRIC_DRAWING_ROOT' ||
+        event.type === 'FABRIC_DRAWING_ROOT_RESPONSE'
+    ).length,
+    0,
+    'an established but unverified missing baseline must not overwrite an incomparable root'
+  );
+  assert.equal(joiningResetCount, 0);
+  assert.equal(stableMissingReview.getDrawingsV3RootSnapshot().present, false);
+  assert.equal(joiningOldReview.getDrawingsV3RootSnapshot().present, true);
+  assert.equal(stableMissingReview.getDrawingsV3RootSnapshot().baselineConflict, true);
+  assert.equal(joiningOldReview.getDrawingsV3RootSnapshot().baselineConflict, true);
+  joiningOldReview.isDirty = true;
+  assert.equal(
+    await joiningOldReview.save(),
+    false,
+    'an incomparable startup root must block comment-only disk writes immediately'
+  );
+  assert.equal(saveReviewCalls, 0);
+  assert.equal(
+    joiningOldReview.getDrawingsV3RootSnapshot().baselineConflict,
+    true,
+    'rereading the same local disk root must not clear the collaboration hold'
+  );
+
+  assert.equal(await joiningOldReview.applyExternalDrawingsV3(undefined, {
+    present: false
+  }), true);
+  joiningOldReview.dispatchEvent(new CustomEvent('saved'));
+  await flush();
+  await flush();
+  const tombstoneEvent = missingPair.joiningLiveblocks.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT'
+  );
   assert.equal(tombstoneEvent?.present, false);
   assert.equal(Object.hasOwn(tombstoneEvent, 'root'), false);
   assert.equal(Object.hasOwn(tombstoneEvent, 'chunkCount'), false);
@@ -5175,16 +6503,414 @@ test('Fabric drawing sync propagates an absent drawingsV3 tombstone without resu
     suffix: 'tombstone-present'
   });
   const presentSeed = presentPair.stableLiveblocks.sentEvents.find(
-    event => event.type === 'FABRIC_DRAWING_ROOT'
+    event => event.type === 'FABRIC_DRAWING_ROOT' ||
+      event.type === 'FABRIC_DRAWING_ROOT_RESPONSE'
   );
-  assert.equal(presentSeed?.present, true);
-  assert.deepEqual(
-    joiningMissingReview.getDrawingsV3RootSnapshot().value,
-    stablePresentRoot,
-    'a stale missing joiner must not erase the stable peer root'
+  assert.equal(presentSeed, undefined);
+  assert.deepEqual(stablePresentReview.getDrawingsV3RootSnapshot().value, stablePresentRoot);
+  assert.equal(
+    joiningMissingReview.getDrawingsV3RootSnapshot().present,
+    false,
+    'incomparable present/missing startup baselines must be preserved on both peers'
   );
   presentPair.stableSync.stop();
   presentPair.joiningSync.stop();
   stablePresentReview.disconnect();
   joiningMissingReview.disconnect();
+
+  const awaitComments = createCommentManager();
+  const awaitStore = await createFabricStore();
+  const awaitManager = new ReviewDataManager({
+    autoSave: false,
+    commentManager: awaitComments,
+    fabricDrawingPersistenceProvider: awaitStore
+  });
+  awaitManager.connect();
+  assert.equal(await awaitManager.setVideoFile(
+    'C:/reviews/baseline-conflict-await.mp4',
+    { fabricDrawingPersistenceContext: FABRIC_CONTEXT }
+  ), true);
+  addSubstantiveComment(awaitManager, awaitComments, 'baseline-await-comment');
+  const finalSnapshotStarted = createDeferred();
+  const finalSnapshotGate = createDeferred();
+  awaitManager.setFinalFabricSnapshotHandler(async () => {
+    finalSnapshotStarted.resolve();
+    await finalSnapshotGate.promise;
+  });
+  const saveCallsBeforeAwaitRace = saveReviewCalls;
+  const pendingAwaitSave = awaitManager.save();
+  await finalSnapshotStarted.promise;
+  awaitManager.markDrawingsV3BaselineConflict();
+  finalSnapshotGate.resolve();
+  assert.equal(await pendingAwaitSave, false);
+  assert.equal(
+    saveReviewCalls,
+    saveCallsBeforeAwaitRace,
+    'a conflict received during final Fabric hydration must stop the pending write'
+  );
+  awaitManager.disconnect();
+
+  const ipcConflictRoot = createFabricRoot({
+    documentId: 'fabric-ipc-conflict-root',
+    revision: 4
+  });
+  let ipcConflictDisk = createReviewRoot({
+    reviewDocumentId: REVIEW_ID_EXISTING,
+    drawingsV3: ipcConflictRoot
+  });
+  const ipcConflictStarted = createDeferred();
+  const ipcConflictGate = createDeferred();
+  let ipcConflictWrites = 0;
+  window.electronAPI = {
+    loadReview: async () => structuredClone(ipcConflictDisk),
+    saveReview: async (_path, data) => {
+      ipcConflictWrites += 1;
+      ipcConflictStarted.resolve();
+      await ipcConflictGate.promise;
+      ipcConflictDisk = structuredClone(data);
+      return { success: true, versionToken: 'ipc-conflict-write' };
+    }
+  };
+  const ipcConflictComments = createCommentManager();
+  const ipcConflictStore = await createFabricStore();
+  const ipcConflictManager = new ReviewDataManager({
+    autoSave: false,
+    commentManager: ipcConflictComments,
+    fabricDrawingPersistenceProvider: ipcConflictStore
+  });
+  let ipcConflictSavedEvents = 0;
+  ipcConflictManager.addEventListener('saved', () => {
+    ipcConflictSavedEvents += 1;
+  });
+  ipcConflictManager.connect();
+  assert.equal(await ipcConflictManager.setVideoFile(
+    'C:/reviews/baseline-conflict-ipc.mp4',
+    { fabricDrawingPersistenceContext: FABRIC_CONTEXT }
+  ), true);
+  addSubstantiveComment(
+    ipcConflictManager,
+    ipcConflictComments,
+    'baseline-conflict-during-ipc'
+  );
+  const pendingIpcConflictSave = ipcConflictManager.save();
+  await ipcConflictStarted.promise;
+  ipcConflictManager.markDrawingsV3BaselineConflict();
+  ipcConflictGate.resolve();
+  assert.equal(await pendingIpcConflictSave, false);
+  assert.equal(ipcConflictWrites, 1, 'the already-started physical write cannot be undone');
+  assert.equal(ipcConflictSavedEvents, 0);
+  assert.equal(
+    ipcConflictManager.getDrawingsV3RootSnapshot().baselineConflict,
+    true
+  );
+  assert.equal(ipcConflictManager.hasUnsavedChanges(), true);
+  ipcConflictManager.disconnect();
+
+  const ipcRaceRootA = createFabricRoot({
+    documentId: 'fabric-ipc-race-a',
+    revision: 7
+  });
+  const ipcRaceRootB = createFabricRoot({
+    documentId: 'fabric-ipc-race-b',
+    revision: 7
+  });
+  let ipcRaceDisk = createReviewRoot({
+    reviewDocumentId: REVIEW_ID_EXISTING,
+    drawingsV3: ipcRaceRootA
+  });
+  const ipcRaceStarted = createDeferred();
+  const ipcRaceGate = createDeferred();
+  const ipcRacePayloads = [];
+  window.electronAPI = {
+    loadReview: async () => structuredClone(ipcRaceDisk),
+    saveReview: async (_path, data) => {
+      ipcRacePayloads.push(structuredClone(data));
+      if (ipcRacePayloads.length === 1) {
+        ipcRaceStarted.resolve();
+        await ipcRaceGate.promise;
+      }
+      ipcRaceDisk = structuredClone(data);
+      return {
+        success: true,
+        versionToken: `ipc-race-write-${ipcRacePayloads.length}`
+      };
+    }
+  };
+  const ipcRaceComments = createCommentManager();
+  const ipcRaceStore = await createFabricStore();
+  const ipcRaceManager = new ReviewDataManager({
+    autoSave: false,
+    commentManager: ipcRaceComments,
+    fabricDrawingPersistenceProvider: ipcRaceStore
+  });
+  let ipcRaceSavedEvents = 0;
+  ipcRaceManager.addEventListener('saved', () => {
+    ipcRaceSavedEvents += 1;
+  });
+  ipcRaceManager.connect();
+  assert.equal(await ipcRaceManager.setVideoFile(
+    'C:/reviews/external-root-during-ipc.mp4',
+    { fabricDrawingPersistenceContext: FABRIC_CONTEXT }
+  ), true);
+  addSubstantiveComment(ipcRaceManager, ipcRaceComments, 'external-root-during-ipc');
+  const pendingIpcRaceSave = ipcRaceManager.save();
+  await ipcRaceStarted.promise;
+  assert.equal(await ipcRaceManager.applyExternalDrawingsV3(ipcRaceRootB), true);
+  ipcRaceGate.resolve();
+  assert.equal(await pendingIpcRaceSave, true);
+  assert.equal(ipcRacePayloads.length, 2);
+  assert.deepEqual(ipcRacePayloads[0].drawingsV3, ipcRaceRootA);
+  assert.deepEqual(ipcRacePayloads[1].drawingsV3, ipcRaceRootB);
+  assert.deepEqual(ipcRaceDisk.drawingsV3, ipcRaceRootB);
+  assert.deepEqual(ipcRaceStore.exportRootValue(), ipcRaceRootB);
+  assert.deepEqual(ipcRaceManager.getDrawingsV3RootSnapshot().value, ipcRaceRootB);
+  assert.equal(ipcRaceManager.getDrawingsV3RootSnapshot().stale, false);
+  assert.equal(ipcRaceSavedEvents, 1);
+  ipcRaceManager.disconnect();
+
+  let inFlightDisk = createReviewRoot({
+    reviewDocumentId: REVIEW_ID_EXISTING,
+    drawingsV3: ipcRaceRootA
+  });
+  const inFlightSaveStarted = createDeferred();
+  const inFlightSaveGate = createDeferred();
+  const inFlightInstallStarted = createDeferred();
+  const inFlightInstallGate = createDeferred();
+  const inFlightPayloads = [];
+  window.electronAPI = {
+    loadReview: async () => structuredClone(inFlightDisk),
+    saveReview: async (_path, data) => {
+      inFlightPayloads.push(structuredClone(data));
+      if (inFlightPayloads.length === 1) {
+        inFlightSaveStarted.resolve();
+        await inFlightSaveGate.promise;
+      }
+      inFlightDisk = structuredClone(data);
+      return {
+        success: true,
+        versionToken: `in-flight-write-${inFlightPayloads.length}`
+      };
+    }
+  };
+  const inFlightComments = createCommentManager();
+  const inFlightStore = await createFabricStore();
+  const inFlightManager = new ReviewDataManager({
+    autoSave: false,
+    commentManager: inFlightComments,
+    fabricDrawingPersistenceProvider: inFlightStore
+  });
+  let inFlightSavedEvents = 0;
+  inFlightManager.addEventListener('saved', () => {
+    inFlightSavedEvents += 1;
+  });
+  inFlightManager.connect();
+  assert.equal(await inFlightManager.setVideoFile(
+    'C:/reviews/external-root-hydration-during-ipc.mp4',
+    { fabricDrawingPersistenceContext: FABRIC_CONTEXT }
+  ), true);
+  inFlightManager.setFabricDrawingSourceRefreshHandler(async ({ installSource }) => {
+    inFlightInstallStarted.resolve();
+    await inFlightInstallGate.promise;
+    return installSource();
+  });
+  addSubstantiveComment(
+    inFlightManager,
+    inFlightComments,
+    'external-root-hydration-during-ipc'
+  );
+  const pendingInFlightSave = inFlightManager.save();
+  await inFlightSaveStarted.promise;
+  const pendingInFlightApply = inFlightManager.applyExternalDrawingsV3(ipcRaceRootB);
+  await inFlightInstallStarted.promise;
+  inFlightSaveGate.resolve();
+  assert.equal(await pendingInFlightSave, false);
+  assert.equal(inFlightPayloads.length, 1);
+  assert.equal(inFlightSavedEvents, 0);
+  assert.equal(inFlightManager.hasUnsavedChanges(), true);
+  inFlightInstallGate.resolve();
+  assert.equal(await pendingInFlightApply, true);
+  assert.deepEqual(inFlightStore.exportRootValue(), ipcRaceRootB);
+  assert.equal(await inFlightManager.save(), true);
+  assert.equal(inFlightPayloads.length, 2);
+  assert.deepEqual(inFlightPayloads[1].drawingsV3, ipcRaceRootB);
+  assert.deepEqual(inFlightDisk.drawingsV3, ipcRaceRootB);
+  assert.equal(inFlightSavedEvents, 1);
+  inFlightManager.disconnect();
+
+  const localRaceRoot = createFabricRoot({
+    documentId: 'fabric-local-change-during-ipc',
+    revision: 0
+  });
+  let localRaceDisk = createReviewRoot({
+    reviewDocumentId: REVIEW_ID_EXISTING,
+    drawingsV3: localRaceRoot
+  });
+  const localRaceStarted = createDeferred();
+  const localRaceGate = createDeferred();
+  const localRacePayloads = [];
+  window.electronAPI = {
+    loadReview: async () => structuredClone(localRaceDisk),
+    saveReview: async (_path, data) => {
+      localRacePayloads.push(structuredClone(data));
+      if (localRacePayloads.length === 1) {
+        localRaceStarted.resolve();
+        await localRaceGate.promise;
+      }
+      localRaceDisk = structuredClone(data);
+      return {
+        success: true,
+        versionToken: `local-race-write-${localRacePayloads.length}`
+      };
+    }
+  };
+  const localRaceComments = createCommentManager();
+  const localRaceStore = await createFabricStore();
+  const localRaceManager = new ReviewDataManager({
+    autoSave: false,
+    commentManager: localRaceComments,
+    fabricDrawingPersistenceProvider: localRaceStore
+  });
+  localRaceManager.connect();
+  assert.equal(await localRaceManager.setVideoFile(
+    'C:/reviews/local-fabric-change-during-ipc.mp4',
+    { fabricDrawingPersistenceContext: FABRIC_CONTEXT }
+  ), true);
+  addSubstantiveComment(
+    localRaceManager,
+    localRaceComments,
+    'local-fabric-change-during-ipc'
+  );
+  const pendingLocalRaceSave = localRaceManager.save();
+  await localRaceStarted.promise;
+  const localRaceRecord = createFabricRecord('local-change-during-ipc');
+  assert.equal(localRaceStore.applyTransition(
+    createFabricTransition(1, localRaceRecord)
+  ).applied, true);
+  const latestLocalRaceRoot = localRaceStore.exportRootValue();
+  localRaceGate.resolve();
+  assert.equal(await pendingLocalRaceSave, true);
+  assert.equal(localRacePayloads.length, 2);
+  assert.deepEqual(localRacePayloads[0].drawingsV3, localRaceRoot);
+  assert.deepEqual(localRacePayloads[1].drawingsV3, latestLocalRaceRoot);
+  assert.deepEqual(localRaceDisk.drawingsV3, latestLocalRaceRoot);
+  assert.equal(localRaceManager.hasUnsavedChanges(), false);
+  localRaceManager.disconnect();
+
+  let autoSaveWriteCalls = 0;
+  window.electronAPI = {
+    loadReview: async path => structuredClone(reviewRoots.get(path) || null),
+    saveReview: async () => {
+      autoSaveWriteCalls += 1;
+      return { success: true };
+    }
+  };
+  const autoSaveComments = createCommentManager();
+  const autoSaveStore = await createFabricStore();
+  const autoSaveManager = new ReviewDataManager({
+    autoSave: true,
+    autoSaveDelay: 5,
+    commentManager: autoSaveComments,
+    fabricDrawingPersistenceProvider: autoSaveStore
+  });
+  autoSaveManager.connect();
+  assert.equal(await autoSaveManager.setVideoFile(
+    'C:/reviews/baseline-conflict-autosave.mp4',
+    { fabricDrawingPersistenceContext: FABRIC_CONTEXT }
+  ), true);
+  autoSaveManager.markDrawingsV3BaselineConflict();
+  const saveCallsBeforeAutoSave = autoSaveWriteCalls;
+  addSubstantiveComment(
+    autoSaveManager,
+    autoSaveComments,
+    'baseline-autosave-comment'
+  );
+  await new Promise(resolve => setTimeout(resolve, 30));
+  assert.equal(autoSaveWriteCalls, saveCallsBeforeAutoSave);
+  assert.equal(autoSaveManager.hasUnsavedChanges(), true);
+  autoSaveManager.clearDrawingsV3BaselineConflict();
+  await new Promise(resolve => setTimeout(resolve, 50));
+  assert.equal(
+    autoSaveWriteCalls,
+    saveCallsBeforeAutoSave + 1,
+    'clearing the hold must retry the dirty autosave without another user input'
+  );
+  assert.equal(autoSaveManager.hasUnsavedChanges(), false);
+  autoSaveManager.disconnect();
+
+  for (const stopMode of ['pause', 'disconnect']) {
+    const stoppedAutoSaveRoot = createFabricRoot({
+      documentId: `fabric-authority-autosave-${stopMode}`,
+      revision: 3
+    });
+    const stoppedReloadStarted = createDeferred();
+    const stoppedReloadGate = createDeferred();
+    let stoppedAutoSaveWrites = 0;
+    window.electronAPI = {
+      loadReview: async () => createReviewRoot({
+        reviewDocumentId: REVIEW_ID_EXISTING,
+        drawingsV3: stoppedAutoSaveRoot
+      }),
+      loadReviewSnapshot: async () => {
+        stoppedReloadStarted.resolve();
+        return stoppedReloadGate.promise;
+      },
+      saveReview: async () => {
+        stoppedAutoSaveWrites += 1;
+        return { success: true };
+      }
+    };
+    const stoppedComments = createCommentManager();
+    const stoppedStore = await createFabricStore();
+    const stoppedManager = new ReviewDataManager({
+      autoSave: true,
+      autoSaveDelay: 5,
+      commentManager: stoppedComments,
+      fabricDrawingPersistenceProvider: stoppedStore
+    });
+    stoppedManager.connect();
+    assert.equal(await stoppedManager.setVideoFile(
+      `C:/reviews/authority-autosave-${stopMode}.mp4`,
+      { fabricDrawingPersistenceContext: FABRIC_CONTEXT }
+    ), true);
+    addSubstantiveComment(
+      stoppedManager,
+      stoppedComments,
+      `authority-autosave-${stopMode}`
+    );
+    const pendingStoppedReload = stoppedManager.reloadDrawingsV3FromDisk();
+    await stoppedReloadStarted.promise;
+    if (stopMode === 'pause') {
+      stoppedManager.pauseAutoSave();
+    } else {
+      stoppedManager.disconnect();
+    }
+    stoppedReloadGate.resolve({
+      data: createReviewRoot({
+        reviewDocumentId: REVIEW_ID_EXISTING,
+        drawingsV3: stoppedAutoSaveRoot
+      }),
+      versionToken: `authority-autosave-${stopMode}`
+    });
+    assert.equal(await pendingStoppedReload, true);
+    await new Promise(resolve => setTimeout(resolve, 30));
+    assert.equal(
+      stoppedAutoSaveWrites,
+      0,
+      `a completed authority transition must not restart ${stopMode}d autosave`
+    );
+    assert.equal(stoppedManager.hasUnsavedChanges(), true);
+    if (stopMode === 'pause') {
+      assert.equal(stoppedStore.applyTransition(
+        createFabricTransition(1, createFabricRecord('changed-while-autosave-paused'))
+      ).applied, true);
+      await new Promise(resolve => setTimeout(resolve, 30));
+      assert.equal(
+        stoppedAutoSaveWrites,
+        0,
+        'a Fabric transition received while paused must stay dirty without writing'
+      );
+      assert.equal(stoppedManager.getDrawingsV3RootSnapshot().localChanges, true);
+    }
+    stoppedManager.disconnect();
+  }
 });

--- a/scripts/tests/review-data-manager-save.test.js
+++ b/scripts/tests/review-data-manager-save.test.js
@@ -2454,6 +2454,109 @@ test('external supported drawingsV3 is re-imported before an unrelated save when
   manager.disconnect();
 });
 
+test('accepted broadcast drawingsV3 remains the save baseline while disk replication is stale', async () => {
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const fabricStore = await createFabricStore();
+  const commentManager = createCommentManager();
+  const initialFabric = createFabricRoot({
+    documentId: 'fabric-document-broadcast-baseline-a'
+  });
+  const broadcastFabric = createFabricRoot({
+    documentId: 'fabric-document-broadcast-baseline-b',
+    revision: 9,
+    keyframes: [{
+      id: 'broadcast-baseline-frame',
+      frame: 36,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      mutationSequence: 1,
+      objects: [createFabricRecord('broadcast-baseline-stroke')]
+    }]
+  });
+  const diskRoot = createReviewRoot({
+    reviewDocumentId: REVIEW_ID_EXISTING,
+    drawingsV3: initialFabric
+  });
+  let savedRoot = null;
+  window.electronAPI = {
+    loadReview: async () => structuredClone(diskRoot),
+    saveReview: async (_path, data) => {
+      savedRoot = structuredClone(data);
+      return { success: true };
+    }
+  };
+  const manager = new ReviewDataManager({
+    autoSave: false,
+    commentManager,
+    fabricDrawingPersistenceProvider: fabricStore
+  });
+  manager.connect();
+  await manager.setVideoFile('C:/reviews/fabric.mp4', {
+    fabricDrawingPersistenceContext: FABRIC_CONTEXT
+  });
+
+  assert.equal(await manager.applyExternalDrawingsV3(broadcastFabric), true);
+  const acceptedSnapshot = manager.getDrawingsV3RootSnapshot();
+  assert.equal(acceptedSnapshot.present, true);
+  assert.equal(acceptedSnapshot.stale, false);
+  assert.deepEqual(acceptedSnapshot.value, broadcastFabric);
+  assert.deepEqual(fabricStore.exportRootValue(), broadcastFabric);
+
+  addSubstantiveComment(manager, commentManager, 'broadcast-baseline-comment');
+  assert.equal(await manager.save(), true);
+  assert.deepEqual(savedRoot.drawingsV3, broadcastFabric);
+  assert.deepEqual(fabricStore.exportRootValue(), broadcastFabric);
+  manager.disconnect();
+});
+
+test('failed external drawingsV3 installation retries the same payload instead of accepting it early', async () => {
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const fabricStore = await createFabricStore();
+  const originalImportRootValue = fabricStore.importRootValue;
+  const initialFabric = createFabricRoot({
+    documentId: 'fabric-document-retry-baseline-a'
+  });
+  const externalFabric = createFabricRoot({
+    documentId: 'fabric-document-retry-baseline-b',
+    revision: 4
+  });
+  let externalImportAttempts = 0;
+  const retryingFabricStore = {
+    ...fabricStore,
+    importRootValue(rootValue, context) {
+      if (rootValue?.documentId === externalFabric.documentId) {
+        externalImportAttempts += 1;
+        if (externalImportAttempts === 1) {
+          return { accepted: false, preserved: false };
+        }
+      }
+      return originalImportRootValue(rootValue, context);
+    }
+  };
+  window.electronAPI = {
+    loadReview: async () => createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: initialFabric
+    })
+  };
+  const manager = new ReviewDataManager({
+    autoSave: false,
+    fabricDrawingPersistenceProvider: retryingFabricStore
+  });
+  await manager.setVideoFile('C:/reviews/fabric.mp4', {
+    fabricDrawingPersistenceContext: FABRIC_CONTEXT
+  });
+
+  assert.equal(await manager.applyExternalDrawingsV3(externalFabric), false);
+  assert.equal(externalImportAttempts, 1);
+  assert.equal(await manager.applyExternalDrawingsV3(externalFabric), true);
+  assert.equal(externalImportAttempts, 2, 'the rejected payload must reach the provider again');
+  assert.deepEqual(fabricStore.exportRootValue(), externalFabric);
+  const acceptedSnapshot = manager.getDrawingsV3RootSnapshot();
+  assert.equal(acceptedSnapshot.stale, false);
+  assert.deepEqual(acceptedSnapshot.value, externalFabric);
+});
+
 test('external future and missing drawingsV3 are adopted opaquely when local Fabric is clean', async () => {
   const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
 
@@ -3896,4 +3999,117 @@ test('Fabric drawing sync drops queued roots from a stopped session after restar
     'the restarted session must still apply new roots'
   );
   sync.stop();
+});
+
+test('Fabric drawing sync requests a stable peer seed after an earlier join broadcast was missed', async () => {
+  const { FabricDrawingSync } = await import(
+    '../../renderer/scripts/modules/fabric-drawing-sync.js'
+  );
+  let now = 0;
+
+  class LinkedLiveblocksManager extends EventTarget {
+    constructor() {
+      super();
+      this.peer = null;
+      this.hasOthers = false;
+      this.sentEvents = [];
+    }
+
+    hasOtherCollaborators() {
+      return this.hasOthers;
+    }
+
+    broadcastEvent(event) {
+      this.sentEvents.push(structuredClone(event));
+      this.peer?.dispatchEvent(new CustomEvent('broadcastReceived', {
+        detail: { event: structuredClone(event) }
+      }));
+    }
+  }
+
+  class StubReviewDataManager extends EventTarget {
+    constructor(rootValue) {
+      super();
+      this.currentBframePath = 'C:/reviews/fabric-handshake.bframe';
+      this.rootValue = structuredClone(rootValue);
+      this.appliedRoots = [];
+    }
+
+    getDrawingsV3RootSnapshot() {
+      return {
+        present: true,
+        value: structuredClone(this.rootValue),
+        fingerprint: `present:${JSON.stringify(this.rootValue)}`,
+        stale: false
+      };
+    }
+
+    async applyExternalDrawingsV3(rootValue) {
+      this.appliedRoots.push(structuredClone(rootValue));
+      this.rootValue = structuredClone(rootValue);
+      return true;
+    }
+  }
+
+  const latestRoot = createFabricRoot({
+    documentId: 'fabric-document-stable-peer',
+    revision: 12
+  });
+  const staleRoot = createFabricRoot({
+    documentId: 'fabric-document-joining-peer',
+    revision: 2
+  });
+  const liveblocksA = new LinkedLiveblocksManager();
+  const liveblocksB = new LinkedLiveblocksManager();
+  liveblocksA.peer = liveblocksB;
+  liveblocksB.peer = liveblocksA;
+  const reviewA = new StubReviewDataManager(latestRoot);
+  const reviewB = new StubReviewDataManager(staleRoot);
+  const syncA = new FabricDrawingSync({
+    liveblocksManager: liveblocksA,
+    reviewDataManager: reviewA,
+    now: () => now
+  });
+  const syncB = new FabricDrawingSync({
+    liveblocksManager: liveblocksB,
+    reviewDataManager: reviewB,
+    now: () => now
+  });
+
+  syncA.start();
+  liveblocksA.hasOthers = true;
+  syncA.broadcastCurrentState();
+  assert.deepEqual(reviewB.appliedRoots, [], 'the pre-subscription seed must be missed');
+  liveblocksA.sentEvents.length = 0;
+  liveblocksB.sentEvents.length = 0;
+  liveblocksA.hasOthers = false;
+
+  now = 10001;
+  syncB.start();
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(
+    liveblocksB.sentEvents.filter(event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST').length,
+    1,
+    'the joining peer must request one post-subscription seed'
+  );
+  assert.equal(
+    liveblocksA.sentEvents.filter(event => event.type === 'FABRIC_DRAWING_ROOT').length,
+    1,
+    'the stable peer must answer once even before its Others view catches up'
+  );
+  assert.deepEqual(reviewB.appliedRoots, [latestRoot]);
+
+  liveblocksA.sentEvents.length = 0;
+  liveblocksB.sentEvents.length = 0;
+  liveblocksA.broadcastEvent({ type: 'FABRIC_DRAWING_ROOT_REQUEST' });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(
+    liveblocksB.sentEvents.filter(event => event.type === 'FABRIC_DRAWING_ROOT').length,
+    0,
+    'a newly joined peer must not seed its potentially stale root during stabilization'
+  );
+
+  syncB.stop();
+  syncA.stop();
 });

--- a/scripts/tests/review-data-manager-save.test.js
+++ b/scripts/tests/review-data-manager-save.test.js
@@ -4006,6 +4006,83 @@ test('newer same-file drawingsV3 reload wins when an older hydration finishes la
   manager.disconnect();
 });
 
+test('an accepted Broadcast invalidates an older pending drawingsV3 disk reload', async () => {
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const fabricStore = await createFabricStore();
+  const initialFabric = createFabricRoot({
+    documentId: 'fabric-cross-channel-initial'
+  });
+  const olderDiskFabric = createFabricRoot({
+    documentId: 'fabric-cross-channel-disk-b',
+    revision: 5
+  });
+  const broadcastFabric = createFabricRoot({
+    documentId: 'fabric-cross-channel-broadcast-c',
+    revision: 6
+  });
+  const freshDiskFabric = createFabricRoot({
+    documentId: 'fabric-cross-channel-fresh-d',
+    revision: 7
+  });
+  const olderReadStarted = createDeferred();
+  const olderRead = createDeferred();
+  let snapshotReadCount = 0;
+  window.electronAPI = {
+    loadReview: async () => createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: initialFabric
+    }),
+    loadReviewSnapshot: async () => {
+      snapshotReadCount += 1;
+      if (snapshotReadCount === 1) {
+        olderReadStarted.resolve();
+        return olderRead.promise;
+      }
+      return {
+        data: createReviewRoot({
+          reviewDocumentId: REVIEW_ID_EXISTING,
+          drawingsV3: freshDiskFabric
+        }),
+        versionToken: 'fabric-cross-channel-fresh-d'
+      };
+    }
+  };
+  const manager = new ReviewDataManager({
+    autoSave: false,
+    fabricDrawingPersistenceProvider: fabricStore
+  });
+  manager.connect();
+  assert.equal(await manager.setVideoFile('C:/reviews/fabric-cross-channel.mp4', {
+    fabricDrawingPersistenceContext: FABRIC_CONTEXT
+  }), true);
+
+  const olderReload = manager.reloadDrawingsV3FromDisk();
+  await olderReadStarted.promise;
+  assert.equal(await manager.applyExternalDrawingsV3(broadcastFabric), true);
+  assert.deepEqual(fabricStore.exportRootValue(), broadcastFabric);
+
+  olderRead.resolve({
+    data: createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: olderDiskFabric
+    }),
+    versionToken: 'fabric-cross-channel-older-b'
+  });
+  assert.equal(await olderReload, false);
+  assert.deepEqual(fabricStore.exportRootValue(), broadcastFabric);
+  const broadcastSnapshot = manager.getDrawingsV3RootSnapshot();
+  assert.equal(broadcastSnapshot.stale, false);
+  assert.deepEqual(broadcastSnapshot.value, broadcastFabric);
+
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.deepEqual(
+    fabricStore.exportRootValue(),
+    freshDiskFabric,
+    'the Broadcast fence must not block a later fresh disk reload'
+  );
+  manager.disconnect();
+});
+
 test('Fabric drawing sync drops queued roots from a stopped session after restart', async () => {
   const { FabricDrawingSync } = await import(
     '../../renderer/scripts/modules/fabric-drawing-sync.js'
@@ -4710,5 +4787,228 @@ test('the currently observed disk root stays protected beyond the stale history 
     diskRoot,
     'a genuinely new disk root outside the observed/stale history must still install'
   );
+
+  const previouslyObservedDiskRoot = structuredClone(diskRoot);
+  const postInstallBroadcastRoots = Array.from({ length: 9 }, (_unused, index) =>
+    createFabricRoot({
+      documentId: `fabric-observed-disk-d${index + 20}`,
+      revision: index + 20
+    }));
+  for (const broadcastRoot of postInstallBroadcastRoots) {
+    assert.equal(await manager.applyExternalDrawingsV3(broadcastRoot), true);
+  }
+  const postInstallWinner = postInstallBroadcastRoots.at(-1);
+  reloadImportCount = 0;
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.equal(reloadImportCount, 0);
+  assert.deepEqual(fabricStore.exportRootValue(), postInstallWinner);
+
+  diskRoot = postInstallWinner;
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  diskRoot = previouslyObservedDiskRoot;
+  reloadImportCount = 0;
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.equal(
+    reloadImportCount,
+    0,
+    'the previous observed root must enter stale history when disk observation advances'
+  );
+  assert.deepEqual(fabricStore.exportRootValue(), postInstallWinner);
   manager.disconnect();
+});
+
+test('Fabric drawing sync propagates an absent drawingsV3 tombstone without resurrecting a delayed root', async () => {
+  const { FabricDrawingSync } = await import(
+    '../../renderer/scripts/modules/fabric-drawing-sync.js'
+  );
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const flush = () => new Promise(resolve => setImmediate(resolve));
+  const oldRoot = createFabricRoot({
+    documentId: 'fabric-tombstone-delayed-old',
+    revision: 12
+  });
+  const stablePresentRoot = createFabricRoot({
+    documentId: 'fabric-tombstone-stable-present',
+    revision: 12
+  });
+  const reviewRoots = new Map([
+    ['C:/reviews/fabric-tombstone-stable-missing.bframe', createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING
+    })],
+    ['C:/reviews/fabric-tombstone-joining-old.bframe', createReviewRoot({
+      reviewDocumentId: REVIEW_ID_REMOTE,
+      drawingsV3: oldRoot
+    })],
+    ['C:/reviews/fabric-tombstone-stable-present.bframe', createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: stablePresentRoot
+    })],
+    ['C:/reviews/fabric-tombstone-joining-missing.bframe', createReviewRoot({
+      reviewDocumentId: REVIEW_ID_REMOTE
+    })]
+  ]);
+  window.electronAPI = {
+    loadReview: async path => structuredClone(reviewRoots.get(path) || null)
+  };
+
+  class LinkedLiveblocksManager extends EventTarget {
+    constructor(connectionId) {
+      super();
+      this.connectionId = connectionId;
+      this.peer = null;
+      this.sentEvents = [];
+    }
+
+    getSelf() {
+      return { connectionId: this.connectionId };
+    }
+
+    hasOtherCollaborators() {
+      return true;
+    }
+
+    broadcastEvent(event) {
+      const cloned = structuredClone(event);
+      this.sentEvents.push(cloned);
+      this.peer?.dispatchEvent(new CustomEvent('broadcastReceived', {
+        detail: { event: cloned }
+      }));
+    }
+  }
+
+  const createLoadedManager = async (videoPath, fabricStore) => {
+    const manager = new ReviewDataManager({
+      autoSave: false,
+      fabricDrawingPersistenceProvider: fabricStore
+    });
+    manager.connect();
+    assert.equal(await manager.setVideoFile(videoPath, {
+      fabricDrawingPersistenceContext: FABRIC_CONTEXT
+    }), true);
+    return manager;
+  };
+  const startStableAndJoiner = async ({ stableReview, joiningReview, suffix }) => {
+    let now = 0;
+    const stableLiveblocks = new LinkedLiveblocksManager(`${suffix}-stable`);
+    const joiningLiveblocks = new LinkedLiveblocksManager(`${suffix}-joining`);
+    stableLiveblocks.peer = joiningLiveblocks;
+    joiningLiveblocks.peer = stableLiveblocks;
+    const stableSync = new FabricDrawingSync({
+      liveblocksManager: stableLiveblocks,
+      reviewDataManager: stableReview,
+      now: () => now,
+      actorId: `${suffix}-stable`
+    });
+    const joiningSync = new FabricDrawingSync({
+      liveblocksManager: joiningLiveblocks,
+      reviewDataManager: joiningReview,
+      now: () => now,
+      actorId: `${suffix}-joining`
+    });
+    stableSync.start();
+    stableLiveblocks.sentEvents.length = 0;
+    joiningLiveblocks.sentEvents.length = 0;
+    now = 10001;
+    joiningSync.start();
+    await flush();
+    await flush();
+    return {
+      stableLiveblocks,
+      joiningLiveblocks,
+      stableSync,
+      joiningSync
+    };
+  };
+
+  const stableMissingStore = await createFabricStore();
+  const joiningOldStore = await createFabricStore();
+  const originalJoiningReset = joiningOldStore.reset;
+  let joiningResetCount = 0;
+  const joiningOldStoreSpy = {
+    ...joiningOldStore,
+    reset(...args) {
+      joiningResetCount += 1;
+      return originalJoiningReset(...args);
+    }
+  };
+  const stableMissingReview = await createLoadedManager(
+    'C:/reviews/fabric-tombstone-stable-missing.mp4',
+    stableMissingStore
+  );
+  const joiningOldReview = await createLoadedManager(
+    'C:/reviews/fabric-tombstone-joining-old.mp4',
+    joiningOldStoreSpy
+  );
+  joiningResetCount = 0;
+  const missingPair = await startStableAndJoiner({
+    stableReview: stableMissingReview,
+    joiningReview: joiningOldReview,
+    suffix: 'tombstone-missing'
+  });
+  const joinRequest = missingPair.joiningLiveblocks.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT_REQUEST'
+  );
+  const tombstoneEvent = missingPair.stableLiveblocks.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT'
+  );
+  assert.ok(joinRequest?.syncVersion);
+  assert.equal(tombstoneEvent?.present, false);
+  assert.equal(Object.hasOwn(tombstoneEvent, 'root'), false);
+  assert.equal(Object.hasOwn(tombstoneEvent, 'chunkCount'), false);
+  assert.ok(tombstoneEvent.syncVersion.clock > joinRequest.syncVersion.clock);
+  assert.equal(joiningResetCount, 1);
+  const joiningMissingSnapshot = joiningOldReview.getDrawingsV3RootSnapshot();
+  assert.equal(joiningMissingSnapshot.present, false);
+  assert.equal(joiningMissingSnapshot.stale, false);
+
+  missingPair.joiningLiveblocks.sentEvents.length = 0;
+  joiningOldReview.dispatchEvent(new CustomEvent('saved'));
+  assert.equal(
+    missingPair.joiningLiveblocks.sentEvents.filter(
+      event => event.type === 'FABRIC_DRAWING_ROOT'
+    ).length,
+    0,
+    'an unrelated save after tombstone hydration must not resurrect the delayed root'
+  );
+  missingPair.joiningSync.broadcastCurrentState();
+  await flush();
+  const repeatedTombstone = missingPair.joiningLiveblocks.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT'
+  );
+  assert.equal(repeatedTombstone?.present, false);
+  assert.deepEqual(repeatedTombstone.syncVersion, tombstoneEvent.syncVersion);
+  assert.equal(stableMissingReview.getDrawingsV3RootSnapshot().present, false);
+  missingPair.stableSync.stop();
+  missingPair.joiningSync.stop();
+  stableMissingReview.disconnect();
+  joiningOldReview.disconnect();
+
+  const stablePresentStore = await createFabricStore();
+  const joiningMissingStore = await createFabricStore();
+  const stablePresentReview = await createLoadedManager(
+    'C:/reviews/fabric-tombstone-stable-present.mp4',
+    stablePresentStore
+  );
+  const joiningMissingReview = await createLoadedManager(
+    'C:/reviews/fabric-tombstone-joining-missing.mp4',
+    joiningMissingStore
+  );
+  const presentPair = await startStableAndJoiner({
+    stableReview: stablePresentReview,
+    joiningReview: joiningMissingReview,
+    suffix: 'tombstone-present'
+  });
+  const presentSeed = presentPair.stableLiveblocks.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT'
+  );
+  assert.equal(presentSeed?.present, true);
+  assert.deepEqual(
+    joiningMissingReview.getDrawingsV3RootSnapshot().value,
+    stablePresentRoot,
+    'a stale missing joiner must not erase the stable peer root'
+  );
+  presentPair.stableSync.stop();
+  presentPair.joiningSync.stop();
+  stablePresentReview.disconnect();
+  joiningMissingReview.disconnect();
 });

--- a/scripts/tests/review-data-manager-save.test.js
+++ b/scripts/tests/review-data-manager-save.test.js
@@ -4083,6 +4083,101 @@ test('an accepted Broadcast invalidates an older pending drawingsV3 disk reload'
   manager.disconnect();
 });
 
+test('a higher-version same-root Broadcast invalidates an older pending disk reload', async () => {
+  const { FabricDrawingSync } = await import(
+    '../../renderer/scripts/modules/fabric-drawing-sync.js'
+  );
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const fabricStore = await createFabricStore();
+  const currentFabric = createFabricRoot({
+    documentId: 'fabric-same-root-epoch-current',
+    revision: 1
+  });
+  const olderDiskFabric = createFabricRoot({
+    documentId: 'fabric-same-root-epoch-older-disk',
+    revision: 2
+  });
+  const diskReadStarted = createDeferred();
+  const diskRead = createDeferred();
+  window.electronAPI = {
+    loadReview: async () => createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: currentFabric
+    }),
+    loadReviewSnapshot: async () => {
+      diskReadStarted.resolve();
+      return diskRead.promise;
+    }
+  };
+  const manager = new ReviewDataManager({
+    autoSave: false,
+    fabricDrawingPersistenceProvider: fabricStore
+  });
+  manager.connect();
+  assert.equal(await manager.setVideoFile('C:/reviews/fabric-same-root-epoch.mp4', {
+    fabricDrawingPersistenceContext: FABRIC_CONTEXT
+  }), true);
+
+  class StubLiveblocksManager extends EventTarget {
+    constructor() {
+      super();
+      this.sentEvents = [];
+    }
+
+    getSelf() {
+      return { connectionId: 'same-root-local' };
+    }
+
+    hasOtherCollaborators() {
+      return true;
+    }
+
+    broadcastEvent(event) {
+      this.sentEvents.push(structuredClone(event));
+    }
+
+    receive(event) {
+      this.dispatchEvent(new CustomEvent('broadcastReceived', {
+        detail: { event: structuredClone(event) }
+      }));
+    }
+  }
+  const liveblocksManager = new StubLiveblocksManager();
+  const sync = new FabricDrawingSync({
+    liveblocksManager,
+    reviewDataManager: manager,
+    actorId: 'same-root-local'
+  });
+  sync.start();
+  liveblocksManager.sentEvents.length = 0;
+  sync.broadcastCurrentState();
+  const currentRootEvent = liveblocksManager.sentEvents.find(
+    event => event.type === 'FABRIC_DRAWING_ROOT'
+  );
+  assert.ok(currentRootEvent?.fingerprint);
+
+  const olderReload = manager.reloadDrawingsV3FromDisk();
+  await diskReadStarted.promise;
+  liveblocksManager.receive({
+    ...currentRootEvent,
+    transferId: 'same-root-remote-higher-version',
+    syncVersion: { clock: 10, actorId: 'same-root-remote' }
+  });
+  await new Promise(resolve => setImmediate(resolve));
+  diskRead.resolve({
+    data: createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: olderDiskFabric
+    }),
+    versionToken: 'same-root-older-disk'
+  });
+
+  assert.equal(await olderReload, false);
+  assert.deepEqual(fabricStore.exportRootValue(), currentFabric);
+  sync.stop();
+  manager.disconnect();
+});
+
 test('Fabric drawing sync drops queued roots from a stopped session after restart', async () => {
   const { FabricDrawingSync } = await import(
     '../../renderer/scripts/modules/fabric-drawing-sync.js'

--- a/scripts/tests/review-data-manager-save.test.js
+++ b/scripts/tests/review-data-manager-save.test.js
@@ -4619,3 +4619,96 @@ test('a causally superseded Fabric root cannot return through disk reload', asyn
   );
   manager.disconnect();
 });
+
+test('the currently observed disk root stays protected beyond the stale history cap', async () => {
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const fabricStore = await createFabricStore();
+  let diskRoot = createFabricRoot({
+    documentId: 'fabric-observed-disk-d0',
+    revision: 0
+  });
+  window.electronAPI = {
+    loadReview: async () => createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: diskRoot
+    })
+  };
+  const originalImportRootValue = fabricStore.importRootValue;
+  let reloadImportCount = 0;
+  const spyingFabricStore = {
+    ...fabricStore,
+    importRootValue(rootValue, context) {
+      reloadImportCount += 1;
+      return originalImportRootValue(rootValue, context);
+    }
+  };
+  const manager = new ReviewDataManager({
+    autoSave: false,
+    fabricDrawingPersistenceProvider: spyingFabricStore
+  });
+  manager.connect();
+  assert.equal(await manager.setVideoFile('C:/reviews/observed-disk-cap.mp4', {
+    fabricDrawingPersistenceContext: FABRIC_CONTEXT
+  }), true);
+
+  const broadcastRoots = Array.from({ length: 9 }, (_unused, index) =>
+    createFabricRoot({
+      documentId: `fabric-observed-disk-d${index + 1}`,
+      revision: index + 1
+    }));
+  for (const broadcastRoot of broadcastRoots) {
+    assert.equal(await manager.applyExternalDrawingsV3(broadcastRoot), true);
+  }
+  const latestBroadcastRoot = broadcastRoots.at(-1);
+  assert.deepEqual(fabricStore.exportRootValue(), latestBroadcastRoot);
+
+  reloadImportCount = 0;
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.equal(reloadImportCount, 0);
+  assert.deepEqual(
+    fabricStore.exportRootValue(),
+    latestBroadcastRoot,
+    'the still-observed D0 disk root must not be evicted by D1-D9 history'
+  );
+  const finalSnapshot = manager.getDrawingsV3RootSnapshot();
+  assert.equal(finalSnapshot.stale, false);
+  assert.deepEqual(finalSnapshot.value, latestBroadcastRoot);
+
+  diskRoot = broadcastRoots[0];
+  reloadImportCount = 0;
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.equal(reloadImportCount, 0);
+  assert.deepEqual(fabricStore.exportRootValue(), latestBroadcastRoot);
+
+  const laterBroadcastRoots = Array.from({ length: 9 }, (_unused, index) =>
+    createFabricRoot({
+      documentId: `fabric-observed-disk-d${index + 10}`,
+      revision: index + 10
+    }));
+  for (const broadcastRoot of laterBroadcastRoots) {
+    assert.equal(await manager.applyExternalDrawingsV3(broadcastRoot), true);
+  }
+  const finalBroadcastRoot = laterBroadcastRoots.at(-1);
+  reloadImportCount = 0;
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.equal(reloadImportCount, 0);
+  assert.deepEqual(
+    fabricStore.exportRootValue(),
+    finalBroadcastRoot,
+    'a confirmed D0-to-D1 disk advance must move the protected fingerprint to D1'
+  );
+
+  diskRoot = createFabricRoot({
+    documentId: 'fabric-observed-disk-new-d19',
+    revision: 19
+  });
+  reloadImportCount = 0;
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.equal(reloadImportCount, 1);
+  assert.deepEqual(
+    fabricStore.exportRootValue(),
+    diskRoot,
+    'a genuinely new disk root outside the observed/stale history must still install'
+  );
+  manager.disconnect();
+});

--- a/scripts/tests/review-data-manager-save.test.js
+++ b/scripts/tests/review-data-manager-save.test.js
@@ -4912,6 +4912,87 @@ test('the currently observed disk root stays protected beyond the stale history 
   manager.disconnect();
 });
 
+test('an accepted intermediate root stays blocked when Drive exposes it after later broadcasts', async () => {
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const fabricStore = await createFabricStore();
+  const diskRoot0 = createFabricRoot({
+    documentId: 'fabric-delayed-intermediate-d0',
+    revision: 0
+  });
+  let diskRoot = diskRoot0;
+  window.electronAPI = {
+    loadReview: async () => createReviewRoot({
+      reviewDocumentId: REVIEW_ID_EXISTING,
+      drawingsV3: diskRoot
+    })
+  };
+  const originalImportRootValue = fabricStore.importRootValue;
+  let reloadImportCount = 0;
+  const spyingFabricStore = {
+    ...fabricStore,
+    importRootValue(rootValue, context) {
+      reloadImportCount += 1;
+      return originalImportRootValue(rootValue, context);
+    }
+  };
+  const manager = new ReviewDataManager({
+    autoSave: false,
+    fabricDrawingPersistenceProvider: spyingFabricStore
+  });
+  manager.connect();
+  assert.equal(await manager.setVideoFile('C:/reviews/delayed-intermediate.mp4', {
+    fabricDrawingPersistenceContext: FABRIC_CONTEXT
+  }), true);
+
+  const acceptedRoots = Array.from({ length: 10 }, (_unused, index) =>
+    createFabricRoot({
+      documentId: `fabric-delayed-intermediate-d${index + 1}`,
+      revision: index + 1
+    }));
+  for (const rootValue of acceptedRoots) {
+    assert.equal(await manager.applyExternalDrawingsV3(rootValue), true);
+  }
+  const currentRoot = acceptedRoots.at(-1);
+  const staleIdentities = [...manager._drawingsV3ExternalStaleFingerprints];
+  assert.equal(staleIdentities.length, 10);
+  assert.ok(staleIdentities.every(identity => identity.length <= 80));
+  assert.ok(staleIdentities.every(identity => !identity.includes('fabric-delayed-intermediate')));
+  diskRoot = acceptedRoots[0];
+  reloadImportCount = 0;
+
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.equal(
+    reloadImportCount,
+    0,
+    'an accepted D1 must not be forgotten before delayed disk replication exposes it'
+  );
+  assert.deepEqual(fabricStore.exportRootValue(), currentRoot);
+  assert.deepEqual(manager.getDrawingsV3RootSnapshot().value, currentRoot);
+  assert.equal(manager.getDrawingsV3RootSnapshot().stale, false);
+
+  const unseenDiskRoot = createFabricRoot({
+    documentId: 'fabric-delayed-intermediate-unseen',
+    revision: 11
+  });
+  diskRoot = unseenDiskRoot;
+  reloadImportCount = 0;
+  assert.equal(await manager.reloadDrawingsV3FromDisk(), true);
+  assert.equal(reloadImportCount, 1);
+  assert.deepEqual(
+    fabricStore.exportRootValue(),
+    unseenDiskRoot,
+    'a genuinely unseen disk root must still install'
+  );
+
+  assert.equal(await manager.applyExternalDrawingsV3(acceptedRoots[0]), true);
+  assert.deepEqual(
+    fabricStore.exportRootValue(),
+    acceptedRoots[0],
+    'an explicit causal winner must still bypass stale disk protection once'
+  );
+  manager.disconnect();
+});
+
 test('Fabric drawing sync propagates an absent drawingsV3 tombstone without resurrecting a delayed root', async () => {
   const { FabricDrawingSync } = await import(
     '../../renderer/scripts/modules/fabric-drawing-sync.js'

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -244,12 +244,12 @@ test('release build scripts pin stable while trial build scripts pin trial regar
   assert.match(packageJson.scripts['test:mpv'], /runtime-profile\.test\.js/);
 });
 
-test('stable engine promotion uses the 2.0.3 beta release version consistently', () => {
+test('stable engine promotion uses the 2.1.0 beta release version consistently', () => {
   const rootDir = path.resolve(__dirname, '..', '..');
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.0.3-beta');
-  assert.equal(packageLock.version, '2.0.3-beta');
-  assert.equal(packageLock.packages[''].version, '2.0.3-beta');
+  assert.equal(packageJson.version, '2.1.0-beta');
+  assert.equal(packageLock.version, '2.1.0-beta');
+  assert.equal(packageLock.packages[''].version, '2.1.0-beta');
 });


### PR DESCRIPTION
## 📋 업데이트 요약

- 🎨 그린 선부터 하이라이트·댓글까지 되돌리기가 자연스러운 순서로 이어지고, 처리 중 새로 만든 항목이 뒤늦은 응답 때문에 지워지지 않습니다.
- 🤝 여러 사용자가 동시에 그리거나 늦게 들어와도 오래된 그림이 다시 살아나는 경로를 막았습니다. 어느 쪽이 최신인지 증명할 수 없는 시작 상태는 임의로 덮지 않고 안전하게 저장을 보류합니다.
- ⏳ 영상 복구 중 그리기를 켰다가 취소하면 준비 완료 뒤 모드가 저절로 다시 켜지지 않습니다.
- ⌨️ 영상 위에 포커스가 있어도 재생·이동·되돌리기 단축키가 올바른 기능으로 한 번만 전달됩니다.
- 🛟 새 드로잉 기능을 끈 환경에서도 기존 그리기 방식은 그대로 동작합니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`와 `fabric-drawing-pilot-controller.js`는 Fabric 히스토리가 비었을 때만 전역 undo/redo로 폴백합니다. 입력 시점의 global history revision을 캡처하고 Fabric IPC부터 조건부 전역 폴백 완료까지 한 queue에서 직렬화합니다. Fabric 폴백 자체의 stack 이동만 fence에서 제외하고, 새 댓글·하이라이트·파일 전환은 계속 revision을 올려 대기 중 폴백과 늦은 stack commit을 차단합니다.
- `main/mpv-overlay-host.js`, `mpv-overlay-keyboard-relay.js`, `keyboard-shortcut-targets.js`는 오버레이 Ctrl/Cmd+Z/Y를 renderer 단일 경로로 즉시 전달합니다. history chord는 남아 있는 입력칸 포커스에 막히지 않고, Tab 등 일반 키는 기존 active-element 정책을 유지합니다.
- `fabric-drawing-pilot-controller.js`의 복구·hydration 경로는 입력 revision과 owner를 await 뒤 재검증해 취소된 활성화 요청의 부활을 차단합니다.
- `fabric-drawing-sync.js`는 세션 actor와 Lamport clock, 부재 tombstone, inline/chunk version, session generation fence를 사용합니다. 모든 live 세션이 안정화 뒤 seed를 한 번 재요청하고, V2 응답·청크는 요청자에게만 전달합니다. raw baseline 응답은 기존 revision을 유지하고 실제 로컬 저장만 clock을 올려 네트워크 순서가 낮은 revision을 승자로 만들지 못하게 했습니다.
- 시작 baseline은 실제 provider 검증을 통과한 같은 documentId에서만 revision과 지문으로 비교합니다. 부재·opaque·다른 documentId는 peer별 conflict hold로 fail-closed 처리하고, 실제 Fabric 저장·인과 root·유효한 파일 전진으로 해소합니다.
- `review-data-manager.js`는 owner와 reload epoch, 실제 디스크 관측 지문, compact stale identity history를 분리합니다. 외부 root나 disk hydration이 저장 중 끼어들면 authority epoch를 IPC 전후로 재검증하고, 이미 기록된 stale payload를 현재로 승인·Broadcast하지 않은 채 최신 root를 bounded retry로 다시 저장합니다. in-flight 상태는 review context별 token으로 관리해 이전 파일 작업이 새 파일 저장을 막지 않습니다.
- baseline hold가 풀리면 dirty autosave를 다시 예약하되 `pauseAutoSave()`와 disconnect를 우회하지 않습니다. pause 중 실제 Fabric provider 변경도 dirty/localChanges만 보존하고 파일을 쓰지 않습니다.
- `app.js`의 자동·명시 seed에서는 삭제 상태를 표현하지 못하는 댓글·레거시 드로잉 전체 전송을 제외하고 causal Fabric만 유지했습니다. connected file watcher는 500ms 안의 최신 알림을 trailing reload 한 번으로 합칩니다.
- `main/mpv-manager.js`의 모든 mpv 실행에 입력 소비 차단 3종을 적용했고, 버전은 `2.1.0-beta`입니다. 생성 번들 `renderer/scripts/lib/mpv-fabric-overlay.iife.js`와 `mpv/`는 변경하지 않았습니다.

## 🚧 개발 난항

- 계획 구현 뒤 반복 적대 리뷰에서 hydration 취소, 파일 owner 전환, stop→start 큐, 구독 전 seed 유실, 동시 root 교차 적용, 청크 interleave, disk/Broadcast 역전, 부재 root 부활, additive 댓글·레거시 seed, 10초 동시 합류 경합을 차례로 재현했습니다.
- 단순 재전파는 상충 stale 이력에서 무한 ping-pong을 만들었고, 모든 raw root를 새 clock으로 승격하면 3명 방에서 낮은 revision이 네트워크 순서만으로 승리했습니다. targeted V2 handshake, raw revision 유지, actor별 hold로 교체했습니다.
- 부재·opaque·다른 documentId의 fresh baseline은 영속된 인과 정보가 없어 어느 쪽이 최신인지 증명할 수 없습니다. 이 경우 임의 수렴보다 저장 보류를 택했으며, 파일 채널이나 실제 Fabric 편집까지 즉시 수렴하지 않을 수 있는 tradeoff를 DEVLOG에 기록했습니다.
- 저장 IPC가 끝나기 직전에 root가 바뀌는 창은 이미 발생한 물리 write를 되돌릴 수 없어, 그 payload를 observed/stale 이력으로만 남기고 최신 상태를 재수집하는 방식으로 닫았습니다.
- 마지막 재리뷰에서는 빠른 Ctrl+Z/Y 두 번 중 첫 폴백이 history revision을 바꿔 두 번째 정상 입력을 누락하는 경합을 재현했습니다. IPC와 폴백 Promise를 함께 직렬화하고 비동기 undo/redo 중 새 작업·파일 전환이 끼면 과거 action을 stack에 되살리지 않도록 보강했습니다.
- 최초 전체 테스트에서 종료 중 Git process handle이 고정 PID `12345`와 충돌한 복구 테스트는 handle 소멸 뒤 코드 변경 없이 통과했습니다. 실제 2-인스턴스 원격 획 전파와 Windows 실키 라우팅은 자동화 한계로 부분 확인 상태입니다.

## ✅ 테스트 가이드

### 실사용자용

1. 선·하이라이트·댓글을 만든 뒤 Ctrl+Z/Y를 반복해 최근 작업부터 올바른 순서로 취소·복구되는지 확인합니다.
2. 같은 리뷰 파일을 두 앱에서 열고 양쪽에서 거의 동시에 그린 뒤 최종 그림이 같아지는지 확인합니다.
3. 영상 전환 직후 그리기를 켰다가 취소하고, 준비가 끝난 뒤 모드가 저절로 켜지지 않는지 확인합니다.
4. 영상 위와 댓글 입력칸을 번갈아 클릭한 뒤 Ctrl+Z, Space, 화살표가 각각 올바른 대상으로 한 번만 전달되는지 확인합니다.
5. Fabric 시험 기능을 끈 실행에서 기존 그리기 도구로 선을 그릴 수 있는지 확인합니다.

### 개발자용

- `package.json`의 `test:*` 25종: **25/25 PASS, 1,904/1,904 PASS**
- `npm.cmd run test:fabric-drawing-pilot`: **329/329 PASS**
- `npm.cmd run test:fabric-drawing-persistence`: **155/155 PASS**
- `npm.cmd run test:mpv`: **290/290 PASS**
- `npm.cmd run lint`: **오류 0건, 기존 경고 59건**
- `npm.cmd run build`: PASS (`2.1.0-beta`, Windows unpacked package)
- `git diff --check`: PASS
- `renderer/scripts/lib/mpv-fabric-overlay.iife.js`, `mpv/`: `origin/main` 대비 변경 0건
- 실제 앱은 Fabric 획·하이라이트 저장, 도구 Undo/Redo, B 준비 취소 후 passive 유지, 레거시 킬 스위치 입력을 확인했습니다. 2-인스턴스 원격 획 전파와 실제 Windows 키 라우팅은 부분 확인입니다.
