### PR TITLE
[v2.1.2-beta] 드로잉 오버레이 표시·반영 회귀 수정

### DIFF
--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -3215,6 +3215,8 @@ class MPVOverlayHost {
       hostWindow.webContents?.invalidate?.();
       hostWindow.setFocusable?.(true);
       hostWindow.setIgnoreMouseEvents?.(false);
+      // 네이티브 확장 스타일 변경이 직전 repaint 예약을 무효화할 수 있어 한 번 더 강제한다
+      hostWindow.webContents?.invalidate?.();
       return;
     }
 
@@ -3863,6 +3865,8 @@ class MPVOverlayHost {
       this.window.show();
     }
     this.window.moveTop?.();
+    // 숨김 중 갱신된 DOM(툴바·드로잉)이 이전 프레임으로 남지 않게 재표시 직후 재합성을 강제한다
+    this.window.webContents?.invalidate?.();
   }
 
   _toScreenBounds(bounds, mainWindow) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.1.1-beta",
+  "version": "2.1.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.1.1-beta",
+      "version": "2.1.2-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.1.1-beta",
+  "version": "2.1.2-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -17591,7 +17591,6 @@ void main() {
               left: "12px",
               display: "flex",
               zIndex: "2",
-              transition: "opacity 100ms ease",
               pointerEvents: "none"
             });
             const brushButton = labelToolbarButton(createButton("Brush", "brush"), "\uBE0C\uB7EC\uC2DC \uB3C4\uAD6C (B)");

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -15432,15 +15432,20 @@ void main() {
         function updateObjectMetric() {
           metrics.setObjectCount(sceneStore.getDiagnostics().objectCount);
         }
-        function renderActiveScene() {
+        function renderActiveScene(options2 = {}) {
           if (!fabricCanvas) return;
           strokeFillGeometryCache.clear();
           strokeFillGeometryCacheWeight = 0;
           const snapshot = sceneStore.getActiveSceneSnapshot();
+          const paths = (snapshot?.objects || []).map((record) => makeFabricPath(record));
           fabricCanvas.clear();
-          for (const record of snapshot?.objects || []) fabricCanvas.add(makeFabricPath(record));
+          for (const path of paths) fabricCanvas.add(path);
           refreshSelectionInteractionPolicy();
-          fabricCanvas.requestRenderAll();
+          if (options2.immediate === true && typeof fabricCanvas.renderAll === "function") {
+            fabricCanvas.renderAll();
+          } else {
+            fabricCanvas.requestRenderAll();
+          }
           updateObjectMetric();
         }
         function setToolMode(tool) {
@@ -17718,7 +17723,7 @@ void main() {
           tokenState.inputRevision = Number(request.inputRevision);
           currentSession = session;
           applyViewport(session);
-          renderActiveScene();
+          renderActiveScene({ immediate: true });
           setToolMode(session.tool);
           inputEnabled = true;
           setSurfaceInput(true);

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -14835,6 +14835,7 @@ void main() {
         let destroyed = false;
         let inputEnabled = false;
         let currentSession = null;
+        let lastPaintedScene = null;
         let activeStroke = null;
         let activeLasso = null;
         let lastSelectionGesture = null;
@@ -15447,6 +15448,35 @@ void main() {
             fabricCanvas.requestRenderAll();
           }
           updateObjectMetric();
+        }
+        function repaintLastPaintedScene(options2 = {}) {
+          if (destroyed || !fabricCanvas || inputEnabled || !lastPaintedScene) return;
+          if (typeof sceneStore.getSceneSnapshot !== "function") return;
+          const snapshot = sceneStore.getSceneSnapshot(
+            lastPaintedScene.stableVideoIdentity,
+            lastPaintedScene.targetFrame
+          );
+          if (!snapshot) {
+            if (options2.clearWhenMissing === true) {
+              fabricCanvas.clear();
+              if (typeof fabricCanvas.renderAll === "function") fabricCanvas.renderAll();
+              else fabricCanvas.requestRenderAll();
+            }
+            return;
+          }
+          if (options2.force !== true) {
+            const snapshotIds = (snapshot.objects || []).map((record) => record.id || null);
+            const canvasIds = fabricCanvas.getObjects().filter((object) => !object.__baeframeTransient).map((object) => object.__baeframeObjectId);
+            if (snapshotIds.length === canvasIds.length && snapshotIds.every((id, index) => id === canvasIds[index])) {
+              return;
+            }
+          }
+          const paths = (snapshot.objects || []).map((record) => makeFabricPath(record));
+          for (const path of paths) path.set({ selectable: false, evented: false });
+          fabricCanvas.clear();
+          for (const path of paths) fabricCanvas.add(path);
+          if (typeof fabricCanvas.renderAll === "function") fabricCanvas.renderAll();
+          else fabricCanvas.requestRenderAll();
         }
         function setToolMode(tool) {
           if (!fabricCanvas) return;
@@ -17512,6 +17542,7 @@ void main() {
           inputEnabled = false;
           currentSession = null;
           sceneStore.deactivateSession();
+          repaintLastPaintedScene();
           syncPersistenceBadge();
         }
         function releaseSurfaceResources() {
@@ -17724,6 +17755,10 @@ void main() {
           currentSession = session;
           applyViewport(session);
           renderActiveScene({ immediate: true });
+          lastPaintedScene = {
+            stableVideoIdentity: session.stableVideoIdentity,
+            targetFrame: session.targetFrame
+          };
           setToolMode(session.tool);
           inputEnabled = true;
           setSurfaceInput(true);
@@ -17743,7 +17778,20 @@ void main() {
             return { accepted: false, reason: "persistence-unavailable" };
           }
           try {
-            return sceneStore.hydrateVideo(clonePlain(request));
+            const result = sceneStore.hydrateVideo(clonePlain(request));
+            if (result?.accepted === true) {
+              if (lastPaintedScene && lastPaintedScene.stableVideoIdentity === String(request?.stableVideoIdentity || "")) {
+                repaintLastPaintedScene({ force: true, clearWhenMissing: true });
+              } else if (lastPaintedScene) {
+                lastPaintedScene = null;
+                if (fabricCanvas) {
+                  fabricCanvas.clear();
+                  if (typeof fabricCanvas.renderAll === "function") fabricCanvas.renderAll();
+                  else fabricCanvas.requestRenderAll();
+                }
+              }
+            }
+            return result;
           } catch (_error) {
             return { accepted: false, reason: "invalid-hydration-request" };
           }
@@ -17922,6 +17970,7 @@ void main() {
         }
         function destroy() {
           if (destroyed) return { destroyed: true, reused: true };
+          lastPaintedScene = null;
           disableInput();
           releaseSurfaceResources();
           strokeFillGeometryCache.clear();

--- a/renderer/scripts/modules/fabric-drawing-pilot-controller.js
+++ b/renderer/scripts/modules/fabric-drawing-pilot-controller.js
@@ -1088,12 +1088,29 @@ export function createFabricDrawingPilotController(options = {}) {
         return false;
       }
 
+      let installedSource = null;
       try {
-        await installSource();
+        installedSource = await installSource();
       } catch (error) {
         installError = error;
       }
       if (!persistenceVideoMatches(owner)) return false;
+      if (installError === null && installedSource === false) {
+        // 소스 설치가 명시적으로 거부되면 설치 안 된 소스로 재수화하지 않는다.
+        // 사용자가 그리던 중이면 드로잉 입력만 복원하고, 아니면 대기 상태로 내린다.
+        if (resumeRequested) {
+          const rejectOwner = capturePersistenceOwner();
+          return startEnable(persistenceVideoContext, () => ownsPersistenceOwner(rejectOwner));
+        }
+        if (persistenceQuitSuspension) {
+          // 종료 준비 유예 중에는 정상 경로(1120-1128행)처럼 재개 의도를 복원하고 recovering으로 홀드한다
+          resumeRequested = quitResumeIntent;
+          setState('recovering');
+          return false;
+        }
+        setState('passive');
+        return false;
+      }
 
       persistenceOwnerEpoch += 1;
       persistenceBoundSourceEpoch = null;

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -2660,15 +2660,20 @@ function createFabricOverlayRuntime(options = {}) {
     metrics.setObjectCount(sceneStore.getDiagnostics().objectCount);
   }
 
-  function renderActiveScene() {
+  function renderActiveScene(options = {}) {
     if (!fabricCanvas) return;
     strokeFillGeometryCache.clear();
     strokeFillGeometryCacheWeight = 0;
     const snapshot = sceneStore.getActiveSceneSnapshot();
+    const paths = (snapshot?.objects || []).map(record => makeFabricPath(record));
     fabricCanvas.clear();
-    for (const record of snapshot?.objects || []) fabricCanvas.add(makeFabricPath(record));
+    for (const path of paths) fabricCanvas.add(path);
     refreshSelectionInteractionPolicy();
-    fabricCanvas.requestRenderAll();
+    if (options.immediate === true && typeof fabricCanvas.renderAll === 'function') {
+      fabricCanvas.renderAll();
+    } else {
+      fabricCanvas.requestRenderAll();
+    }
     updateObjectMetric();
   }
 
@@ -5211,7 +5216,7 @@ function createFabricOverlayRuntime(options = {}) {
     tokenState.inputRevision = Number(request.inputRevision);
     currentSession = session;
     applyViewport(session);
-    renderActiveScene();
+    renderActiveScene({ immediate: true });
     setToolMode(session.tool);
     inputEnabled = true;
     setSurfaceInput(true);

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -2004,6 +2004,7 @@ function createFabricOverlayRuntime(options = {}) {
   let destroyed = false;
   let inputEnabled = false;
   let currentSession = null;
+  let lastPaintedScene = null;
   let activeStroke = null;
   let activeLasso = null;
   let lastSelectionGesture = null;
@@ -2675,6 +2676,43 @@ function createFabricOverlayRuntime(options = {}) {
       fabricCanvas.requestRenderAll();
     }
     updateObjectMetric();
+  }
+
+  function repaintLastPaintedScene(options = {}) {
+    if (destroyed || !fabricCanvas || inputEnabled || !lastPaintedScene) return;
+    if (typeof sceneStore.getSceneSnapshot !== 'function') return;
+    const snapshot = sceneStore.getSceneSnapshot(
+      lastPaintedScene.stableVideoIdentity,
+      lastPaintedScene.targetFrame
+    );
+    if (!snapshot) {
+      // 스냅샷 부재의 의미는 호출 맥락에 따라 다르다:
+      // - disable 경로(기본): '정보 없음'(씬 축출 등) — 화면을 보존한다.
+      // - 수화 직후((e), clearWhenMissing): 수화가 그 프레임 키프레임을 싣지 않았다는
+      //   '삭제 확정' — 삭제된 획이 화면에 남지 않게 캔버스를 비운다.
+      if (options.clearWhenMissing === true) {
+        fabricCanvas.clear();
+        if (typeof fabricCanvas.renderAll === 'function') fabricCanvas.renderAll();
+        else fabricCanvas.requestRenderAll();
+      }
+      return;
+    }
+    if (options.force !== true) {
+      const snapshotIds = (snapshot.objects || []).map(record => record.id || null);
+      const canvasIds = fabricCanvas.getObjects()
+        .filter(object => !object.__baeframeTransient)
+        .map(object => object.__baeframeObjectId);
+      if (snapshotIds.length === canvasIds.length &&
+          snapshotIds.every((id, index) => id === canvasIds[index])) {
+        return;
+      }
+    }
+    const paths = (snapshot.objects || []).map(record => makeFabricPath(record));
+    for (const path of paths) path.set({ selectable: false, evented: false });
+    fabricCanvas.clear();
+    for (const path of paths) fabricCanvas.add(path);
+    if (typeof fabricCanvas.renderAll === 'function') fabricCanvas.renderAll();
+    else fabricCanvas.requestRenderAll();
   }
 
   function setToolMode(tool) {
@@ -5000,6 +5038,7 @@ function createFabricOverlayRuntime(options = {}) {
     inputEnabled = false;
     currentSession = null;
     sceneStore.deactivateSession();
+    repaintLastPaintedScene();
     syncPersistenceBadge();
   }
 
@@ -5217,6 +5256,10 @@ function createFabricOverlayRuntime(options = {}) {
     currentSession = session;
     applyViewport(session);
     renderActiveScene({ immediate: true });
+    lastPaintedScene = {
+      stableVideoIdentity: session.stableVideoIdentity,
+      targetFrame: session.targetFrame
+    };
     setToolMode(session.tool);
     inputEnabled = true;
     setSurfaceInput(true);
@@ -5237,7 +5280,25 @@ function createFabricOverlayRuntime(options = {}) {
       return { accepted: false, reason: 'persistence-unavailable' };
     }
     try {
-      return sceneStore.hydrateVideo(clonePlain(request));
+      const result = sceneStore.hydrateVideo(clonePlain(request));
+      if (result?.accepted === true) {
+        if (lastPaintedScene &&
+            lastPaintedScene.stableVideoIdentity === String(request?.stableVideoIdentity || '')) {
+          // 수화는 같은 objectId를 유지한 채 내용(pathData·transform)만 바꿀 수 있으므로
+          // id 비교를 생략하고 강제 재도색하며(disable 배선은 기본 호출 = id 비교 유지),
+          // 수화 결과에 이 프레임 키프레임이 없으면 '삭제 확정'이므로 캔버스를 비운다
+          repaintLastPaintedScene({ force: true, clearWhenMissing: true });
+        } else if (lastPaintedScene) {
+          // 다른 영상의 수화: 이전 영상 잔상이 새 영상 위에 남지 않게 캔버스를 비운다
+          lastPaintedScene = null;
+          if (fabricCanvas) {
+            fabricCanvas.clear();
+            if (typeof fabricCanvas.renderAll === 'function') fabricCanvas.renderAll();
+            else fabricCanvas.requestRenderAll();
+          }
+        }
+      }
+      return result;
     } catch (_error) {
       return { accepted: false, reason: 'invalid-hydration-request' };
     }
@@ -5438,6 +5499,7 @@ function createFabricOverlayRuntime(options = {}) {
 
   function destroy() {
     if (destroyed) return { destroyed: true, reused: true };
+    lastPaintedScene = null;
     disableInput();
     releaseSurfaceResources();
     strokeFillGeometryCache.clear();

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -5079,7 +5079,6 @@ function createFabricOverlayRuntime(options = {}) {
         left: '12px',
         display: 'flex',
         zIndex: '2',
-        transition: 'opacity 100ms ease',
         pointerEvents: 'none'
       });
       const brushButton = labelToolbarButton(createButton('Brush', 'brush'), '브러시 도구 (B)');

--- a/scripts/tests/fabric-drawing-persistence-controller.test.js
+++ b/scripts/tests/fabric-drawing-persistence-controller.test.js
@@ -1199,3 +1199,94 @@ test('overlay-host-unavailable save preserves the current video for host recover
   assert.equal(harness.calls.hydrate.at(-1).persistenceSessionId, currentPersistenceSessionId);
   assert.equal(harness.controller.getState(), 'active');
 });
+
+test('a rejected passive source refresh skips hydration and stays passive', async () => {
+  const harness = createHarness();
+  assert.equal(await prepareVideo(harness), true);
+  const hydrateCount = harness.calls.hydrate.length;
+  harness.calls.order.length = 0;
+
+  const result = await harness.controller.refreshPersistenceSource(() => {
+    harness.calls.order.push('install-source');
+    return false;
+  });
+
+  assert.deepEqual(harness.calls.order, [
+    'input:off:1',
+    'export:1',
+    'install-source'
+  ]);
+  assert.equal(harness.calls.hydrate.length, hydrateCount);
+  assert.equal(result, false);
+  assert.equal(harness.controller.getState(), 'passive');
+});
+
+test('a rejected active source refresh skips hydration and restores drawing input', async () => {
+  const harness = createHarness();
+  assert.equal(await prepareVideo(harness), true);
+  assert.equal(await harness.controller.toggle(), true);
+  const hydrateCount = harness.calls.hydrate.length;
+  harness.calls.order.length = 0;
+
+  const result = await harness.controller.refreshPersistenceSource(() => {
+    harness.calls.order.push('install-source');
+    return false;
+  });
+
+  assert.deepEqual(harness.calls.order, [
+    'input:off:1',
+    'export:1',
+    'install-source',
+    'input:on:1'
+  ]);
+  assert.equal(harness.calls.hydrate.length, hydrateCount);
+  assert.equal(result, true);
+  assert.equal(harness.controller.getState(), 'active');
+});
+
+test('a throwing source install releases the refresh queue for a later refresh', async () => {
+  const harness = createHarness();
+  assert.equal(await prepareVideo(harness), true);
+
+  await assert.rejects(
+    harness.controller.refreshPersistenceSource(() => {
+      harness.calls.order.push('install-source:throw');
+      throw new Error('source install failed');
+    }),
+    /source install failed/
+  );
+
+  const result = await harness.controller.refreshPersistenceSource(() => {
+    harness.calls.order.push('install-source:retry');
+    return true;
+  });
+  assert.equal(result, true);
+  assert.equal(harness.calls.order.includes('install-source:retry'), true);
+  assert.equal(harness.controller.getState(), 'passive');
+});
+
+test('a rejected source refresh preserves quit suspension resume intent', async () => {
+  const harness = createHarness();
+  assert.equal(await prepareVideo(harness), true);
+  assert.equal(await harness.controller.toggle(), true);
+  assert.equal(await harness.controller.preparePersistenceForQuit(), true);
+  const hydrateCount = harness.calls.hydrate.length;
+  harness.calls.order.length = 0;
+
+  const result = await harness.controller.refreshPersistenceSource(() => {
+    harness.calls.order.push('install-source');
+    return false;
+  });
+
+  assert.equal(result, false);
+  assert.equal(harness.controller.getState(), 'recovering');
+  assert.equal(harness.controller.getStatusSnapshot().resumeRequested, true);
+  assert.equal(harness.calls.hydrate.length, hydrateCount);
+  assert.deepEqual(harness.calls.order, [
+    'input:off:1',
+    'export:1',
+    'install-source'
+  ]);
+  assert.equal(await harness.controller.resumeAfterQuitCancelled(), true);
+  assert.equal(harness.controller.getState(), 'active');
+});

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -303,3 +303,13 @@ test('persistence gate abandon is load-local and does not rebuild transition own
   );
   assert.doesNotMatch(loadVideo, /rearmedAfterAbandon/);
 });
+
+test('Fabric 툴바 표시는 페이드 없이 한 프레임에 완성된다', () => {
+  // 툴바 opacity 트랜지션은 오버레이 창이 연속 프레임을 만들지 못해 표시를 무한 지연시킨다
+  assert.doesNotMatch(fabricRuntimeSource, /transition:\s*'opacity/);
+  const iifeSource = normalizeNewlines(fs.readFileSync(
+    path.join(rootDir, 'renderer/scripts/lib/mpv-fabric-overlay.iife.js'),
+    'utf8'
+  ));
+  assert.equal(iifeSource.includes('opacity 100ms ease'), false);
+});

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -11551,3 +11551,51 @@ test('runtime and adapter sources have no review persistence or IPC integration'
     /ReviewDataManager|saveReview|saveError|_onDataChanged|ipcRenderer|electronAPI/
   );
 });
+
+test('재진입 재도색은 rAF를 기다리지 않고 화면 컨텍스트에 동기 반영된다', async () => {
+  const harness = createRealFabricHarness();
+  try {
+    harness.drawStroke([
+      { x: 30, y: 70 },
+      { x: 80, y: 90 },
+      { x: 140, y: 75 }
+    ], 907);
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 2,
+      enabled: false
+    }).accepted, true);
+    // 재진입 직전에 화면 컨텍스트를 비워 '이전 잔상'과 신규 도색을 구분한다
+    harness.canvas.contextContainer.clearRect(
+      0, 0, harness.canvas.lowerCanvasEl.width, harness.canvas.lowerCanvasEl.height
+    );
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 3,
+      enabled: true,
+      session: {
+        sessionId: 'real-fabric-session-repaint',
+        stableVideoIdentity: 'real-fabric-video',
+        targetFrame: 0,
+        sourceWidth: 200,
+        sourceHeight: 200,
+        canvasRect: { left: 0, top: 0, width: 200, height: 200 },
+        viewportTransform: { scale: 1, panX: 0, panY: 0 },
+        tool: 'brush'
+      }
+    }).accepted, true);
+    // rAF/타이머를 flush하지 않은 동기 시점에 화면 컨텍스트에 픽셀이 있어야 한다
+    const { width, height } = harness.canvas.lowerCanvasEl;
+    const data = harness.canvas.lowerCanvasEl.getContext('2d')
+      .getImageData(0, 0, width, height).data;
+    let painted = 0;
+    for (let i = 3; i < data.length; i += 4) {
+      if (data[i] > 0) painted += 1;
+    }
+    assert.ok(painted > 0, '재진입 직후 rAF 없이 획이 화면 컨텍스트에 그려져 있어야 한다');
+  } finally {
+    await harness.destroy();
+  }
+});

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -11599,3 +11599,110 @@ test('재진입 재도색은 rAF를 기다리지 않고 화면 컨텍스트에 �
     await harness.destroy();
   }
 });
+
+test('passive 수화 직후 현재 씬이 캔버스에 재도색된다', async () => {
+  const harness = createRealFabricHarness();
+  try {
+    harness.drawStroke([
+      { x: 30, y: 70 },
+      { x: 80, y: 90 },
+      { x: 140, y: 75 }
+    ], 917);
+    assert.equal(harness.runtime.setDrawingInput({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 2,
+      enabled: false
+    }).accepted, true);
+    // 소실 상황 재현: 외부 요인으로 캔버스가 비워졌다고 가정한다
+    harness.canvas.clear();
+    assert.equal(
+      harness.canvas.getObjects().filter(object => !object.__baeframeTransient).length,
+      0
+    );
+    const hydrated = harness.runtime.hydrateDrawingVideo({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      persistenceSessionId: 'real-fabric-persistence',
+      stableVideoIdentity: 'real-fabric-video',
+      fps: 24,
+      totalFrames: 240,
+      keyframes: [{
+        id: 'hydrated-keyframe',
+        frame: 0,
+        sourceWidth: 200,
+        sourceHeight: 200,
+        mutationSequence: 1,
+        objects: [makeHistoryStroke('hydrated-stroke')]
+      }]
+    });
+    assert.equal(hydrated.accepted, true);
+    const restored = harness.canvas.getObjects().filter(object => !object.__baeframeTransient);
+    assert.equal(restored.length, 1, '수화 직후 현재 프레임 씬이 캔버스에 다시 그려져야 한다');
+    assert.equal(restored[0].__baeframeObjectId, 'hydrated-stroke');
+    assert.equal(restored[0].selectable, false);
+    assert.equal(restored[0].evented, false);
+    // 같은 id로 내용(transform)만 바뀐 재수화도 화면에 반영되어야 한다 — force 재도색 검증
+    const rehydrated = harness.runtime.hydrateDrawingVideo({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      persistenceSessionId: 'real-fabric-persistence',
+      stableVideoIdentity: 'real-fabric-video',
+      fps: 24,
+      totalFrames: 240,
+      keyframes: [{
+        id: 'hydrated-keyframe-2',
+        frame: 0,
+        sourceWidth: 200,
+        sourceHeight: 200,
+        mutationSequence: 2,
+        objects: [{
+          ...makeHistoryStroke('hydrated-stroke'),
+          transform: {
+            left: 120, top: 0, scaleX: 1, scaleY: 1, angle: 0,
+            skewX: 0, skewY: 0, flipX: false, flipY: false
+          }
+        }]
+      }]
+    });
+    assert.equal(rehydrated.accepted, true);
+    const moved = harness.canvas.getObjects().filter(object => !object.__baeframeTransient);
+    assert.equal(moved.length, 1);
+    assert.equal(moved[0].left, 120, '같은 id의 내용 변경 재수화가 화면에 반영되어야 한다');
+    // 해당 프레임 키프레임이 빠진(=삭제된) 재수화는 캔버스를 비워야 한다 — clearWhenMissing 검증
+    const emptied = harness.runtime.hydrateDrawingVideo({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      persistenceSessionId: 'real-fabric-persistence',
+      stableVideoIdentity: 'real-fabric-video',
+      fps: 24,
+      totalFrames: 240,
+      keyframes: []
+    });
+    assert.equal(emptied.accepted, true);
+    assert.equal(
+      harness.canvas.getObjects().filter(object => !object.__baeframeTransient).length,
+      0,
+      '삭제 확정 재수화 후 캔버스에 획이 남으면 안 된다'
+    );
+  } finally {
+    await harness.destroy();
+  }
+});
+
+test('lastPaintedScene이 없는 초기 상태의 disable은 예외 없이 완료된다', () => {
+  FakeCanvas.instances = [];
+  const document = new FakeDocument();
+  const root = document.createElement('div');
+  const runtime = createFabricOverlayRuntime({
+    fabric: { Canvas: FakeCanvas, Path: FakePath },
+    document
+  });
+  assert.equal(runtime.prepare(root).prepared, true);
+  assert.equal(runtime.setDrawingInput({
+    hostGeneration: 1,
+    videoGeneration: 1,
+    inputRevision: 1,
+    enabled: false
+  }).accepted, true);
+});

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -1917,6 +1917,14 @@ test('successful drawing activation repaints before pointer input without z-orde
     0,
     'toggling drawing input must not restack the native window or reintroduce flicker'
   );
+  const repaintIndices = events
+    .map(([name], index) => (name === 'webContents.invalidate' ? index : -1))
+    .filter(index => index >= 0);
+  assert.ok(repaintIndices.length >= 2, '활성화 시퀀스는 강제 재합성을 두 번 이상 예약해야 한다');
+  assert.ok(
+    repaintIndices[repaintIndices.length - 1] > nativeEnableIndex,
+    '네이티브 플래그 확정 뒤에도 재합성이 한 번 더 강제되어야 한다'
+  );
 });
 
 test('relays keyboard input through the focused main renderer and restores main focus on disable', async () => {
@@ -4151,7 +4159,8 @@ test('hides and restores the native overlay host with the mpv embed host', async
     constructor() {
       this.destroyed = false;
       this.webContents = {
-        executeJavaScript: async () => true
+        executeJavaScript: async () => true,
+        invalidate: () => events.push(['webContents.invalidate'])
       };
     }
     loadURL() {
@@ -4192,6 +4201,11 @@ test('hides and restores the native overlay host with the mpv embed host', async
   assert.deepEqual(showResult, { success: true, visible: true, ready: true });
   assert.ok(events.some(([name]) => name === 'hide'));
   assert.ok(events.filter(([name]) => name === 'showInactive').length >= 2);
+  const showIndex = events.map(([name]) => name).lastIndexOf('showInactive');
+  const repaintAfterShow = events.findIndex(
+    ([name], index) => name === 'webContents.invalidate' && index > showIndex
+  );
+  assert.ok(repaintAfterShow > showIndex, '창 재표시 직후 재합성이 강제되어야 한다');
   assert.equal(host.window.isDestroyed(), false);
 });
 

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -244,12 +244,12 @@ test('release build scripts pin stable while trial build scripts pin trial regar
   assert.match(packageJson.scripts['test:mpv'], /runtime-profile\.test\.js/);
 });
 
-test('stable engine promotion uses the 2.1.1 beta release version consistently', () => {
+test('stable engine promotion uses the 2.1.2 beta release version consistently', () => {
   const rootDir = path.resolve(__dirname, '..', '..');
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.1.1-beta');
-  assert.equal(packageLock.version, '2.1.1-beta');
-  assert.equal(packageLock.packages[''].version, '2.1.1-beta');
+  assert.equal(packageJson.version, '2.1.2-beta');
+  assert.equal(packageLock.version, '2.1.2-beta');
+  assert.equal(packageLock.packages[''].version, '2.1.2-beta');
 });


### PR DESCRIPTION
## 📋 업데이트 요약

- 🖌️ 드로잉 모드에 들어가면 이제 첫 획을 그리기 전에도 도구 메뉴가 즉시 보입니다.
- 👀 드로잉 모드를 나갔다가 다시 들어오거나 화면이 다시 표시돼도 저장된 획이 사라져 보이지 않도록 복원 흐름을 보강했습니다.
- 🔄 외부 변경으로 드로잉 데이터가 다시 불러와질 때 현재 장면을 바로 화면에 반영하고, 다른 영상의 획이 남는 현상을 막았습니다.
- 🛡️ 충돌 때문에 새 드로잉 소스 적용이 거부된 경우, 적용되지 않은 데이터로 화면을 다시 만드는 잘못된 흐름을 차단했습니다.
- 📦 버전을 `2.1.2-beta`로 올렸습니다.

## 🔧 상세 기술 설명

- `renderer/scripts/modules/mpv-fabric-overlay-runtime.js`
  - 툴바의 `opacity 100ms` 전환을 제거해 단일 합성 프레임에서도 표시가 완료되게 했습니다.
  - `renderActiveScene(options)`가 캔버스를 지우기 전에 Fabric 경로를 준비하고, B 재진입 경로에서만 `renderAll()`로 동기 도색하도록 했습니다.
  - `lastPaintedScene`과 `repaintLastPaintedScene()`을 추가해 passive 이탈·수화 후 마지막 장면을 복원하고, 같은 ID의 내용 변경 및 삭제도 반영합니다.
  - 각 런타임 변경 커밋마다 `renderer/scripts/lib/mpv-fabric-overlay.iife.js`를 다시 생성해 같은 커밋에 포함했습니다.
- `main/mpv-overlay-host.js`
  - 네이티브 입력 플래그 확정 뒤와 숨겨졌던 오버레이 창 재표시 뒤에 `webContents.invalidate()`를 추가했습니다. 기존 첫 invalidate의 순서는 유지했습니다.
- `renderer/scripts/modules/fabric-drawing-pilot-controller.js`
  - `installSource()`가 명시적으로 `false`를 반환한 경우에만 수화를 건너뛰고, 활성 재개·대기·종료 유예 상태를 각각 보존합니다.
- 회귀 테스트
  - 소스/번들 페이드, 두 invalidate 순서, 실 Fabric 화면 컨텍스트 동기 도색, passive 수화 복원·동일 ID 갱신·삭제, 설치 거부 상태를 RED→GREEN으로 고정했습니다.
  - 계획서의 버전 상승과 충돌한 `scripts/tests/runtime-profile.test.js`의 버전 고정 4줄만 `2.1.2-beta`로 갱신했습니다.

## 🚧 개발 난항

- 실제 데이터는 `drawingsV3`에 정상 저장되고 있었지만, 투명 오버레이 창이 새 프레임을 화면에 내보내지 않아 저장 실패처럼 보였습니다. 저장 경로를 건드리지 않고 표시 계층만 수정했습니다.
- 일반 B-off에서는 기존 Fabric 객체 인스턴스를 유지해야 하지만, 수화 직후에는 같은 객체 ID라도 경로·변형이 달라질 수 있었습니다. 평상시에는 ID 일치 시 재생성을 생략하고, 수화 때만 강제 재도색하는 두 경로로 분리했습니다.
- 버전 상승 뒤 기존 mpv 테스트가 `2.1.1-beta`를 직접 기대해 1건 실패했습니다. 전체 테스트 GREEN과 버전 요구를 함께 지키기 위해 해당 버전 단언 4줄만 최소 갱신했습니다.
- 알려진 한계: B를 끈 채 정지 화면에서 다른 프레임으로 이동하면 마지막 드로잉이 잠시 남을 수 있습니다. passive 프레임 변경 채널 신설이 필요한 별도 범위라 이번 PR에는 포함하지 않았습니다.

## ✅ 테스트 가이드

### 실사용자용

1. mpv 영상에서 일시정지 후 B를 누르고, 아무 입력 없이 드로잉 도구 메뉴가 즉시 보이는지 확인합니다.
2. 획을 2~3개 그리고 자동저장 완료 뒤 B를 끕니다. 아무 입력 없이 획이 그대로 보이는지 확인합니다.
3. B를 다시 켰을 때 획과 도구 메뉴가 즉시 보이는지 확인합니다.
4. 댓글 입력창을 열었다 닫아도 획과 메뉴가 유지되는지 확인합니다.
5. 다른 영상으로 전환했을 때 이전 영상의 획이 남지 않는지 확인합니다.

위 실제 Electron UI 시나리오는 자동 테스트와 분리된 수동 확인 항목입니다.

### 개발자용

- RED 기록: 작업별 판별 테스트가 수정 전 각각 의도한 원인으로 실패함을 확인했습니다.
- GREEN: `test:*` 25개 스위트, `1,933 pass / 0 fail / 0 cancelled`, 모든 스크립트 exit 0.
- 주요 집중 검증: `test:fabric-drawing-pilot` 346, `test:mpv` 299, `test:drawing` 291, `test:fabric-drawing-persistence` 155.
- `npm.cmd run build`: `2.1.2-beta` Windows unpacked build exit 0.
- 전체 브랜치 독립 리뷰: Critical 0, Important 0, 머지 가능 판정.
