### PR TITLE
[v2.2.0-beta] 드로잉 타임라인 읽기 전용 투영

### DIFF
--- a/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
+++ b/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
@@ -121,7 +121,9 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 - mpv에서 선택한 합성 키프레임이 HTML5 fallback으로 넘어갈 때만 선택을 지우고, 순수 레거시 키프레임 선택은 그대로 보존한다.
 - 정규화한 영상 경로와 파일럿 상태 훅의 `videoGeneration`을 함께 기억해 새 경로는 즉시, 같은 경로 재로드는 영상 확정 때 이전 합성 선택을 지운다. 같은 원본의 편집·재렌더·오버레이 호스트 복구에서는 선택을 유지한다.
 - 읽기 전용 합성 행의 가시성·잠금 버튼을 숨겨 존재하지 않는 레거시 레이어로 no-op 이벤트가 전달되지 않게 했다.
-- `routeKeydown(e)`와 기존 legacy shortcut 차단 함수의 인접성, 기존 조기 반환 본문은 그대로 보존했다. 별도 keyboard/click 방화벽은 추가하지 않았다.
+- passive 파일럿 투영 중에는 기존 legacy shortcut 차단 함수가 `undo`, `redo`, `drawMode`를 제외한 레거시 드로잉 변이 단축키를 막는다. HTML5/non-mpv와 키프레임 탐색은 기존 동작을 유지한다.
+- 이어보기 또는 컷리스트 집계 모드에서는 원본 영상의 로컬 frame을 전체 타임라인 좌표로 오인하지 않도록 합성 레이어를 truthy 빈 배열 `[]`로 억제한다. 진입·이탈 때 즉시 다시 렌더해 준비 중 stale 행까지 제거한다.
+- `routeKeydown(e)`와 기존 legacy shortcut 차단 함수의 인접성, 기존 조기 반환 본문은 그대로 보존했다. 새 keyboard/click listener는 추가하지 않았다.
 - 패키지와 lockfile의 루트 버전을 `2.2.0-beta`로 올리고 runtime-profile 테스트의 이름 1곳과 버전 리터럴 3곳만 함께 변경했다.
 
 ## 계획 대비 실제 차이와 버전 테스트 판정
@@ -132,6 +134,7 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 4. 작업 6 구현 후 독립 리뷰에서 합성 키프레임 선택이 HTML5 fallback 뒤 남는 경로가 발견됐다. 사용자가 최소 범위 수정과 실행형 회귀 테스트 1개 추가를 승인해 실제 최종 테스트 수는 `1,935`가 됐다.
 5. PR ② Codex 1차 리뷰에서 mpv→mpv 원본 교체 선택 잔존과 읽기 전용 행의 무동작 가시성·잠금 버튼이 P2로 확인됐다. 리뷰 루프 규칙에 따라 실행형/CSS 회귀 테스트 2개를 먼저 RED로 확인한 뒤 최소 보강했고, 최종 테스트 수는 `1,937`이 됐다. force-push 없이 별도 한글 리뷰 보강 커밋으로 기록한다.
 6. PR ② Codex 2차 리뷰에서 1차 보강의 `sourceEpoch`가 같은 영상의 오버레이 호스트 복구 때도 증가해 선택을 과도하게 지우는 P2가 확인됐다. 기존 실행형 테스트를 같은 영상 복구와 실제 영상 확정을 구분하도록 강화하고, 정규화 영상 경로와 상태 훅이 이미 캐시한 `videoGeneration` 비교로 교체했다. 독립 타이밍 재검토에서 새 경로 렌더가 generation 발표보다 먼저 오는 구간도 RED로 추가 확인해 경로 변경 즉시 clear하도록 보강했다. 신규 테스트 수는 늘지 않는다.
+7. PR ② Codex 3차 리뷰에서 계획서의 “키프레임 편집 10종 모두 `state.isDrawMode` 2차 가드가 있다”는 분석이 실제 코드와 다르고, 숫자/Shift 숫자 편집 5종이 passive 투영 뒤의 레거시 데이터와 history를 바꿀 수 있음이 확인됐다. 또한 작업 6은 이어보기·컷리스트의 전체 좌표계에서 원본 로컬 frame을 그대로 투영하는 경우를 누락했다. 기존 중앙 shortcut 차단을 passive 소유권까지 넓히고, 집계 모드에서는 truthy `[]`로 행과 캐시를 비우며 세 모드 전환 경로에서 즉시 다시 렌더했다. 판별 테스트 3개가 추가되어 실제 최종 테스트 수는 `1,940`이다.
 
 ## 리스크 및 우려 사항
 
@@ -147,6 +150,8 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 | mpv에서 선택한 합성 키프레임이 다른 mpv 원본에서도 같은 layer id로 남음 | 높음 | Codex 1차 리뷰에서 확인. 정규화 영상 경로 변경을 즉시 비교하고, 같은 경로 재로드는 새 영상의 `afterVideoReady` 승인 때 증가하는 캐시된 `videoGeneration`으로 판정해 선택을 정리 |
 | 같은 영상의 오버레이 호스트 복구가 원본 교체로 오인돼 선택이 풀림 | 중간 | Codex 2차 리뷰에서 확인. rebind 때 증가하는 `sourceEpoch` 비교를 제거하고, 호스트 복구에는 모두 유지되는 영상 경로와 `videoGeneration`으로 판정 |
 | 읽기 전용 합성 행의 가시성·잠금 버튼이 눌리지만 아무 동작도 하지 않음 | 중간 | 합성 header 아래 두 버튼만 `display: none`과 `pointer-events: none`으로 숨기고 legacy 레이어 버튼은 유지 |
+| passive 투영 뒤 숫자 편집 단축키가 숨은 레거시 레이어와 history를 변경함 | 높음 | Codex 3차 리뷰에서 계획 분석 오류를 확인. 기존 중앙 shortcut 차단을 passive 소유권에도 적용하고 undo/redo/drawMode·탐색·HTML5 음성 대조를 실행 검증 |
+| 이어보기·컷리스트에서 로컬 frame 투영이 전체 타임라인의 잘못된 위치에 표시됨 | 높음 | 집계 모드 진입 즉시 truthy `[]`를 렌더해 행과 `_lastDrawingLayers`를 비우고, 이탈 때 현재 원본 투영을 복원. drag/delete 차단은 유지 |
 | 실제 Windows Electron의 CSS 표시·마우스 drag/delete 감각이 자동 테스트와 다름 | 중간 | Windows unpacked build에서 계획서 작업 6 수동 시나리오를 실행해 아래 결과를 분리 기록 |
 
 ## 테스트 방법과 RED→GREEN 증거
@@ -165,12 +170,16 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 | Codex 1차 리뷰 보강 | source epoch·합성 행 control 생산 코드 적용 전: exit 1, tests 350 / pass 348 / fail 2 / cancelled 0 | exit 0, tests/pass 350/350 / fail 0 / cancelled 0 |
 | Codex 2차 리뷰 보강 | 동일 영상 복구 판별 강화 뒤 source 단독 exit 1, tests 16 / pass 15 / fail 1 / cancelled 0; focused exit 1, tests 350 / pass 349 / fail 1 / cancelled 0 | source 단독 exit 0, 16/16; focused exit 0, 350/350 / fail 0 / cancelled 0 |
 | Codex 2차 타이밍 보강 | cached generation이 아직 이전 값인 새 경로 렌더를 추가한 뒤 source 단독 exit 1, tests 16 / pass 15 / fail 1 / cancelled 0; focused exit 1, tests 350 / pass 349 / fail 1 / cancelled 0 | 정규화 경로 비교 추가 뒤 source 단독 exit 0, 16/16; focused exit 0, 350/350 / fail 0 / cancelled 0 |
+| Codex 3차 리뷰 보강 | passive shortcut·집계 투영 판별 추가 뒤 source 단독 exit 1, tests 18 / pass 16 / fail 2 / cancelled 0; focused exit 1, tests 352 / pass 350 / fail 2 / cancelled 0 | 1차 최소 보강 뒤 source 18/18, focused 352/352 |
+| Codex 3차 전환 보강 | 준비 중 duration 0과 모드 전환 즉시 재렌더 판별 뒤 source 단독 exit 1, tests 19 / pass 17 / fail 2 / cancelled 0 | mode-only 억제와 세 전환 재렌더 뒤 source 19/19; focused 353/353 / fail 0 / cancelled 0 |
 
 작업 6 RED의 두 실패는 기존 CSS 예외 부재를 잡은 `capture keyboard and click firewalls stop legacy drawing mutations while keeping navigation separate`와 신규 `파일럿 드로잉은 타임라인에 읽기 전용으로 투영된다`였다. 생산 코드 변경 전에는 source test 한 파일만 수정돼 있었다.
 
 작업 6 리뷰 보강 RED는 실제 `renderActiveDrawingLayers()`를 추출해 실행했을 때 HTML5 fallback이 legacy render만 호출하고 합성 선택을 지우지 않아 발생했다. 최소 수정 뒤에는 합성 선택이 있을 때 `clearSelection()`이 legacy render보다 먼저 호출되고, 순수 legacy 선택에서는 clear가 호출되지 않는 음성 대조까지 GREEN이 됐다.
 
 Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했을 때 `sourceEpoch`가 바뀌어도 clear가 호출되지 않은 문제와, 합성 header 전용 가시성·잠금 CSS가 없는 문제를 각각 판별했다. 1차 GREEN 뒤 Codex 2차 리뷰에서 rebind도 epoch를 올리는 반례가 확인됐다. 강화된 테스트는 같은 경로·`videoGeneration`의 복구에서는 render만, cached generation 발표 전이라도 새 경로면 clear→render, 다음 generation이 확정되면 clear→render, 같은 source에서 재선택하면 다시 render만 호출되는 계약을 실행 검증한다.
+
+Codex 3차 리뷰 보강 RED는 실제 shortcut guard를 추출해 passive 투영에서 `drawingLayerAdd`를 포함한 레거시 변이가 통과하는 문제와, 실제 투영 함수를 실행해 집계 모드에서 로컬 frame 레이어가 반환되는 문제를 각각 잡았다. 추가 lifecycle 점검에서는 duration이 아직 0인 준비 구간과 모드 전환 함수에 즉시 재렌더가 없는 상태도 RED로 고정했다. 최종 GREEN은 passive에서 변이 단축키만 막고, 이어보기·컷리스트 진입 시 `[]`를 렌더해 stale 행과 캐시를 비우며 이탈 시 원본 투영을 복원한다.
 
 ### 작업 6 정적 계약
 
@@ -183,13 +192,15 @@ Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했
 - HTML5 fallback의 합성 선택 정리: 1건, 순수 legacy 선택 보존 음성 대조 포함
 - mpv source identity 전환 선택 정리: 정규화 경로 또는 확정 video generation이 바뀔 때만 clear, 같은 원본 선택 유지
 - 합성 header의 가시성·잠금 control: 숨김, legacy control은 변경 없음
+- passive 파일럿 소유권 shortcut: undo/redo/drawMode와 navigation은 유지, 레거시 드로잉 변이는 차단
+- 집계 타임라인 투영: 이어보기·컷리스트에서 truthy `[]`, 세 모드 전환 경로에서 즉시 재렌더
 - package/lock/package-root version: 모두 `2.2.0-beta`
 
 ### 최종 25-suite 게이트
 
 | script | exit | tests | pass | fail | cancelled |
 |---|---:|---:|---:|---:|---:|
-| `test:fabric-drawing-pilot` | 0 | 350 | 350 | 0 | 0 |
+| `test:fabric-drawing-pilot` | 0 | 353 | 353 | 0 | 0 |
 | `test:fabric-drawing-persistence` | 0 | 155 | 155 | 0 | 0 |
 | `test:recent` | 0 | 18 | 18 | 0 | 0 |
 | `test:frame-grid` | 0 | 35 | 35 | 0 | 0 |
@@ -214,15 +225,15 @@ Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했
 | `test:version` | 0 | 2 | 2 | 0 | 0 |
 | `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
 | `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
-| **합계** | **모든 script 0** | **1,937** | **1,937** | **0** | **0** |
+| **합계** | **모든 script 0** | **1,940** | **1,940** | **0** | **0** |
 
-기준 `1,925`와 비교하면 계획 명시 신규 테스트 9개, 사용자 승인 리뷰 보강 테스트 1개, Codex 리뷰 보강 테스트 2개로 총 12개가 늘었고 모두 통과했다. PR ① 끝의 `1,933`에서 작업 6 계획 테스트 1개와 두 차례 리뷰 보강 테스트 3개가 추가된 결과다.
+기준 `1,925`와 비교하면 계획 명시 신규 테스트 9개, 사용자 승인 리뷰 보강 테스트 1개, Codex 리뷰 1차 보강 테스트 2개, Codex 리뷰 3차 보강 테스트 3개로 총 15개가 늘었고 모두 통과했다. PR ① 끝의 `1,933`에서 작업 6 계획 테스트 1개와 리뷰 보강 테스트 6개가 추가된 결과다.
 
 ### 빌드와 검증 경계
 
 - `npm.cmd run build`: exit 0, `2.2.0-beta` Windows x64 unpacked build 완료
 - prebuild bundle: exit 0, `renderer/scripts/lib/mpv-fabric-overlay.iife.js` 919.4kb; source 변화가 없어 추가 추적 diff 없음
-- ReviewFileCasHelper: Codex 2차 리뷰 보강 뒤 생성 성공, electron-builder before-pack 최종 source/package SHA-256 `e6cf87a0cfac3ad08f378129f90b3f8c64f2b54d7412a2e59c9b3c688dc54026`
+- ReviewFileCasHelper: Codex 3차 리뷰 보강 뒤 생성 성공, electron-builder before-pack 최종 source/package SHA-256 `878bc1e76997cef935eb081c6a8a62ffc7a09f80c3e8fa5924bb065902452fa1`
 - automated/source 검증: TDD RED→GREEN, 25-suite, source 계약, JavaScript syntax, Windows build 수행
 
 ### Windows Electron 수동 검증
@@ -235,9 +246,10 @@ Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했
 - 추가 전환 확인: `manual-a`의 투영 마커 선택 뒤 다른 mpv 파일을 열면 이전 클립이 사라졌고, 이어 HTML5 파일을 열어도 화면에는 이전 합성 행이 남지 않았다 — 화면 잔상 없음 PASS.
 - 수동 검증과 별개로, 독립 리뷰에서 `timeline.selectedKeyframes` 내부에는 합성 선택이 HTML5 전환 뒤 남는 경로가 확인됐다. HTML5 레거시 드로잉 모드 재진입 후 Delete가 `removeKeyframes()`의 layer 조회 전 `_saveToHistory()`를 호출해 no-op undo를 추가할 수 있는 문제였다. 이는 계획서가 ‘이 밖의 편집 진입 경로는 없다’고 한 분석과 달라진 지점이다. 사용자 승인 뒤 HTML5 fallback에서 합성 선택만 조건부로 정리했고, 실제 함수 실행 테스트로 clear→render 순서와 legacy 선택 보존을 검증했다.
 - PR ② Codex 1차 리뷰에서 화면 잔상과 별개로 mpv→mpv 전환 때 동일 synthetic layer id 선택이 남는 경로와 합성 header의 무동작 control이 확인됐다. 2차 리뷰에서는 최초 `sourceEpoch` 보강이 같은 영상의 호스트 복구까지 선택을 지우는 반례를 찾았다. 최종 구현은 캐시된 `videoGeneration` 실행 테스트와 합성 header 전용 CSS 계약으로 두 경계를 모두 RED→GREEN 검증한다.
