### PR TITLE
[v2.2.0-beta] 드로잉 타임라인 통합 테스트 보강

### DIFF
--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -2167,7 +2167,7 @@ function createActualLoadRaceScenario({
     scheduleDeferredCollaborationStart: () => {}, startCollaborationForVideoLoad: async () => true,
     startDeferredReviewFileDiscovery: () => {},
     showToast: (message, type) => { effects.toasts.push({ message, type }); },
-    renderVideoMarkers: () => {},
+    renderVideoMarkers: () => {}, renderActiveDrawingLayers: () => {},
     updateTimelineMarkers: () => {}, updateCommentList: () => {},
     compositionLayerManager: { setVideoInfo: () => {}, setPlaybackState: () => {}, render: () => {} },
     renderCompositionLayerTimeline: () => {}, renderHighlights: () => {},


### PR DESCRIPTION
## 📋 업데이트 요약

- 드로잉 타임라인 변경과 재생목록 전환 검증이 함께 실행될 때 발생하던 잘못된 실패를 바로잡았습니다.
- 실제 앱 기능이나 화면은 바뀌지 않으며, 배포 전 검증이 실제 동작과 같은 조건에서 정확하게 수행됩니다.

## 🔧 상세 기술 설명

- scripts/tests/playlist-continuous-runtime.test.js의 createActualLoadRaceScenario 테스트 환경에 renderActiveDrawingLayers 더미 의존성을 추가했습니다.
- Task 6 이후 loadVideo가 드로잉 타임라인 렌더 헬퍼를 호출하지만, 동시에 main에 합쳐진 재생목록 실행형 테스트는 해당 의존성을 제공하지 않아 ReferenceError를 영상 로드 실패로 해석했습니다.
- 제품 코드와 버전은 변경하지 않았습니다.

## 🚧 개발 난항

- PR #176과 PR #178은 각각의 브랜치에서는 통과했지만, 두 변경이 main에서 처음 만난 exact-merge 전체 검증에서 재생목록 테스트 9개가 연속 실패했습니다.
- 실패 뒤 보류 중인 비동기 약속 때문에 테스트 프로세스가 종료되지 않는 현상까지 있어, exact-merge RED를 재현한 뒤 테스트 하네스 누락과 제품 회귀를 분리했습니다.

## ✅ 테스트 가이드

### 실사용자용

- 제품 동작 변경은 없습니다.
- 배포 후 mpv 영상에서 드로잉 타임라인 행이 표시되고, 이어붙이기 재생 전환이 정상인지 확인합니다.

### 개발자용

- RED: test:playlist 303개 중 294 통과, 9 실패, 취소 0.
- GREEN: test:playlist 318/318 통과, 실패·취소 0.
- 전체: 25개 테스트 스크립트 2,008/2,008 통과, 실패·취소 0.