### PR TITLE
[v2.2.1-beta] B 해제 후 드로잉 표시 복원

### DIFF
--- a/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
+++ b/DEVLOG/2026-08-24-드로잉-표시-반영-회귀-구현.md
@@ -260,3 +260,84 @@ Codex 4차 리뷰 보강 RED는 빈 playlist/cutlist에서도 mode-only `[]`가 
 - PR ①은 [#177](https://github.com/baehandoridori/BAEFRAME/pull/177)로 merge됐고 merge commit은 `e0a4ee68afcf6c51e0f5897b9d8241aa0e042658`이다.
 - PR ②는 [#178](https://github.com/baehandoridori/BAEFRAME/pull/178)이며 위 merge commit에서 분기한 `feat/드로잉-타임라인-레이어-투영`에 작업 6 구현 커밋과 Codex 리뷰 보강 커밋들을 포함한다.
 - PR ② 버전은 `2.2.0-beta`이며, Codex 4차 P2 두 건의 RED→GREEN 보강 뒤 명시 완료 신호를 다시 받아 머지·배포한다.
+
+## 2026-08-25 후속 핫픽스: B 해제 뒤 드로잉 표시 복원
+
+### 사용자 증상과 원인
+
+- 증상: 드로잉 레이어와 저장 데이터는 정상인데 B로 드로잉 모드를 해제하면 영상 위의 획과 툴바가 사라지고, 다시 B를 눌러도 보이지 않았다.
+- 실제 패키지의 실패 상태에서 Fabric runtime은 frame 0의 object 2개와 오류 없는 scene을 계속 보유했다. overlay 문서의 lower canvas에도 alpha pixel 2,938개가 남아 있어 데이터 삭제나 캔버스 clear가 아님을 확인했다.
+- Windows HWND 순서를 직접 확인하자 같은 bounds의 mpv embed BrowserWindow가 Fabric overlay BrowserWindow 바로 위에 있었다. B 전환의 `setFocusable()`/포커스 반환이 두 sibling 창의 z-order를 바꾼 것이 화면 소실의 원인이었다.
+- 처음 검토한 runtime 강제 `renderAll()`과 `webContents.invalidate()`만으로는 가려진 창 내부 픽셀만 다시 그릴 뿐 창 순서를 복원하지 못했다. 패키지 재현에서 효과가 없음을 확인하고 runtime 소스·IIFE 변경은 모두 제거했다.
+
+### 최소 구현
+
+- `main/mpv-overlay-host.js`
+  - B-on: 네이티브 입력 플래그 확정 뒤 overlay를 `moveTop()`하고 invalidate한다.
+  - B-off: passive scene runtime 반영이 성공하고 요청이 여전히 최신일 때 overlay를 `moveTop()`하고 invalidate한다.
+  - 늦게 끝난 과거 enable을 최신 disable로 보상하는 경로도 runtime의 중복 요청 거절 여부와 무관하게 최신 토큰을 재검증한 뒤 overlay 순서를 복원한다.
+- `scripts/tests/mpv-overlay-host.test.js`
+  - B-on, B-off, 늦은 enable 보상의 runtime/native/restack 순서를 각각 실행 검증한다.
+  - 보상용 중복 disable은 실제 runtime 계약대로 `accepted: false`를 반환하도록 해, 잘못된 accepted 조건을 판별한다.
+- `scripts/run-fabric-drawing-pilot-diagnostics.js`와 통합 테스트
+  - 기존의 “B 100회 동안 moveTop 0회” 계약을, 초기 미준비 disable을 제외한 99회의 준비된 입력 전환과 정확히 일치하는 restack 계약으로 교체했다.
+  - 창 생성·로드·bounds·show/hide·destroy, 영상 소유자, 재생, 타임라인, 저장 무변경 계약은 그대로 유지한다.
+- 버전: `2.2.1-beta`로 patch +1하고 package/lock/runtime profile 기대값을 함께 맞췄다.
+
+### RED → GREEN
+
+| 판별 | RED | GREEN |
+|---|---|---|
+| B-on/B-off 창 순서 복원 | 생산 코드 수정 전 focused 2 tests / pass 0 / fail 2 / cancelled 0 / exit 1 | 2/2 / fail 0 / cancelled 0 / exit 0 |
+| 늦은 enable 보상 | 실제 중복 disable을 `accepted: false`로 만든 focused 1 test / pass 0 / fail 1 / cancelled 0 / exit 1 | 1/1 / fail 0 / cancelled 0 / exit 0 |
+| 원본 구현 역주입 독립 판별 | host 전체 80 tests 중 pass 77 / fail 3 / cancelled 0 / exit 1 | 현 구현 host 80/80 / fail 0 / cancelled 0 / exit 0 |
+| 통합 진단 계약 | 새 99회 restack 기대를 적용한 직후 focused 368 tests / pass 367 / fail 1 / cancelled 0 / exit 1 | 진단 validator 갱신 뒤 368/368 / fail 0 / cancelled 0 / exit 0 |
+
+### 계획 및 기존 계약과 달라진 지점
+
+- 원 계획과 기존 통합 진단은 B 토글 중 `moveTop`이 0회여야 한다고 가정했다. 실제 Windows 패키지에서 focusable 전환이 sibling mpv 창을 overlay 위로 올리는 반례를 확인했으므로, 이 가정만 실기 증거에 맞게 변경했다.
+- `moveTop()`은 `alwaysOnTop`을 켜지 않으며, 이 host가 bounds/show/reposition 경로에서 이미 사용하던 동일한 복원 동작이다. 창 hide/show나 Fabric scene 의미는 변경하지 않았다.
+- Fabric runtime과 생성 IIFE는 `origin/main`과 동일하다. 런타임 수정 커밋이 아니므로 번들 추적 diff도 없다.
+
+### Windows 패키지 실기 검증
+
+- `2.2.1-beta` unpacked 패키지에서 frame 0의 object 2개 fixture를 열어 B-on 화면의 획과 툴바를 확인했다.
+- B 20회, 250ms 간격: 224개 화면 샘플 모두 획 유지, 최종 object 2개, 오류 0.
+- B 100회, 25ms 간격 재검증: 178개 화면 샘플 모두 획 유지, red pixel 최소/최대 모두 185, 최종 active/input enabled, input revision 222, object 2개, frame 0, stale drop 0, surface error 0.
+- 최종 B-off: 획은 보이고 툴바만 의도대로 숨김, canvas alpha pixel 2,938개, passive/input disabled, 오류 0.
+- 최종 B-on: 획과 툴바 모두 다시 표시, active/input enabled, object 2개, frame 0, 오류 0.
+
+### 후속 전체 검증
+
+| script | exit | tests | pass | fail | cancelled |
+|---|---:|---:|---:|---:|---:|
+| `test:fabric-drawing-pilot` | 0 | 368 | 368 | 0 | 0 |
+| `test:fabric-drawing-persistence` | 0 | 155 | 155 | 0 | 0 |
+| `test:recent` | 0 | 18 | 18 | 0 | 0 |
+| `test:frame-grid` | 0 | 35 | 35 | 0 | 0 |
+| `test:cluster` | 0 | 43 | 43 | 0 | 0 |
+| `test:composition` | 0 | 60 | 60 | 0 | 0 |
+| `test:playlist-ordering` | 0 | 17 | 17 | 0 | 0 |
+| `test:playlist-continuous` | 0 | 13 | 13 | 0 | 0 |
+| `test:playlist-comments` | 0 | 9 | 9 | 0 | 0 |
+| `test:playlist` | 0 | 318 | 318 | 0 | 0 |
+| `test:cutlist` | 0 | 82 | 82 | 0 | 0 |
+| `test:drawing` | 0 | 291 | 291 | 0 | 0 |
+| `test:drawing-v3-hardening` | 0 | 174 | 174 | 0 | 0 |
+| `test:drawing-v3-adapter` | 0 | 34 | 34 | 0 | 0 |
+| `test:drawing-v3-store-observer` | 0 | 19 | 19 | 0 | 0 |
+| `test:video-pan` | 0 | 17 | 17 | 0 | 0 |
+| `test:mpv` | 0 | 302 | 302 | 0 | 0 |
+| `test:fps` | 0 | 7 | 7 | 0 | 0 |
+| `test:audio-waveform` | 0 | 2 | 2 | 0 | 0 |
+| `test:collaboration` | 0 | 5 | 5 | 0 | 0 |
+| `test:comment-input` | 0 | 19 | 19 | 0 | 0 |
+| `test:toast-stack` | 0 | 9 | 9 | 0 | 0 |
+| `test:version` | 0 | 2 | 2 | 0 | 0 |
+| `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
+| `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
+| **합계** | **모든 script 0** | **2,008** | **2,008** | **0** | **0** |
+
+- 계획 시작 기준 `1,925` 대비 `+83`이며 전체 통과했다.
+- `npm.cmd run build`: exit 0, `2.2.1-beta` Windows x64 unpacked build 완료.
+- `node --check` 대상 host/diagnostics와 `git diff --check`: 모두 exit 0.

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -2611,6 +2611,12 @@ class MPVOverlayHost {
     }
 
     const stillCurrent = this._inputRequestStillDesired(hostWindow, request);
+    if (!request.enabled && runtimeResult?.accepted === true && stillCurrent) {
+      // focusable:false 전환은 Windows에서 sibling mpv 창을 위로 올릴 수 있다.
+      // passive 장면을 다시 그린 뒤 overlay의 순서를 복원하고 즉시 present한다.
+      hostWindow.moveTop?.();
+      hostWindow.webContents?.invalidate?.();
+    }
     if (request.enabled && runtimeResult?.accepted === true && stillCurrent) {
       this.activeSessionId = request.session?.sessionId || null;
       this.currentToolRevision = 0;
@@ -3215,7 +3221,9 @@ class MPVOverlayHost {
       hostWindow.webContents?.invalidate?.();
       hostWindow.setFocusable?.(true);
       hostWindow.setIgnoreMouseEvents?.(false);
-      // 네이티브 확장 스타일 변경이 직전 repaint 예약을 무효화할 수 있어 한 번 더 강제한다
+      // 네이티브 확장 스타일 변경이 sibling mpv 창을 위로 올릴 수 있으므로
+      // overlay 순서를 복원한 뒤 재합성을 한 번 더 강제한다.
+      hostWindow.moveTop?.();
       hostWindow.webContents?.invalidate?.();
       return;
     }
@@ -3291,6 +3299,10 @@ class MPVOverlayHost {
     };
     try {
       await this._executeFabricMethod('setDrawingInput', disableRequest);
+      if (this._inputRequestStillDesired(hostWindow, disableRequest)) {
+        hostWindow.moveTop?.();
+        hostWindow.webContents?.invalidate?.();
+      }
     } catch (error) {
       this.fabricLastError = error.message;
       this.logger.debug('stale Fabric drawing enable compensation failed', { error: error.message });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.2.0-beta",
+  "version": "2.2.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.2.0-beta",
+      "version": "2.2.1-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.2.0-beta",
+  "version": "2.2.1-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/scripts/run-fabric-drawing-pilot-diagnostics.js
+++ b/scripts/run-fabric-drawing-pilot-diagnostics.js
@@ -271,10 +271,18 @@ function validateDiagnostics(raw) {
   }
 
   for (const field of HOST_LIFECYCLE_FIELDS) {
+    if (field === 'moveTop') continue;
     const delta = after.host[field] - before.host[field];
     if (delta !== 0) {
       violations.push(`host lifecycle changed: ${field} delta ${delta}`);
     }
+  }
+  const moveTopDelta = after.host.moveTop - before.host.moveTop;
+  const expectedMoveTopDelta = Math.max(0, toggleCount - 1);
+  if (moveTopDelta !== expectedMoveTopDelta) {
+    violations.push(
+      `overlay restack delta must match prepared input transitions; expected ${expectedMoveTopDelta}, received ${moveTopDelta}`
+    );
   }
   if (after.host.construct < 1) {
     violations.push('host was not constructed before the lifecycle baseline');

--- a/scripts/tests/fabric-drawing-pilot-integration.test.js
+++ b/scripts/tests/fabric-drawing-pilot-integration.test.js
@@ -660,6 +660,7 @@ function makeValidRawDiagnostics() {
   const after = structuredClone(before);
   after.controller.inputRevision = 101;
   after.counters.toggleCount = 100;
+  after.host.moveTop = before.host.moveTop + 99;
 
   return {
     before,
@@ -718,7 +719,7 @@ test('controller history shortcuts round-trip a real Fabric stroke without persi
   assert.equal(harness.runtime.getDiagnostics().lastError, null);
 });
 
-test('synthetic controller/runtime boundary preserves no-save, playback, owner, media, and timeline canaries', async (t) => {
+test('synthetic controller/runtime boundary restores native stack order and preserves all other canaries', async (t) => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'baeframe-fabric-drawing-'));
   t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
   const bframePath = path.join(tempDir, 'integration-evidence.bframe');
@@ -755,7 +756,10 @@ test('synthetic controller/runtime boundary preserves no-save, playback, owner, 
   const hostAfter = hostHarness.snapshot();
   assert.equal(hostHarness.windows.length, 1);
   assert.equal(hostHarness.host.window, hostWindow);
-  assert.deepEqual(hostAfter, hostBefore);
+  assert.deepEqual(hostAfter, {
+    ...hostBefore,
+    moveTop: hostBefore.moveTop + 99
+  });
 
   const shadowObserver = createThrowingDrawingV3Observer();
   const harness = createRuntimeControllerHarness({
@@ -936,6 +940,13 @@ test('validator rejects playback, save, host, file, owner, media, timeline, cont
       /host/i,
       (raw) => {
         raw.after.host.construct += 1;
+      }
+    ],
+    [
+      'overlay restack count',
+      /restack/i,
+      (raw) => {
+        raw.after.host.moveTop -= 1;
       }
     ],
     [

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -1870,7 +1870,7 @@ test('injects and prepares Fabric once per host generation before enabling nativ
   assert.equal(getReadCount(), 1);
 });
 
-test('successful drawing activation repaints before pointer input without z-order churn', async () => {
+test('successful drawing activation repaints and restores the overlay above the video host', async () => {
   const { host, events } = createDrawingHostHarness();
   const ensured = await host.ensure({ x: 0, y: 0, width: 640, height: 360 });
   const { hostGeneration } = ensured.drawingCapability;
@@ -1902,6 +1902,7 @@ test('successful drawing activation repaints before pointer input without z-orde
     name === 'setFocusable' && value === true);
   const nativeEnableIndex = events.findIndex(([name, value]) =>
     name === 'setIgnoreMouseEvents' && value === false);
+  const moveTopIndex = events.findIndex(([name]) => name === 'moveTop');
   assert.ok(runtimeEnableIndex >= 0);
   assert.ok(
     repaintIndex > runtimeEnableIndex,
@@ -1912,18 +1913,17 @@ test('successful drawing activation repaints before pointer input without z-orde
     'pointer activation must wait until the visible toolbar repaint is scheduled'
   );
   assert.ok(nativeEnableIndex > focusableEnableIndex);
-  assert.equal(
-    events.filter(([name]) => name === 'moveTop').length,
-    0,
-    'toggling drawing input must not restack the native window or reintroduce flicker'
+  assert.ok(
+    moveTopIndex > nativeEnableIndex,
+    'B-on must restore the overlay above the sibling mpv video host after native flags change'
   );
   const repaintIndices = events
     .map(([name], index) => (name === 'webContents.invalidate' ? index : -1))
     .filter(index => index >= 0);
   assert.ok(repaintIndices.length >= 2, '활성화 시퀀스는 강제 재합성을 두 번 이상 예약해야 한다');
   assert.ok(
-    repaintIndices[repaintIndices.length - 1] > nativeEnableIndex,
-    '네이티브 플래그 확정 뒤에도 재합성이 한 번 더 강제되어야 한다'
+    repaintIndices[repaintIndices.length - 1] > moveTopIndex,
+    '창 순서 복원 뒤에도 재합성이 한 번 더 강제되어야 한다'
   );
 });
 
@@ -1993,9 +1993,28 @@ test('relays keyboard input through the focused main renderer and restores main 
   const mainFocusIndex = events.findIndex(([name]) => name === 'mainWindow.focus');
   const focusableDisableIndex = events.findIndex(([name, value]) =>
     name === 'setFocusable' && value === false);
+  const runtimeDisableIndex = events.findIndex(([name, value]) =>
+    name === 'executeJavaScript' &&
+    value.includes?.('.setDrawingInput(') &&
+    value.includes('"enabled":false'));
+  const moveTopAfterRuntimeDisableIndex = events.findIndex(
+    ([name], index) => name === 'moveTop' && index > runtimeDisableIndex
+  );
+  const repaintAfterRuntimeDisableIndex = events.findIndex(
+    ([name], index) => name === 'webContents.invalidate' && index > runtimeDisableIndex
+  );
   assert.ok(ignoreIndex >= 0);
   assert.ok(focusableDisableIndex > ignoreIndex);
   assert.ok(mainFocusIndex > focusableDisableIndex);
+  assert.ok(runtimeDisableIndex > focusableDisableIndex);
+  assert.ok(
+    moveTopAfterRuntimeDisableIndex > runtimeDisableIndex,
+    'B-off must restore the passive drawing overlay above the sibling mpv video host'
+  );
+  assert.ok(
+    repaintAfterRuntimeDisableIndex > moveTopAfterRuntimeDisableIndex,
+    'B-off must present the Fabric repaint after restoring the native window order'
+  );
 });
 
 test('V Delete Space and repeat relay keep the active drawing overlay focused', async () => {
@@ -3242,6 +3261,12 @@ test('a later disable keeps click-through when an older enable finishes late', a
     executeDrawing(script) {
       if (!script.includes('.setDrawingInput(')) return undefined;
       const request = readFabricMethodPayload(script, 'setDrawingInput');
+      const duplicateDisable = !request.enabled && runtimeRequests.some(previous => (
+        !previous.enabled &&
+        previous.hostGeneration === request.hostGeneration &&
+        previous.videoGeneration === request.videoGeneration &&
+        previous.inputRevision === request.inputRevision
+      ));
       runtimeRequests.push(request);
       if (request.enabled) {
         return lateEnable.promise.then((result) => {
@@ -3250,7 +3275,7 @@ test('a later disable keeps click-through when an older enable finishes late', a
         });
       }
       runtimeEnabled = false;
-      return { accepted: true, enabled: false };
+      return { accepted: !duplicateDisable, enabled: false };
     }
   });
   const ensured = await host.ensure({ x: 0, y: 0, width: 640, height: 360 });
@@ -3294,6 +3319,30 @@ test('a later disable keeps click-through when an older enable finishes late', a
     inputRevision: 3,
     enabled: false
   });
+  const compensationDisableIndex = events
+    .map(([name, value], index) => (
+      name === 'executeJavaScript' &&
+      value.includes?.('.setDrawingInput(') &&
+      value.includes('"enabled":false')
+        ? index
+        : -1
+    ))
+    .filter(index => index >= 0)
+    .at(-1);
+  const compensationMoveTopIndex = events.findIndex(
+    ([name], index) => name === 'moveTop' && index > compensationDisableIndex
+  );
+  const compensationRepaintIndex = events.findIndex(
+    ([name], index) => name === 'webContents.invalidate' && index > compensationMoveTopIndex
+  );
+  assert.ok(
+    compensationMoveTopIndex > compensationDisableIndex,
+    'stale enable compensation must restore the passive overlay above the video host'
+  );
+  assert.ok(
+    compensationRepaintIndex > compensationMoveTopIndex,
+    'stale enable compensation must repaint after restoring the native window order'
+  );
 });
 
 test('revalidates desired input tokens after Fabric preparation before invoking the runtime', async () => {

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -244,12 +244,12 @@ test('release build scripts pin stable while trial build scripts pin trial regar
   assert.match(packageJson.scripts['test:mpv'], /runtime-profile\.test\.js/);
 });
 
-test('stable engine promotion uses the 2.2.0 beta release version consistently', () => {
+test('stable engine promotion uses the 2.2.1 beta release version consistently', () => {
   const rootDir = path.resolve(__dirname, '..', '..');
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.2.0-beta');
-  assert.equal(packageLock.version, '2.2.0-beta');
-  assert.equal(packageLock.packages[''].version, '2.2.0-beta');
+  assert.equal(packageJson.version, '2.2.1-beta');
+  assert.equal(packageLock.version, '2.2.1-beta');
+  assert.equal(packageLock.packages[''].version, '2.2.1-beta');
 });


### PR DESCRIPTION
## 📋 업데이트 요약

- 🖌️ 드로잉 모드에서 B를 눌러 나와도 영상 위의 드로잉이 그대로 보입니다.
- 🔁 다시 B를 눌러 들어가면 기존 획과 드로잉 도구가 정상적으로 다시 나타납니다.
- 🛡️ 빠르게 B를 반복 입력해도 드로잉 데이터와 영상 재생 상태가 바뀌지 않습니다.
- 🔢 테스트 버전을 2.2.1-beta로 올렸습니다.

## 🔧 상세 기술 설명

- main/mpv-overlay-host.js의 B-on/B-off 네이티브 입력 전환 뒤 Fabric overlay BrowserWindow를 moveTop()하고 invalidate()해 sibling mpv embed 창보다 위에 복원합니다.
- 비동기로 늦게 끝난 과거 enable 응답을 보상하는 경로에서도 최신 input token을 다시 확인한 뒤 같은 복원을 수행합니다. 중복 disable이 runtime에서 accepted:false로 거절되는 정상 경로도 처리합니다.
- scripts/tests/mpv-overlay-host.test.js에 B-on, B-off, stale enable compensation의 호출 순서와 경합 판별을 추가했습니다.
- Fabric 통합 진단은 기존 moveTop 0회 가정을 폐기하고, 100회 probe에서 초기 미준비 disable을 제외한 준비된 전환 99회와 restack 횟수가 정확히 일치하도록 검증합니다. 창 생성·삭제, 저장, 재생, 타임라인 불변식은 유지합니다.
- Fabric runtime 소스와 생성 IIFE는 origin/main과 동일하며 이번 수정에는 포함하지 않았습니다.

## 🚧 개발 난항

- 처음에는 캔버스 재도색 문제로 보고 renderAll()과 invalidate()를 보강했지만, 단위 테스트는 통과해도 실제 Windows 패키지에서는 증상이 남았습니다.
- 실패 상태의 overlay 문서와 canvas에는 object 2개와 alpha pixel이 그대로 남아 있었습니다. Windows HWND 순서를 직접 확인한 결과 mpv 영상 창이 드로잉 창 바로 위로 올라가 화면을 덮고 있었습니다.
- 기존 설계와 통합 진단은 B 토글 중 창 재정렬 0회를 요구했지만, setFocusable 전환이 sibling 창 순서를 바꾸는 실제 Windows 반례가 확인돼 해당 계약만 수정했습니다.
- 늦은 enable 보상에서는 같은 revision의 중복 disable이 accepted:false가 되는 runtime 규칙을 테스트에 그대로 반영해 잘못된 accepted 조건화를 막았습니다.

## ✅ 테스트 가이드

### 실사용자용

1. 영상 frame 0에서 B를 누르고 획을 그립니다.
2. B를 눌러 드로잉 모드에서 나왔을 때 획은 남고 도구만 숨는지 확인합니다.
3. 다시 B를 눌렀을 때 획과 도구가 모두 보이는지 확인합니다.
4. B를 빠르게 여러 번 반복한 뒤에도 획이 사라지지 않는지 확인합니다.

실제 Windows unpacked 패키지에서 B 20회/250ms와 B 100회/25ms를 검증했고 마지막 100회 실행의 178개 화면 샘플 모두 획을 유지했습니다.

### 개발자용

- npm.cmd run test:fabric-drawing-pilot: 368/368 PASS
- npm.cmd run test:mpv: 302/302 PASS
- 전체 25-suite: 2,008/2,008 PASS, fail 0, cancelled 0
- npm.cmd run build: exit 0
- node --check 및 git diff --check: exit 0
- origin/main host 구현 역주입: 새 판별 테스트 3개 RED
- 현 구현: host 80/80 GREEN