+- PR ② Codex 3차 리뷰에서 실제 Windows 수동 시나리오가 다루지 못한 passive 숫자 단축키와 집계 타임라인 좌표계가 확인됐다. 계획서의 2차 가드 전제가 실제 코드와 달랐던 지점이며, 중앙 shortcut guard와 mode transition source 테스트로 자동 회귀를 고정했다. 이번 보강 뒤 수동 UI 축은 다시 실행하지 않았고 자동·source 검증과 구분한다.
 
 ## PR 상태
 
 - PR ①은 [#177](https://github.com/baehandoridori/BAEFRAME/pull/177)로 merge됐고 merge commit은 `e0a4ee68afcf6c51e0f5897b9d8241aa0e042658`이다.
 - PR ②는 [#178](https://github.com/baehandoridori/BAEFRAME/pull/178)이며 위 merge commit에서 분기한 `feat/드로잉-타임라인-레이어-투영`에 작업 6 구현 커밋과 Codex 리뷰 보강 커밋들을 포함한다.
-- PR ② 버전은 `2.2.0-beta`이며, P2 두 건의 RED→GREEN 보강 뒤 Codex 명시 완료 신호를 다시 받아 머지·배포한다.
+- PR ② 버전은 `2.2.0-beta`이며, Codex 3차 P2 두 건의 RED→GREEN 보강 뒤 명시 완료 신호를 다시 받아 머지·배포한다.

--- a/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
+++ b/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
@@ -1,0 +1,228 @@
+# 드로잉 표시 반영 회귀 구현
+
+- 기준 버전: `2.1.1-beta`
+- PR ① 완료 버전: `2.1.2-beta`
+- PR ② 목표/현재 버전: `2.2.0-beta`
+- PR ①: [#177](https://github.com/baehandoridori/BAEFRAME/pull/177), merge SHA `e0a4ee68afcf6c51e0f5897b9d8241aa0e042658`
+- PR ② 브랜치: `feat/드로잉-타임라인-레이어-투영`
+- 구현 기간: 2026-08-24 ~ 2026-08-25
+
+## 요약
+
+| 작업/Phase | 목적 | 주요 수정 파일 | 상태 | 커밋 |
+|---|---|---|---|---|
+| 작업 1 | Fabric 툴바가 페이드 대기 없이 한 프레임에 표시되게 함 | Fabric runtime/source bundle, source test, 버전 파일, runtime-profile test | ✅ 완료 | `dd8391f` |
+| 작업 2 | 네이티브 오버레이 입력 활성화·재표시 직후 강제 재합성 | `main/mpv-overlay-host.js`, host test | ✅ 완료 | `af3d467` |
+| 작업 3 | B 재진입 장면을 rAF 전에 동기 도색 | Fabric runtime/source bundle, runtime test | ✅ 완료 | `cc2a371` |
+| 작업 4 | passive 수화 뒤 마지막 장면을 복원하고 삭제된 장면은 비움 | Fabric runtime/source bundle, runtime test | ✅ 완료 | `b47e8a7` |
+| 작업 5 | 명시적으로 거부된 `drawingsV3` 소스의 재수화를 차단 | pilot controller, persistence-controller test | ✅ 완료 | `9da465c` |
+| 작업 6 | `drawingsV3`를 읽기 전용 타임라인 레이어로 투영 | `app.js`, `main.css`, source test, 버전 파일, runtime-profile test, 본 문서 | ✅ 완료 | 본 문서를 포함한 PR ② 단일 커밋 |
+
+## 배경과 사용자에게 보이는 결과
+
+Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기존 타임라인은 레거시 `drawings`를 읽는 `drawingManager.layers`만 표시했다. 동시에 파일럿 모드 CSS가 기존 드로잉 행을 모두 숨겨, 저장된 Fabric 키프레임이 있어도 타임라인에서는 드로잉 위치를 확인할 수 없었다. 표시가 늦거나 재진입·수화 뒤 비어 보이는 문제, 네이티브 오버레이의 재합성 누락, 거부된 소스를 잘못 수화하는 문제도 같은 사용자 증상을 강화했다.
+
+작업 1~5는 실제 Fabric 캔버스가 한 프레임 안에 다시 그려지고, 수화·재진입·호스트 재표시·소스 거부 경계에서 화면 상태가 틀어지지 않게 했다. 작업 6은 `drawingsV3` 키프레임을 타임라인에 하나의 `드로잉` 행으로 보여 준다. 이 행은 보기 전용이며, 레거시 `drawings`에는 아무것도 쓰지 않는다. 사용자는 파일럿 드로잉이 어느 프레임에 있는지 타임라인에서 확인할 수 있지만, 해당 행을 드래그하거나 선택 삭제해서 레거시 undo 기록을 오염시킬 수는 없다.
+
+## Phase 1: 툴바 페이드 제거와 `2.1.2-beta`
+
+### 수정 파일
+
+- `renderer/scripts/modules/mpv-fabric-overlay-runtime.js`
+- `renderer/scripts/lib/mpv-fabric-overlay.iife.js`
+- `scripts/tests/fabric-drawing-pilot-source.test.js`
+- `package.json`
+- `package-lock.json`
+- `scripts/tests/runtime-profile.test.js`
+
+### 구현
+
+- Fabric 툴바의 `opacity 100ms ease` transition 한 줄을 제거해 첫 프레임에 완성된 상태로 표시한다.
+- runtime source에서 bundle을 다시 생성하고, source와 bundle 모두 페이드 문자열이 없는지 고정했다.
+- 패키지와 lockfile의 루트 버전을 `2.1.2-beta`로 올렸다.
+- 계획에서 누락된 runtime-profile의 고정 버전 테스트 이름과 세 리터럴도 같은 버전으로 맞췄다.
+
+## Phase 2: 오버레이 재합성 보강
+
+### 수정 파일
+
+- `main/mpv-overlay-host.js`
+- `scripts/tests/mpv-overlay-host.test.js`
+
+### 구현
+
+- native input enable에서 포커스와 마우스 입력 플래그를 확정한 뒤 tail `webContents.invalidate()`를 추가했다.
+- 오버레이 창을 show/showInactive하고 `moveTop`까지 끝낸 뒤 optional invalidate를 추가했다.
+- 기존 첫 invalidate 순서는 그대로 보존하고, 활성화·재표시의 마지막 상태가 실제 화면에 다시 합성되는지 테스트했다.
+
+## Phase 3: 재진입 장면 동기 도색
+
+### 수정 파일
+
+- `renderer/scripts/modules/mpv-fabric-overlay-runtime.js`
+- `renderer/scripts/lib/mpv-fabric-overlay.iife.js`
+- `scripts/tests/mpv-fabric-overlay-runtime.test.js`
+
+### 구현
+
+- `renderActiveScene(options = {})`가 스냅샷을 Fabric path로 변환한 뒤 `immediate`일 때 `renderAll()`로 동기 도색하도록 했다.
+- B 입력 enable 재진입 한 곳만 `renderActiveScene({ immediate: true })`를 사용한다.
+- 나머지 상호작용 렌더는 기존 `requestRenderAll()` 예약 방식을 유지했다.
+
+## Phase 4: passive 마지막 장면 복원
+
+### 수정 파일
+
+- `renderer/scripts/modules/mpv-fabric-overlay-runtime.js`
+- `renderer/scripts/lib/mpv-fabric-overlay.iife.js`
+- `scripts/tests/mpv-fabric-overlay-runtime.test.js`
+
+### 구현
+
+- 마지막으로 도색한 video identity와 frame을 `lastPaintedScene`으로 기억한다.
+- 수화가 수락되면 같은 장면을 강제로 다시 그리고, 수화 문서에서 그 frame이 사라졌다면 캔버스를 비운다.
+- 일반 B-off에서는 이미 그린 Fabric 객체를 불필요하게 다시 만들지 않아 객체 identity를 보존한다.
+- runtime destroy에서 마지막 장면 포인터를 해제한다.
+
+## Phase 5: 거부된 소스 재수화 차단
+
+### 수정 파일
+
+- `renderer/scripts/modules/fabric-drawing-pilot-controller.js`
+- `scripts/tests/fabric-drawing-persistence-controller.test.js`
+
+### 구현
+
+- `installSource()`가 literal `false`를 반환한 경우에만 명시적 설치 거부로 처리한다.
+- 거부 뒤 hydration/export를 건너뛰고, active 재개·passive·quit suspension 의도를 각각 보존한다.
+- 객체를 반환하는 기존 성공 계약과 throw 계약은 그대로 유지한다.
+
+## Phase 6: `drawingsV3` 읽기 전용 타임라인 투영
+
+### 수정 파일
+
+- `renderer/scripts/app.js`
+- `renderer/styles/main.css`
+- `scripts/tests/fabric-drawing-pilot-source.test.js`
+- `package.json`
+- `package-lock.json`
+- `scripts/tests/runtime-profile.test.js`
+- `DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md`
+
+### 구현
+
+- `getFabricPilotTimelineLayers()`가 현재 hydration 문서의 유효한 frame을 정렬하고 `isEmpty`를 계산해 id `fabric-pilot-drawing-layer`인 합성 레이어 하나를 만든다.
+- 레이어는 이름 `드로잉`, `locked: true`, `visible: true`이며 다음 키프레임 직전까지의 표시 범위를 계산한다.
+- `renderActiveDrawingLayers()`가 파일럿 소유권과 mpv 활성 상태에 따라 합성 레이어 또는 기존 `drawingManager.layers`를 선택한다.
+- 기존 직접 렌더 14곳을 helper 호출로 바꿨다. 직접 레거시 렌더는 helper의 fallback 1건만 남겼다.
+- persistence store 변경은 rAF 1회로 합쳐 렌더하고, 파일럿 state/hydration 변화는 기존 조기 반환보다 앞에서 즉시 갱신한다.
+- CSS는 합성 레이어의 header/row만 보이게 예외 처리하고 `.layer-action-btn`은 계속 숨긴다.
+- 합성 레이어가 활성인 동안 keyframe drag와 선택 keyframe delete를 반환시켜 레거시 undo·데이터 변경을 막는다.
+- mpv에서 선택한 합성 키프레임이 HTML5 fallback으로 넘어갈 때만 선택을 지우고, 순수 레거시 키프레임 선택은 그대로 보존한다.
+- `routeKeydown(e)`와 기존 legacy shortcut 차단 함수의 인접성, 기존 조기 반환 본문은 그대로 보존했다. 별도 keyboard/click 방화벽은 추가하지 않았다.
+- 패키지와 lockfile의 루트 버전을 `2.2.0-beta`로 올리고 runtime-profile 테스트의 이름 1곳과 버전 리터럴 3곳만 함께 변경했다.
+
+## 계획 대비 실제 차이와 버전 테스트 판정
+
+1. 작업 1 계획은 `2.1.2-beta` 패치 버전 상승과 전체 GREEN을 동시에 요구했지만 `scripts/tests/runtime-profile.test.js`가 `2.1.1-beta`를 고정한다는 점을 파일 범위에서 누락했다. 생산 동작을 바꾸지 않는 최소 보정으로 테스트 이름 1곳과 리터럴 3곳만 Task 1에 포함했다.
+2. 같은 이유로 작업 6의 `2.2.0-beta` minor 상승 시 해당 테스트의 `2.1.2-beta` 기대값이 전체 게이트를 깨뜨린다. Task 6에서도 같은 네 줄만 `2.2.0-beta`로 변경했다.
+3. 계획의 시작 기준은 전체 `1,925` tests이고, 명시적으로 추가되는 테스트는 작업 1의 1개, 작업 3의 1개, 작업 4의 2개, 작업 5의 4개, 작업 6의 1개로 총 9개다. 따라서 계획대로의 최종 산술값은 `1,934`다. 계획 서두의 최종 `1,933`은 PR ① 작업 1~5 완료 시점의 실제 수치와 같지만 작업 6 신규 테스트 1개를 포함하지 않은 값이다.
+4. 작업 6 구현 후 독립 리뷰에서 합성 키프레임 선택이 HTML5 fallback 뒤 남는 경로가 발견됐다. 사용자가 최소 범위 수정과 실행형 회귀 테스트 1개 추가를 승인해 실제 최종 테스트 수는 `1,935`가 됐다.
+
+## 리스크 및 우려 사항
+
+| 리스크 | 심각도 | 완화/현재 상태 |
+|---|---|---|
+| `drawingsV3`를 레거시 `drawings`에도 기록해 두 데이터가 갈라짐 | 높음 | hydration 문서를 읽어 합성 UI만 만들며 legacy write를 추가하지 않음 |
+| 합성 키프레임 drag/delete가 레거시 undo와 데이터에 들어감 | 높음 | 두 잔여 mutation entry에서 파일럿 레이어 활성 여부를 먼저 확인해 반환 |
+| hydration 연속 변경마다 deep clone과 DOM rebuild가 반복됨 | 중간 | store subscription을 rAF 한 번으로 coalescing |
+| 파일럿이 아닌 경로에서 기존 레이어가 사라짐 | 높음 | helper fallback 1건으로 기존 `drawingManager.layers`와 active id를 그대로 렌더 |
+| 파일럿 state hook의 기존 조기 반환 때문에 타임라인이 갱신되지 않음 | 중간 | `renderActiveDrawingLayers()`를 조기 반환 바로 앞에 배치 |
+| passive 상태에서 정지한 채 다른 frame으로 seek하면 마지막 도색 frame이 남을 수 있음 | 중간 | passive frame-change 통지 채널이 없어 이번 범위에서 의도적으로 유지한 알려진 잔여 제한; 후속 설계 필요 |
+| mpv에서 선택한 합성 키프레임이 HTML5 전환 뒤 내부 선택 배열에 남음 | 높음 | 독립 리뷰에서 확인 후 사용자 승인 범위로 해결. HTML5 fallback 직전에 합성 선택이 있을 때만 `clearSelection()`하고, 실행형 회귀 테스트로 clear→legacy render 순서와 순수 legacy 선택 보존을 함께 검증 |
+| 실제 Windows Electron의 CSS 표시·마우스 drag/delete 감각이 자동 테스트와 다름 | 중간 | Windows unpacked build에서 계획서 작업 6 수동 시나리오를 실행해 아래 결과를 분리 기록 |
+
+## 테스트 방법과 RED→GREEN 증거
+
+### 작업별 TDD
+
+| 작업 | RED | GREEN |
+|---|---|---|
+| 작업 1 | `test:fabric-drawing-pilot` exit 1, tests 339 / pass 338 / fail 1 / cancelled 0 | focused 339/339, 이후 version ruling 반영 후 `test:mpv` 299/299와 `test:version` 2/2 |
+| 작업 2 | `test:mpv` exit 1, tests 299 / pass 297 / fail 2 / cancelled 0 | exit 0, tests/pass 299/299 / fail 0 / cancelled 0 |
+| 작업 3 | `test:fabric-drawing-pilot` exit 1, tests 340 / pass 339 / fail 1 / cancelled 0 | exit 0, tests/pass 340/340 / fail 0 / cancelled 0 |
+| 작업 4 | `test:fabric-drawing-pilot` exit 1, tests 342 / pass 341 / fail 1 / cancelled 0; 안전망 1개는 RED-exempt PASS | exit 0, tests/pass 342/342 / fail 0 / cancelled 0 |
+| 작업 5 | `test:fabric-drawing-pilot` exit 1, tests 346 / pass 343 / fail 3 / cancelled 0; 안전망 1개 PASS | exit 0, tests/pass 346/346 / fail 0 / cancelled 0 |
+| 작업 6 | F1/F2만 먼저 적용: exit 1, tests 347 / pass 345 / fail 2 / cancelled 0 | exit 0, tests/pass 347/347 / fail 0 / cancelled 0 |
+| 작업 6 리뷰 보강 | 선택 정리 생산 코드 적용 전: exit 1, tests 348 / pass 347 / fail 1 / cancelled 0 | exit 0, tests/pass 348/348 / fail 0 / cancelled 0 |
+
+작업 6 RED의 두 실패는 기존 CSS 예외 부재를 잡은 `capture keyboard and click firewalls stop legacy drawing mutations while keeping navigation separate`와 신규 `파일럿 드로잉은 타임라인에 읽기 전용으로 투영된다`였다. 생산 코드 변경 전에는 source test 한 파일만 수정돼 있었다.
+
+작업 6 리뷰 보강 RED는 실제 `renderActiveDrawingLayers()`를 추출해 실행했을 때 HTML5 fallback이 legacy render만 호출하고 합성 선택을 지우지 않아 발생했다. 최소 수정 뒤에는 합성 선택이 있을 때 `clearSelection()`이 legacy render보다 먼저 호출되고, 순수 legacy 선택에서는 clear가 호출되지 않는 음성 대조까지 GREEN이 됐다.
+
+### 작업 6 정적 계약
+
+- 직접 `timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);`: 1건, helper fallback 내부만 존재
+- 파일럿 직접 렌더 `timeline.renderDrawingLayers(pilotLayers, null);`: 1건
+- 기존 14개 호출부: 모두 `renderActiveDrawingLayers()`로 교체
+- keydown 보호 인접성: 유지
+- state hook의 기존 early-return 본문: 유지, 갱신 호출은 그 앞에 위치
+- 새 legacy `drawings` write: 0건
+- HTML5 fallback의 합성 선택 정리: 1건, 순수 legacy 선택 보존 음성 대조 포함
+- package/lock/package-root version: 모두 `2.2.0-beta`
+
+### 최종 25-suite 게이트
+
+| script | exit | tests | pass | fail | cancelled |
+|---|---:|---:|---:|---:|---:|
+| `test:fabric-drawing-pilot` | 0 | 348 | 348 | 0 | 0 |
+| `test:fabric-drawing-persistence` | 0 | 155 | 155 | 0 | 0 |
+| `test:recent` | 0 | 18 | 18 | 0 | 0 |
+| `test:frame-grid` | 0 | 35 | 35 | 0 | 0 |
+| `test:cluster` | 0 | 43 | 43 | 0 | 0 |
+| `test:composition` | 0 | 60 | 60 | 0 | 0 |
+| `test:playlist-ordering` | 0 | 17 | 17 | 0 | 0 |
+| `test:playlist-continuous` | 0 | 13 | 13 | 0 | 0 |
+| `test:playlist-comments` | 0 | 9 | 9 | 0 | 0 |
+| `test:playlist` | 0 | 268 | 268 | 0 | 0 |
+| `test:cutlist` | 0 | 82 | 82 | 0 | 0 |
+| `test:drawing` | 0 | 291 | 291 | 0 | 0 |
+| `test:drawing-v3-hardening` | 0 | 174 | 174 | 0 | 0 |
+| `test:drawing-v3-adapter` | 0 | 34 | 34 | 0 | 0 |
+| `test:drawing-v3-store-observer` | 0 | 19 | 19 | 0 | 0 |
+| `test:video-pan` | 0 | 17 | 17 | 0 | 0 |
+| `test:mpv` | 0 | 299 | 299 | 0 | 0 |
+| `test:fps` | 0 | 7 | 7 | 0 | 0 |
+| `test:audio-waveform` | 0 | 2 | 2 | 0 | 0 |
+| `test:collaboration` | 0 | 5 | 5 | 0 | 0 |
+| `test:comment-input` | 0 | 19 | 19 | 0 | 0 |
+| `test:toast-stack` | 0 | 9 | 9 | 0 | 0 |
+| `test:version` | 0 | 2 | 2 | 0 | 0 |
+| `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
+| `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
+| **합계** | **모든 script 0** | **1,935** | **1,935** | **0** | **0** |
+
+기준 `1,925`와 비교하면 계획 명시 신규 테스트 9개와 사용자 승인 리뷰 보강 테스트 1개, 총 10개가 늘었고 모두 통과했다. PR ① 끝의 `1,933`에서 작업 6 계획 테스트 1개와 리뷰 보강 테스트 1개가 추가된 결과다.
+
+### 빌드와 검증 경계
+
+- `npm.cmd run build`: exit 0, `2.2.0-beta` Windows x64 unpacked build 완료
+- prebuild bundle: exit 0, `renderer/scripts/lib/mpv-fabric-overlay.iife.js` 919.4kb; source 변화가 없어 추가 추적 diff 없음
+- ReviewFileCasHelper: 생성 성공, SHA-256 `730378da3d31548acceded1a80aa9953e2cd532e59bc6c758101a35a768ce667`
+- automated/source 검증: TDD RED→GREEN, 25-suite, source 계약, JavaScript syntax, Windows build 수행
+
+### Windows Electron 수동 검증
+
+- fixture: bundled FFmpeg로 만든 6초/24fps mp4 두 개와 `manual-a.bframe`의 `drawingsV3` frame 0 획 1개를 사용했다. 검증 뒤 앱은 종료했고, 임시로 끈 `mpv 직접 재생` 설정은 원래 켬 상태로 복원했다.
+- 시나리오 ①: mpv `manual-a.mp4` 로드 직후 타임라인에 잠긴 `드로잉` 행과 frame 0 클립이 표시됨 — PASS.
+- 시나리오 ②: B 진입 뒤 frame 0에 새 획을 그리자 `.bframe`의 `drawingsV3` keyframe/object가 각각 1개로 저장되고 타임라인 클립이 즉시 표시됨 — PASS. 단, B 클릭 직후 툴바의 첫 캡처는 투명 native overlay 창에서 보이지 않았고 첫 획/설정 창 왕복 뒤 표시되어, 작업 1의 ‘입력 전 같은 프레임 표시’는 이 자동 캡처만으로 수동 PASS를 주장하지 않는다.
+- 시나리오 ③: 투영 마커를 끌어도 frame 0에 남았고, 선택 후 Delete에도 클립 및 `.bframe` keyframe/object 수와 mtime이 변하지 않음 — drag/delete 차단 PASS. 파일럿 재진입 후 `2`·`3`·`4`·`Shift+2`를 차례로 입력해도 화면과 `.bframe` mtime/SHA-256이 그대로여서 지정 단축키 차단도 PASS. drag no-op 뒤 Ctrl+Z가 레거시 히스토리를 건드리지 않는지는 독립적으로 관찰할 레거시 history fixture가 없어 source 방화벽 테스트 결과와 구분한다.
+- 시나리오 ④: `mpv 직접 재생`을 임시로 끈 뒤 같은 파일을 HTML5로 다시 열자 합성 `드로잉` 행 대신 기존 `레이어 1`, 레이어 추가/삭제, 표시/잠금 UI가 나타남 — PASS.
+- 추가 전환 확인: `manual-a`의 투영 마커 선택 뒤 다른 mpv 파일을 열면 이전 클립이 사라졌고, 이어 HTML5 파일을 열어도 화면에는 이전 합성 행이 남지 않았다 — 화면 잔상 없음 PASS.
+- 수동 검증과 별개로, 독립 리뷰에서 `timeline.selectedKeyframes` 내부에는 합성 선택이 HTML5 전환 뒤 남는 경로가 확인됐다. HTML5 레거시 드로잉 모드 재진입 후 Delete가 `removeKeyframes()`의 layer 조회 전 `_saveToHistory()`를 호출해 no-op undo를 추가할 수 있는 문제였다. 이는 계획서가 ‘이 밖의 편집 진입 경로는 없다’고 한 분석과 달라진 지점이다. 사용자 승인 뒤 HTML5 fallback에서 합성 선택만 조건부로 정리했고, 실제 함수 실행 테스트로 clear→render 순서와 legacy 선택 보존을 검증했다.
+
+## PR 상태
+
+- PR ①은 [#177](https://github.com/baehandoridori/BAEFRAME/pull/177)로 merge됐고 merge commit은 `e0a4ee68afcf6c51e0f5897b9d8241aa0e042658`이다.
+- PR ②는 위 merge commit에서 분기한 `feat/드로잉-타임라인-레이어-투영`에 작업 6 단일 구현 커밋으로 준비했다.
+- PR ② 버전은 `2.2.0-beta`이며, 승인된 선택 누출 보강을 포함해 최종 게이트와 독립 재리뷰 뒤 PR을 생성한다.

--- a/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
+++ b/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
@@ -16,7 +16,7 @@
 | 작업 3 | B 재진입 장면을 rAF 전에 동기 도색 | Fabric runtime/source bundle, runtime test | ✅ 완료 | `cc2a371` |
 | 작업 4 | passive 수화 뒤 마지막 장면을 복원하고 삭제된 장면은 비움 | Fabric runtime/source bundle, runtime test | ✅ 완료 | `b47e8a7` |
 | 작업 5 | 명시적으로 거부된 `drawingsV3` 소스의 재수화를 차단 | pilot controller, persistence-controller test | ✅ 완료 | `9da465c` |
-| 작업 6 | `drawingsV3`를 읽기 전용 타임라인 레이어로 투영 | `app.js`, `main.css`, source test, 버전 파일, runtime-profile test, 본 문서 | ✅ 완료 | 본 문서를 포함한 PR ② 단일 커밋 |
+| 작업 6 | `drawingsV3`를 읽기 전용 타임라인 레이어로 투영 | `app.js`, `main.css`, source test, 버전 파일, runtime-profile test, 본 문서 | ✅ 완료 | 본 문서를 포함한 PR ② 구현 커밋과 Codex 리뷰 보강 커밋 |
 
 ## 배경과 사용자에게 보이는 결과
 
@@ -119,6 +119,8 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 - CSS는 합성 레이어의 header/row만 보이게 예외 처리하고 `.layer-action-btn`은 계속 숨긴다.
 - 합성 레이어가 활성인 동안 keyframe drag와 선택 keyframe delete를 반환시켜 레거시 undo·데이터 변경을 막는다.
 - mpv에서 선택한 합성 키프레임이 HTML5 fallback으로 넘어갈 때만 선택을 지우고, 순수 레거시 키프레임 선택은 그대로 보존한다.
+- persistence store의 `sourceEpoch`를 기억해 mpv→mpv 원본 교체 때도 이전 합성 선택만 지우고, 같은 원본의 편집·재렌더에서는 선택을 유지한다.
+- 읽기 전용 합성 행의 가시성·잠금 버튼을 숨겨 존재하지 않는 레거시 레이어로 no-op 이벤트가 전달되지 않게 했다.
 - `routeKeydown(e)`와 기존 legacy shortcut 차단 함수의 인접성, 기존 조기 반환 본문은 그대로 보존했다. 별도 keyboard/click 방화벽은 추가하지 않았다.
 - 패키지와 lockfile의 루트 버전을 `2.2.0-beta`로 올리고 runtime-profile 테스트의 이름 1곳과 버전 리터럴 3곳만 함께 변경했다.
 
@@ -128,6 +130,7 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 2. 같은 이유로 작업 6의 `2.2.0-beta` minor 상승 시 해당 테스트의 `2.1.2-beta` 기대값이 전체 게이트를 깨뜨린다. Task 6에서도 같은 네 줄만 `2.2.0-beta`로 변경했다.
 3. 계획의 시작 기준은 전체 `1,925` tests이고, 명시적으로 추가되는 테스트는 작업 1의 1개, 작업 3의 1개, 작업 4의 2개, 작업 5의 4개, 작업 6의 1개로 총 9개다. 따라서 계획대로의 최종 산술값은 `1,934`다. 계획 서두의 최종 `1,933`은 PR ① 작업 1~5 완료 시점의 실제 수치와 같지만 작업 6 신규 테스트 1개를 포함하지 않은 값이다.
 4. 작업 6 구현 후 독립 리뷰에서 합성 키프레임 선택이 HTML5 fallback 뒤 남는 경로가 발견됐다. 사용자가 최소 범위 수정과 실행형 회귀 테스트 1개 추가를 승인해 실제 최종 테스트 수는 `1,935`가 됐다.
+5. PR ② Codex 1차 리뷰에서 mpv→mpv 원본 교체 선택 잔존과 읽기 전용 행의 무동작 가시성·잠금 버튼이 P2로 확인됐다. 리뷰 루프 규칙에 따라 실행형/CSS 회귀 테스트 2개를 먼저 RED로 확인한 뒤 최소 보강했고, 최종 테스트 수는 `1,937`이 됐다. force-push 없이 별도 한글 리뷰 보강 커밋으로 기록한다.
 
 ## 리스크 및 우려 사항
 
@@ -140,6 +143,8 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 | 파일럿 state hook의 기존 조기 반환 때문에 타임라인이 갱신되지 않음 | 중간 | `renderActiveDrawingLayers()`를 조기 반환 바로 앞에 배치 |
 | passive 상태에서 정지한 채 다른 frame으로 seek하면 마지막 도색 frame이 남을 수 있음 | 중간 | passive frame-change 통지 채널이 없어 이번 범위에서 의도적으로 유지한 알려진 잔여 제한; 후속 설계 필요 |
 | mpv에서 선택한 합성 키프레임이 HTML5 전환 뒤 내부 선택 배열에 남음 | 높음 | 독립 리뷰에서 확인 후 사용자 승인 범위로 해결. HTML5 fallback 직전에 합성 선택이 있을 때만 `clearSelection()`하고, 실행형 회귀 테스트로 clear→legacy render 순서와 순수 legacy 선택 보존을 함께 검증 |
+| mpv에서 선택한 합성 키프레임이 다른 mpv 원본에서도 같은 layer id로 남음 | 높음 | Codex 1차 리뷰에서 확인. mutation에는 변하지 않고 원본 설치·무효화에만 증가하는 persistence `sourceEpoch`를 비교해 원본 교체 때만 합성 선택을 정리 |
+| 읽기 전용 합성 행의 가시성·잠금 버튼이 눌리지만 아무 동작도 하지 않음 | 중간 | 합성 header 아래 두 버튼만 `display: none`과 `pointer-events: none`으로 숨기고 legacy 레이어 버튼은 유지 |
 | 실제 Windows Electron의 CSS 표시·마우스 drag/delete 감각이 자동 테스트와 다름 | 중간 | Windows unpacked build에서 계획서 작업 6 수동 시나리오를 실행해 아래 결과를 분리 기록 |
 
 ## 테스트 방법과 RED→GREEN 증거
@@ -155,10 +160,13 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 | 작업 5 | `test:fabric-drawing-pilot` exit 1, tests 346 / pass 343 / fail 3 / cancelled 0; 안전망 1개 PASS | exit 0, tests/pass 346/346 / fail 0 / cancelled 0 |
 | 작업 6 | F1/F2만 먼저 적용: exit 1, tests 347 / pass 345 / fail 2 / cancelled 0 | exit 0, tests/pass 347/347 / fail 0 / cancelled 0 |
 | 작업 6 리뷰 보강 | 선택 정리 생산 코드 적용 전: exit 1, tests 348 / pass 347 / fail 1 / cancelled 0 | exit 0, tests/pass 348/348 / fail 0 / cancelled 0 |
+| Codex 1차 리뷰 보강 | source epoch·합성 행 control 생산 코드 적용 전: exit 1, tests 350 / pass 348 / fail 2 / cancelled 0 | exit 0, tests/pass 350/350 / fail 0 / cancelled 0 |
 
 작업 6 RED의 두 실패는 기존 CSS 예외 부재를 잡은 `capture keyboard and click firewalls stop legacy drawing mutations while keeping navigation separate`와 신규 `파일럿 드로잉은 타임라인에 읽기 전용으로 투영된다`였다. 생산 코드 변경 전에는 source test 한 파일만 수정돼 있었다.
 
 작업 6 리뷰 보강 RED는 실제 `renderActiveDrawingLayers()`를 추출해 실행했을 때 HTML5 fallback이 legacy render만 호출하고 합성 선택을 지우지 않아 발생했다. 최소 수정 뒤에는 합성 선택이 있을 때 `clearSelection()`이 legacy render보다 먼저 호출되고, 순수 legacy 선택에서는 clear가 호출되지 않는 음성 대조까지 GREEN이 됐다.
+
+Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했을 때 `sourceEpoch`가 바뀌어도 clear가 호출되지 않은 문제와, 합성 header 전용 가시성·잠금 CSS가 없는 문제를 각각 판별했다. GREEN에서는 첫 원본과 같은 epoch의 선택은 유지하고 다음 원본에서만 clear하며, 두 control만 숨기는 계약을 확인했다.
 
 ### 작업 6 정적 계약
 
@@ -169,13 +177,15 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 - state hook의 기존 early-return 본문: 유지, 갱신 호출은 그 앞에 위치
 - 새 legacy `drawings` write: 0건
 - HTML5 fallback의 합성 선택 정리: 1건, 순수 legacy 선택 보존 음성 대조 포함
+- mpv source epoch 전환 선택 정리: 원본 변경 때만 clear, 같은 원본 선택 유지
+- 합성 header의 가시성·잠금 control: 숨김, legacy control은 변경 없음
 - package/lock/package-root version: 모두 `2.2.0-beta`
 
 ### 최종 25-suite 게이트
 
 | script | exit | tests | pass | fail | cancelled |
 |---|---:|---:|---:|---:|---:|
-| `test:fabric-drawing-pilot` | 0 | 348 | 348 | 0 | 0 |
+| `test:fabric-drawing-pilot` | 0 | 350 | 350 | 0 | 0 |
 | `test:fabric-drawing-persistence` | 0 | 155 | 155 | 0 | 0 |
 | `test:recent` | 0 | 18 | 18 | 0 | 0 |
 | `test:frame-grid` | 0 | 35 | 35 | 0 | 0 |
@@ -200,15 +210,15 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 | `test:version` | 0 | 2 | 2 | 0 | 0 |
 | `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
 | `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
-| **합계** | **모든 script 0** | **1,935** | **1,935** | **0** | **0** |
+| **합계** | **모든 script 0** | **1,937** | **1,937** | **0** | **0** |
 
-기준 `1,925`와 비교하면 계획 명시 신규 테스트 9개와 사용자 승인 리뷰 보강 테스트 1개, 총 10개가 늘었고 모두 통과했다. PR ① 끝의 `1,933`에서 작업 6 계획 테스트 1개와 리뷰 보강 테스트 1개가 추가된 결과다.
+기준 `1,925`와 비교하면 계획 명시 신규 테스트 9개, 사용자 승인 리뷰 보강 테스트 1개, Codex 리뷰 보강 테스트 2개로 총 12개가 늘었고 모두 통과했다. PR ① 끝의 `1,933`에서 작업 6 계획 테스트 1개와 두 차례 리뷰 보강 테스트 3개가 추가된 결과다.
 
 ### 빌드와 검증 경계
 
 - `npm.cmd run build`: exit 0, `2.2.0-beta` Windows x64 unpacked build 완료
 - prebuild bundle: exit 0, `renderer/scripts/lib/mpv-fabric-overlay.iife.js` 919.4kb; source 변화가 없어 추가 추적 diff 없음
-- ReviewFileCasHelper: 생성 성공, SHA-256 `730378da3d31548acceded1a80aa9953e2cd532e59bc6c758101a35a768ce667`
+- ReviewFileCasHelper: Codex 1차 리뷰 보강 뒤 생성 성공, 해당 branch build SHA-256 `15a68c6975fd92066ea82f9664b5ae0f954d5af8338e0c2550391fd568cb8e9c`
 - automated/source 검증: TDD RED→GREEN, 25-suite, source 계약, JavaScript syntax, Windows build 수행
 
 ### Windows Electron 수동 검증
@@ -220,9 +230,10 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 - 시나리오 ④: `mpv 직접 재생`을 임시로 끈 뒤 같은 파일을 HTML5로 다시 열자 합성 `드로잉` 행 대신 기존 `레이어 1`, 레이어 추가/삭제, 표시/잠금 UI가 나타남 — PASS.
 - 추가 전환 확인: `manual-a`의 투영 마커 선택 뒤 다른 mpv 파일을 열면 이전 클립이 사라졌고, 이어 HTML5 파일을 열어도 화면에는 이전 합성 행이 남지 않았다 — 화면 잔상 없음 PASS.
 - 수동 검증과 별개로, 독립 리뷰에서 `timeline.selectedKeyframes` 내부에는 합성 선택이 HTML5 전환 뒤 남는 경로가 확인됐다. HTML5 레거시 드로잉 모드 재진입 후 Delete가 `removeKeyframes()`의 layer 조회 전 `_saveToHistory()`를 호출해 no-op undo를 추가할 수 있는 문제였다. 이는 계획서가 ‘이 밖의 편집 진입 경로는 없다’고 한 분석과 달라진 지점이다. 사용자 승인 뒤 HTML5 fallback에서 합성 선택만 조건부로 정리했고, 실제 함수 실행 테스트로 clear→render 순서와 legacy 선택 보존을 검증했다.
+- PR ② Codex 1차 리뷰에서 화면 잔상과 별개로 mpv→mpv 전환 때 동일 synthetic layer id 선택이 남는 경로와 합성 header의 무동작 control이 확인됐다. `sourceEpoch` 실행 테스트와 합성 header 전용 CSS 계약을 RED→GREEN으로 추가했다.
 
 ## PR 상태
 
 - PR ①은 [#177](https://github.com/baehandoridori/BAEFRAME/pull/177)로 merge됐고 merge commit은 `e0a4ee68afcf6c51e0f5897b9d8241aa0e042658`이다.
-- PR ②는 위 merge commit에서 분기한 `feat/드로잉-타임라인-레이어-투영`에 작업 6 단일 구현 커밋으로 준비했다.
-- PR ② 버전은 `2.2.0-beta`이며, 승인된 선택 누출 보강을 포함해 최종 게이트와 독립 재리뷰 뒤 PR을 생성한다.
+- PR ②는 [#178](https://github.com/baehandoridori/BAEFRAME/pull/178)이며 위 merge commit에서 분기한 `feat/드로잉-타임라인-레이어-투영`에 작업 6 구현 커밋과 Codex 1차 리뷰 보강 커밋을 포함한다.
+- PR ② 버전은 `2.2.0-beta`이며, P2 두 건의 RED→GREEN 보강 뒤 Codex 명시 완료 신호를 다시 받아 머지·배포한다.

--- a/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
+++ b/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
@@ -112,7 +112,7 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 ### 구현
 
 - `getFabricPilotTimelineLayers()`가 현재 hydration 문서의 유효한 frame을 정렬하고 `isEmpty`를 계산해 id `fabric-pilot-drawing-layer`인 합성 레이어 하나를 만든다.
-- 레이어는 이름 `드로잉`, `locked: true`, `visible: true`이며 다음 키프레임 직전까지의 표시 범위를 계산한다.
+- 레이어는 이름 `드로잉`, `locked: true`, `visible: true`이며 Fabric runtime의 exact-frame scene 의미에 맞춰 저장된 각 장면의 한 프레임만 표시한다.
 - `renderActiveDrawingLayers()`가 파일럿 소유권과 mpv 활성 상태에 따라 합성 레이어 또는 기존 `drawingManager.layers`를 선택한다.
 - 기존 직접 렌더 14곳을 helper 호출로 바꿨다. 직접 레거시 렌더는 helper의 fallback 1건만 남겼다.
 - persistence store 변경은 rAF 1회로 합쳐 렌더하고, 파일럿 state/hydration 변화는 기존 조기 반환보다 앞에서 즉시 갱신한다.
@@ -122,7 +122,7 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 - 정규화한 영상 경로와 파일럿 상태 훅의 `videoGeneration`을 함께 기억해 새 경로는 즉시, 같은 경로 재로드는 영상 확정 때 이전 합성 선택을 지운다. 같은 원본의 편집·재렌더·오버레이 호스트 복구에서는 선택을 유지한다.
 - 읽기 전용 합성 행의 가시성·잠금 버튼을 숨겨 존재하지 않는 레거시 레이어로 no-op 이벤트가 전달되지 않게 했다.
 - passive 파일럿 투영 중에는 기존 legacy shortcut 차단 함수가 `undo`, `redo`, `drawMode`를 제외한 레거시 드로잉 변이 단축키를 막는다. HTML5/non-mpv와 키프레임 탐색은 기존 동작을 유지한다.
-- 이어보기 또는 컷리스트 집계 모드에서는 원본 영상의 로컬 frame을 전체 타임라인 좌표로 오인하지 않도록 합성 레이어를 truthy 빈 배열 `[]`로 억제한다. 진입·이탈 때 즉시 다시 렌더해 준비 중 stale 행까지 제거한다.
+- 이어보기 또는 컷리스트의 실제 aggregate segment가 설치된 동안에는 원본 영상의 로컬 frame을 전체 타임라인 좌표로 오인하지 않도록 합성 레이어를 truthy 빈 배열 `[]`로 억제한다. aggregate setter/clear 직후 즉시 다시 렌더하므로 빈·준비 중 로컬 타임라인은 투영을 유지하고 설치 완료 뒤 stale 행은 남지 않는다.
 - `routeKeydown(e)`와 기존 legacy shortcut 차단 함수의 인접성, 기존 조기 반환 본문은 그대로 보존했다. 새 keyboard/click listener는 추가하지 않았다.
 - 패키지와 lockfile의 루트 버전을 `2.2.0-beta`로 올리고 runtime-profile 테스트의 이름 1곳과 버전 리터럴 3곳만 함께 변경했다.
 
@@ -135,6 +135,7 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 5. PR ② Codex 1차 리뷰에서 mpv→mpv 원본 교체 선택 잔존과 읽기 전용 행의 무동작 가시성·잠금 버튼이 P2로 확인됐다. 리뷰 루프 규칙에 따라 실행형/CSS 회귀 테스트 2개를 먼저 RED로 확인한 뒤 최소 보강했고, 최종 테스트 수는 `1,937`이 됐다. force-push 없이 별도 한글 리뷰 보강 커밋으로 기록한다.
 6. PR ② Codex 2차 리뷰에서 1차 보강의 `sourceEpoch`가 같은 영상의 오버레이 호스트 복구 때도 증가해 선택을 과도하게 지우는 P2가 확인됐다. 기존 실행형 테스트를 같은 영상 복구와 실제 영상 확정을 구분하도록 강화하고, 정규화 영상 경로와 상태 훅이 이미 캐시한 `videoGeneration` 비교로 교체했다. 독립 타이밍 재검토에서 새 경로 렌더가 generation 발표보다 먼저 오는 구간도 RED로 추가 확인해 경로 변경 즉시 clear하도록 보강했다. 신규 테스트 수는 늘지 않는다.
 7. PR ② Codex 3차 리뷰에서 계획서의 “키프레임 편집 10종 모두 `state.isDrawMode` 2차 가드가 있다”는 분석이 실제 코드와 다르고, 숫자/Shift 숫자 편집 5종이 passive 투영 뒤의 레거시 데이터와 history를 바꿀 수 있음이 확인됐다. 또한 작업 6은 이어보기·컷리스트의 전체 좌표계에서 원본 로컬 frame을 그대로 투영하는 경우를 누락했다. 기존 중앙 shortcut 차단을 passive 소유권까지 넓히고, 집계 모드에서는 truthy `[]`로 행과 캐시를 비우며 세 모드 전환 경로에서 즉시 다시 렌더했다. 판별 테스트 3개가 추가되어 실제 최종 테스트 수는 `1,940`이다.
+8. PR ② Codex 4차 리뷰에서 계획서가 지시한 “다음 키프레임 직전 또는 영상 끝까지” 범위는 exact `(video identity, targetFrame)` scene만 활성화하는 Fabric runtime 의미와 달라, 실제 드로잉이 없는 프레임까지 표시함이 확인됐다. 합성 레이어만 `start === end === frame`으로 교정했다. 또한 3차 보강의 mode-only 억제는 빈 컷리스트의 정상 로컬 타임라인까지 숨겼다. 최종 구현은 실제 duration·segment가 설치된 aggregate 상태만 억제하고 playlist/cutlist setter와 clear 경계에서 즉시 다시 렌더한다. exact-frame 판별 테스트 1개가 추가되어 실제 최종 테스트 수는 `1,941`이다.
 
 ## 리스크 및 우려 사항
 
@@ -151,7 +152,8 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 | 같은 영상의 오버레이 호스트 복구가 원본 교체로 오인돼 선택이 풀림 | 중간 | Codex 2차 리뷰에서 확인. rebind 때 증가하는 `sourceEpoch` 비교를 제거하고, 호스트 복구에는 모두 유지되는 영상 경로와 `videoGeneration`으로 판정 |
 | 읽기 전용 합성 행의 가시성·잠금 버튼이 눌리지만 아무 동작도 하지 않음 | 중간 | 합성 header 아래 두 버튼만 `display: none`과 `pointer-events: none`으로 숨기고 legacy 레이어 버튼은 유지 |
 | passive 투영 뒤 숫자 편집 단축키가 숨은 레거시 레이어와 history를 변경함 | 높음 | Codex 3차 리뷰에서 계획 분석 오류를 확인. 기존 중앙 shortcut 차단을 passive 소유권에도 적용하고 undo/redo/drawMode·탐색·HTML5 음성 대조를 실행 검증 |
-| 이어보기·컷리스트에서 로컬 frame 투영이 전체 타임라인의 잘못된 위치에 표시됨 | 높음 | 집계 모드 진입 즉시 truthy `[]`를 렌더해 행과 `_lastDrawingLayers`를 비우고, 이탈 때 현재 원본 투영을 복원. drag/delete 차단은 유지 |
+| 이어보기·컷리스트에서 로컬 frame 투영이 전체 타임라인의 잘못된 위치에 표시됨 | 높음 | 실제 aggregate duration·segment가 설치된 동안 truthy `[]`를 렌더하고 setter/clear 직후 캐시를 갱신. 빈·준비 중 로컬 타임라인과 drag/delete 차단은 유지 |
+| sparse Fabric 장면이 다음 장면 또는 영상 끝까지 존재하는 것처럼 표시됨 | 높음 | Codex 4차 리뷰에서 계획 의미 오류를 확인. synthetic layer 범위만 exact 단일 frame으로 교정하고 legacy DrawingLayer hold 동작은 변경하지 않음 |
 | 실제 Windows Electron의 CSS 표시·마우스 drag/delete 감각이 자동 테스트와 다름 | 중간 | Windows unpacked build에서 계획서 작업 6 수동 시나리오를 실행해 아래 결과를 분리 기록 |
 
 ## 테스트 방법과 RED→GREEN 증거
@@ -172,6 +174,7 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 | Codex 2차 타이밍 보강 | cached generation이 아직 이전 값인 새 경로 렌더를 추가한 뒤 source 단독 exit 1, tests 16 / pass 15 / fail 1 / cancelled 0; focused exit 1, tests 350 / pass 349 / fail 1 / cancelled 0 | 정규화 경로 비교 추가 뒤 source 단독 exit 0, 16/16; focused exit 0, 350/350 / fail 0 / cancelled 0 |
 | Codex 3차 리뷰 보강 | passive shortcut·집계 투영 판별 추가 뒤 source 단독 exit 1, tests 18 / pass 16 / fail 2 / cancelled 0; focused exit 1, tests 352 / pass 350 / fail 2 / cancelled 0 | 1차 최소 보강 뒤 source 18/18, focused 352/352 |
 | Codex 3차 전환 보강 | 준비 중 duration 0과 모드 전환 즉시 재렌더 판별 뒤 source 단독 exit 1, tests 19 / pass 17 / fail 2 / cancelled 0 | mode-only 억제와 세 전환 재렌더 뒤 source 19/19; focused 353/353 / fail 0 / cancelled 0 |
+| Codex 4차 리뷰 보강 | 빈 aggregate·exact-frame·setter 갱신 판별 뒤 source 단독 exit 1, tests 20 / pass 17 / fail 3 / cancelled 0; focused exit 1, tests 354 / pass 351 / fail 3 / cancelled 0 | actual aggregate 판정과 exact-frame 교정 뒤 source 20/20; focused 354/354 / fail 0 / cancelled 0 |
 
 작업 6 RED의 두 실패는 기존 CSS 예외 부재를 잡은 `capture keyboard and click firewalls stop legacy drawing mutations while keeping navigation separate`와 신규 `파일럿 드로잉은 타임라인에 읽기 전용으로 투영된다`였다. 생산 코드 변경 전에는 source test 한 파일만 수정돼 있었다.
 
@@ -180,6 +183,8 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했을 때 `sourceEpoch`가 바뀌어도 clear가 호출되지 않은 문제와, 합성 header 전용 가시성·잠금 CSS가 없는 문제를 각각 판별했다. 1차 GREEN 뒤 Codex 2차 리뷰에서 rebind도 epoch를 올리는 반례가 확인됐다. 강화된 테스트는 같은 경로·`videoGeneration`의 복구에서는 render만, cached generation 발표 전이라도 새 경로면 clear→render, 다음 generation이 확정되면 clear→render, 같은 source에서 재선택하면 다시 render만 호출되는 계약을 실행 검증한다.
 
 Codex 3차 리뷰 보강 RED는 실제 shortcut guard를 추출해 passive 투영에서 `drawingLayerAdd`를 포함한 레거시 변이가 통과하는 문제와, 실제 투영 함수를 실행해 집계 모드에서 로컬 frame 레이어가 반환되는 문제를 각각 잡았다. 추가 lifecycle 점검에서는 duration이 아직 0인 준비 구간과 모드 전환 함수에 즉시 재렌더가 없는 상태도 RED로 고정했다. 최종 GREEN은 passive에서 변이 단축키만 막고, 이어보기·컷리스트 진입 시 `[]`를 렌더해 stale 행과 캐시를 비우며 이탈 시 원본 투영을 복원한다.
+
+Codex 4차 리뷰 보강 RED는 빈 playlist/cutlist에서도 mode-only `[]`가 반환되는 과잉 억제, sparse frame 10·20이 각각 10~19·20~99로 늘어나는 의미 불일치, aggregate setter/clear 뒤 캐시 갱신 누락을 서로 분리해 판별했다. 최종 GREEN은 타임라인이 실제 local인 준비·빈 상태에서는 투영을 유지하고, aggregate segment 설치와 같은 동기 호출 스택에서 `[]`로 교체하며, 각 Fabric scene은 정확히 한 프레임만 표시한다.
 
 ### 작업 6 정적 계약
 
@@ -193,14 +198,15 @@ Codex 3차 리뷰 보강 RED는 실제 shortcut guard를 추출해 passive 투�
 - mpv source identity 전환 선택 정리: 정규화 경로 또는 확정 video generation이 바뀔 때만 clear, 같은 원본 선택 유지
 - 합성 header의 가시성·잠금 control: 숨김, legacy control은 변경 없음
 - passive 파일럿 소유권 shortcut: undo/redo/drawMode와 navigation은 유지, 레거시 드로잉 변이는 차단
-- 집계 타임라인 투영: 이어보기·컷리스트에서 truthy `[]`, 세 모드 전환 경로에서 즉시 재렌더
+- 집계 타임라인 투영: 실제 duration·segment가 설치된 이어보기·컷리스트에서만 truthy `[]`, setter/clear 경계에서 즉시 재렌더
+- Fabric scene 범위: sparse scene을 포함해 `start === end === frame`, legacy hold 범위는 변경 없음
 - package/lock/package-root version: 모두 `2.2.0-beta`
 
 ### 최종 25-suite 게이트
 
 | script | exit | tests | pass | fail | cancelled |
 |---|---:|---:|---:|---:|---:|
-| `test:fabric-drawing-pilot` | 0 | 353 | 353 | 0 | 0 |
+| `test:fabric-drawing-pilot` | 0 | 354 | 354 | 0 | 0 |
 | `test:fabric-drawing-persistence` | 0 | 155 | 155 | 0 | 0 |
 | `test:recent` | 0 | 18 | 18 | 0 | 0 |
 | `test:frame-grid` | 0 | 35 | 35 | 0 | 0 |
@@ -225,15 +231,15 @@ Codex 3차 리뷰 보강 RED는 실제 shortcut guard를 추출해 passive 투�
 | `test:version` | 0 | 2 | 2 | 0 | 0 |
 | `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
 | `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
-| **합계** | **모든 script 0** | **1,940** | **1,940** | **0** | **0** |
+| **합계** | **모든 script 0** | **1,941** | **1,941** | **0** | **0** |
 
-기준 `1,925`와 비교하면 계획 명시 신규 테스트 9개, 사용자 승인 리뷰 보강 테스트 1개, Codex 리뷰 1차 보강 테스트 2개, Codex 리뷰 3차 보강 테스트 3개로 총 15개가 늘었고 모두 통과했다. PR ① 끝의 `1,933`에서 작업 6 계획 테스트 1개와 리뷰 보강 테스트 6개가 추가된 결과다.
+기준 `1,925`와 비교하면 계획 명시 신규 테스트 9개, 사용자 승인 리뷰 보강 테스트 1개, Codex 리뷰 1차 보강 테스트 2개, Codex 리뷰 3차 보강 테스트 3개, Codex 리뷰 4차 보강 테스트 1개로 총 16개가 늘었고 모두 통과했다. PR ① 끝의 `1,933`에서 작업 6 계획 테스트 1개와 리뷰 보강 테스트 7개가 추가된 결과다.
 
 ### 빌드와 검증 경계
 
 - `npm.cmd run build`: exit 0, `2.2.0-beta` Windows x64 unpacked build 완료
 - prebuild bundle: exit 0, `renderer/scripts/lib/mpv-fabric-overlay.iife.js` 919.4kb; source 변화가 없어 추가 추적 diff 없음
-- ReviewFileCasHelper: Codex 3차 리뷰 보강 뒤 생성 성공, electron-builder before-pack 최종 source/package SHA-256 `878bc1e76997cef935eb081c6a8a62ffc7a09f80c3e8fa5924bb065902452fa1`
+- ReviewFileCasHelper: Codex 4차 리뷰 보강 뒤 생성 성공, electron-builder before-pack 최종 source/package SHA-256 `32d52e3ad2de9a159463124692c87c8610b78759832957f931f0bf6d7d73514b`
 - automated/source 검증: TDD RED→GREEN, 25-suite, source 계약, JavaScript syntax, Windows build 수행
 
 ### Windows Electron 수동 검증
@@ -247,9 +253,10 @@ Codex 3차 리뷰 보강 RED는 실제 shortcut guard를 추출해 passive 투�
 - 수동 검증과 별개로, 독립 리뷰에서 `timeline.selectedKeyframes` 내부에는 합성 선택이 HTML5 전환 뒤 남는 경로가 확인됐다. HTML5 레거시 드로잉 모드 재진입 후 Delete가 `removeKeyframes()`의 layer 조회 전 `_saveToHistory()`를 호출해 no-op undo를 추가할 수 있는 문제였다. 이는 계획서가 ‘이 밖의 편집 진입 경로는 없다’고 한 분석과 달라진 지점이다. 사용자 승인 뒤 HTML5 fallback에서 합성 선택만 조건부로 정리했고, 실제 함수 실행 테스트로 clear→render 순서와 legacy 선택 보존을 검증했다.
 - PR ② Codex 1차 리뷰에서 화면 잔상과 별개로 mpv→mpv 전환 때 동일 synthetic layer id 선택이 남는 경로와 합성 header의 무동작 control이 확인됐다. 2차 리뷰에서는 최초 `sourceEpoch` 보강이 같은 영상의 호스트 복구까지 선택을 지우는 반례를 찾았다. 최종 구현은 캐시된 `videoGeneration` 실행 테스트와 합성 header 전용 CSS 계약으로 두 경계를 모두 RED→GREEN 검증한다.
 - PR ② Codex 3차 리뷰에서 실제 Windows 수동 시나리오가 다루지 못한 passive 숫자 단축키와 집계 타임라인 좌표계가 확인됐다. 계획서의 2차 가드 전제가 실제 코드와 달랐던 지점이며, 중앙 shortcut guard와 mode transition source 테스트로 자동 회귀를 고정했다. 이번 보강 뒤 수동 UI 축은 다시 실행하지 않았고 자동·source 검증과 구분한다.
+- PR ② Codex 4차 리뷰에서 계획서의 hold 범위와 Fabric runtime의 exact-frame scene 의미가 다름을 확인했고, mode-only aggregate 억제가 빈 컷리스트의 정상 로컬 투영까지 숨기는 반례도 확인했다. sparse exact-frame, 빈/실제 aggregate, setter/clear 갱신을 실제 helper 실행과 source 계약으로 RED→GREEN 고정했다.
 
 ## PR 상태
 
 - PR ①은 [#177](https://github.com/baehandoridori/BAEFRAME/pull/177)로 merge됐고 merge commit은 `e0a4ee68afcf6c51e0f5897b9d8241aa0e042658`이다.
 - PR ②는 [#178](https://github.com/baehandoridori/BAEFRAME/pull/178)이며 위 merge commit에서 분기한 `feat/드로잉-타임라인-레이어-투영`에 작업 6 구현 커밋과 Codex 리뷰 보강 커밋들을 포함한다.
-- PR ② 버전은 `2.2.0-beta`이며, Codex 3차 P2 두 건의 RED→GREEN 보강 뒤 명시 완료 신호를 다시 받아 머지·배포한다.
+- PR ② 버전은 `2.2.0-beta`이며, Codex 4차 P2 두 건의 RED→GREEN 보강 뒤 명시 완료 신호를 다시 받아 머지·배포한다.

--- a/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
+++ b/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
@@ -119,7 +119,7 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 - CSS는 합성 레이어의 header/row만 보이게 예외 처리하고 `.layer-action-btn`은 계속 숨긴다.
 - 합성 레이어가 활성인 동안 keyframe drag와 선택 keyframe delete를 반환시켜 레거시 undo·데이터 변경을 막는다.
 - mpv에서 선택한 합성 키프레임이 HTML5 fallback으로 넘어갈 때만 선택을 지우고, 순수 레거시 키프레임 선택은 그대로 보존한다.
-- persistence store의 `sourceEpoch`를 기억해 mpv→mpv 원본 교체 때도 이전 합성 선택만 지우고, 같은 원본의 편집·재렌더에서는 선택을 유지한다.
+- 정규화한 영상 경로와 파일럿 상태 훅의 `videoGeneration`을 함께 기억해 새 경로는 즉시, 같은 경로 재로드는 영상 확정 때 이전 합성 선택을 지운다. 같은 원본의 편집·재렌더·오버레이 호스트 복구에서는 선택을 유지한다.
 - 읽기 전용 합성 행의 가시성·잠금 버튼을 숨겨 존재하지 않는 레거시 레이어로 no-op 이벤트가 전달되지 않게 했다.
 - `routeKeydown(e)`와 기존 legacy shortcut 차단 함수의 인접성, 기존 조기 반환 본문은 그대로 보존했다. 별도 keyboard/click 방화벽은 추가하지 않았다.
 - 패키지와 lockfile의 루트 버전을 `2.2.0-beta`로 올리고 runtime-profile 테스트의 이름 1곳과 버전 리터럴 3곳만 함께 변경했다.
@@ -131,6 +131,7 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 3. 계획의 시작 기준은 전체 `1,925` tests이고, 명시적으로 추가되는 테스트는 작업 1의 1개, 작업 3의 1개, 작업 4의 2개, 작업 5의 4개, 작업 6의 1개로 총 9개다. 따라서 계획대로의 최종 산술값은 `1,934`다. 계획 서두의 최종 `1,933`은 PR ① 작업 1~5 완료 시점의 실제 수치와 같지만 작업 6 신규 테스트 1개를 포함하지 않은 값이다.
 4. 작업 6 구현 후 독립 리뷰에서 합성 키프레임 선택이 HTML5 fallback 뒤 남는 경로가 발견됐다. 사용자가 최소 범위 수정과 실행형 회귀 테스트 1개 추가를 승인해 실제 최종 테스트 수는 `1,935`가 됐다.
 5. PR ② Codex 1차 리뷰에서 mpv→mpv 원본 교체 선택 잔존과 읽기 전용 행의 무동작 가시성·잠금 버튼이 P2로 확인됐다. 리뷰 루프 규칙에 따라 실행형/CSS 회귀 테스트 2개를 먼저 RED로 확인한 뒤 최소 보강했고, 최종 테스트 수는 `1,937`이 됐다. force-push 없이 별도 한글 리뷰 보강 커밋으로 기록한다.
+6. PR ② Codex 2차 리뷰에서 1차 보강의 `sourceEpoch`가 같은 영상의 오버레이 호스트 복구 때도 증가해 선택을 과도하게 지우는 P2가 확인됐다. 기존 실행형 테스트를 같은 영상 복구와 실제 영상 확정을 구분하도록 강화하고, 정규화 영상 경로와 상태 훅이 이미 캐시한 `videoGeneration` 비교로 교체했다. 독립 타이밍 재검토에서 새 경로 렌더가 generation 발표보다 먼저 오는 구간도 RED로 추가 확인해 경로 변경 즉시 clear하도록 보강했다. 신규 테스트 수는 늘지 않는다.
 
 ## 리스크 및 우려 사항
 
@@ -143,7 +144,8 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 | 파일럿 state hook의 기존 조기 반환 때문에 타임라인이 갱신되지 않음 | 중간 | `renderActiveDrawingLayers()`를 조기 반환 바로 앞에 배치 |
 | passive 상태에서 정지한 채 다른 frame으로 seek하면 마지막 도색 frame이 남을 수 있음 | 중간 | passive frame-change 통지 채널이 없어 이번 범위에서 의도적으로 유지한 알려진 잔여 제한; 후속 설계 필요 |
 | mpv에서 선택한 합성 키프레임이 HTML5 전환 뒤 내부 선택 배열에 남음 | 높음 | 독립 리뷰에서 확인 후 사용자 승인 범위로 해결. HTML5 fallback 직전에 합성 선택이 있을 때만 `clearSelection()`하고, 실행형 회귀 테스트로 clear→legacy render 순서와 순수 legacy 선택 보존을 함께 검증 |
-| mpv에서 선택한 합성 키프레임이 다른 mpv 원본에서도 같은 layer id로 남음 | 높음 | Codex 1차 리뷰에서 확인. mutation에는 변하지 않고 원본 설치·무효화에만 증가하는 persistence `sourceEpoch`를 비교해 원본 교체 때만 합성 선택을 정리 |
+| mpv에서 선택한 합성 키프레임이 다른 mpv 원본에서도 같은 layer id로 남음 | 높음 | Codex 1차 리뷰에서 확인. 정규화 영상 경로 변경을 즉시 비교하고, 같은 경로 재로드는 새 영상의 `afterVideoReady` 승인 때 증가하는 캐시된 `videoGeneration`으로 판정해 선택을 정리 |
+| 같은 영상의 오버레이 호스트 복구가 원본 교체로 오인돼 선택이 풀림 | 중간 | Codex 2차 리뷰에서 확인. rebind 때 증가하는 `sourceEpoch` 비교를 제거하고, 호스트 복구에는 모두 유지되는 영상 경로와 `videoGeneration`으로 판정 |
 | 읽기 전용 합성 행의 가시성·잠금 버튼이 눌리지만 아무 동작도 하지 않음 | 중간 | 합성 header 아래 두 버튼만 `display: none`과 `pointer-events: none`으로 숨기고 legacy 레이어 버튼은 유지 |
 | 실제 Windows Electron의 CSS 표시·마우스 drag/delete 감각이 자동 테스트와 다름 | 중간 | Windows unpacked build에서 계획서 작업 6 수동 시나리오를 실행해 아래 결과를 분리 기록 |
 
@@ -161,12 +163,14 @@ Fabric 파일럿 드로잉은 `.bframe`의 `drawingsV3`에 저장되지만 기�
 | 작업 6 | F1/F2만 먼저 적용: exit 1, tests 347 / pass 345 / fail 2 / cancelled 0 | exit 0, tests/pass 347/347 / fail 0 / cancelled 0 |
 | 작업 6 리뷰 보강 | 선택 정리 생산 코드 적용 전: exit 1, tests 348 / pass 347 / fail 1 / cancelled 0 | exit 0, tests/pass 348/348 / fail 0 / cancelled 0 |
 | Codex 1차 리뷰 보강 | source epoch·합성 행 control 생산 코드 적용 전: exit 1, tests 350 / pass 348 / fail 2 / cancelled 0 | exit 0, tests/pass 350/350 / fail 0 / cancelled 0 |
+| Codex 2차 리뷰 보강 | 동일 영상 복구 판별 강화 뒤 source 단독 exit 1, tests 16 / pass 15 / fail 1 / cancelled 0; focused exit 1, tests 350 / pass 349 / fail 1 / cancelled 0 | source 단독 exit 0, 16/16; focused exit 0, 350/350 / fail 0 / cancelled 0 |
+| Codex 2차 타이밍 보강 | cached generation이 아직 이전 값인 새 경로 렌더를 추가한 뒤 source 단독 exit 1, tests 16 / pass 15 / fail 1 / cancelled 0; focused exit 1, tests 350 / pass 349 / fail 1 / cancelled 0 | 정규화 경로 비교 추가 뒤 source 단독 exit 0, 16/16; focused exit 0, 350/350 / fail 0 / cancelled 0 |
 
 작업 6 RED의 두 실패는 기존 CSS 예외 부재를 잡은 `capture keyboard and click firewalls stop legacy drawing mutations while keeping navigation separate`와 신규 `파일럿 드로잉은 타임라인에 읽기 전용으로 투영된다`였다. 생산 코드 변경 전에는 source test 한 파일만 수정돼 있었다.
 
 작업 6 리뷰 보강 RED는 실제 `renderActiveDrawingLayers()`를 추출해 실행했을 때 HTML5 fallback이 legacy render만 호출하고 합성 선택을 지우지 않아 발생했다. 최소 수정 뒤에는 합성 선택이 있을 때 `clearSelection()`이 legacy render보다 먼저 호출되고, 순수 legacy 선택에서는 clear가 호출되지 않는 음성 대조까지 GREEN이 됐다.
 
-Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했을 때 `sourceEpoch`가 바뀌어도 clear가 호출되지 않은 문제와, 합성 header 전용 가시성·잠금 CSS가 없는 문제를 각각 판별했다. GREEN에서는 첫 원본과 같은 epoch의 선택은 유지하고 다음 원본에서만 clear하며, 두 control만 숨기는 계약을 확인했다.
+Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했을 때 `sourceEpoch`가 바뀌어도 clear가 호출되지 않은 문제와, 합성 header 전용 가시성·잠금 CSS가 없는 문제를 각각 판별했다. 1차 GREEN 뒤 Codex 2차 리뷰에서 rebind도 epoch를 올리는 반례가 확인됐다. 강화된 테스트는 같은 경로·`videoGeneration`의 복구에서는 render만, cached generation 발표 전이라도 새 경로면 clear→render, 다음 generation이 확정되면 clear→render, 같은 source에서 재선택하면 다시 render만 호출되는 계약을 실행 검증한다.
 
 ### 작업 6 정적 계약
 
@@ -177,7 +181,7 @@ Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했
 - state hook의 기존 early-return 본문: 유지, 갱신 호출은 그 앞에 위치
 - 새 legacy `drawings` write: 0건
 - HTML5 fallback의 합성 선택 정리: 1건, 순수 legacy 선택 보존 음성 대조 포함
-- mpv source epoch 전환 선택 정리: 원본 변경 때만 clear, 같은 원본 선택 유지
+- mpv source identity 전환 선택 정리: 정규화 경로 또는 확정 video generation이 바뀔 때만 clear, 같은 원본 선택 유지
 - 합성 header의 가시성·잠금 control: 숨김, legacy control은 변경 없음
 - package/lock/package-root version: 모두 `2.2.0-beta`
 
@@ -218,7 +222,7 @@ Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했
 
 - `npm.cmd run build`: exit 0, `2.2.0-beta` Windows x64 unpacked build 완료
 - prebuild bundle: exit 0, `renderer/scripts/lib/mpv-fabric-overlay.iife.js` 919.4kb; source 변화가 없어 추가 추적 diff 없음
-- ReviewFileCasHelper: Codex 1차 리뷰 보강 뒤 생성 성공, 해당 branch build SHA-256 `15a68c6975fd92066ea82f9664b5ae0f954d5af8338e0c2550391fd568cb8e9c`
+- ReviewFileCasHelper: Codex 2차 리뷰 보강 뒤 생성 성공, electron-builder before-pack 최종 source/package SHA-256 `e6cf87a0cfac3ad08f378129f90b3f8c64f2b54d7412a2e59c9b3c688dc54026`
 - automated/source 검증: TDD RED→GREEN, 25-suite, source 계약, JavaScript syntax, Windows build 수행
 
 ### Windows Electron 수동 검증
@@ -230,10 +234,10 @@ Codex 1차 리뷰 보강 RED 두 건은 같은 실제 함수를 연속 실행했
 - 시나리오 ④: `mpv 직접 재생`을 임시로 끈 뒤 같은 파일을 HTML5로 다시 열자 합성 `드로잉` 행 대신 기존 `레이어 1`, 레이어 추가/삭제, 표시/잠금 UI가 나타남 — PASS.
 - 추가 전환 확인: `manual-a`의 투영 마커 선택 뒤 다른 mpv 파일을 열면 이전 클립이 사라졌고, 이어 HTML5 파일을 열어도 화면에는 이전 합성 행이 남지 않았다 — 화면 잔상 없음 PASS.
 - 수동 검증과 별개로, 독립 리뷰에서 `timeline.selectedKeyframes` 내부에는 합성 선택이 HTML5 전환 뒤 남는 경로가 확인됐다. HTML5 레거시 드로잉 모드 재진입 후 Delete가 `removeKeyframes()`의 layer 조회 전 `_saveToHistory()`를 호출해 no-op undo를 추가할 수 있는 문제였다. 이는 계획서가 ‘이 밖의 편집 진입 경로는 없다’고 한 분석과 달라진 지점이다. 사용자 승인 뒤 HTML5 fallback에서 합성 선택만 조건부로 정리했고, 실제 함수 실행 테스트로 clear→render 순서와 legacy 선택 보존을 검증했다.
-- PR ② Codex 1차 리뷰에서 화면 잔상과 별개로 mpv→mpv 전환 때 동일 synthetic layer id 선택이 남는 경로와 합성 header의 무동작 control이 확인됐다. `sourceEpoch` 실행 테스트와 합성 header 전용 CSS 계약을 RED→GREEN으로 추가했다.
+- PR ② Codex 1차 리뷰에서 화면 잔상과 별개로 mpv→mpv 전환 때 동일 synthetic layer id 선택이 남는 경로와 합성 header의 무동작 control이 확인됐다. 2차 리뷰에서는 최초 `sourceEpoch` 보강이 같은 영상의 호스트 복구까지 선택을 지우는 반례를 찾았다. 최종 구현은 캐시된 `videoGeneration` 실행 테스트와 합성 header 전용 CSS 계약으로 두 경계를 모두 RED→GREEN 검증한다.
 
 ## PR 상태
 
 - PR ①은 [#177](https://github.com/baehandoridori/BAEFRAME/pull/177)로 merge됐고 merge commit은 `e0a4ee68afcf6c51e0f5897b9d8241aa0e042658`이다.
-- PR ②는 [#178](https://github.com/baehandoridori/BAEFRAME/pull/178)이며 위 merge commit에서 분기한 `feat/드로잉-타임라인-레이어-투영`에 작업 6 구현 커밋과 Codex 1차 리뷰 보강 커밋을 포함한다.
+- PR ②는 [#178](https://github.com/baehandoridori/BAEFRAME/pull/178)이며 위 merge commit에서 분기한 `feat/드로잉-타임라인-레이어-투영`에 작업 6 구현 커밋과 Codex 리뷰 보강 커밋들을 포함한다.
 - PR ② 버전은 `2.2.0-beta`이며, P2 두 건의 RED→GREEN 보강 뒤 Codex 명시 완료 신호를 다시 받아 머지·배포한다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.1.2-beta",
+  "version": "2.2.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.1.2-beta",
+      "version": "2.2.0-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.1.2-beta",
+  "version": "2.2.0-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1003,6 +1003,7 @@ async function initApp() {
     playlistTimelineUpdateToken += 1;
     playlistAggregateCommentRanges = [];
     timeline.clearPlaylistTimeline();
+    renderActiveDrawingLayers();
   }
 
   function beginPlaylistReplacement() {
@@ -6187,7 +6188,14 @@ async function initApp() {
         !isMpvPilotPlaybackActive()) {
       return null;
     }
-    if (playlistUIState.mode === 'continuous' || cutlistUIState.active) {
+    const hasPlaylistAggregateTimeline = playlistUIState.mode === 'continuous' &&
+      timeline.playlistDuration > 0 &&
+      timeline.playlistSegments?.length > 0;
+    const hasCutlistAggregateTimeline = cutlistUIState.active &&
+      getCutlistManager().isActive() &&
+      timeline.cutlistDuration > 0 &&
+      timeline.cutlistSegments?.length > 0;
+    if (hasPlaylistAggregateTimeline || hasCutlistAggregateTimeline) {
       return [];
     }
     const doc = fabricDrawingPersistenceStore.getHydrationDocument?.();
@@ -6207,11 +6215,9 @@ async function initApp() {
       opacity: 1,
       keyframes,
       getKeyframeRanges(totalFrames) {
-        return keyframes.map((kf, index) => ({
+        return keyframes.map(kf => ({
           start: kf.frame,
-          end: keyframes[index + 1]
-            ? keyframes[index + 1].frame - 1
-            : Math.max(kf.frame, (Number(totalFrames) || 0) - 1),
+          end: kf.frame,
           keyframe: kf
         }));
       }
@@ -18193,6 +18199,7 @@ async function initApp() {
 
       const { segments, totalDuration } = buildPlaylistSegments(items, metadata);
       timeline.setPlaylistTimeline(segments, totalDuration);
+      renderActiveDrawingLayers();
       timeline.setCurrentTime(getContinuousTimelinePlaybackTime());
 
       const aggregateRanges = [];
@@ -19357,12 +19364,14 @@ async function initApp() {
       timeline.setCurrentCutId(null);
       timeline.setCutlistTimeline([], 0);
       cutlistAggregateCommentRanges = [];
+      renderActiveDrawingLayers();
       return;
     }
 
     const cutlistTimeline = cutlistManager.getTimeline();
     timeline.setCutlistTimeline(cutlistTimeline.segments, cutlistTimeline.totalDuration);
     timeline.setCurrentCutId(cutlistManager.currentCutId);
+    renderActiveDrawingLayers();
   }
 
   async function updateCutlistAggregateComments() {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6023,14 +6023,20 @@ async function initApp() {
   ].join(',');
 
   function shouldBlockFabricDrawingLegacyShortcut(event) {
-    if (!isFabricDrawingPilotEngaged()) return false;
+    const engaged = isFabricDrawingPilotEngaged();
+    if (!engaged && !shouldSuppressLegacyDrawingForFabricPilot()) return false;
+    const matchedAction = [...FABRIC_DRAWING_LEGACY_SHORTCUTS]
+      .find(action => userSettings.matchShortcut(action, event));
+    if (!engaged) {
+      return Boolean(matchedAction) &&
+        !['undo', 'redo', 'drawMode'].includes(matchedAction);
+    }
     const key = String(event.key || '').toLowerCase();
     if ((event.ctrlKey || event.metaKey) && ['c', 'v', 'z', 'y'].includes(key)) return true;
     if (event.code === 'KeyE' && !event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
       return true;
     }
-    return [...FABRIC_DRAWING_LEGACY_SHORTCUTS]
-      .some(action => userSettings.matchShortcut(action, event));
+    return Boolean(matchedAction);
   }
 
   function handleFabricDrawingPilotLegacyClick(event) {
@@ -6180,6 +6186,9 @@ async function initApp() {
     if (!fabricDrawingPilotController.shouldOwnDrawingShortcut() ||
         !isMpvPilotPlaybackActive()) {
       return null;
+    }
+    if (playlistUIState.mode === 'continuous' || cutlistUIState.active) {
+      return [];
     }
     const doc = fabricDrawingPersistenceStore.getHydrationDocument?.();
     const keyframes = (doc?.keyframes || [])
@@ -18750,6 +18759,7 @@ async function initApp() {
       timeline.clearCommentMarkers();
       updatePlaylistContinuousTimeline();
     }
+    renderActiveDrawingLayers();
   }
 
   function exitPlaylistContinuousModeForCutlist() {
@@ -18975,6 +18985,7 @@ async function initApp() {
     updateCurrentCutDisplay(currentCut);
     void refreshCommentRangesForCurrentMode();
     updateCommentList(getActiveCommentFilter());
+    renderActiveDrawingLayers();
   }
 
   function hideCutlistSidebar() {
@@ -18989,6 +19000,7 @@ async function initApp() {
     timeline.setCutlistTimeline([], 0);
     void refreshCommentRangesForCurrentMode();
     updateCommentList(getActiveCommentFilter());
+    renderActiveDrawingLayers();
   }
 
   function updateCutlistUI() {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1596,7 +1596,7 @@ async function initApp() {
 
     // .bframe에서 로드된 데이터가 있으면 다시 렌더링
     if (drawingManager.layers.length > 0) {
-      timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+      renderActiveDrawingLayers();
       drawingManager.renderFrame(videoPlayer.currentFrame);
     }
 
@@ -1915,7 +1915,7 @@ async function initApp() {
 
   // 레이어 변경 시 타임라인 업데이트
   drawingManager.addEventListener('layersChanged', () => {
-    timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+    renderActiveDrawingLayers();
     scheduleMpvOverlayStateSync();
   });
 
@@ -1958,7 +1958,7 @@ async function initApp() {
   // 레이어 선택
   timeline.addEventListener('layerSelect', (e) => {
     drawingManager.setActiveLayer(e.detail.layerId);
-    timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+    renderActiveDrawingLayers();
   });
 
   // 레이어 가시성 토글
@@ -2102,6 +2102,8 @@ async function initApp() {
 
   // 키프레임 이동
   timeline.addEventListener('keyframesMove', (e) => {
+    // 파일럿 투영 레이어는 읽기 전용 — 드래그 이동이 레거시 undo 히스토리를 오염시키지 않게 차단
+    if (getFabricPilotTimelineLayers()) return;
     const { keyframes, frameDelta, anchor } = e.detail;
     if (drawingManager.moveKeyframes(keyframes)) {
       // 이동 성공 시 선택 상태 업데이트
@@ -2110,12 +2112,14 @@ async function initApp() {
         frame: kf.toFrame
       }));
       timeline.setKeyframeSelection(movedSelection, { anchor });
-      timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+      renderActiveDrawingLayers();
       showToast(`키프레임 ${frameDelta > 0 ? '+' : ''}${frameDelta} 프레임 이동`, 'info');
     }
   });
 
   function deleteSelectedOrCurrentKeyframes() {
+    // 파일럿 투영 레이어는 읽기 전용 — passive에서 선택된 투영 키프레임의 삭제 시도를 차단
+    if (getFabricPilotTimelineLayers()) return false;
     const selectedKeyframes = Array.isArray(timeline.selectedKeyframes)
       ? timeline.selectedKeyframes
       : [];
@@ -2124,7 +2128,7 @@ async function initApp() {
       const removedCount = drawingManager.removeKeyframes(selectedKeyframes);
       if (removedCount > 0) {
         timeline.clearSelection();
-        timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+        renderActiveDrawingLayers();
         showToast(`키프레임 ${removedCount}개가 삭제되었습니다.`, 'info');
       } else {
         showToast('삭제할 수 있는 선택 키프레임이 없습니다.', 'warn');
@@ -2134,7 +2138,7 @@ async function initApp() {
 
     const removed = drawingManager.removeKeyframe();
     if (removed) {
-      timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+      renderActiveDrawingLayers();
       showToast('키프레임이 삭제되었습니다.', 'info');
     } else {
       showToast('삭제할 키프레임이 없습니다.', 'warn');
@@ -4012,7 +4016,7 @@ async function initApp() {
   });
 
   function renderDrawingLayerTimeline() {
-    timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+    renderActiveDrawingLayers();
   }
 
   function addDrawingLayer() {
@@ -6170,6 +6174,58 @@ async function initApp() {
     return isMpvPilotPlaybackActive() && isFabricDrawingPilotControllerEngaged();
   }
 
+  // 파일럿 드로잉(drawingsV3)을 타임라인 드로잉 레이어로 읽기 전용 투영한다.
+  // 레거시 drawings 필드와의 이중 기록을 피하기 위해 데이터는 절대 쓰지 않는다.
+  function getFabricPilotTimelineLayers() {
+    if (!fabricDrawingPilotController.shouldOwnDrawingShortcut() ||
+        !isMpvPilotPlaybackActive()) {
+      return null;
+    }
+    const doc = fabricDrawingPersistenceStore.getHydrationDocument?.();
+    const keyframes = (doc?.keyframes || [])
+      .map(kf => ({
+        frame: Number(kf.frame),
+        isEmpty: !(Array.isArray(kf.objects) && kf.objects.length > 0)
+      }))
+      .filter(kf => Number.isInteger(kf.frame) && kf.frame >= 0)
+      .sort((a, b) => a.frame - b.frame);
+    return [{
+      id: 'fabric-pilot-drawing-layer',
+      name: '드로잉',
+      color: '#4f8ef7',
+      visible: true,
+      locked: true,
+      opacity: 1,
+      keyframes,
+      getKeyframeRanges(totalFrames) {
+        return keyframes.map((kf, index) => ({
+          start: kf.frame,
+          end: keyframes[index + 1]
+            ? keyframes[index + 1].frame - 1
+            : Math.max(kf.frame, (Number(totalFrames) || 0) - 1),
+          keyframe: kf
+        }));
+      }
+    }];
+  }
+
+  function renderActiveDrawingLayers() {
+    try {
+      const pilotLayers = getFabricPilotTimelineLayers();
+      if (pilotLayers) {
+        timeline.renderDrawingLayers(pilotLayers, null);
+        return;
+      }
+      const hasFabricPilotSelection = Array.isArray(timeline.selectedKeyframes) &&
+        timeline.selectedKeyframes.some(keyframe => keyframe.layerId === 'fabric-pilot-drawing-layer');
+      if (hasFabricPilotSelection) timeline.clearSelection();
+      timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+    } catch (_error) {
+      // 파일럿 상태 훅(notifyStateChange)이 예외를 빈 catch로 삼키므로,
+      // 렌더 실패가 뒤따르는 UI 상태 확정 흐름까지 끊지 않게 여기서 격리한다
+    }
+  }
+
   function requiresMpvReviewFreeze() {
     return state.isCommentMode ||
       (state.isDrawMode && !fabricDrawingPilotController.isActiveOrPreparing());
@@ -7275,6 +7331,15 @@ async function initApp() {
       }
       return Promise.resolve(false);
     }
+  });
+  let fabricPilotTimelineRenderQueued = false;
+  fabricDrawingPersistenceStore.subscribe(() => {
+    if (fabricPilotTimelineRenderQueued) return;
+    fabricPilotTimelineRenderQueued = true;
+    requestAnimationFrame(() => {
+      fabricPilotTimelineRenderQueued = false;
+      renderActiveDrawingLayers();
+    });
   });
   reviewDataManager.setFabricDrawingSourceRefreshHandler(
     ({ installSource }) =>
@@ -9698,7 +9763,7 @@ async function initApp() {
       updateTimelineMarkers();
       updateCommentList();
       // 그리기 레이어 UI 및 캔버스 다시 렌더링
-      timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+      renderActiveDrawingLayers();
       drawingManager.renderFrame(videoPlayer.currentFrame);
       compositionLayerManager.setVideoInfo({ duration: videoPlayer.duration });
       compositionLayerManager.setPlaybackState({
@@ -10157,6 +10222,7 @@ async function initApp() {
       (active || preparing || nextState === 'recovering');
     const wasEngaged = fabricDrawingPilotUiEngaged;
     scheduleMpvOverlayStateSync({ force: true });
+    renderActiveDrawingLayers();
     if (!engaged && !wasEngaged) {
       if (nextState === 'failed') notifyFabricDrawingPilotFailure();
       else fabricDrawingPilotFailureToastShown = false;
@@ -13642,7 +13708,7 @@ async function initApp() {
       e.stopPropagation();
       const pastedCount = drawingManager.pasteFrames();
       if (pastedCount > 0) {
-        timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+        renderActiveDrawingLayers();
         showToast(`프레임 ${pastedCount}개 붙여넣기됨`, 'success');
       } else {
         showToast('붙여넣을 프레임이 없습니다', 'warning');
@@ -13766,14 +13832,14 @@ async function initApp() {
     if (userSettings.matchShortcut('keyframeAddBlank2', e)) {
       e.preventDefault();
       drawingManager.addBlankKeyframe();
-      timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+      renderActiveDrawingLayers();
       return;
     }
     // Shift+2: 키프레임을 일반 프레임으로 변환
     if (userSettings.matchShortcut('keyframeConvertToFrame', e)) {
       e.preventDefault();
       if (drawingManager.convertKeyframeToFrame()) {
-        timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+        renderActiveDrawingLayers();
       }
       return;
     }
@@ -13781,7 +13847,7 @@ async function initApp() {
     if (userSettings.matchShortcut('keyframeConvertToKeyframe', e)) {
       e.preventDefault();
       if (drawingManager.convertFrameToKeyframe()) {
-        timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+        renderActiveDrawingLayers();
       }
       return;
     }
@@ -13789,14 +13855,14 @@ async function initApp() {
     if (userSettings.matchShortcut('insertFrame', e)) {
       e.preventDefault();
       drawingManager.insertFrame();
-      timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+      renderActiveDrawingLayers();
       return;
     }
     // 4: 프레임 삭제
     if (userSettings.matchShortcut('deleteFrame', e)) {
       e.preventDefault();
       drawingManager.deleteFrame();
-      timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
+      renderActiveDrawingLayers();
       return;
     }
     // E: 지우개 모드 (드로잉 모드에서만 작동)

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6209,15 +6209,25 @@ async function initApp() {
     }];
   }
 
+  let lastFabricPilotTimelineSourceEpoch = null;
+
   function renderActiveDrawingLayers() {
     try {
       const pilotLayers = getFabricPilotTimelineLayers();
+      const hasFabricPilotSelection = Array.isArray(timeline.selectedKeyframes) &&
+        timeline.selectedKeyframes.some(keyframe => keyframe.layerId === 'fabric-pilot-drawing-layer');
       if (pilotLayers) {
+        const sourceEpoch = fabricDrawingPersistenceStore.getSourceEpoch();
+        if (lastFabricPilotTimelineSourceEpoch !== null &&
+            sourceEpoch !== lastFabricPilotTimelineSourceEpoch &&
+            hasFabricPilotSelection) {
+          timeline.clearSelection();
+        }
+        lastFabricPilotTimelineSourceEpoch = sourceEpoch;
         timeline.renderDrawingLayers(pilotLayers, null);
         return;
       }
-      const hasFabricPilotSelection = Array.isArray(timeline.selectedKeyframes) &&
-        timeline.selectedKeyframes.some(keyframe => keyframe.layerId === 'fabric-pilot-drawing-layer');
+      lastFabricPilotTimelineSourceEpoch = null;
       if (hasFabricPilotSelection) timeline.clearSelection();
       timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
     } catch (_error) {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6209,7 +6209,8 @@ async function initApp() {
     }];
   }
 
-  let lastFabricPilotTimelineSourceEpoch = null;
+  let lastFabricPilotTimelineVideoGeneration = null;
+  let lastFabricPilotTimelineStableVideoIdentity = null;
 
   function renderActiveDrawingLayers() {
     try {
@@ -6217,17 +6218,26 @@ async function initApp() {
       const hasFabricPilotSelection = Array.isArray(timeline.selectedKeyframes) &&
         timeline.selectedKeyframes.some(keyframe => keyframe.layerId === 'fabric-pilot-drawing-layer');
       if (pilotLayers) {
-        const sourceEpoch = fabricDrawingPersistenceStore.getSourceEpoch();
-        if (lastFabricPilotTimelineSourceEpoch !== null &&
-            sourceEpoch !== lastFabricPilotTimelineSourceEpoch &&
+        const videoGeneration = fabricDrawingPilotStatusSnapshot?.videoGeneration ?? null;
+        const stableVideoIdentity = normalizeComparableFilePath(
+          videoPlayer.filePath || state.currentFile
+        );
+        const sourceChanged =
+          (lastFabricPilotTimelineVideoGeneration !== null &&
+            videoGeneration !== lastFabricPilotTimelineVideoGeneration) ||
+          (lastFabricPilotTimelineStableVideoIdentity !== null &&
+            stableVideoIdentity !== lastFabricPilotTimelineStableVideoIdentity);
+        if (sourceChanged &&
             hasFabricPilotSelection) {
           timeline.clearSelection();
         }
-        lastFabricPilotTimelineSourceEpoch = sourceEpoch;
+        lastFabricPilotTimelineVideoGeneration = videoGeneration;
+        lastFabricPilotTimelineStableVideoIdentity = stableVideoIdentity;
         timeline.renderDrawingLayers(pilotLayers, null);
         return;
       }
-      lastFabricPilotTimelineSourceEpoch = null;
+      lastFabricPilotTimelineVideoGeneration = null;
+      lastFabricPilotTimelineStableVideoIdentity = null;
       if (hasFabricPilotSelection) timeline.clearSelection();
       timeline.renderDrawingLayers(drawingManager.layers, drawingManager.activeLayerId);
     } catch (_error) {

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -1132,6 +1132,12 @@ body.fabric-drawing-pilot-enabled.mpv-pilot-mode .drawing-track-row:not([data-la
   pointer-events: none;
 }
 
+body.fabric-drawing-pilot-enabled.mpv-pilot-mode .drawing-layer-header[data-layer-id="fabric-pilot-drawing-layer"] .layer-visibility,
+body.fabric-drawing-pilot-enabled.mpv-pilot-mode .drawing-layer-header[data-layer-id="fabric-pilot-drawing-layer"] .layer-lock {
+  display: none;
+  pointer-events: none;
+}
+
 .mpv-review-freeze-frame {
   position: absolute;
   z-index: 1;

--- a/renderer/styles/main.css
+++ b/renderer/styles/main.css
@@ -1126,8 +1126,8 @@ body.fabric-drawing-pilot-enabled.mpv-pilot-mode .layer-settings-popup {
 }
 
 body.fabric-drawing-pilot-enabled.mpv-pilot-mode .layer-action-btn,
-body.fabric-drawing-pilot-enabled.mpv-pilot-mode .drawing-layer-header,
-body.fabric-drawing-pilot-enabled.mpv-pilot-mode .drawing-track-row {
+body.fabric-drawing-pilot-enabled.mpv-pilot-mode .drawing-layer-header:not([data-layer-id="fabric-pilot-drawing-layer"]),
+body.fabric-drawing-pilot-enabled.mpv-pilot-mode .drawing-track-row:not([data-layer-id="fabric-pilot-drawing-layer"]) {
   display: none;
   pointer-events: none;
 }

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -540,8 +540,14 @@ test('집계 타임라인에서는 현재 영상의 로컬 드로잉 투영을 �
 
   let mpvActive = true;
   let hydrationReads = 0;
+  let cutlistManagerActive = false;
   const playlistState = { mode: 'review' };
-  const timelineState = { playlistDuration: 0, cutlistDuration: 0 };
+  const timelineState = {
+    playlistDuration: 0,
+    playlistSegments: [],
+    cutlistDuration: 0,
+    cutlistSegments: []
+  };
   const cutlistState = { active: false };
   const getProjection = new Function(
     'fabricDrawingPilotController',
@@ -550,6 +556,7 @@ test('집계 타임라인에서는 현재 영상의 로컬 드로잉 투영을 �
     'playlistUIState',
     'timeline',
     'cutlistUIState',
+    'getCutlistManager',
     `${projectionSource}\nreturn getFabricPilotTimelineLayers;`
   )(
     { shouldOwnDrawingShortcut: () => true },
@@ -562,32 +569,113 @@ test('집계 타임라인에서는 현재 영상의 로컬 드로잉 투영을 �
     },
     playlistState,
     timelineState,
-    cutlistState
+    cutlistState,
+    () => ({ isActive: () => cutlistManagerActive })
   );
 
   assert.equal(getProjection().length, 1);
   assert.equal(hydrationReads, 1);
 
   playlistState.mode = 'continuous';
+  assert.equal(getProjection().length, 1);
+  assert.equal(hydrationReads, 2);
+
+  timelineState.playlistDuration = 30;
+  timelineState.playlistSegments = [{}];
   const playlistProjection = getProjection();
   assert.deepEqual(playlistProjection, []);
   assert.equal(Boolean(playlistProjection), true);
-  assert.equal(hydrationReads, 1);
+  assert.equal(hydrationReads, 2);
 
   playlistState.mode = 'review';
+  timelineState.playlistDuration = 0;
+  timelineState.playlistSegments = [];
   cutlistState.active = true;
+  assert.equal(getProjection().length, 1);
+  assert.equal(hydrationReads, 3);
+
+  cutlistManagerActive = true;
+  assert.equal(getProjection().length, 1);
+  assert.equal(hydrationReads, 4);
+
+  timelineState.cutlistDuration = 30;
+  timelineState.cutlistSegments = [{}];
   const cutlistProjection = getProjection();
   assert.deepEqual(cutlistProjection, []);
   assert.equal(Boolean(cutlistProjection), true);
-  assert.equal(hydrationReads, 1);
+  assert.equal(hydrationReads, 4);
 
   cutlistState.active = false;
   timelineState.cutlistDuration = 0;
+  timelineState.cutlistSegments = [];
   mpvActive = false;
   assert.equal(getProjection(), null);
 });
 
+test('파일럿 투영 범위는 저장된 장면의 단일 프레임만 표시한다', () => {
+  const projectionSource = appSource.match(
+    /function getFabricPilotTimelineLayers\(\) \{[\s\S]*?\n  \}\n\n  let lastFabricPilotTimeline/
+  )?.[0]?.replace(/\n\n  let lastFabricPilotTimeline$/, '');
+  assert.ok(projectionSource, 'timeline projection source should be extractable');
+
+  const getProjection = new Function(
+    'fabricDrawingPilotController',
+    'isMpvPilotPlaybackActive',
+    'fabricDrawingPersistenceStore',
+    'playlistUIState',
+    'timeline',
+    'cutlistUIState',
+    'getCutlistManager',
+    `${projectionSource}\nreturn getFabricPilotTimelineLayers;`
+  )(
+    { shouldOwnDrawingShortcut: () => true },
+    () => true,
+    {
+      getHydrationDocument: () => ({
+        keyframes: [
+          { frame: 10, objects: [{}] },
+          { frame: 20, objects: [{}] }
+        ]
+      })
+    },
+    { mode: 'review' },
+    {
+      playlistDuration: 0,
+      playlistSegments: [],
+      cutlistDuration: 0,
+      cutlistSegments: []
+    },
+    { active: false },
+    () => ({ isActive: () => false })
+  );
+
+  const [layer] = getProjection();
+  assert.deepEqual(
+    layer.getKeyframeRanges(100).map(range => ({ start: range.start, end: range.end })),
+    [
+      { start: 10, end: 10 },
+      { start: 20, end: 20 }
+    ]
+  );
+});
+
 test('집계 모드 전환은 드로잉 투영 캐시를 즉시 다시 그린다', () => {
+  const resetPlaylistSource = appSource.match(
+    /function resetPlaylistContinuousTimelineState\(\) \{[\s\S]*?\n  \}\n\n  function beginPlaylistReplacement/
+  )?.[0] || '';
+  assert.match(
+    resetPlaylistSource,
+    /timeline\.clearPlaylistTimeline\(\);[\s\S]*renderActiveDrawingLayers\(\);/
+  );
+
+  const updatePlaylistSource = appSource.match(
+    /async function updatePlaylistContinuousTimeline\(\) \{[\s\S]*?\n  \}\n\n  async function quickCheckPlaylistForContinuous/
+  )?.[0] || '';
+  assert.match(
+    updatePlaylistSource,
+    /timeline\.setPlaylistTimeline\(segments, totalDuration\);[\s\S]*renderActiveDrawingLayers\(\);/
+  );
+
   const playlistModeSource = appSource.match(
     /function setPlaylistMode\(mode\) \{[\s\S]*?\n  \}\n\n  function exitPlaylistContinuousModeForCutlist/
   )?.[0] || '';
@@ -610,5 +698,13 @@ test('집계 모드 전환은 드로잉 투영 캐시를 즉시 다시 그린다
   assert.match(
     hideCutlistSource,
     /cutlistUIState\.active = false;[\s\S]*renderActiveDrawingLayers\(\);/
+  );
+
+  const updateCutlistSource = appSource.match(
+    /function updateCutlistTimeline\(\) \{[\s\S]*?\n  \}\n\n  async function updateCutlistAggregateComments/
+  )?.[0] || '';
+  assert.equal(
+    (updateCutlistSource.match(/renderActiveDrawingLayers\(\);/g) || []).length,
+    2
   );
 });

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -361,11 +361,15 @@ test('HTML5 fallback은 합성 키프레임 선택을 지운 뒤 레거시 레�
     'getFabricPilotTimelineLayers',
     'timeline',
     'drawingManager',
+    'fabricDrawingPersistenceStore',
+    'lastFabricPilotTimelineSourceEpoch',
     `${renderSource}\nreturn renderActiveDrawingLayers;`
   )(
     () => null,
     timelineHarness,
-    { layers: legacyLayers, activeLayerId: 'legacy-layer' }
+    { layers: legacyLayers, activeLayerId: 'legacy-layer' },
+    { getSourceEpoch: () => 1 },
+    null
   );
 
   renderActiveDrawingLayers();
@@ -383,4 +387,59 @@ test('HTML5 fallback은 합성 키프레임 선택을 지운 뒤 레거시 레�
   assert.deepEqual(calls, [
     { type: 'render', layers: legacyLayers, activeLayerId: 'legacy-layer' }
   ]);
+});
+
+test('mpv 드로잉 소스가 바뀌면 이전 합성 키프레임 선택을 지운다', () => {
+  const renderSource = appSource.match(
+    /function renderActiveDrawingLayers\(\) \{[\s\S]*?\n  \}\n\n  function requiresMpvReviewFreeze/
+  )?.[0]?.replace(/\n\n  function requiresMpvReviewFreeze$/, '');
+  assert.ok(renderSource, 'renderActiveDrawingLayers source should be extractable');
+
+  let sourceEpoch = 1;
+  const calls = [];
+  const timelineHarness = {
+    selectedKeyframes: [{ layerId: 'fabric-pilot-drawing-layer', frame: 12 }],
+    clearSelection() {
+      calls.push('clear');
+      this.selectedKeyframes = [];
+    },
+    renderDrawingLayers() {
+      calls.push('render');
+    }
+  };
+  const renderActiveDrawingLayers = new Function(
+    'getFabricPilotTimelineLayers',
+    'timeline',
+    'drawingManager',
+    'fabricDrawingPersistenceStore',
+    'lastFabricPilotTimelineSourceEpoch',
+    `${renderSource}\nreturn renderActiveDrawingLayers;`
+  )(
+    () => [{ id: 'fabric-pilot-drawing-layer' }],
+    timelineHarness,
+    { layers: [], activeLayerId: null },
+    { getSourceEpoch: () => sourceEpoch },
+    null
+  );
+
+  renderActiveDrawingLayers();
+  assert.deepEqual(calls, ['render']);
+
+  calls.length = 0;
+  sourceEpoch = 2;
+  renderActiveDrawingLayers();
+  assert.deepEqual(calls, ['clear', 'render']);
+
+  calls.length = 0;
+  timelineHarness.selectedKeyframes = [{ layerId: 'fabric-pilot-drawing-layer', frame: 24 }];
+  renderActiveDrawingLayers();
+  assert.deepEqual(calls, ['render']);
+  assert.match(appSource, /let lastFabricPilotTimelineSourceEpoch = null;/);
+});
+
+test('읽기 전용 합성 행의 가시성·잠금 버튼은 숨긴다', () => {
+  assert.match(
+    mainCss,
+    /body\.fabric-drawing-pilot-enabled\.mpv-pilot-mode \.drawing-layer-header\[data-layer-id="fabric-pilot-drawing-layer"\] \.layer-visibility,\nbody\.fabric-drawing-pilot-enabled\.mpv-pilot-mode \.drawing-layer-header\[data-layer-id="fabric-pilot-drawing-layer"\] \.layer-lock \{\n\s+display:\s*none;\n\s+pointer-events:\s*none;\n\}/
+  );
 });

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -487,3 +487,128 @@ test('읽기 전용 합성 행의 가시성·잠금 버튼은 숨긴다', () => 
     /body\.fabric-drawing-pilot-enabled\.mpv-pilot-mode \.drawing-layer-header\[data-layer-id="fabric-pilot-drawing-layer"\] \.layer-visibility,\nbody\.fabric-drawing-pilot-enabled\.mpv-pilot-mode \.drawing-layer-header\[data-layer-id="fabric-pilot-drawing-layer"\] \.layer-lock \{\n\s+display:\s*none;\n\s+pointer-events:\s*none;\n\}/
   );
 });
+
+test('passive 파일럿 투영은 레거시 드로잉 변이 단축키만 차단한다', () => {
+  const guardSource = appSource.match(
+    /function shouldBlockFabricDrawingLegacyShortcut\(event\) \{[\s\S]*?\n  \}\n\n  function handleFabricDrawingPilotLegacyClick/
+  )?.[0]?.replace(/\n\n  function handleFabricDrawingPilotLegacyClick$/, '');
+  assert.ok(guardSource, 'legacy shortcut guard source should be extractable');
+
+  const actionListSource = appSource.match(
+    /const FABRIC_DRAWING_LEGACY_SHORTCUTS = new Set\(\[([\s\S]*?)\n  \]\);/
+  )?.[1] || '';
+  const actions = [...actionListSource.matchAll(/'([^']+)'/g)].map(match => match[1]);
+  const actionSet = new Set(actions);
+  let engaged = false;
+  let projectionOwned = true;
+  const shouldBlock = new Function(
+    'FABRIC_DRAWING_LEGACY_SHORTCUTS',
+    'userSettings',
+    'isFabricDrawingPilotEngaged',
+    'shouldSuppressLegacyDrawingForFabricPilot',
+    `${guardSource}\nreturn shouldBlockFabricDrawingLegacyShortcut;`
+  )(
+    actionSet,
+    { matchShortcut: (action, event) => action === event.action },
+    () => engaged,
+    () => projectionOwned
+  );
+
+  const passiveExceptions = new Set(['undo', 'redo', 'drawMode']);
+  for (const action of actions) {
+    assert.equal(
+      shouldBlock({ action, key: '', code: '' }),
+      !passiveExceptions.has(action),
+      `passive projection shortcut boundary: ${action}`
+    );
+  }
+  assert.equal(shouldBlock({ action: 'prevKeyframe', key: '', code: '' }), false);
+  assert.equal(shouldBlock({ key: 'e', code: 'KeyE' }), false);
+
+  projectionOwned = false;
+  assert.equal(shouldBlock({ action: 'insertFrame', key: '', code: '' }), false);
+
+  engaged = true;
+  assert.equal(shouldBlock({ key: 'z', code: 'KeyZ', ctrlKey: true }), true);
+});
+
+test('집계 타임라인에서는 현재 영상의 로컬 드로잉 투영을 숨긴다', () => {
+  const projectionSource = appSource.match(
+    /function getFabricPilotTimelineLayers\(\) \{[\s\S]*?\n  \}\n\n  let lastFabricPilotTimeline/
+  )?.[0]?.replace(/\n\n  let lastFabricPilotTimeline$/, '');
+  assert.ok(projectionSource, 'timeline projection source should be extractable');
+
+  let mpvActive = true;
+  let hydrationReads = 0;
+  const playlistState = { mode: 'review' };
+  const timelineState = { playlistDuration: 0, cutlistDuration: 0 };
+  const cutlistState = { active: false };
+  const getProjection = new Function(
+    'fabricDrawingPilotController',
+    'isMpvPilotPlaybackActive',
+    'fabricDrawingPersistenceStore',
+    'playlistUIState',
+    'timeline',
+    'cutlistUIState',
+    `${projectionSource}\nreturn getFabricPilotTimelineLayers;`
+  )(
+    { shouldOwnDrawingShortcut: () => true },
+    () => mpvActive,
+    {
+      getHydrationDocument: () => {
+        hydrationReads += 1;
+        return { keyframes: [{ frame: 12, objects: [{}] }] };
+      }
+    },
+    playlistState,
+    timelineState,
+    cutlistState
+  );
+
+  assert.equal(getProjection().length, 1);
+  assert.equal(hydrationReads, 1);
+
+  playlistState.mode = 'continuous';
+  const playlistProjection = getProjection();
+  assert.deepEqual(playlistProjection, []);
+  assert.equal(Boolean(playlistProjection), true);
+  assert.equal(hydrationReads, 1);
+
+  playlistState.mode = 'review';
+  cutlistState.active = true;
+  const cutlistProjection = getProjection();
+  assert.deepEqual(cutlistProjection, []);
+  assert.equal(Boolean(cutlistProjection), true);
+  assert.equal(hydrationReads, 1);
+
+  cutlistState.active = false;
+  timelineState.cutlistDuration = 0;
+  mpvActive = false;
+  assert.equal(getProjection(), null);
+});
+
+test('집계 모드 전환은 드로잉 투영 캐시를 즉시 다시 그린다', () => {
+  const playlistModeSource = appSource.match(
+    /function setPlaylistMode\(mode\) \{[\s\S]*?\n  \}\n\n  function exitPlaylistContinuousModeForCutlist/
+  )?.[0] || '';
+  assert.match(
+    playlistModeSource,
+    /playlistUIState\.mode = nextMode;[\s\S]*renderActiveDrawingLayers\(\);/
+  );
+
+  const showCutlistSource = appSource.match(
+    /function showCutlistSidebar\(\) \{[\s\S]*?\n  \}\n\n  function hideCutlistSidebar/
+  )?.[0] || '';
+  assert.match(
+    showCutlistSource,
+    /cutlistUIState\.active = true;[\s\S]*renderActiveDrawingLayers\(\);/
+  );
+
+  const hideCutlistSource = appSource.match(
+    /function hideCutlistSidebar\(\) \{[\s\S]*?\n  \}\n\n  function updateCutlistUI/
+  )?.[0] || '';
+  assert.match(
+    hideCutlistSource,
+    /cutlistUIState\.active = false;[\s\S]*renderActiveDrawingLayers\(\);/
+  );
+});

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -123,7 +123,7 @@ test('capture keyboard and click firewalls stop legacy drawing mutations while k
   assert.match(mainCss, /body\.fabric-drawing-pilot-enabled\.mpv-pilot-mode \.drawing-overlay[\s\S]+visibility:\s*hidden;[\s\S]+pointer-events:\s*none(?:\s*!important)?;/);
   assert.match(
     mainCss,
-    /body\.fabric-drawing-pilot-enabled\.mpv-pilot-mode \.drawing-layer-header,[\s\S]+body\.fabric-drawing-pilot-enabled\.mpv-pilot-mode \.drawing-track-row[\s\S]+display:\s*none;[\s\S]+pointer-events:\s*none;/
+    /body\.fabric-drawing-pilot-enabled\.mpv-pilot-mode \.drawing-layer-header:not\(\[data-layer-id="fabric-pilot-drawing-layer"\]\),[\s\S]+body\.fabric-drawing-pilot-enabled\.mpv-pilot-mode \.drawing-track-row:not\(\[data-layer-id="fabric-pilot-drawing-layer"\]\)[\s\S]+display:\s*none;[\s\S]+pointer-events:\s*none;/
   );
   assert.match(appSource, /function shouldSuppressLegacyDrawingForFabricPilot\(\) \{[\s\S]+fabricDrawingPilotController\.shouldOwnDrawingShortcut\(\)[\s\S]+isMpvPilotPlaybackActive\(\)[\s\S]+\}/);
   assert.match(appSource, /const suppressLegacyDrawing = shouldSuppressLegacyDrawingForFabricPilot\(\);[\s\S]+drawingDataUrl: suppressLegacyDrawing \? '' : getCompositedDrawingOverlayDataUrl\(\),[\s\S]+onionDataUrl: !suppressLegacyDrawing && drawingManager\.onionSkin\?\.enabled/);
@@ -312,4 +312,75 @@ test('Fabric 툴바 표시는 페이드 없이 한 프레임에 완성된다', (
     'utf8'
   ));
   assert.equal(iifeSource.includes('opacity 100ms ease'), false);
+});
+
+test('파일럿 드로잉은 타임라인에 읽기 전용으로 투영된다', () => {
+  assert.match(appSource, /function getFabricPilotTimelineLayers\(\)/);
+  assert.match(appSource, /function renderActiveDrawingLayers\(\)/);
+  assert.match(appSource, /fabricDrawingPersistenceStore\.subscribe\(\(\) => \{/);
+  // 헬퍼 외부에 직접 렌더 호출이 남지 않았다 (헬퍼 내부 폴백 1건만 허용)
+  const directCalls = appSource.match(
+    /timeline\.renderDrawingLayers\(drawingManager\.layers, drawingManager\.activeLayerId\);/g
+  ) || [];
+  assert.equal(directCalls.length, 1);
+  // 상태 변화 훅이 조기 반환보다 앞에서 투영을 갱신한다
+  assert.match(
+    appSource,
+    /scheduleMpvOverlayStateSync\(\{ force: true \}\);\n\s+renderActiveDrawingLayers\(\);\n\s+if \(!engaged && !wasEngaged\) \{/
+  );
+  // 투영 레이어 드래그·삭제 차단
+  assert.match(
+    appSource,
+    /keyframesMove', \(e\) => \{[\s\S]{0,400}?if \(getFabricPilotTimelineLayers\(\)\) return;/
+  );
+  assert.match(
+    appSource,
+    /function deleteSelectedOrCurrentKeyframes\(\) \{[\s\S]{0,400}?if \(getFabricPilotTimelineLayers\(\)\) return false;/
+  );
+});
+
+test('HTML5 fallback은 합성 키프레임 선택을 지운 뒤 레거시 레이어를 렌더한다', () => {
+  const renderSource = appSource.match(
+    /function renderActiveDrawingLayers\(\) \{[\s\S]*?\n  \}\n\n  function requiresMpvReviewFreeze/
+  )?.[0]?.replace(/\n\n  function requiresMpvReviewFreeze$/, '');
+  assert.ok(renderSource, 'renderActiveDrawingLayers source should be extractable');
+
+  const legacyLayers = [{ id: 'legacy-layer' }];
+  const calls = [];
+  const timelineHarness = {
+    selectedKeyframes: [{ layerId: 'fabric-pilot-drawing-layer', frame: 0 }],
+    clearSelection() {
+      calls.push('clear');
+      this.selectedKeyframes = [];
+    },
+    renderDrawingLayers(layers, activeLayerId) {
+      calls.push({ type: 'render', layers, activeLayerId });
+    }
+  };
+  const renderActiveDrawingLayers = new Function(
+    'getFabricPilotTimelineLayers',
+    'timeline',
+    'drawingManager',
+    `${renderSource}\nreturn renderActiveDrawingLayers;`
+  )(
+    () => null,
+    timelineHarness,
+    { layers: legacyLayers, activeLayerId: 'legacy-layer' }
+  );
+
+  renderActiveDrawingLayers();
+
+  assert.deepEqual(calls, [
+    'clear',
+    { type: 'render', layers: legacyLayers, activeLayerId: 'legacy-layer' }
+  ]);
+
+  calls.length = 0;
+  timelineHarness.selectedKeyframes = [{ layerId: 'legacy-layer', frame: 12 }];
+
+  renderActiveDrawingLayers();
+
+  assert.deepEqual(calls, [
+    { type: 'render', layers: legacyLayers, activeLayerId: 'legacy-layer' }
+  ]);
 });

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -363,13 +363,25 @@ test('HTML5 fallback은 합성 키프레임 선택을 지운 뒤 레거시 레�
     'drawingManager',
     'fabricDrawingPersistenceStore',
     'lastFabricPilotTimelineSourceEpoch',
+    'fabricDrawingPilotStatusSnapshot',
+    'lastFabricPilotTimelineVideoGeneration',
+    'lastFabricPilotTimelineStableVideoIdentity',
+    'videoPlayer',
+    'state',
+    'normalizeComparableFilePath',
     `${renderSource}\nreturn renderActiveDrawingLayers;`
   )(
     () => null,
     timelineHarness,
     { layers: legacyLayers, activeLayerId: 'legacy-layer' },
     { getSourceEpoch: () => 1 },
-    null
+    null,
+    { videoGeneration: 1 },
+    null,
+    null,
+    { filePath: 'C:\\videos\\a.mp4' },
+    { currentFile: 'C:\\videos\\a.mp4' },
+    value => String(value || '').replace(/\//g, '\\').toLowerCase()
   );
 
   renderActiveDrawingLayers();
@@ -389,13 +401,15 @@ test('HTML5 fallback은 합성 키프레임 선택을 지운 뒤 레거시 레�
   ]);
 });
 
-test('mpv 드로잉 소스가 바뀌면 이전 합성 키프레임 선택을 지운다', () => {
+test('동일 mpv 원본 복구는 선택을 유지하고 실제 소스 교체만 선택을 지운다', () => {
   const renderSource = appSource.match(
     /function renderActiveDrawingLayers\(\) \{[\s\S]*?\n  \}\n\n  function requiresMpvReviewFreeze/
   )?.[0]?.replace(/\n\n  function requiresMpvReviewFreeze$/, '');
   assert.ok(renderSource, 'renderActiveDrawingLayers source should be extractable');
 
   let sourceEpoch = 1;
+  const statusSnapshot = { videoGeneration: 1 };
+  const videoPlayerHarness = { filePath: 'C:\\videos\\a.mp4' };
   const calls = [];
   const timelineHarness = {
     selectedKeyframes: [{ layerId: 'fabric-pilot-drawing-layer', frame: 12 }],
@@ -413,13 +427,25 @@ test('mpv 드로잉 소스가 바뀌면 이전 합성 키프레임 선택을 지
     'drawingManager',
     'fabricDrawingPersistenceStore',
     'lastFabricPilotTimelineSourceEpoch',
+    'fabricDrawingPilotStatusSnapshot',
+    'lastFabricPilotTimelineVideoGeneration',
+    'lastFabricPilotTimelineStableVideoIdentity',
+    'videoPlayer',
+    'state',
+    'normalizeComparableFilePath',
     `${renderSource}\nreturn renderActiveDrawingLayers;`
   )(
     () => [{ id: 'fabric-pilot-drawing-layer' }],
     timelineHarness,
     { layers: [], activeLayerId: null },
     { getSourceEpoch: () => sourceEpoch },
-    null
+    null,
+    statusSnapshot,
+    null,
+    null,
+    videoPlayerHarness,
+    { currentFile: videoPlayerHarness.filePath },
+    value => String(value || '').replace(/\//g, '\\').toLowerCase()
   );
 
   renderActiveDrawingLayers();
@@ -428,13 +454,31 @@ test('mpv 드로잉 소스가 바뀌면 이전 합성 키프레임 선택을 지
   calls.length = 0;
   sourceEpoch = 2;
   renderActiveDrawingLayers();
-  assert.deepEqual(calls, ['clear', 'render']);
+  assert.deepEqual(calls, ['render']);
 
   calls.length = 0;
   timelineHarness.selectedKeyframes = [{ layerId: 'fabric-pilot-drawing-layer', frame: 24 }];
+  videoPlayerHarness.filePath = 'C:\\videos\\b.mp4';
+  renderActiveDrawingLayers();
+  assert.deepEqual(calls, ['clear', 'render']);
+
+  calls.length = 0;
+  timelineHarness.selectedKeyframes = [{ layerId: 'fabric-pilot-drawing-layer', frame: 36 }];
   renderActiveDrawingLayers();
   assert.deepEqual(calls, ['render']);
-  assert.match(appSource, /let lastFabricPilotTimelineSourceEpoch = null;/);
+
+  calls.length = 0;
+  timelineHarness.selectedKeyframes = [{ layerId: 'fabric-pilot-drawing-layer', frame: 48 }];
+  statusSnapshot.videoGeneration = 2;
+  renderActiveDrawingLayers();
+  assert.deepEqual(calls, ['clear', 'render']);
+
+  calls.length = 0;
+  timelineHarness.selectedKeyframes = [{ layerId: 'fabric-pilot-drawing-layer', frame: 60 }];
+  renderActiveDrawingLayers();
+  assert.deepEqual(calls, ['render']);
+  assert.match(appSource, /let lastFabricPilotTimelineVideoGeneration = null;/);
+  assert.match(appSource, /let lastFabricPilotTimelineStableVideoIdentity = null;/);
 });
 
 test('읽기 전용 합성 행의 가시성·잠금 버튼은 숨긴다', () => {

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -244,12 +244,12 @@ test('release build scripts pin stable while trial build scripts pin trial regar
   assert.match(packageJson.scripts['test:mpv'], /runtime-profile\.test\.js/);
 });
 
-test('stable engine promotion uses the 2.1.2 beta release version consistently', () => {
+test('stable engine promotion uses the 2.2.0 beta release version consistently', () => {
   const rootDir = path.resolve(__dirname, '..', '..');
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.1.2-beta');
-  assert.equal(packageLock.version, '2.1.2-beta');
-  assert.equal(packageLock.packages[''].version, '2.1.2-beta');
+  assert.equal(packageJson.version, '2.2.0-beta');
+  assert.equal(packageLock.version, '2.2.0-beta');
+  assert.equal(packageLock.packages[''].version, '2.2.0-beta');
 });


### PR DESCRIPTION
## 📋 업데이트 요약

- 🎞️ Fabric 드로잉이 있는 프레임을 타임라인의 잠긴 `드로잉` 행과 클립으로 확인할 수 있습니다.
- ✏️ 새 획이 저장되면 해당 프레임의 클립도 바로 갱신됩니다.
- 🛡️ 이 클립은 보기 전용이라 끌어서 옮기거나 Delete·숫자 단축키로 바꿀 수 없습니다.
- 🔄 mpv와 일반 재생 화면을 오갈 때 이전 드로잉 선택이 남아 첫 삭제나 되돌리기를 방해하던 전환 문제도 함께 막았습니다.
- 🧩 일반 HTML5 재생에서는 기존 `레이어 1` 편집 화면을 그대로 사용합니다.

## 🔧 상세 기술 설명

- `renderer/scripts/app.js`에 `getFabricPilotTimelineLayers()`를 추가해 현재 hydration document의 유효 frame을 정렬하고 다음 keyframe 직전까지의 range와 `isEmpty`를 계산합니다. 결과는 `fabric-pilot-drawing-layer` 한 행으로만 투영하며 legacy `drawings`에는 쓰지 않습니다.
- `renderActiveDrawingLayers()`가 mpv Fabric 소유권일 때 합성 행을, 그 외에는 기존 `drawingManager.layers`를 렌더합니다. 기존 직접 렌더 14곳을 이 helper로 통일하고 persistence 변경은 requestAnimationFrame 한 번으로 합쳤습니다.
- state/hydration 변화는 기존 early-return 전에 반영하고, 합성 행이 활성일 때 keyframe drag와 선택 삭제를 차단합니다.
- 독립 리뷰에서 발견한 전환 선택 누출은 HTML5 fallback 직전에 합성 layer 선택이 있을 때만 `timeline.clearSelection()`하도록 좁게 처리했습니다. 순수 legacy 선택은 보존됩니다.
- `renderer/styles/main.css`는 합성 header/row만 표시하고 action 버튼은 계속 숨깁니다.
- `scripts/tests/fabric-drawing-pilot-source.test.js`는 실제 `renderActiveDrawingLayers()`를 추출·실행해 clear → legacy render 순서와 legacy 선택 보존을 검증합니다.
- `package.json`, `package-lock.json`, `runtime-profile.test.js`를 `2.2.0-beta`에 맞췄고 구현·검증 내역은 `DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md`에 기록했습니다.

## 🚧 개발 난항

- 계획서의 최종 수치 `1,933`은 실제로 PR ① 작업 1~5 완료 수치였습니다. 기준 1,925에 계획 명시 테스트 9개를 더하면 1,934이고, 독립 리뷰 후 승인된 회귀 테스트 1개까지 포함해 최종 실측은 1,935입니다.
- 버전 상승 시 `runtime-profile.test.js`의 고정 버전 assertion도 함께 바뀌어야 하지만 계획 파일 목록에 빠져 있었습니다. 생산 동작을 건드리지 않고 테스트 이름 1곳과 버전 리터럴 3곳만 갱신했습니다.
- 최초 구현 후 독립 리뷰에서 보이지 않는 합성 선택이 HTML5로 넘어가 no-op undo를 만들 수 있음을 발견했습니다. 생산 코드보다 실행형 테스트를 먼저 추가해 1건 RED를 확인한 뒤 조건부 정리로 GREEN을 만들었습니다.
- Windows 수동 검증에서 native overlay 특성 때문에 B 진입 직후 툴바의 첫 화면 캡처는 명확하지 않았습니다. 새 획 저장·타임라인 반영·drag/Delete/숫자 단축키 차단·HTML5 fallback은 확인했으며, 첫 입력 전 툴바 노출은 자동 회귀 테스트 근거와 수동 캡처 경계를 구분해 DEVLOG에 남겼습니다.
- passive 상태에서 정지한 채 다른 frame으로 직접 seek할 때 즉시 재도색할 통지 채널이 없는 제한은 이번 명시 범위 밖이라 유지했습니다.

## ✅ 테스트 가이드

### 실사용자용

1. mpv 직접 재생이 켜진 상태에서 `drawingsV3`가 든 파일을 열고 타임라인에 잠긴 `드로잉` 행과 해당 프레임 클립이 보이는지 확인합니다.
2. B로 드로잉에 들어가 새 획을 그린 뒤 클립이 바로 생기는지 확인합니다.
3. 클립 drag, Delete, `2`·`3`·`4`·`Shift+2`를 시도해 드로잉과 파일 내용이 바뀌지 않는지 확인합니다.
4. mpv 직접 재생을 잠시 끄고 같은 파일을 열어 기존 `레이어 1`과 레이어 편집 UI가 그대로 보이는지 확인한 뒤 설정을 복원합니다.

### 개발자용

- Task 6 계획 RED: `test:fabric-drawing-pilot` 347 tests / 345 pass / 2 fail / cancelled 0 / exit 1
- Task 6 계획 GREEN: 347/347 / fail 0 / cancelled 0 / exit 0
- 리뷰 보강 RED: 348 tests / 347 pass / 1 fail / cancelled 0 / exit 1
- 리뷰 보강 GREEN: 348/348 / fail 0 / cancelled 0 / exit 0
- 부록 B 전체: 25 scripts / 1,935 pass / fail 0 / cancelled 0 / failed scripts 0
- `node --check renderer/scripts/app.js`: exit 0
- `npm.cmd run build`: `2.2.0-beta` Windows x64 packaging exit 0
- 독립 재리뷰 3건: Critical 0 / Important 0 / Ready Yes