### PR TITLE
[v2.3.0] 드로잉 키프레임 재생 표시와 이동 완성

### DIFF
--- a/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
+++ b/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
@@ -127,12 +127,13 @@
 | 지연된 B-on 승인 시 live frame 관측 | display controller 1 / pass 0 / fail 1 / cancelled 0 / exit 1, pointerdown target 10(기대 20) | 1/1 / fail 0 / cancelled 0 / exit 0; 승인 시점 context frame 20 확정 |
 | 지연된 B-on 승인 직후 runtime preview | display controller 1 / pass 0 / fail 1 / cancelled 0 / exit 1, frame update `[]`(기대 `[20]`) | 1/1 / fail 0 / cancelled 0 / exit 0; changed frame forced active sync |
 | pointerdown 승인 대기 중 coalesced 펜 샘플 | focused 2 / pass 0 / fail 2 / cancelled 0 / exit 1, 중간 좌표·압력 유실 및 1,024개 상한 미적용 | 2/2 / fail 0 / cancelled 0 / exit 0; 순서 보존·초과 시 gesture 취소 |
+| buffered pointerup 뒤 implicit capture loss | focused 2 / pass 1 / fail 1 / cancelled 0 / exit 1, confirm이 stale로 거절 | 2/2 / fail 0 / cancelled 0 / exit 0; 정상 완료 보존·pointerup 전 capture loss는 계속 취소 |
 
 ## 최종 25-suite 게이트
 
 | script | exit | tests | pass | fail | cancelled |
 |---|---:|---:|---:|---:|---:|
-| `test:fabric-drawing-pilot` | 0 | 436 | 436 | 0 | 0 |
+| `test:fabric-drawing-pilot` | 0 | 438 | 438 | 0 | 0 |
 | `test:fabric-drawing-persistence` | 0 | 156 | 156 | 0 | 0 |
 | `test:recent` | 0 | 18 | 18 | 0 | 0 |
 | `test:frame-grid` | 0 | 38 | 38 | 0 | 0 |
@@ -157,13 +158,13 @@
 | `test:version` | 0 | 2 | 2 | 0 | 0 |
 | `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
 | `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
-| **합계** | **모두 0** | **2,107** | **2,107** | **0** | **0** |
+| **합계** | **모두 0** | **2,109** | **2,109** | **0** | **0** |
 
-- 사용자 지정 기준선 `1,925` 대비 `+182`개이며 25개 named suite가 모두 통과했다.
+- 사용자 지정 기준선 `1,925` 대비 `+184`개이며 25개 named suite가 모두 통과했다.
 - ESLint: exit 0, error 0, 기존 warning 59.
 - 변경 생산 JavaScript 9개 `node --check`: exit 0.
 - `git diff --check`: exit 0.
-- runtime bundle 2회 재생성 SHA-256 일치: `AF738246C1D1841F83902393CCD256E0973F1299F687BD349574F368D49F7B43`.
+- runtime bundle 2회 재생성 SHA-256 일치: `FF8C4A08EF3FEF5512D0B42035CA9C46D7BDD7AF5E374903C03C152C36FCDFEF`.
 - Windows x64 unpacked preflight build: exit 0.
 
 ## Windows 패키지 실기 검증
@@ -193,6 +194,7 @@
 10. 같은 리뷰에서 passive 표시 IPC만 deadline 없이 raw Promise를 기다리는 비대칭이 발견됐다. 기존 persistence IPC deadline을 적용해 미응답 요청을 false로 정리하고 최신 trailing 한 건을 계속 처리하도록 맞췄다.
 11. PR 2차 리뷰에서 B-on input 승인이 지연되는 동안 playhead가 이동해도 준비 완료 시 옛 session frame을 새 시각의 관측으로 기록하는 경합이 발견됐다. 승인 시점의 live context frame을 다시 샘플하고, 달라졌으면 observation과 runtime preview를 forced active-frame sync로 함께 맞췄다.
 12. PR 3차 리뷰에서 pointerdown 프레임 승인을 기다리는 동안 브라우저가 묶어 보낸 고주파 펜 좌표를 wrapper 한 점으로 축약하는 입력 손실이 발견됐다. 일반 입력 경로와 같은 coalesced sample 순서를 pending buffer에도 적용하고, 기존 1,024개 상한을 묶음 전체에 원자적으로 검사했다.
+13. PR 4차 리뷰에서 빠른 클릭의 `pointerup`이 pending buffer에 들어간 직후 브라우저의 implicit `lostpointercapture`가 정상 완료 gesture를 취소하는 경합이 발견됐다. 같은 포인터의 buffered pointerup이 이미 있을 때만 capture loss를 정상 종료로 무시하고, 그 전의 실제 capture loss·pointercancel·blur는 계속 실패로 닫았다.
 
 ## 리스크와 보호 범위
 
@@ -204,6 +206,7 @@
 - passive 표시 IPC는 deadline 뒤 in-flight를 해제하고 최신 trailing 한 건만 이어서 전송한다. 늦은 응답은 accepted signature를 바꾸지 않는다.
 - B-on input 승인 시점에는 live playhead를 다시 샘플한다. 초기 session frame과 달라졌으면 pointerdown observation과 runtime preview를 같은 active-frame 요청으로 즉시 맞춘다.
 - pointerdown 승인을 기다리는 펜 이동은 coalesced 좌표와 pressure를 순서대로 보존하며, 총 pending event가 1,024개를 넘으면 부분 stroke를 만들지 않고 입력을 취소한다.
+- pending pointerup 뒤의 implicit capture loss는 정상 완료를 보존하지만, pointerup 전에 capture를 잃으면 부분 입력을 저장하지 않고 취소한다.
 - 적용 대상 mpv Fabric 준비 실패는 자동재생보다 먼저 load를 실패로 닫고, 비적용 엔진·소유권 경로에는 이 판정을 확장하지 않는다.
 - 비동기 키프레임 이동의 history 예약은 이동 action과 대기 외부 action의 FIFO 순서를 보장하며, owner 상실이나 이동 실패에서도 대기 action을 유실하지 않는다.
 - 실제 Windows modal/background/다른 앱과의 상대 z-order는 자동 테스트가 완전히 모델링하지 못한다. current accepted 요청에만 restack하는 범위로 부작용을 제한했다.

--- a/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
+++ b/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
@@ -1,0 +1,207 @@
+# 드로잉 키프레임 표시·이동 구현
+
+- 기준 브랜치/커밋: `origin/main` / `68d37ac`
+- 기준 버전: `2.2.1-beta`
+- 구현 버전: `2.3.0-beta`
+- 작업 브랜치: `codex/드로잉-키프레임-표시-이동`
+- 설계: `docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md`
+- 구현일: 2026-08-25
+
+## 요약
+
+| Phase | 사용자 결과 | 주요 수정 영역 | 상태 |
+|---|---|---|---|
+| 1. 의미 계약 | Adobe Animate 방식의 exact marker·hold·empty break·overwrite를 고정 | 설계 문서, 실행형 테스트 | ✅ 완료 |
+| 2. 재생 표시 | B를 누르지 않아도 현재 프레임의 드로잉이 재생·탐색 중 표시됨 | app, controller, preload/IPC, host, runtime/IIFE | ✅ 완료 |
+| 3. 편집·이동 | B-on 재생 중 새 획은 현재 프레임에 생기고, 타임라인 이동은 기존 목적지를 덮어씀 | persistence store, timeline, app | ✅ 완료 |
+| 4. 콜드 스타트·검증 | 협업 연결을 기다리지 않고 로컬 드로잉을 먼저 준비하며 자동재생도 그 뒤 시작 | app, playlist runtime test, 전체 게이트, Windows 실기 | ✅ 완료 |
+| 5. 릴리스 | PR 리뷰·merge commit 빌드·공유드라이브 교체·해시 parity | GitHub, release worktree, 공유드라이브 | 🔄 진행중 |
+
+## 배경과 사용자에게 보이는 결과
+
+기존 Fabric 드로잉은 `.bframe`의 `drawingsV3`에 프레임별로 정상 저장됐지만, B-off 화면은 마지막으로 활성화한 장면만 계속 다시 그렸다. 그래서 100f 드로잉이 100f 전에도 남고, 여러 키프레임이 있어도 마지막 장면만 보였다. 반대로 B를 다시 누르면 그 순간의 exact scene을 읽어 화면이 나타났기 때문에 B가 사실상 표시 스위치처럼 보였다.
+
+이번 구현은 B를 입력·편집 스위치로만 남긴다. 첫 키프레임 전에는 blank, 내용 키프레임부터 다음 키프레임 직전까지는 hold, 빈 키프레임부터는 다시 blank다. 재생 중에도 source keyframe이 바뀌는 순간 장면이 바뀌고, B-on 상태에서 재생한 뒤 새로 그리면 첫 입력 시점의 현재 프레임에 copy-on-write 키프레임이 생긴다.
+
+타임라인의 Fabric 마커는 정확한 프레임에 유지하되 노출 막대는 다음 키프레임 직전까지 보인다. 마커를 빈 프레임으로 옮기면 이동하고, 다른 키프레임 위로 옮기면 사용자가 승인한 Adobe Animate 방식대로 목적지를 통째로 덮어쓴다. undo/redo는 덮어쓰기 전 목적지도 함께 복구한다.
+
+## 실기에서 추가로 확인한 세 가지 원인
+
+1. **표시 DTO 불일치**
+   - controller는 공통 protocol envelope를 passive 표시 요청에 덧붙였다.
+   - host/runtime는 표시 전용 exact-key DTO만 허용해 실제 경로가 `invalid-presentation-request`로 거부됐다.
+   - 단위 IPC stub이 extra key를 검사하지 않아 거짓 GREEN이었다.
+
+2. **네이티브 창 순서**
+   - runtime canvas에는 픽셀이 있었지만 sibling mpv embed BrowserWindow가 overlay 위에 있었다.
+   - B-on만 `moveTop()`을 실행해 그때서야 이미 그려진 장면이 보였다.
+   - passive current request가 승인된 경우에만 `runtime render → moveTop → invalidate` 순서로 복구했다.
+
+3. **협업 대기가 로컬 준비를 차단**
+   - `loadVideo()`가 로컬 review 설치 뒤 협업 저장소 연결을 먼저 `await`하고 Fabric `afterVideoReady()`를 나중에 호출했다.
+   - 실제 콜드 스타트에서 협업 `getStorage()` Promise가 pending이라 controller는 `recovering`, host는 `videoGeneration: -1`, runtime은 미준비 상태에 머물렀다.
+   - 순서를 `setVideoFile → setFps → afterVideoReady → 선택적 자동재생 → collaboration`으로 바꿨다. `!engineSwap`, load token, stale/cancel guard는 유지했다.
+
+## Phase 1: 표시 의미와 저장 모델
+
+### 구현
+
+- persistence store가 `targetFrame` 이하의 마지막 keyframe을 표시 `sourceFrame`으로 해석한다.
+- empty keyframe도 유효한 source로 유지하되 화면은 비워 이전 hold를 끊는다.
+- runtime은 passive 표시만으로 scene·transition·history를 만들지 않는다.
+- hold 프레임의 B-on은 source를 읽기 전용으로 보여 주고, 첫 실제 mutation 직전에만 target exact scene으로 materialize한다.
+- pointerdown을 controller가 관측한 프레임과 handshake해 한 획 전체를 같은 프레임에 고정한다. confirm 실패·timeout·stale owner는 negative ACK로 pending 입력을 해제한다.
+- passive viewport는 영상 원본 크기, canvas rect, zoom/pan을 함께 적용해 fresh host와 B-off resize에서도 좌표를 유지한다.
+
+### 주요 파일
+
+- `renderer/scripts/modules/fabric-drawing-persistence-store.js`
+- `renderer/scripts/modules/fabric-drawing-pilot-controller.js`
+- `renderer/scripts/modules/mpv-fabric-overlay-runtime.js`
+- `renderer/scripts/lib/mpv-fabric-overlay.iife.js`
+- `main/mpv-overlay-host.js`
+- `main/ipc-handlers.js`
+- `preload/preload.js`
+- `preload/mpv-overlay-preload.js`
+
+## Phase 2: B-off 재생 표시
+
+### 구현
+
+- `syncPlaybackPositionUI()`, mpv frame update, state passive 진입, 재생 시작이 현재 frame 표시 동기화를 호출한다.
+- controller는 source·store·viewport signature가 바뀔 때만 passive presentation을 보낸다.
+- passive DTO는 host/runtime allowlist와 같은 12개 필드만 보내며 공통 envelope를 섞지 않는다.
+- runtime은 source snapshot을 non-interactive Fabric canvas에 동기 도색한다.
+- host는 current·accepted 응답만 overlay `moveTop()`과 `invalidate()`로 전면 복구한다. stale·reject·throw는 창 순서를 바꾸지 않는다.
+- 실제 controller → host exact validator → runtime → Fabric canvas 통합 테스트가 정·역방향 hold/empty 상태와 B enable 0회를 검증한다.
+
+## Phase 3: active 재생 편집과 키프레임 이동
+
+### active 재생 편집
+
+- B-on 상태에서도 frame 후보를 지속 갱신하되 재생만으로 provisional scene이나 keyframe을 만들지 않는다.
+- 실제 pointerdown·clear·delete·undo·redo 직전에 최신 확정 frame으로 원자 retarget한다.
+- 획 도중 들어온 frame은 다음 입력까지 보류해 10f에서 시작한 획이 20f로 찢어지지 않게 한다.
+- source scene을 target에 copy-on-write하고 첫 mutation에서만 persistence transition을 만든다.
+- disable 직전 renderer store가 늦어도 runtime-local 최신 committed source를 보존해 직전 획이 옛 장면으로 되돌아가지 않는다.
+
+### 타임라인 이동
+
+- synthetic 행은 `locked: true`를 유지하면서 `timelineKeyframesMovable`로 marker drag만 허용한다.
+- Fabric drag는 legacy `drawingManager.moveKeyframes()`를 호출하지 않는다.
+- store는 모든 source/target을 먼저 검증하고 시작 스냅샷 기준으로 단일·다중·겹침 이동을 한 번에 적용한다.
+- 기존 목적지 keyframe은 source 스냅샷으로 덮어쓴다.
+- touched-frame before/after 스냅샷을 global history token으로 저장해 undo/redo 때 덮어쓴 목적지도 복구한다.
+- 비동기 persistence refresh를 시작하기 전에 global history 자리를 예약한다. 이동 tail 중 들어온 외부 action은 예약 뒤 FIFO로 대기하고, 전역 undo/redo는 예약 해제까지 기다려 실제 발생 순서대로 처리한다.
+- 이동 결과의 문서 owner가 사라져 history action을 commit하지 못해도 대기 중인 외부 action은 버리지 않고 원래 순서로 history에 반영한다.
+- 전역 Undo가 이미 실행 중이면 Fabric 이동은 store를 변경하기 전에 거절해 진행 중인 inverse action과 새 이동이 교차하지 않게 한다.
+- drag 중 source rerender가 발생하면 render revision fence로 옛 gesture를 폐기한다.
+
+## Phase 4: 콜드 스타트와 자동재생 순서
+
+- 로컬 review 설치와 FPS 확정 직후 Fabric `afterVideoReady()`를 실행한다.
+- mpv·비음성·Fabric 소유 경로에서는 `afterVideoReady()`가 명시적으로 `true`를 반환한 뒤에만 `playVideoAfterMediaLoad()`를 호출한다. `false`면 자동재생 전에 load를 실패로 닫고 Fabric 취소·파괴 정리를 수행한다.
+- HTML5, 음성, engine swap, mpv 비소유 경로는 이 fail-closed 판정의 비적용 control로 두어 기존 자동재생 의미를 유지한다. engine swap은 중복 `afterVideoReady()`도 호출하지 않는다.
+- 그 다음 협업 연결을 시작하므로 네트워크 저장소가 pending이어도 로컬 passive 표시와 첫 프레임은 준비된다.
+- engine swap은 기존 세션을 유지해 중복 수화를 건너뛰고, stale/cancel load는 기존 token fence로 종료한다.
+
+## RED → GREEN 기록
+
+| 판별 | RED | GREEN |
+|---|---|---|
+| persistence 이동·timeline drag | focused 56 / pass 48 / fail 8 / cancelled 0 / exit 1 | 56/56 / fail 0 / cancelled 0 / exit 0 |
+| passive viewport | focused 344 / pass 338 / fail 6 / cancelled 0 / exit 1 | 345/345 / fail 0 / cancelled 0 / exit 0 |
+| active frame retarget 1차 | focused 338 / pass 333 / fail 5 / cancelled 0 / exit 1 | 기능 보강 뒤 Fabric 397/397, mpv 306/306 |
+| active retarget 독립 리뷰 보강 | focused 360 / pass 346 / fail 14 / cancelled 0 / exit 1 | focused 363/363, Fabric 415/415, mpv 310/310 |
+| pointerdown handshake·negative ACK·stale passive source | focused 287 / pass 281 / fail 6 / cancelled 0 / exit 1 | focused 287/287, 6파일 통합 467/467, Fabric 427/427, mpv 320/320 |
+| 재생 시작 force-present | source focused 24 / pass 23 / fail 1 / cancelled 0 / exit 1 | 24/24 / fail 0 / cancelled 0 / exit 0 |
+| passive host restack | host 95 / pass 93 / fail 2 / cancelled 0 / exit 1 | 95/95 / fail 0 / cancelled 0 / exit 0 |
+| 실제 controller→host→runtime DTO | integration 8 / pass 7 / fail 1 / cancelled 0 / exit 1, `invalid-presentation-request` | 8/8 / fail 0 / cancelled 0 / exit 0 |
+| 콜드 스타트 local ready | 판별 테스트 각각 0/1 / fail 1 / exit 1 | 각각 1/1, focused 2/2 / fail 0 / cancelled 0 / exit 0 |
+| 적용 대상 mpv Fabric `readiness=false` fail-closed와 비적용 control | 6 / pass 5 / fail 1 / cancelled 0 / exit 1 | 6/6 / fail 0 / cancelled 0 / exit 0; HTML5·음성·engine swap·mpv 비소유 자동재생 유지 |
+| 이동 tail 중 Undo 대기 | 1 / pass 0 / fail 1 / cancelled 0 / exit 1 | 1/1 / fail 0 / cancelled 0 / exit 0 |
+| 이동 tail 중 외부 history push 순서 | 1 / pass 0 / fail 1 / cancelled 0 / exit 1 | 1/1 / fail 0 / cancelled 0 / exit 0 |
+| 전역 Undo 진행 중 inverse 이동 차단 | 1 / pass 0 / fail 1 / cancelled 0 / exit 1 | 1/1 / fail 0 / cancelled 0 / exit 0 |
+
+## 최종 25-suite 게이트
+
+| script | exit | tests | pass | fail | cancelled |
+|---|---:|---:|---:|---:|---:|
+| `test:fabric-drawing-pilot` | 0 | 431 | 431 | 0 | 0 |
+| `test:fabric-drawing-persistence` | 0 | 155 | 155 | 0 | 0 |
+| `test:recent` | 0 | 18 | 18 | 0 | 0 |
+| `test:frame-grid` | 0 | 38 | 38 | 0 | 0 |
+| `test:cluster` | 0 | 43 | 43 | 0 | 0 |
+| `test:composition` | 0 | 60 | 60 | 0 | 0 |
+| `test:playlist-ordering` | 0 | 17 | 17 | 0 | 0 |
+| `test:playlist-continuous` | 0 | 13 | 13 | 0 | 0 |
+| `test:playlist-comments` | 0 | 9 | 9 | 0 | 0 |
+| `test:playlist` | 0 | 326 | 326 | 0 | 0 |
+| `test:cutlist` | 0 | 82 | 82 | 0 | 0 |
+| `test:drawing` | 0 | 291 | 291 | 0 | 0 |
+| `test:drawing-v3-hardening` | 0 | 174 | 174 | 0 | 0 |
+| `test:drawing-v3-adapter` | 0 | 34 | 34 | 0 | 0 |
+| `test:drawing-v3-store-observer` | 0 | 19 | 19 | 0 | 0 |
+| `test:video-pan` | 0 | 17 | 17 | 0 | 0 |
+| `test:mpv` | 0 | 321 | 321 | 0 | 0 |
+| `test:fps` | 0 | 7 | 7 | 0 | 0 |
+| `test:audio-waveform` | 0 | 2 | 2 | 0 | 0 |
+| `test:collaboration` | 0 | 5 | 5 | 0 | 0 |
+| `test:comment-input` | 0 | 19 | 19 | 0 | 0 |
+| `test:toast-stack` | 0 | 9 | 9 | 0 | 0 |
+| `test:version` | 0 | 2 | 2 | 0 | 0 |
+| `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
+| `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
+| **합계** | **모두 0** | **2,101** | **2,101** | **0** | **0** |
+
+- 사용자 지정 기준선 `1,925` 대비 `+176`개이며 25개 named suite가 모두 통과했다.
+- ESLint: exit 0, error 0, 기존 warning 59.
+- 변경 생산 JavaScript 9개 `node --check`: exit 0.
+- `git diff --check`: exit 0.
+- runtime bundle 2회 재생성 SHA-256 일치: `9F4F0197817604520364B28B44747C927DDC94B58BB2D5EF35060ECDDEA9020B`.
+- Windows x64 unpacked preflight build: exit 0.
+
+## Windows 패키지 실기 검증
+
+- 빌드: `C:\Users\user\AppData\Local\Temp\BAEFRAME-passive-fixed-build-20260825-210212\win-unpacked`
+- fixture: `C:\Users\user\AppData\Local\Temp\BAEFRAME-15s-drawing-test-20260825-163704.mp4`와 인접 `.bframe`
+- fixture keyframe: 17, 26, 41, 141, 183, 197, 206, 226, 289, 321.
+- 새 multi-instance profile과 CDP port 9334로 실행하고 B를 한 번도 누르지 않았다.
+- 콜드 스타트 직후: body state `passive`, host/video generation `1/1`, runtime `prepared: true`, `desiredInputEnabled: false`, `lastError: null`.
+- B 입력 카운터: attempted 0 / accepted 0 / rejected 0.
+- 0f에서는 첫 keyframe 전 blank를 확인했다.
+- 재생 중 155f와 324f에서 각각 141f와 321f source의 누적 드로잉이 영상 위에 표시되는 것을 Windows 캡처로 확인했다.
+- 최종 overlay 진단: presentation revision 25, target 321, source 321, lower canvas alpha pixel 55,867, error 없음.
+- 검증 후 새 빌드만 종료했고, 사용자가 열어 둔 기존 BAEFRAME 프로세스는 건드리지 않았다.
+
+## 계획·설계와 실제가 달랐던 지점
+
+1. 이전 릴리스는 Fabric sparse scene을 exact 한 프레임 표시로 해석했지만, 사용자가 승인한 제품 의미는 Adobe Animate 방식의 exact marker + hold 노출이었다. 이번 설계가 이전 제한을 명시적으로 대체한다.
+2. component test의 IPC stub은 extra key를 허용해 실제 host exact validator의 거부를 놓쳤다. 실제 controller→host→runtime 통합 테스트를 추가했다.
+3. canvas redraw와 Chromium invalidate만으로는 Windows sibling BrowserWindow의 z-order가 복구되지 않았다. current accepted passive presentation에만 네이티브 restack을 추가했다.
+4. 초기 설계 뒤 실제 cold start에서 협업 await가 로컬 Fabric 준비를 막는 별도 순서 문제가 발견됐다. 로컬 준비와 자동재생을 협업보다 앞으로 이동했다.
+5. active 재생의 단순 비동기 frame push만으로는 pointerdown 프레임을 엄밀히 고정하지 못했다. pointerdown handshake, bounded request, negative ACK, owner/session fence로 확장했다.
+6. 이동 undo token은 덮어쓴 목적지까지 복구하기 위해 touched frame의 before/after deep snapshot을 보유한다. 매우 큰 문서에서는 global history 메모리 사용량이 커질 수 있으므로 후속 history byte cap 검토가 필요하다.
+7. 콜드 스타트 순서를 옮긴 첫 구현은 `afterVideoReady()`를 기다리기만 하고 반환값 `false`를 성공처럼 통과시켰다. 실제 mpv Fabric 소유 경로는 자동재생 전에 실패로 닫고, HTML5·음성·engine swap·mpv 비소유 경로는 기존 동작을 유지하도록 적용 경계를 추가했다.
+8. 최초 이동 구현은 persistence refresh tail이 끝난 뒤에야 global history action을 넣어, 그 사이 Undo가 이전 action을 꺼내거나 외부 push가 이동보다 앞에 놓일 수 있었다. 이동 시작 시 history 자리를 예약하고 외부 action을 FIFO로 보류하며, owner 상실 시에도 보류 action을 보존하고 진행 중 Undo와의 역방향 이동을 store commit 전에 차단했다.
+
+## 리스크와 보호 범위
+
+- legacy `drawings`, HTML5 drawing manager와 legacy undo는 변경하지 않는다.
+- Fabric layer header 잠금·가시성·삭제 제어는 계속 차단하고 marker drag만 허용한다.
+- playlist/cutlist의 실제 aggregate timeline에서는 로컬 frame 투영을 계속 억제한다.
+- stale host/video/input/session/source 응답은 최신 상태를 덮지 못한다.
+- passive frame IPC는 source·store·viewport가 같으면 중복 제거해 매 프레임 deep render하지 않는다.
+- 적용 대상 mpv Fabric 준비 실패는 자동재생보다 먼저 load를 실패로 닫고, 비적용 엔진·소유권 경로에는 이 판정을 확장하지 않는다.
+- 비동기 키프레임 이동의 history 예약은 이동 action과 대기 외부 action의 FIFO 순서를 보장하며, owner 상실이나 이동 실패에서도 대기 action을 유실하지 않는다.
+- 실제 Windows modal/background/다른 앱과의 상대 z-order는 자동 테스트가 완전히 모델링하지 못한다. current accepted 요청에만 restack하는 범위로 부작용을 제한했다.
+
+## 릴리스 기록
+
+- 구현 커밋: 배포 완료 후 기록
+- PR: 배포 완료 후 기록
+- Codex GitHub 리뷰: 배포 완료 후 기록
+- merge commit: 배포 완료 후 기록
+- exact-merge build: 배포 완료 후 기록
+- 공유드라이브 배포 경로: `G:\공유 드라이브\JBBJ 자료실\한솔이의 두근두근 실험실\BAEFRAME\테스트버전 빌드`
+- source → staging → live 전체 파일 path/size/SHA-256 parity: 배포 완료 후 실제 파일 수·zero-byte·mismatch·핵심 해시 기록

--- a/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
+++ b/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
@@ -126,12 +126,13 @@
 | passive 표시 IPC 영구 대기 복구 | display controller 1 / pass 0 / fail 1 / cancelled 0 / exit 1, 최신 trailing이 timeout | 1/1 / fail 0 / cancelled 0 / exit 0; deadline 뒤 최신 trailing 전송·늦은 응답 폐기 |
 | 지연된 B-on 승인 시 live frame 관측 | display controller 1 / pass 0 / fail 1 / cancelled 0 / exit 1, pointerdown target 10(기대 20) | 1/1 / fail 0 / cancelled 0 / exit 0; 승인 시점 context frame 20 확정 |
 | 지연된 B-on 승인 직후 runtime preview | display controller 1 / pass 0 / fail 1 / cancelled 0 / exit 1, frame update `[]`(기대 `[20]`) | 1/1 / fail 0 / cancelled 0 / exit 0; changed frame forced active sync |
+| pointerdown 승인 대기 중 coalesced 펜 샘플 | focused 2 / pass 0 / fail 2 / cancelled 0 / exit 1, 중간 좌표·압력 유실 및 1,024개 상한 미적용 | 2/2 / fail 0 / cancelled 0 / exit 0; 순서 보존·초과 시 gesture 취소 |
 
 ## 최종 25-suite 게이트
 
 | script | exit | tests | pass | fail | cancelled |
 |---|---:|---:|---:|---:|---:|
-| `test:fabric-drawing-pilot` | 0 | 434 | 434 | 0 | 0 |
+| `test:fabric-drawing-pilot` | 0 | 436 | 436 | 0 | 0 |
 | `test:fabric-drawing-persistence` | 0 | 156 | 156 | 0 | 0 |
 | `test:recent` | 0 | 18 | 18 | 0 | 0 |
 | `test:frame-grid` | 0 | 38 | 38 | 0 | 0 |
@@ -156,13 +157,13 @@
 | `test:version` | 0 | 2 | 2 | 0 | 0 |
 | `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
 | `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
-| **합계** | **모두 0** | **2,105** | **2,105** | **0** | **0** |
+| **합계** | **모두 0** | **2,107** | **2,107** | **0** | **0** |
 
-- 사용자 지정 기준선 `1,925` 대비 `+180`개이며 25개 named suite가 모두 통과했다.
+- 사용자 지정 기준선 `1,925` 대비 `+182`개이며 25개 named suite가 모두 통과했다.
 - ESLint: exit 0, error 0, 기존 warning 59.
 - 변경 생산 JavaScript 9개 `node --check`: exit 0.
 - `git diff --check`: exit 0.
-- runtime bundle 2회 재생성 SHA-256 일치: `9F4F0197817604520364B28B44747C927DDC94B58BB2D5EF35060ECDDEA9020B`.
+- runtime bundle 2회 재생성 SHA-256 일치: `AF738246C1D1841F83902393CCD256E0973F1299F687BD349574F368D49F7B43`.
 - Windows x64 unpacked preflight build: exit 0.
 
 ## Windows 패키지 실기 검증
@@ -191,6 +192,7 @@
 9. PR 1차 리뷰에서 passive playback이 held source의 전체 object/point payload를 프레임마다 복제하는 hot path가 발견됐다. 기존 full-keyframe API를 보존하고 frame-only binary-search API를 추가해 표시 경로만 경량화했다.
 10. 같은 리뷰에서 passive 표시 IPC만 deadline 없이 raw Promise를 기다리는 비대칭이 발견됐다. 기존 persistence IPC deadline을 적용해 미응답 요청을 false로 정리하고 최신 trailing 한 건을 계속 처리하도록 맞췄다.
 11. PR 2차 리뷰에서 B-on input 승인이 지연되는 동안 playhead가 이동해도 준비 완료 시 옛 session frame을 새 시각의 관측으로 기록하는 경합이 발견됐다. 승인 시점의 live context frame을 다시 샘플하고, 달라졌으면 observation과 runtime preview를 forced active-frame sync로 함께 맞췄다.
+12. PR 3차 리뷰에서 pointerdown 프레임 승인을 기다리는 동안 브라우저가 묶어 보낸 고주파 펜 좌표를 wrapper 한 점으로 축약하는 입력 손실이 발견됐다. 일반 입력 경로와 같은 coalesced sample 순서를 pending buffer에도 적용하고, 기존 1,024개 상한을 묶음 전체에 원자적으로 검사했다.
 
 ## 리스크와 보호 범위
 
@@ -201,6 +203,7 @@
 - passive frame IPC는 source·store·viewport가 같으면 중복 제거하고, held source 해석은 object payload를 clone하지 않는다.
 - passive 표시 IPC는 deadline 뒤 in-flight를 해제하고 최신 trailing 한 건만 이어서 전송한다. 늦은 응답은 accepted signature를 바꾸지 않는다.
 - B-on input 승인 시점에는 live playhead를 다시 샘플한다. 초기 session frame과 달라졌으면 pointerdown observation과 runtime preview를 같은 active-frame 요청으로 즉시 맞춘다.
+- pointerdown 승인을 기다리는 펜 이동은 coalesced 좌표와 pressure를 순서대로 보존하며, 총 pending event가 1,024개를 넘으면 부분 stroke를 만들지 않고 입력을 취소한다.
 - 적용 대상 mpv Fabric 준비 실패는 자동재생보다 먼저 load를 실패로 닫고, 비적용 엔진·소유권 경로에는 이 판정을 확장하지 않는다.
 - 비동기 키프레임 이동의 history 예약은 이동 action과 대기 외부 action의 FIFO 순서를 보장하며, owner 상실이나 이동 실패에서도 대기 action을 유실하지 않는다.
 - 실제 Windows modal/background/다른 앱과의 상대 z-order는 자동 테스트가 완전히 모델링하지 못한다. current accepted 요청에만 restack하는 범위로 부작용을 제한했다.

--- a/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
+++ b/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
@@ -124,12 +124,14 @@
 | 전역 Undo 진행 중 inverse 이동 차단 | 1 / pass 0 / fail 1 / cancelled 0 / exit 1 | 1/1 / fail 0 / cancelled 0 / exit 0 |
 | held source 경량 해석 | persistence store 22 / pass 21 / fail 1 / cancelled 0 / exit 1, API 부재 | 22/22 / fail 0 / cancelled 0 / exit 0; 전체 keyframe clone 없이 frame만 해석 |
 | passive 표시 IPC 영구 대기 복구 | display controller 1 / pass 0 / fail 1 / cancelled 0 / exit 1, 최신 trailing이 timeout | 1/1 / fail 0 / cancelled 0 / exit 0; deadline 뒤 최신 trailing 전송·늦은 응답 폐기 |
+| 지연된 B-on 승인 시 live frame 관측 | display controller 1 / pass 0 / fail 1 / cancelled 0 / exit 1, pointerdown target 10(기대 20) | 1/1 / fail 0 / cancelled 0 / exit 0; 승인 시점 context frame 20 확정 |
+| 지연된 B-on 승인 직후 runtime preview | display controller 1 / pass 0 / fail 1 / cancelled 0 / exit 1, frame update `[]`(기대 `[20]`) | 1/1 / fail 0 / cancelled 0 / exit 0; changed frame forced active sync |
 
 ## 최종 25-suite 게이트
 
 | script | exit | tests | pass | fail | cancelled |
 |---|---:|---:|---:|---:|---:|
-| `test:fabric-drawing-pilot` | 0 | 433 | 433 | 0 | 0 |
+| `test:fabric-drawing-pilot` | 0 | 434 | 434 | 0 | 0 |
 | `test:fabric-drawing-persistence` | 0 | 156 | 156 | 0 | 0 |
 | `test:recent` | 0 | 18 | 18 | 0 | 0 |
 | `test:frame-grid` | 0 | 38 | 38 | 0 | 0 |
@@ -154,9 +156,9 @@
 | `test:version` | 0 | 2 | 2 | 0 | 0 |
 | `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
 | `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
-| **합계** | **모두 0** | **2,104** | **2,104** | **0** | **0** |
+| **합계** | **모두 0** | **2,105** | **2,105** | **0** | **0** |
 
-- 사용자 지정 기준선 `1,925` 대비 `+179`개이며 25개 named suite가 모두 통과했다.
+- 사용자 지정 기준선 `1,925` 대비 `+180`개이며 25개 named suite가 모두 통과했다.
 - ESLint: exit 0, error 0, 기존 warning 59.
 - 변경 생산 JavaScript 9개 `node --check`: exit 0.
 - `git diff --check`: exit 0.
@@ -188,6 +190,7 @@
 8. 최초 이동 구현은 persistence refresh tail이 끝난 뒤에야 global history action을 넣어, 그 사이 Undo가 이전 action을 꺼내거나 외부 push가 이동보다 앞에 놓일 수 있었다. 이동 시작 시 history 자리를 예약하고 외부 action을 FIFO로 보류하며, owner 상실 시에도 보류 action을 보존하고 진행 중 Undo와의 역방향 이동을 store commit 전에 차단했다.
 9. PR 1차 리뷰에서 passive playback이 held source의 전체 object/point payload를 프레임마다 복제하는 hot path가 발견됐다. 기존 full-keyframe API를 보존하고 frame-only binary-search API를 추가해 표시 경로만 경량화했다.
 10. 같은 리뷰에서 passive 표시 IPC만 deadline 없이 raw Promise를 기다리는 비대칭이 발견됐다. 기존 persistence IPC deadline을 적용해 미응답 요청을 false로 정리하고 최신 trailing 한 건을 계속 처리하도록 맞췄다.
+11. PR 2차 리뷰에서 B-on input 승인이 지연되는 동안 playhead가 이동해도 준비 완료 시 옛 session frame을 새 시각의 관측으로 기록하는 경합이 발견됐다. 승인 시점의 live context frame을 다시 샘플하고, 달라졌으면 observation과 runtime preview를 forced active-frame sync로 함께 맞췄다.
 
 ## 리스크와 보호 범위
 
@@ -197,6 +200,7 @@
 - stale host/video/input/session/source 응답은 최신 상태를 덮지 못한다.
 - passive frame IPC는 source·store·viewport가 같으면 중복 제거하고, held source 해석은 object payload를 clone하지 않는다.
 - passive 표시 IPC는 deadline 뒤 in-flight를 해제하고 최신 trailing 한 건만 이어서 전송한다. 늦은 응답은 accepted signature를 바꾸지 않는다.
+- B-on input 승인 시점에는 live playhead를 다시 샘플한다. 초기 session frame과 달라졌으면 pointerdown observation과 runtime preview를 같은 active-frame 요청으로 즉시 맞춘다.
 - 적용 대상 mpv Fabric 준비 실패는 자동재생보다 먼저 load를 실패로 닫고, 비적용 엔진·소유권 경로에는 이 판정을 확장하지 않는다.
 - 비동기 키프레임 이동의 history 예약은 이동 action과 대기 외부 action의 FIFO 순서를 보장하며, owner 상실이나 이동 실패에서도 대기 action을 유실하지 않는다.
 - 실제 Windows modal/background/다른 앱과의 상대 z-order는 자동 테스트가 완전히 모델링하지 못한다. current accepted 요청에만 restack하는 범위로 부작용을 제한했다.

--- a/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
+++ b/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
@@ -122,13 +122,15 @@
 | 이동 tail 중 Undo 대기 | 1 / pass 0 / fail 1 / cancelled 0 / exit 1 | 1/1 / fail 0 / cancelled 0 / exit 0 |
 | 이동 tail 중 외부 history push 순서 | 1 / pass 0 / fail 1 / cancelled 0 / exit 1 | 1/1 / fail 0 / cancelled 0 / exit 0 |
 | 전역 Undo 진행 중 inverse 이동 차단 | 1 / pass 0 / fail 1 / cancelled 0 / exit 1 | 1/1 / fail 0 / cancelled 0 / exit 0 |
+| held source 경량 해석 | persistence store 22 / pass 21 / fail 1 / cancelled 0 / exit 1, API 부재 | 22/22 / fail 0 / cancelled 0 / exit 0; 전체 keyframe clone 없이 frame만 해석 |
+| passive 표시 IPC 영구 대기 복구 | display controller 1 / pass 0 / fail 1 / cancelled 0 / exit 1, 최신 trailing이 timeout | 1/1 / fail 0 / cancelled 0 / exit 0; deadline 뒤 최신 trailing 전송·늦은 응답 폐기 |
 
 ## 최종 25-suite 게이트
 
 | script | exit | tests | pass | fail | cancelled |
 |---|---:|---:|---:|---:|---:|
-| `test:fabric-drawing-pilot` | 0 | 431 | 431 | 0 | 0 |
-| `test:fabric-drawing-persistence` | 0 | 155 | 155 | 0 | 0 |
+| `test:fabric-drawing-pilot` | 0 | 433 | 433 | 0 | 0 |
+| `test:fabric-drawing-persistence` | 0 | 156 | 156 | 0 | 0 |
 | `test:recent` | 0 | 18 | 18 | 0 | 0 |
 | `test:frame-grid` | 0 | 38 | 38 | 0 | 0 |
 | `test:cluster` | 0 | 43 | 43 | 0 | 0 |
@@ -152,9 +154,9 @@
 | `test:version` | 0 | 2 | 2 | 0 | 0 |
 | `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
 | `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
-| **합계** | **모두 0** | **2,101** | **2,101** | **0** | **0** |
+| **합계** | **모두 0** | **2,104** | **2,104** | **0** | **0** |
 
-- 사용자 지정 기준선 `1,925` 대비 `+176`개이며 25개 named suite가 모두 통과했다.
+- 사용자 지정 기준선 `1,925` 대비 `+179`개이며 25개 named suite가 모두 통과했다.
 - ESLint: exit 0, error 0, 기존 warning 59.
 - 변경 생산 JavaScript 9개 `node --check`: exit 0.
 - `git diff --check`: exit 0.
@@ -184,6 +186,8 @@
 6. 이동 undo token은 덮어쓴 목적지까지 복구하기 위해 touched frame의 before/after deep snapshot을 보유한다. 매우 큰 문서에서는 global history 메모리 사용량이 커질 수 있으므로 후속 history byte cap 검토가 필요하다.
 7. 콜드 스타트 순서를 옮긴 첫 구현은 `afterVideoReady()`를 기다리기만 하고 반환값 `false`를 성공처럼 통과시켰다. 실제 mpv Fabric 소유 경로는 자동재생 전에 실패로 닫고, HTML5·음성·engine swap·mpv 비소유 경로는 기존 동작을 유지하도록 적용 경계를 추가했다.
 8. 최초 이동 구현은 persistence refresh tail이 끝난 뒤에야 global history action을 넣어, 그 사이 Undo가 이전 action을 꺼내거나 외부 push가 이동보다 앞에 놓일 수 있었다. 이동 시작 시 history 자리를 예약하고 외부 action을 FIFO로 보류하며, owner 상실 시에도 보류 action을 보존하고 진행 중 Undo와의 역방향 이동을 store commit 전에 차단했다.
+9. PR 1차 리뷰에서 passive playback이 held source의 전체 object/point payload를 프레임마다 복제하는 hot path가 발견됐다. 기존 full-keyframe API를 보존하고 frame-only binary-search API를 추가해 표시 경로만 경량화했다.
+10. 같은 리뷰에서 passive 표시 IPC만 deadline 없이 raw Promise를 기다리는 비대칭이 발견됐다. 기존 persistence IPC deadline을 적용해 미응답 요청을 false로 정리하고 최신 trailing 한 건을 계속 처리하도록 맞췄다.
 
 ## 리스크와 보호 범위
 
@@ -191,7 +195,8 @@
 - Fabric layer header 잠금·가시성·삭제 제어는 계속 차단하고 marker drag만 허용한다.
 - playlist/cutlist의 실제 aggregate timeline에서는 로컬 frame 투영을 계속 억제한다.
 - stale host/video/input/session/source 응답은 최신 상태를 덮지 못한다.
-- passive frame IPC는 source·store·viewport가 같으면 중복 제거해 매 프레임 deep render하지 않는다.
+- passive frame IPC는 source·store·viewport가 같으면 중복 제거하고, held source 해석은 object payload를 clone하지 않는다.
+- passive 표시 IPC는 deadline 뒤 in-flight를 해제하고 최신 trailing 한 건만 이어서 전송한다. 늦은 응답은 accepted signature를 바꾸지 않는다.
 - 적용 대상 mpv Fabric 준비 실패는 자동재생보다 먼저 load를 실패로 닫고, 비적용 엔진·소유권 경로에는 이 판정을 확장하지 않는다.
 - 비동기 키프레임 이동의 history 예약은 이동 action과 대기 외부 action의 FIFO 순서를 보장하며, owner 상실이나 이동 실패에서도 대기 action을 유실하지 않는다.
 - 실제 Windows modal/background/다른 앱과의 상대 z-order는 자동 테스트가 완전히 모델링하지 못한다. current accepted 요청에만 restack하는 범위로 부작용을 제한했다.

--- a/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
+++ b/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
@@ -128,12 +128,13 @@
 | 지연된 B-on 승인 직후 runtime preview | display controller 1 / pass 0 / fail 1 / cancelled 0 / exit 1, frame update `[]`(기대 `[20]`) | 1/1 / fail 0 / cancelled 0 / exit 0; changed frame forced active sync |
 | pointerdown 승인 대기 중 coalesced 펜 샘플 | focused 2 / pass 0 / fail 2 / cancelled 0 / exit 1, 중간 좌표·압력 유실 및 1,024개 상한 미적용 | 2/2 / fail 0 / cancelled 0 / exit 0; 순서 보존·초과 시 gesture 취소 |
 | buffered pointerup 뒤 implicit capture loss | focused 2 / pass 1 / fail 1 / cancelled 0 / exit 1, confirm이 stale로 거절 | 2/2 / fail 0 / cancelled 0 / exit 0; 정상 완료 보존·pointerup 전 capture loss는 계속 취소 |
+| pointerdown confirm 무응답 local deadline | focused 3 / pass 0 / fail 3 / cancelled 0 / exit 1, deadline timer 미등록 | 3/3 / fail 0 / cancelled 0 / exit 0; 3초 후 capture 해제·다음 gesture 허용·late confirm 폐기 |
 
 ## 최종 25-suite 게이트
 
 | script | exit | tests | pass | fail | cancelled |
 |---|---:|---:|---:|---:|---:|
-| `test:fabric-drawing-pilot` | 0 | 438 | 438 | 0 | 0 |
+| `test:fabric-drawing-pilot` | 0 | 441 | 441 | 0 | 0 |
 | `test:fabric-drawing-persistence` | 0 | 156 | 156 | 0 | 0 |
 | `test:recent` | 0 | 18 | 18 | 0 | 0 |
 | `test:frame-grid` | 0 | 38 | 38 | 0 | 0 |
@@ -158,13 +159,13 @@
 | `test:version` | 0 | 2 | 2 | 0 | 0 |
 | `test:file-drop` | 0 | 4 | 4 | 0 | 0 |
 | `test:hybrid` | 0 | 5 | 5 | 0 | 0 |
-| **합계** | **모두 0** | **2,109** | **2,109** | **0** | **0** |
+| **합계** | **모두 0** | **2,112** | **2,112** | **0** | **0** |
 
-- 사용자 지정 기준선 `1,925` 대비 `+184`개이며 25개 named suite가 모두 통과했다.
+- 사용자 지정 기준선 `1,925` 대비 `+187`개이며 25개 named suite가 모두 통과했다.
 - ESLint: exit 0, error 0, 기존 warning 59.
 - 변경 생산 JavaScript 9개 `node --check`: exit 0.
 - `git diff --check`: exit 0.
-- runtime bundle 2회 재생성 SHA-256 일치: `FF8C4A08EF3FEF5512D0B42035CA9C46D7BDD7AF5E374903C03C152C36FCDFEF`.
+- runtime bundle 2회 재생성 SHA-256 일치: `AFFAE729EC2ECD63C3997C2B77A5B5B8839DF14E66C91FE8E13EAA717C9F8286`.
 - Windows x64 unpacked preflight build: exit 0.
 
 ## Windows 패키지 실기 검증
@@ -195,6 +196,7 @@
 11. PR 2차 리뷰에서 B-on input 승인이 지연되는 동안 playhead가 이동해도 준비 완료 시 옛 session frame을 새 시각의 관측으로 기록하는 경합이 발견됐다. 승인 시점의 live context frame을 다시 샘플하고, 달라졌으면 observation과 runtime preview를 forced active-frame sync로 함께 맞췄다.
 12. PR 3차 리뷰에서 pointerdown 프레임 승인을 기다리는 동안 브라우저가 묶어 보낸 고주파 펜 좌표를 wrapper 한 점으로 축약하는 입력 손실이 발견됐다. 일반 입력 경로와 같은 coalesced sample 순서를 pending buffer에도 적용하고, 기존 1,024개 상한을 묶음 전체에 원자적으로 검사했다.
 13. PR 4차 리뷰에서 빠른 클릭의 `pointerup`이 pending buffer에 들어간 직후 브라우저의 implicit `lostpointercapture`가 정상 완료 gesture를 취소하는 경합이 발견됐다. 같은 포인터의 buffered pointerup이 이미 있을 때만 capture loss를 정상 종료로 무시하고, 그 전의 실제 capture loss·pointercancel·blur는 계속 실패로 닫았다.
+14. PR 5차 리뷰에서 overlay→renderer pointerdown 확인 요청이 전달 중 사라지면 pending gesture가 무기한 입력을 잠그는 복구 공백이 발견됐다. runtime에 3초 local deadline을 두고 정확히 같은 pending object만 취소하며, 정상 confirm·disable·세션 교체·destroy·prepare rollback에서 timer를 정리했다.
 
 ## 리스크와 보호 범위
 
@@ -207,6 +209,7 @@
 - B-on input 승인 시점에는 live playhead를 다시 샘플한다. 초기 session frame과 달라졌으면 pointerdown observation과 runtime preview를 같은 active-frame 요청으로 즉시 맞춘다.
 - pointerdown 승인을 기다리는 펜 이동은 coalesced 좌표와 pressure를 순서대로 보존하며, 총 pending event가 1,024개를 넘으면 부분 stroke를 만들지 않고 입력을 취소한다.
 - pending pointerup 뒤의 implicit capture loss는 정상 완료를 보존하지만, pointerup 전에 capture를 잃으면 부분 입력을 저장하지 않고 취소한다.
+- pointerdown frame confirm이 3초 안에 오지 않으면 capture와 pending lock을 해제한다. 늦은 confirm·cancel은 새 gesture나 저장 상태를 바꾸지 않는다.
 - 적용 대상 mpv Fabric 준비 실패는 자동재생보다 먼저 load를 실패로 닫고, 비적용 엔진·소유권 경로에는 이 판정을 확장하지 않는다.
 - 비동기 키프레임 이동의 history 예약은 이동 action과 대기 외부 action의 FIFO 순서를 보장하며, owner 상실이나 이동 실패에서도 대기 action을 유실하지 않는다.
 - 실제 Windows modal/background/다른 앱과의 상대 z-order는 자동 테스트가 완전히 모델링하지 못한다. current accepted 요청에만 restack하는 범위로 부작용을 제한했다.

--- a/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
+++ b/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
@@ -100,6 +100,7 @@ synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovab
 - 적용 대상 mpv Fabric readiness 실패는 자동재생보다 먼저 load를 실패로 닫고, HTML5·음성·engine swap·mpv 비소유 경로의 기존 재생 의미는 유지한다.
 - 이동 history 예약이 열린 동안의 undo/redo와 외부 push는 FIFO 장벽을 따르며, owner 상실·이동 실패에서도 대기 action을 유실하지 않는다.
 - pointerdown 프레임 승인 대기 중에도 coalesced 펜 좌표·압력을 순서대로 보존하고, bounded pending buffer를 넘으면 전체 gesture를 실패로 닫는다.
+- buffered pointerup 뒤의 implicit capture loss는 정상 완료로 보존하고, pointerup 전 capture loss는 저장 없이 gesture를 취소한다.
 
 ## RED→GREEN 검증
 
@@ -118,7 +119,8 @@ synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovab
 13. passive IPC deadline: 미응답 요청 뒤 최신 trailing이 진행되고, 늦은 응답·자동 retry가 현재 표시를 덮지 않는다.
 14. delayed B-on: input 승인 전 playhead가 이동하면 첫 pointerdown과 runtime preview가 승인 시점 live frame을 사용한다.
 15. 입력 정밀도: pointerdown 승인 대기 중 coalesced move 좌표·압력·pointerup 순서를 보존하고, 1,024개 상한 초과 시 저장 없이 capture를 해제한다.
-16. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
+16. 입력 완료 경합: buffered pointerup 뒤 implicit lostpointercapture는 confirm/replay를 보존하고, pointerup 전 capture loss는 confirm을 거절한다.
+17. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
 
 ## 릴리스
 

--- a/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
+++ b/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
@@ -99,6 +99,7 @@ synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovab
 - 협업 연결 지연·실패는 로컬 Fabric 준비와 B-off 표시를 차단하지 않는다.
 - 적용 대상 mpv Fabric readiness 실패는 자동재생보다 먼저 load를 실패로 닫고, HTML5·음성·engine swap·mpv 비소유 경로의 기존 재생 의미는 유지한다.
 - 이동 history 예약이 열린 동안의 undo/redo와 외부 push는 FIFO 장벽을 따르며, owner 상실·이동 실패에서도 대기 action을 유실하지 않는다.
+- pointerdown 프레임 승인 대기 중에도 coalesced 펜 좌표·압력을 순서대로 보존하고, bounded pending buffer를 넘으면 전체 gesture를 실패로 닫는다.
 
 ## RED→GREEN 검증
 
@@ -116,7 +117,8 @@ synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovab
 12. playback hot path: held source frame 해석이 object payload를 clone하지 않고 exact/hold/empty-break를 보존한다.
 13. passive IPC deadline: 미응답 요청 뒤 최신 trailing이 진행되고, 늦은 응답·자동 retry가 현재 표시를 덮지 않는다.
 14. delayed B-on: input 승인 전 playhead가 이동하면 첫 pointerdown과 runtime preview가 승인 시점 live frame을 사용한다.
-15. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
+15. 입력 정밀도: pointerdown 승인 대기 중 coalesced move 좌표·압력·pointerup 순서를 보존하고, 1,024개 상한 초과 시 저장 없이 capture를 해제한다.
+16. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
 
 ## 릴리스
 

--- a/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
+++ b/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
@@ -46,6 +46,7 @@ controller는 passive 표시 요청과 active 프레임 후보 요청을 각각 
 - passive controller는 host/runtime가 허용하는 표시 전용 exact-key DTO만 전송하며 공통 protocol envelope를 섞지 않는다.
 - passive 표시 요청은 영상 원본 크기, 캔버스 영역, zoom/pan 정보를 함께 보내 fresh host와 B-off resize에서도 같은 좌표를 유지한다.
 - B active 재생 중 runtime은 자기 최신 committed scene으로 hold source를 찾아 읽기 전용 미리보기만 갱신한다. 이 프레임 알림만으로 keyframe·transition·provisional scene을 만들지 않는다.
+- B-on input 승인이 비동기로 지연되면 승인 시점의 live playhead를 다시 샘플한다. 진입 때 캡처한 frame과 달라졌으면 active observation과 runtime preview를 forced frame sync로 즉시 맞춘다.
 - 실제 pointerdown 또는 mutation action 직전에 최신 후보 프레임으로 copy-on-write 전환한다. 한 획이 진행되는 동안 들어온 다음 프레임은 보류해 획 전체를 pointerdown 프레임에 고정하고, 다음 입력부터 최신 프레임을 사용한다.
 - B를 끄거나 수화·영상 전환이 끝나 passive가 되면 현재 playhead를 다시 동기화한다.
 - passive 장면 렌더가 현재 요청으로 승인되면 overlay host는 `moveTop()` 뒤 Chromium 합성을 무효화한다. stale·reject·실패 응답은 창 순서를 바꾸지 않는다.
@@ -114,7 +115,8 @@ synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovab
 11. history 순서: 이동 tail 중 Undo 대기, 이동 뒤 외부 push FIFO, owner 상실 시 대기 action 보존, 진행 중 global Undo와 inverse 이동의 store commit 차단.
 12. playback hot path: held source frame 해석이 object payload를 clone하지 않고 exact/hold/empty-break를 보존한다.
 13. passive IPC deadline: 미응답 요청 뒤 최신 trailing이 진행되고, 늦은 응답·자동 retry가 현재 표시를 덮지 않는다.
-14. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
+14. delayed B-on: input 승인 전 playhead가 이동하면 첫 pointerdown과 runtime preview가 승인 시점 live frame을 사용한다.
+15. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
 
 ## 릴리스
 

--- a/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
+++ b/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
@@ -101,6 +101,7 @@ synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovab
 - 이동 history 예약이 열린 동안의 undo/redo와 외부 push는 FIFO 장벽을 따르며, owner 상실·이동 실패에서도 대기 action을 유실하지 않는다.
 - pointerdown 프레임 승인 대기 중에도 coalesced 펜 좌표·압력을 순서대로 보존하고, bounded pending buffer를 넘으면 전체 gesture를 실패로 닫는다.
 - buffered pointerup 뒤의 implicit capture loss는 정상 완료로 보존하고, pointerup 전 capture loss는 저장 없이 gesture를 취소한다.
+- pointerdown frame confirm은 3초 local deadline 안에 끝나야 하며, 무응답이면 capture와 pending lock을 해제하고 late response는 폐기한다.
 
 ## RED→GREEN 검증
 
@@ -120,7 +121,8 @@ synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovab
 14. delayed B-on: input 승인 전 playhead가 이동하면 첫 pointerdown과 runtime preview가 승인 시점 live frame을 사용한다.
 15. 입력 정밀도: pointerdown 승인 대기 중 coalesced move 좌표·압력·pointerup 순서를 보존하고, 1,024개 상한 초과 시 저장 없이 capture를 해제한다.
 16. 입력 완료 경합: buffered pointerup 뒤 implicit lostpointercapture는 confirm/replay를 보존하고, pointerup 전 capture loss는 confirm을 거절한다.
-17. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
+17. 입력 확인 timeout: confirm 무응답 뒤 deadline이 capture를 해제하고 다음 gesture를 허용하며, 늦은 confirm·cancel과 disable/session replacement/destroy의 stale timer는 현재 상태를 바꾸지 않는다.
+18. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
 
 ## 릴리스
 

--- a/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
+++ b/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
@@ -42,7 +42,7 @@ Windows 콜드 스타트 검증에서는 세 번째 결함도 확인됐다. `loa
 
 controller는 passive 표시 요청과 active 프레임 후보 요청을 각각 최신 하나로 직렬화한다. 요청은 host/video/input/session/revision과 영상 identity로 fence한다. preload/IPC/overlay host는 두 요청을 분리해 전달한다.
 
-- passive runtime은 저장·selection·history를 바꾸지 않은 채 source scene을 non-interactive canvas에 그린다. source가 없거나 empty이면 즉시 비운다.
+- passive runtime은 저장·selection·history를 바꾸지 않은 채 source scene을 non-interactive canvas에 그린다. source가 없거나 empty이면 즉시 비운다. renderer의 프레임 hot path는 held source의 frame 번호만 binary search로 해석하고 전체 object payload를 clone하지 않는다.
 - passive controller는 host/runtime가 허용하는 표시 전용 exact-key DTO만 전송하며 공통 protocol envelope를 섞지 않는다.
 - passive 표시 요청은 영상 원본 크기, 캔버스 영역, zoom/pan 정보를 함께 보내 fresh host와 B-off resize에서도 같은 좌표를 유지한다.
 - B active 재생 중 runtime은 자기 최신 committed scene으로 hold source를 찾아 읽기 전용 미리보기만 갱신한다. 이 프레임 알림만으로 keyframe·transition·provisional scene을 만들지 않는다.
@@ -50,6 +50,7 @@ controller는 passive 표시 요청과 active 프레임 후보 요청을 각각 
 - B를 끄거나 수화·영상 전환이 끝나 passive가 되면 현재 playhead를 다시 동기화한다.
 - passive 장면 렌더가 현재 요청으로 승인되면 overlay host는 `moveTop()` 뒤 Chromium 합성을 무효화한다. stale·reject·실패 응답은 창 순서를 바꾸지 않는다.
 - 재생 시작 시 현재 playhead를 한 번 force-present하여 이미 hold 구간 안에서 시작해도 장면과 네이티브 창 순서를 복구한다. 이후에는 source·store·viewport가 바뀔 때만 다시 표시한다.
+- passive 표시 IPC도 bounded deadline을 사용한다. host가 응답하지 않으면 in-flight를 해제하고 대기열의 최신 프레임 한 건만 이어서 전송하며, 늦은 응답은 현재 accepted signature를 바꾸지 않는다.
 - 새 영상 로드는 `로컬 review 설치 → FPS 설정 → Fabric afterVideoReady → 선택적 자동재생 → 협업 시작` 순서를 지킨다. 협업 Promise가 pending 또는 reject여도 로컬 passive 표시 준비는 먼저 끝나야 한다.
 - mpv·비음성·Fabric 소유 경로에서는 `afterVideoReady()`의 명시적 성공(`true`)이 자동재생의 선행 조건이다. `false`면 자동재생 전에 load를 실패로 닫고 해당 영상의 Fabric 준비와 미디어 surface를 정리한다.
 - HTML5, 음성, engine swap, mpv 비소유 경로는 위 fail-closed 판정의 비적용 범위다. 이 경로들은 기존 자동재생을 유지하며, engine swap은 기존 Fabric 세션을 재사용하고 중복 `afterVideoReady()`를 호출하지 않는다.
@@ -111,7 +112,9 @@ synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovab
 9. 콜드 스타트: 협업 Promise를 pending으로 둬도 `afterVideoReady`가 먼저 완료되고, 자동재생은 그 뒤에만 시작하며, 정상 협업·engine swap·stale/cancel 경로에는 중복 준비·재생이 없음.
 10. readiness 실패: 적용 대상 mpv Fabric의 `afterVideoReady=false`는 자동재생 전 load 실패·정리를 만들고, HTML5·음성·engine swap·mpv 비소유 control은 기존 자동재생을 유지한다.
 11. history 순서: 이동 tail 중 Undo 대기, 이동 뒤 외부 push FIFO, owner 상실 시 대기 action 보존, 진행 중 global Undo와 inverse 이동의 store commit 차단.
-12. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
+12. playback hot path: held source frame 해석이 object payload를 clone하지 않고 exact/hold/empty-break를 보존한다.
+13. passive IPC deadline: 미응답 요청 뒤 최신 trailing이 진행되고, 늦은 응답·자동 retry가 현재 표시를 덮지 않는다.
+14. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
 
 ## 릴리스
 

--- a/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
+++ b/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
@@ -1,0 +1,87 @@
+# Fabric 드로잉 키프레임 hold·이동 설계
+
+## 목표
+
+`drawingsV3` 드로잉을 Adobe Animate의 키프레임 노출 방식으로 표시하고, 타임라인에서 안전하게 이동할 수 있게 한다.
+
+- 첫 키프레임 전에는 드로잉이 보이지 않는다.
+- 내용 키프레임은 다음 키프레임 직전까지 유지(hold)된다.
+- 빈 키프레임은 이전 hold를 끊는다.
+- B-off 탐색·재생 중 현재 프레임에 맞는 장면이 표시된다.
+- hold 프레임에서 B-on 시 원본을 보이되, 첫 실제 변경에서 현재 프레임 키프레임을 copy-on-write로 만든다.
+- 키프레임을 기존 키프레임 위로 이동하면 목적지를 통째로 덮어쓴다.
+- 다중 이동과 undo/redo는 원자적으로 동작한다.
+
+## 원인
+
+현재 Fabric runtime은 `(stableVideoIdentity, targetFrame)` exact scene을 저장하지만, B-off에는 `lastPaintedScene`만 다시 그린다. 렌더러의 `timeupdate`/`frameUpdate`가 오버레이에 현재 프레임을 전달하지 않으므로 마지막 활성 장면이 다른 프레임에도 남는다.
+
+타임라인 투영은 `locked: true`이고 앱도 `keyframesMove`를 즉시 반환한다. 이 차단만 제거하면 synthetic layer가 legacy `drawingManager`로 흘러 실제 `drawingsV3`는 이동하지 않고 legacy history만 오염된다.
+
+## 표시 의미
+
+저장·편집 target과 표시 source를 분리한다.
+
+- `targetFrame`: 새 변경이 귀속되는 현재 프레임.
+- `sourceFrame`: `targetFrame` 이하의 마지막 키프레임. 없으면 `null`.
+- source 키프레임의 objects가 비어 있으면 화면은 빈 상태이며 hold가 끊긴다.
+- 타임라인 마커는 exact frame에 위치하지만 노출 막대는 다음 키프레임 직전까지 이어진다.
+
+예: 내용 100, 빈 150, 내용 200이면 0~99 빈 화면, 100~149는 100 장면, 150~199 빈 화면, 200부터 200 장면이다.
+
+## 프레임 표시 채널
+
+렌더러에서 persistence store가 `sourceFrame`을 해석하고, source가 바뀔 때만 controller에 표시 요청을 보낸다. 매 재생 프레임마다 같은 장면을 다시 그리지 않는다.
+
+controller는 passive 상태에서만 최신 요청 하나를 직렬화한다. 요청은 host/video/presentation revision과 영상 identity로 fence한다. preload/IPC/overlay host는 새 passive frame-present 호출을 전달하고, runtime은 저장·selection·history를 바꾸지 않은 채 source scene을 non-interactive canvas에 그린다. source가 없거나 empty이면 즉시 비운다.
+
+B active 동안 편집 target은 진입 프레임으로 고정한다. passive 요청은 active 세션을 덮지 않는다. B를 끄거나 수화·영상 전환이 끝나 passive가 되면 현재 playhead를 다시 동기화한다.
+
+## hold 프레임 편집
+
+exact target scene이 없고 이전 source scene이 있으면 runtime은 target 좌표에 임시 clone을 만든다.
+
+- 임시 clone은 export와 persistence에서 제외한다.
+- 아무 변경 없이 B를 끄면 임시 clone을 폐기한다.
+- 첫 stroke/transform/delete/clear 직전에 clone을 materialize하고, 전체 base objects를 target의 첫 transition으로 보낸 뒤 실제 변경 transition을 적용한다.
+- source가 empty이면 새 object가 생길 때까지 exact keyframe을 만들지 않는다.
+- 첫 변경의 undo는 변경 전 clone 내용으로 돌아가며, 생성된 target keyframe은 유지한다.
+
+이 방식은 hold 원본을 수정하지 않고 현재 프레임에서만 애니메이션 상태를 분기한다.
+
+## 타임라인 이동
+
+synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovable` 명시 플래그로 키프레임 drag만 허용한다. 헤더 제어·삭제·레거시 단축키는 계속 차단한다.
+
+`fabric-drawing-persistence-store`에 원자 이동 API를 추가한다.
+
+- 모든 source/target과 범위를 먼저 검증한다.
+- source keyframe 스냅샷을 이동 시작 시점 기준으로 캡처한다.
+- 목적지의 기존 keyframe은 선택 여부와 관계없이 source 스냅샷으로 덮어쓴다.
+- 겹치는 다중 이동도 원본 스냅샷 기준으로 계산한다. 예를 들어 100·200을 +100 이동하면 원래 100이 200으로, 원래 200이 300으로 간다.
+- 하나라도 범위를 벗어나거나 source가 없으면 전체를 변경하지 않는다.
+- 성공 시 revision과 change event를 정확히 한 번 증가시킨다.
+- before/after 스냅샷을 global undo/redo에 등록하여 덮어쓴 목적지도 복구한다.
+
+앱은 Fabric drag를 legacy `drawingManager.moveKeyframes()`로 보내지 않는다. 기존 controller의 persistence source refresh 순서를 재사용해 overlay authoritative pull → store 이동 → hydrate/export 검증 → active/passive 복귀를 직렬화한다. store change는 기존 ReviewDataManager dirty/autosave 경로를 사용한다.
+
+## 보호 범위
+
+- legacy `drawings`, legacy undo와 HTML5 동작은 변경하지 않는다.
+- Fabric 키프레임 선택 삭제와 레이어 제어는 이번 범위에서 계속 막는다.
+- playlist/cutlist aggregate timeline suppression은 유지한다.
+- runtime 소스를 바꾸는 커밋에는 `npm run bundle:mpv-fabric-overlay` 결과를 함께 포함한다.
+- 호스트/영상/source epoch가 바뀐 stale 표시·이동 결과는 폐기한다.
+
+## RED→GREEN 검증
+
+1. 표시: 99=blank, 100=exact, 101=held, empty break 이후 blank, 역방향 seek와 재생 source 교체.
+2. active copy-on-write: hold 장면 표시, 첫 변경 전 export 불변, 첫 변경 후 target keyframe 생성과 source 불변.
+3. 이동: 단일·다중·겹침·덮어쓰기, 범위 실패 원자성, revision/event 1회, undo/redo.
+4. 라우팅: Fabric drag는 store/controller만 사용하고 legacy manager/history는 호출하지 않음.
+5. 영속성: autosave와 저장 후 재실행에서 frame·objects·empty break 유지.
+6. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
+
+## 릴리스
+
+기준 `origin/main`은 `2.2.1-beta`이며 표시 채널과 타임라인 편집 기능을 추가하므로 `2.3.0-beta`로 올린다. 독립 리뷰와 Codex PR 리뷰를 통과한 정확한 merge commit에서 Windows beta를 빌드하고, 공유드라이브 테스트 버전을 staging 교체한 뒤 전체 파일 SHA-256 parity와 실행 시나리오를 확인한다.

--- a/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
+++ b/docs/superpowers/specs/2026-08-25-fabric-keyframe-hold-move-design.md
@@ -9,12 +9,19 @@
 - 빈 키프레임은 이전 hold를 끊는다.
 - B-off 탐색·재생 중 현재 프레임에 맞는 장면이 표시된다.
 - hold 프레임에서 B-on 시 원본을 보이되, 첫 실제 변경에서 현재 프레임 키프레임을 copy-on-write로 만든다.
+- mpv Fabric이 드로잉을 소유하는 영상은 로컬 runtime 준비 성공 뒤에만 자동재생한다.
 - 키프레임을 기존 키프레임 위로 이동하면 목적지를 통째로 덮어쓴다.
-- 다중 이동과 undo/redo는 원자적으로 동작한다.
+- 다중 이동과 undo/redo는 비동기 refresh 중 들어온 다른 history action과도 원자적 순서를 유지한다.
 
 ## 원인
 
 현재 Fabric runtime은 `(stableVideoIdentity, targetFrame)` exact scene을 저장하지만, B-off에는 `lastPaintedScene`만 다시 그린다. 렌더러의 `timeupdate`/`frameUpdate`가 오버레이에 현재 프레임을 전달하지 않으므로 마지막 활성 장면이 다른 프레임에도 남는다.
+
+프레임 표시 채널을 연결한 시험판의 실사용 검증에서 두 개의 추가 표시 결함이 확인됐다. 첫째, controller는 passive presentation DTO에 공통 protocol envelope를 덧붙였지만 overlay host와 runtime은 표시 전용 exact-key DTO만 허용했다. 단위 테스트의 IPC stub은 extra key를 검사하지 않아 통과했지만 실제 controller → host 통합 경로는 `invalid-presentation-request`로 runtime 진입 전에 거부됐다. 둘째, 요청 형식을 맞춘 뒤에도 passive `presentDrawingFrame()`은 Fabric canvas를 다시 그리고 Chromium 합성만 무효화했지만, sibling인 mpv embed 창보다 뒤로 내려간 overlay BrowserWindow의 네이티브 창 순서는 복구하지 않았다. 같은 화면 사각형의 실행 창을 Win32 z-order로 확인했을 때 embed가 overlay 바로 위에 있었고, B-on만 기존 `moveTop()` 경로를 타서 그때서야 이미 그려진 장면이 보였다.
+
+Windows 콜드 스타트 검증에서는 세 번째 결함도 확인됐다. `loadVideo()`가 로컬 `.bframe` 설치 뒤 협업 저장소 연결을 먼저 `await`하고 그 다음에 Fabric `afterVideoReady()`를 호출했다. 협업 `getStorage()` Promise가 pending이면 controller가 `recovering`, host가 `videoGeneration: -1`에 머물러 runtime이 준비되지 않았고, 자동재생도 로컬 드로잉 수화보다 먼저 시작할 수 있었다. 네트워크 협업 준비 여부가 로컬 리뷰 표시의 선행 조건이 되어서는 안 된다.
+
+따라서 B는 표시 스위치가 아니라 입력·편집 스위치로만 남겨야 한다. passive 장면이 승인될 때도 overlay를 영상 위로 복구하고, 재생 시작 시 현재 held 장면을 한 번 강제 동기화해야 한다. 같은 source가 유지되는 매 프레임마다 네이티브 창을 다시 올리지는 않는다.
 
 타임라인 투영은 `locked: true`이고 앱도 `keyframesMove`를 즉시 반환한다. 이 차단만 제거하면 synthetic layer가 legacy `drawingManager`로 흘러 실제 `drawingsV3`는 이동하지 않고 legacy history만 오염된다.
 
@@ -31,11 +38,22 @@
 
 ## 프레임 표시 채널
 
-렌더러에서 persistence store가 `sourceFrame`을 해석하고, source가 바뀔 때만 controller에 표시 요청을 보낸다. 매 재생 프레임마다 같은 장면을 다시 그리지 않는다.
+렌더러에서 persistence store가 `sourceFrame`을 해석하고, passive 상태에서는 source·store·viewport signature가 바뀔 때만 controller에 표시 요청을 보낸다. 매 재생 프레임마다 같은 장면을 다시 그리지 않는다.
 
-controller는 passive 상태에서만 최신 요청 하나를 직렬화한다. 요청은 host/video/presentation revision과 영상 identity로 fence한다. preload/IPC/overlay host는 새 passive frame-present 호출을 전달하고, runtime은 저장·selection·history를 바꾸지 않은 채 source scene을 non-interactive canvas에 그린다. source가 없거나 empty이면 즉시 비운다.
+controller는 passive 표시 요청과 active 프레임 후보 요청을 각각 최신 하나로 직렬화한다. 요청은 host/video/input/session/revision과 영상 identity로 fence한다. preload/IPC/overlay host는 두 요청을 분리해 전달한다.
 
-B active 동안 편집 target은 진입 프레임으로 고정한다. passive 요청은 active 세션을 덮지 않는다. B를 끄거나 수화·영상 전환이 끝나 passive가 되면 현재 playhead를 다시 동기화한다.
+- passive runtime은 저장·selection·history를 바꾸지 않은 채 source scene을 non-interactive canvas에 그린다. source가 없거나 empty이면 즉시 비운다.
+- passive controller는 host/runtime가 허용하는 표시 전용 exact-key DTO만 전송하며 공통 protocol envelope를 섞지 않는다.
+- passive 표시 요청은 영상 원본 크기, 캔버스 영역, zoom/pan 정보를 함께 보내 fresh host와 B-off resize에서도 같은 좌표를 유지한다.
+- B active 재생 중 runtime은 자기 최신 committed scene으로 hold source를 찾아 읽기 전용 미리보기만 갱신한다. 이 프레임 알림만으로 keyframe·transition·provisional scene을 만들지 않는다.
+- 실제 pointerdown 또는 mutation action 직전에 최신 후보 프레임으로 copy-on-write 전환한다. 한 획이 진행되는 동안 들어온 다음 프레임은 보류해 획 전체를 pointerdown 프레임에 고정하고, 다음 입력부터 최신 프레임을 사용한다.
+- B를 끄거나 수화·영상 전환이 끝나 passive가 되면 현재 playhead를 다시 동기화한다.
+- passive 장면 렌더가 현재 요청으로 승인되면 overlay host는 `moveTop()` 뒤 Chromium 합성을 무효화한다. stale·reject·실패 응답은 창 순서를 바꾸지 않는다.
+- 재생 시작 시 현재 playhead를 한 번 force-present하여 이미 hold 구간 안에서 시작해도 장면과 네이티브 창 순서를 복구한다. 이후에는 source·store·viewport가 바뀔 때만 다시 표시한다.
+- 새 영상 로드는 `로컬 review 설치 → FPS 설정 → Fabric afterVideoReady → 선택적 자동재생 → 협업 시작` 순서를 지킨다. 협업 Promise가 pending 또는 reject여도 로컬 passive 표시 준비는 먼저 끝나야 한다.
+- mpv·비음성·Fabric 소유 경로에서는 `afterVideoReady()`의 명시적 성공(`true`)이 자동재생의 선행 조건이다. `false`면 자동재생 전에 load를 실패로 닫고 해당 영상의 Fabric 준비와 미디어 surface를 정리한다.
+- HTML5, 음성, engine swap, mpv 비소유 경로는 위 fail-closed 판정의 비적용 범위다. 이 경로들은 기존 자동재생을 유지하며, engine swap은 기존 Fabric 세션을 재사용하고 중복 `afterVideoReady()`를 호출하지 않는다.
+- 위 순서 이동에서도 기존 `!engineSwap`, load token, stale/cancel guard를 유지해 엔진 교체·취소된 로드가 중복 수화나 중복 재생을 만들지 않는다.
 
 ## hold 프레임 편집
 
@@ -62,6 +80,10 @@ synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovab
 - 하나라도 범위를 벗어나거나 source가 없으면 전체를 변경하지 않는다.
 - 성공 시 revision과 change event를 정확히 한 번 증가시킨다.
 - before/after 스냅샷을 global undo/redo에 등록하여 덮어쓴 목적지도 복구한다.
+- 비동기 persistence refresh를 시작하기 전에 global history mutation 자리를 예약한다. 이동이 commit되면 이동 action을 먼저 넣고, tail 동안 들어온 외부 action은 그 뒤에 FIFO로 넣는다.
+- global undo/redo는 예약 장벽이 풀릴 때까지 기다린다. 따라서 tail 도중 Undo를 눌러도 이전 action을 잘못 꺼내지 않고, 나중에 들어온 외부 action부터 이동 action 순으로 되돌린다.
+- 이동 결과의 document owner가 바뀌어 이동 history action을 commit하지 못하거나 이동이 실패해도, 장벽에 대기하던 외부 action은 버리지 않고 원래 순서로 보존한다.
+- global undo/redo가 이미 실행 중이면 새 Fabric 이동은 store mutation 전에 거절해 inverse history 작업과 이동 commit이 교차하지 않게 한다.
 
 앱은 Fabric drag를 legacy `drawingManager.moveKeyframes()`로 보내지 않는다. 기존 controller의 persistence source refresh 순서를 재사용해 overlay authoritative pull → store 이동 → hydrate/export 검증 → active/passive 복귀를 직렬화한다. store change는 기존 ReviewDataManager dirty/autosave 경로를 사용한다.
 
@@ -72,15 +94,24 @@ synthetic 행은 레이어 잠금 상태를 유지하되 `timelineKeyframesMovab
 - playlist/cutlist aggregate timeline suppression은 유지한다.
 - runtime 소스를 바꾸는 커밋에는 `npm run bundle:mpv-fabric-overlay` 결과를 함께 포함한다.
 - 호스트/영상/source epoch가 바뀐 stale 표시·이동 결과는 폐기한다.
+- 협업 연결 지연·실패는 로컬 Fabric 준비와 B-off 표시를 차단하지 않는다.
+- 적용 대상 mpv Fabric readiness 실패는 자동재생보다 먼저 load를 실패로 닫고, HTML5·음성·engine swap·mpv 비소유 경로의 기존 재생 의미는 유지한다.
+- 이동 history 예약이 열린 동안의 undo/redo와 외부 push는 FIFO 장벽을 따르며, owner 상실·이동 실패에서도 대기 action을 유실하지 않는다.
 
 ## RED→GREEN 검증
 
 1. 표시: 99=blank, 100=exact, 101=held, empty break 이후 blank, 역방향 seek와 재생 source 교체.
-2. active copy-on-write: hold 장면 표시, 첫 변경 전 export 불변, 첫 변경 후 target keyframe 생성과 source 불변.
+2. active copy-on-write: 재생 중 hold 미리보기, 프레임 알림만으로 export·transition·scene 수 불변, pointerdown 프레임 고정, 다음 입력의 최신 프레임 전환, source 불변.
 3. 이동: 단일·다중·겹침·덮어쓰기, 범위 실패 원자성, revision/event 1회, undo/redo.
 4. 라우팅: Fabric drag는 store/controller만 사용하고 legacy manager/history는 호출하지 않음.
 5. 영속성: autosave와 저장 후 재실행에서 frame·objects·empty break 유지.
-6. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
+6. viewport: fresh passive 표시와 B-off resize/zoom/pan에서 캔버스 크기·좌표 일치.
+7. 통합 DTO: 실제 controller → host → runtime에서 extra key 없이 presentation이 승인되고, B 입력 enable 0회로 정·역 hold/empty 장면이 표시된다.
+8. 네이티브 표시: B를 한 번도 누르지 않은 재생 시작과 keyframe 경계에서 runtime render → overlay `moveTop()` → invalidate 순서, reject/stale 시 restack 없음.
+9. 콜드 스타트: 협업 Promise를 pending으로 둬도 `afterVideoReady`가 먼저 완료되고, 자동재생은 그 뒤에만 시작하며, 정상 협업·engine swap·stale/cancel 경로에는 중복 준비·재생이 없음.
+10. readiness 실패: 적용 대상 mpv Fabric의 `afterVideoReady=false`는 자동재생 전 load 실패·정리를 만들고, HTML5·음성·engine swap·mpv 비소유 control은 기존 자동재생을 유지한다.
+11. history 순서: 이동 tail 중 Undo 대기, 이동 뒤 외부 push FIFO, owner 상실 시 대기 action 보존, 진행 중 global Undo와 inverse 이동의 store commit 차단.
+12. 회귀: B toggle z-order, mpv runtime/host, HTML5 legacy, playlist/cutlist, 전체 테스트.
 
 ## 릴리스
 

--- a/main/ipc-handlers.js
+++ b/main/ipc-handlers.js
@@ -424,8 +424,17 @@ function setupIpcHandlers({
     invokeFabricDrawingHost(event, () => mpvOverlayHost.setDrawingInput(request)));
   ipcMain.handle('mpv:update-overlay-drawing-tool', (event, request) =>
     invokeFabricDrawingHost(event, () => mpvOverlayHost.updateDrawingTool(request)));
+  ipcMain.handle('mpv:update-overlay-drawing-frame', (event, request) =>
+    invokeFabricDrawingHost(event, () => mpvOverlayHost.updateDrawingFrame(request)));
   ipcMain.handle('mpv:apply-overlay-drawing-action', (event, request) =>
     invokeFabricDrawingHost(event, () => mpvOverlayHost.applyDrawingAction(request)));
+  ipcMain.handle('mpv:confirm-overlay-drawing-pointerdown-frame', (event, request) =>
+    invokeFabricDrawingHost(
+      event,
+      () => mpvOverlayHost.confirmDrawingPointerdownFrame(request)
+    ));
+  ipcMain.handle('mpv:present-overlay-drawing-frame', (event, request) =>
+    invokeFabricDrawingHost(event, () => mpvOverlayHost.presentDrawingFrame(request)));
   ipcMain.handle('mpv:get-overlay-drawing-diagnostics', (event) =>
     invokeFabricDrawingHost(event, () => mpvOverlayHost.getDrawingDiagnostics()));
   ipcMain.handle('mpv:hydrate-overlay-drawing-video', (event, request) =>
@@ -445,6 +454,12 @@ function setupIpcHandlers({
     } catch (_error) {
       // Cursor presence is ephemeral; the next pointer event recovers the signal.
     }
+  });
+  ipcMain.on('mpv-overlay:drawing-pointerdown-frame-request', (event, request) => {
+    if (!isFabricDrawingPilotEnabled || !mpvOverlayHost.isCurrentOverlaySender(event)) {
+      return;
+    }
+    mpvOverlayHost.forwardDrawingPointerdownFrameRequest(event, request);
   });
   ipcMain.on('mpv-overlay:collaboration-action', (event, action) => {
     mpvOverlayHost.forwardCollaborationAction(event, action);

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -65,6 +65,8 @@ const MAX_MPV_COLLABORATION_BOUND = 32768;
 const MPV_COLLABORATION_FALLBACK_COLOR = '#ffd000';
 const MPV_OVERLAY_COLLABORATION_ACTION_CHANNEL = 'mpv-overlay:collaboration-action';
 const MPV_OVERLAY_COLLABORATION_DRAG_RESET_CHANNEL = 'mpv-overlay:collaboration-drag-reset';
+const MPV_OVERLAY_DRAWING_POINTERDOWN_FRAME_CHANNEL =
+  'mpv-overlay:drawing-pointerdown-frame-request';
 const MPV_OVERLAY_COLLABORATION_NON_DRAG_ACTIONS = new Set([
   'collab.indicator-enter',
   'collab.indicator-leave',
@@ -117,6 +119,50 @@ const FABRIC_DRAWING_HYDRATE_REQUEST_KEYS = Object.freeze([
 const FABRIC_DRAWING_EXPORT_REQUEST_KEYS = Object.freeze(
   FABRIC_DRAWING_HYDRATE_REQUEST_KEYS.filter(key => key !== 'keyframes')
 );
+const FABRIC_DRAWING_PRESENTATION_KEYS = Object.freeze([
+  'hostGeneration',
+  'videoGeneration',
+  'presentationRevision',
+  'stableVideoIdentity',
+  'storeRevision',
+  'targetFrame',
+  'sourceFrame',
+  'sourceWidth',
+  'sourceHeight',
+  'canvasRect',
+  'viewportRevision',
+  'viewportTransform'
+]);
+const FABRIC_DRAWING_CANVAS_RECT_KEYS = Object.freeze(['left', 'top', 'width', 'height']);
+const FABRIC_DRAWING_VIEWPORT_TRANSFORM_KEYS = Object.freeze(['scale', 'panX', 'panY']);
+const FABRIC_DRAWING_ACTIVE_FRAME_KEYS = Object.freeze([
+  'hostGeneration',
+  'videoGeneration',
+  'inputRevision',
+  'sessionId',
+  'frameRevision',
+  'targetFrame'
+]);
+const FABRIC_DRAWING_POINTERDOWN_FRAME_REQUEST_KEYS = Object.freeze([
+  'hostGeneration',
+  'videoGeneration',
+  'inputRevision',
+  'sessionId',
+  'pointerdownId',
+  'pointerdownAt'
+]);
+const FABRIC_DRAWING_POINTERDOWN_FRAME_CONFIRM_KEYS = Object.freeze([
+  ...FABRIC_DRAWING_POINTERDOWN_FRAME_REQUEST_KEYS,
+  'targetFrame'
+]);
+const FABRIC_DRAWING_POINTERDOWN_FRAME_CANCEL_KEYS = Object.freeze([
+  ...FABRIC_DRAWING_POINTERDOWN_FRAME_REQUEST_KEYS,
+  'cancelled'
+]);
+const FABRIC_DRAWING_POINTERDOWN_FRAME_CANCEL_RESULT_KEYS = Object.freeze([
+  'accepted',
+  ...FABRIC_DRAWING_POINTERDOWN_FRAME_CANCEL_KEYS
+]);
 const FABRIC_DRAWING_HYDRATE_KEYFRAME_KEYS = Object.freeze([
   'id',
   'frame',
@@ -2125,6 +2171,107 @@ function normalizeFabricDrawingPersistenceRequest(request, {
   return value;
 }
 
+function normalizeFabricDrawingPresentationRequest(request) {
+  if (!isPlainPersistenceRecord(request) ||
+      !hasExactPersistenceKeys(request, FABRIC_DRAWING_PRESENTATION_KEYS)) {
+    return null;
+  }
+  const value = {};
+  for (const key of FABRIC_DRAWING_PRESENTATION_KEYS) value[key] = request[key];
+  if (!isSafePersistenceCount(value.hostGeneration) ||
+      !isSafePersistenceCount(value.videoGeneration) ||
+      !Number.isSafeInteger(value.presentationRevision) ||
+      value.presentationRevision <= 0 ||
+      !isBoundedPersistenceString(value.stableVideoIdentity) ||
+      !isSafePersistenceCount(value.storeRevision) ||
+      !isSafePersistenceCount(value.targetFrame) ||
+      (value.sourceFrame !== null &&
+        (!isSafePersistenceCount(value.sourceFrame) ||
+          value.sourceFrame > value.targetFrame)) ||
+      !Number.isFinite(value.sourceWidth) ||
+      value.sourceWidth <= 0 ||
+      value.sourceWidth > FABRIC_DRAWING_MAX_SOURCE_DIMENSION ||
+      !Number.isFinite(value.sourceHeight) ||
+      value.sourceHeight <= 0 ||
+      value.sourceHeight > FABRIC_DRAWING_MAX_SOURCE_DIMENSION ||
+      !hasExactPersistenceKeys(value.canvasRect, FABRIC_DRAWING_CANVAS_RECT_KEYS) ||
+      !FABRIC_DRAWING_CANVAS_RECT_KEYS.every(key => Number.isFinite(value.canvasRect[key])) ||
+      value.canvasRect.width <= 0 || value.canvasRect.height <= 0 ||
+      value.canvasRect.width > FABRIC_DRAWING_MAX_SOURCE_DIMENSION ||
+      value.canvasRect.height > FABRIC_DRAWING_MAX_SOURCE_DIMENSION ||
+      !isSafePersistenceCount(value.viewportRevision) ||
+      !hasExactPersistenceKeys(
+        value.viewportTransform,
+        FABRIC_DRAWING_VIEWPORT_TRANSFORM_KEYS
+      ) ||
+      !FABRIC_DRAWING_VIEWPORT_TRANSFORM_KEYS.every(
+        key => Number.isFinite(value.viewportTransform[key]) &&
+          Math.abs(value.viewportTransform[key]) <= FABRIC_DRAWING_MAX_TRANSFORM_MAGNITUDE
+      ) ||
+      value.viewportTransform.scale <= 0) {
+    return null;
+  }
+  return {
+    ...value,
+    canvasRect: { ...value.canvasRect },
+    viewportTransform: { ...value.viewportTransform }
+  };
+}
+
+function normalizeFabricDrawingActiveFrameRequest(request) {
+  if (!isPlainPersistenceRecord(request) ||
+      !hasExactPersistenceKeys(request, FABRIC_DRAWING_ACTIVE_FRAME_KEYS)) {
+    return null;
+  }
+  if (!isSafePersistenceCount(request.hostGeneration) ||
+      !isSafePersistenceCount(request.videoGeneration) ||
+      !isSafePersistenceCount(request.inputRevision) ||
+      !isBoundedPersistenceString(request.sessionId) ||
+      !Number.isSafeInteger(request.frameRevision) ||
+      request.frameRevision <= 0 ||
+      !isSafePersistenceCount(request.targetFrame)) {
+    return null;
+  }
+  return { ...request };
+}
+
+function normalizeFabricDrawingPointerdownFrameRequest(request, {
+  includeResolution = false
+} = {}) {
+  const isConfirmation = includeResolution &&
+    hasExactPersistenceKeys(request, FABRIC_DRAWING_POINTERDOWN_FRAME_CONFIRM_KEYS);
+  const isCancellation = includeResolution &&
+    hasExactPersistenceKeys(request, FABRIC_DRAWING_POINTERDOWN_FRAME_CANCEL_KEYS) &&
+    request.cancelled === true;
+  const hasExpectedKeys = includeResolution
+    ? isConfirmation || isCancellation
+    : hasExactPersistenceKeys(request, FABRIC_DRAWING_POINTERDOWN_FRAME_REQUEST_KEYS);
+  if (!isPlainPersistenceRecord(request) ||
+      !hasExpectedKeys ||
+      !Number.isSafeInteger(request.hostGeneration) || request.hostGeneration <= 0 ||
+      !Number.isSafeInteger(request.videoGeneration) || request.videoGeneration <= 0 ||
+      !Number.isSafeInteger(request.inputRevision) || request.inputRevision <= 0 ||
+      !isBoundedPersistenceString(request.sessionId, 256) ||
+      !isBoundedPersistenceString(request.pointerdownId, 256) ||
+      !Number.isSafeInteger(request.pointerdownAt) || request.pointerdownAt < 0 ||
+      (isConfirmation && !isSafePersistenceCount(request.targetFrame))) {
+    return null;
+  }
+  return {
+    hostGeneration: request.hostGeneration,
+    videoGeneration: request.videoGeneration,
+    inputRevision: request.inputRevision,
+    sessionId: request.sessionId,
+    pointerdownId: request.pointerdownId,
+    pointerdownAt: request.pointerdownAt,
+    ...(isConfirmation
+      ? { targetFrame: request.targetFrame }
+      : isCancellation
+        ? { cancelled: true }
+        : {})
+  };
+}
+
 function readFabricDrawingPersistenceFence(value) {
   try {
     if (!value ||
@@ -2398,6 +2545,9 @@ class MPVOverlayHost {
         : FABRIC_DRAWING_SNAPSHOT_MAX_BYTES;
     this.currentVideoGeneration = -1;
     this.currentInputRevision = -1;
+    this.currentDrawingFrameRevision = -1;
+    this.currentPresentationRevision = -1;
+    this.currentStableVideoIdentity = null;
     this.remoteCursorRevision = -1;
     this.collaborationRevision = -1;
     this.collaborationActionSequence = 0;
@@ -2525,6 +2675,49 @@ class MPVOverlayHost {
     return result;
   }
 
+  forwardDrawingPointerdownFrameRequest(event, value) {
+    if (!this.isCurrentOverlaySender(event)) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'drawing-pointerdown-frame-sender-not-allowed'
+      };
+    }
+    const request = normalizeFabricDrawingPointerdownFrameRequest(value);
+    if (!request) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'invalid-drawing-pointerdown-frame-request'
+      };
+    }
+    const hostWindow = this.window;
+    const mainWindow = this.getMainWindow();
+    const mainWebContents = mainWindow?.webContents;
+    if (!hostWindow || hostWindow.isDestroyed?.() || !this.contentLoaded ||
+        this.fabricReadyGeneration !== this.hostGeneration ||
+        !this._drawingTokensMatch(request) ||
+        !mainWindow || mainWindow.isDestroyed?.() ||
+        !mainWebContents || mainWebContents.isDestroyed?.() ||
+        typeof mainWebContents.send !== 'function') {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'drawing-pointerdown-frame-session-not-active'
+      };
+    }
+    try {
+      mainWebContents.send(MPV_OVERLAY_DRAWING_POINTERDOWN_FRAME_CHANNEL, request);
+      return { success: true, accepted: true };
+    } catch (_error) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'drawing-pointerdown-frame-forward-failed'
+      };
+    }
+  }
+
   _resetCollaborationActionRelay({ cancelCurrent = true, resetSequence = true } = {}) {
     const pointerId = this.activeCollaborationDragPointerId;
     if (cancelCurrent && pointerId !== null) {
@@ -2575,8 +2768,14 @@ class MPVOverlayHost {
       this._setNativeDrawingInput(hostWindow, false);
     }
 
+    const videoGenerationChanged = videoGeneration !== this.currentVideoGeneration;
     this.currentVideoGeneration = videoGeneration;
     this.currentInputRevision = inputRevision;
+    this.currentDrawingFrameRevision = -1;
+    if (videoGenerationChanged) {
+      this.currentPresentationRevision = -1;
+      this.currentStableVideoIdentity = null;
+    }
     this.desiredInputEnabled = request.enabled;
     this.activeSessionId = null;
     this.currentToolRevision = -1;
@@ -2674,12 +2873,156 @@ class MPVOverlayHost {
     }
   }
 
+  async updateDrawingFrame(request = {}) {
+    const normalizedRequest = normalizeFabricDrawingActiveFrameRequest(request);
+    const hostWindow = this.window;
+    if (!normalizedRequest ||
+        !hostWindow || hostWindow.isDestroyed?.() || !this.contentLoaded ||
+        this.fabricReadyGeneration !== this.hostGeneration ||
+        !this._drawingTokensMatch(normalizedRequest) ||
+        normalizedRequest.frameRevision <= this.currentDrawingFrameRevision) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'stale-or-invalid-active-frame'
+      };
+    }
+
+    this.currentDrawingFrameRevision = normalizedRequest.frameRevision;
+    try {
+      const result = await this._executeFabricMethod(
+        'updateDrawingFrame',
+        normalizedRequest
+      );
+      if (!this._drawingFrameRequestIsCurrent(hostWindow, normalizedRequest)) {
+        return {
+          success: false,
+          accepted: false,
+          reason: 'stale-active-frame-response'
+        };
+      }
+      if (result?.accepted !== true) {
+        return {
+          success: false,
+          accepted: false,
+          reason: result?.reason || 'active-frame-update-rejected'
+        };
+      }
+      if (result.repainted === true) hostWindow.webContents?.invalidate?.();
+      return {
+        success: true,
+        accepted: true,
+        frameRevision: normalizedRequest.frameRevision,
+        targetFrame: normalizedRequest.targetFrame,
+        sourceFrame: Number.isSafeInteger(result.sourceFrame) ? result.sourceFrame : null
+      };
+    } catch (error) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'active-frame-update-failed',
+        error: error.message
+      };
+    }
+  }
+
+  async confirmDrawingPointerdownFrame(request = {}) {
+    const normalizedRequest = normalizeFabricDrawingPointerdownFrameRequest(request, {
+      includeResolution: true
+    });
+    const hostWindow = this.window;
+    if (!normalizedRequest ||
+        !hostWindow || hostWindow.isDestroyed?.() || !this.contentLoaded ||
+        this.fabricReadyGeneration !== this.hostGeneration ||
+        !this._drawingTokensMatch(normalizedRequest)) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'stale-or-invalid-drawing-pointerdown-frame'
+      };
+    }
+
+    const isCancellation = normalizedRequest.cancelled === true;
+    let result;
+    try {
+      result = await this._executeFabricMethod(
+        'confirmDrawingPointerdownFrame',
+        normalizedRequest
+      );
+    } catch (_error) {
+      if (!this._drawingPointerdownFrameRequestIsCurrent(hostWindow, normalizedRequest)) {
+        return {
+          success: false,
+          accepted: false,
+          reason: 'stale-drawing-pointerdown-frame-response'
+        };
+      }
+      return {
+        success: false,
+        accepted: false,
+        reason: isCancellation
+          ? 'drawing-pointerdown-frame-cancel-failed'
+          : 'drawing-pointerdown-frame-confirm-failed'
+      };
+    }
+
+    if (!this._drawingPointerdownFrameRequestIsCurrent(hostWindow, normalizedRequest)) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'stale-drawing-pointerdown-frame-response'
+      };
+    }
+    if (isCancellation) {
+      const exactCancellationResult =
+        hasExactPersistenceKeys(result, FABRIC_DRAWING_POINTERDOWN_FRAME_CANCEL_RESULT_KEYS) &&
+        result.accepted === true && result.cancelled === true &&
+        FABRIC_DRAWING_POINTERDOWN_FRAME_REQUEST_KEYS.every(
+          key => result[key] === normalizedRequest[key]
+        );
+      if (!exactCancellationResult) {
+        return {
+          success: false,
+          accepted: false,
+          reason: 'drawing-pointerdown-frame-cancel-rejected'
+        };
+      }
+      return {
+        success: true,
+        accepted: true,
+        cancelled: true,
+        hostGeneration: normalizedRequest.hostGeneration,
+        videoGeneration: normalizedRequest.videoGeneration,
+        inputRevision: normalizedRequest.inputRevision,
+        sessionId: normalizedRequest.sessionId,
+        pointerdownId: normalizedRequest.pointerdownId,
+        pointerdownAt: normalizedRequest.pointerdownAt
+      };
+    }
+    if (result?.accepted !== true ||
+        result.pointerdownId !== normalizedRequest.pointerdownId ||
+        result.targetFrame !== normalizedRequest.targetFrame) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'drawing-pointerdown-frame-confirm-rejected'
+      };
+    }
+    return {
+      success: true,
+      accepted: true,
+      pointerdownId: normalizedRequest.pointerdownId,
+      targetFrame: normalizedRequest.targetFrame
+    };
+  }
+
   async applyDrawingAction(request = {}) {
     const validAction = HOST_DRAWING_ACTIONS.has(request.action);
     if (!this._drawingTokensMatch(request) ||
         !validAction ||
         typeof request.actionId !== 'string' ||
-        request.actionId.length === 0 || request.actionId.length > 256) {
+        request.actionId.length === 0 || request.actionId.length > 256 ||
+        (request.targetFrame !== undefined && !isSafePersistenceCount(request.targetFrame))) {
       return { success: false, applied: false, error: 'stale or invalid drawing action request' };
     }
     if (this.completedActionIds.has(request.actionId)) {
@@ -2694,7 +3037,8 @@ class MPVOverlayHost {
       inputRevision: request.inputRevision,
       sessionId: request.sessionId,
       actionId: request.actionId,
-      action: request.action
+      action: request.action,
+      ...(request.targetFrame === undefined ? {} : { targetFrame: request.targetFrame })
     };
     const executionContext = {
       hostWindow: this.window,
@@ -2892,6 +3236,114 @@ class MPVOverlayHost {
     }
   }
 
+  async presentDrawingFrame(request = {}) {
+    const normalizedRequest = normalizeFabricDrawingPresentationRequest(request);
+    if (!normalizedRequest) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'invalid-presentation-request'
+      };
+    }
+    const echo = {
+      presentationRevision: normalizedRequest.presentationRevision,
+      targetFrame: normalizedRequest.targetFrame,
+      sourceFrame: normalizedRequest.sourceFrame
+    };
+    const hostWindow = this.window;
+    if (!hostWindow || hostWindow.isDestroyed?.() || !this.contentLoaded) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'overlay-host-unavailable',
+        ...echo
+      };
+    }
+    const fenceMatches = normalizedRequest.hostGeneration === this.hostGeneration &&
+      normalizedRequest.videoGeneration === this.currentVideoGeneration &&
+      normalizedRequest.stableVideoIdentity === this.currentStableVideoIdentity &&
+      normalizedRequest.presentationRevision > this.currentPresentationRevision;
+    if (!fenceMatches) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'stale-presentation-fence',
+        ...echo
+      };
+    }
+    if (this.desiredInputEnabled) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'drawing-input-enabled',
+        ...echo
+      };
+    }
+
+    this.currentPresentationRevision = normalizedRequest.presentationRevision;
+    const prepared = await this._ensureFabricRuntime();
+    if (!prepared.success) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'drawing-runtime-unavailable',
+        ...echo
+      };
+    }
+    if (!this._drawingPresentationRequestIsCurrent(hostWindow, normalizedRequest, true)) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'stale-presentation-response',
+        ...echo
+      };
+    }
+
+    try {
+      const result = await this._executeFabricMethod(
+        'presentDrawingFrame',
+        normalizedRequest
+      );
+      if (!this._drawingPresentationRequestIsCurrent(hostWindow, normalizedRequest, true)) {
+        return {
+          success: false,
+          accepted: false,
+          reason: 'stale-presentation-response',
+          ...echo
+        };
+      }
+      if (result?.accepted !== true) {
+        return {
+          success: false,
+          accepted: false,
+          reason: this._drawingPersistenceReason(
+            result?.reason,
+            'drawing-presentation-rejected'
+          ),
+          ...echo
+        };
+      }
+      hostWindow.moveTop?.();
+      hostWindow.webContents?.invalidate?.();
+      return { success: true, accepted: true, ...echo };
+    } catch (_error) {
+      if (!this._drawingPresentationRequestIsCurrent(hostWindow, normalizedRequest, true)) {
+        return {
+          success: false,
+          accepted: false,
+          reason: 'stale-presentation-response',
+          ...echo
+        };
+      }
+      return {
+        success: false,
+        accepted: false,
+        reason: 'drawing-presentation-failed',
+        ...echo
+      };
+    }
+  }
+
   async hydrateDrawingVideo(request = {}) {
     const normalizedRequest = normalizeFabricDrawingPersistenceRequest(request, {
       includeKeyframes: true,
@@ -2906,6 +3358,14 @@ class MPVOverlayHost {
     }
     const hostWindow = this.window;
     if (!this._drawingPersistenceRequestIsCurrent(hostWindow, normalizedRequest)) {
+      return {
+        success: false,
+        accepted: false,
+        reason: 'stale-persistence-fence'
+      };
+    }
+    if (this.currentStableVideoIdentity !== null &&
+        normalizedRequest.stableVideoIdentity !== this.currentStableVideoIdentity) {
       return {
         success: false,
         accepted: false,
@@ -2960,6 +3420,7 @@ class MPVOverlayHost {
           )
         };
       }
+      this.currentStableVideoIdentity = normalizedRequest.stableVideoIdentity;
       return {
         success: true,
         accepted: true,
@@ -3257,6 +3718,23 @@ class MPVOverlayHost {
       this.desiredInputEnabled;
   }
 
+  _drawingFrameRequestIsCurrent(hostWindow, request = {}) {
+    return this.window === hostWindow &&
+      !hostWindow.isDestroyed?.() &&
+      this.contentLoaded === true &&
+      this.fabricReadyGeneration === this.hostGeneration &&
+      this._drawingTokensMatch(request) &&
+      request.frameRevision === this.currentDrawingFrameRevision;
+  }
+
+  _drawingPointerdownFrameRequestIsCurrent(hostWindow, request = {}) {
+    return this.window === hostWindow &&
+      !hostWindow.isDestroyed?.() &&
+      this.contentLoaded === true &&
+      this.fabricReadyGeneration === this.hostGeneration &&
+      this._drawingTokensMatch(request);
+  }
+
   _drawingPersistenceRequestIsCurrent(hostWindow, request = {}, requireReady = false) {
     return !!hostWindow &&
       this.window === hostWindow &&
@@ -3264,6 +3742,19 @@ class MPVOverlayHost {
       this.contentLoaded === true &&
       request.hostGeneration === this.hostGeneration &&
       request.videoGeneration === this.currentVideoGeneration &&
+      (!requireReady || this.fabricReadyGeneration === this.hostGeneration);
+  }
+
+  _drawingPresentationRequestIsCurrent(hostWindow, request = {}, requireReady = false) {
+    return !!hostWindow &&
+      this.window === hostWindow &&
+      !hostWindow.isDestroyed?.() &&
+      this.contentLoaded === true &&
+      this.desiredInputEnabled === false &&
+      request.hostGeneration === this.hostGeneration &&
+      request.videoGeneration === this.currentVideoGeneration &&
+      request.presentationRevision === this.currentPresentationRevision &&
+      request.stableVideoIdentity === this.currentStableVideoIdentity &&
       (!requireReady || this.fabricReadyGeneration === this.hostGeneration);
   }
 
@@ -3537,6 +4028,8 @@ class MPVOverlayHost {
     this.fabricRetryAfter = 0;
     this.currentVideoGeneration = -1;
     this.currentInputRevision = -1;
+    this.currentPresentationRevision = -1;
+    this.currentStableVideoIdentity = null;
     this.remoteCursorRevision = -1;
     this.collaborationRevision = -1;
     this.collaborationActionSequence = 0;
@@ -3602,6 +4095,8 @@ class MPVOverlayHost {
     this.fabricRetryAfter = 0;
     this.currentVideoGeneration = -1;
     this.currentInputRevision = -1;
+    this.currentPresentationRevision = -1;
+    this.currentStableVideoIdentity = null;
     this.remoteCursorRevision = -1;
     this.collaborationRevision = -1;
     this.collaborationActionSequence = 0;
@@ -3725,6 +4220,8 @@ class MPVOverlayHost {
       this.fabricRetryAfter = 0;
       this.currentVideoGeneration = -1;
       this.currentInputRevision = -1;
+      this.currentPresentationRevision = -1;
+      this.currentStableVideoIdentity = null;
       this.remoteCursorRevision = -1;
       this.collaborationRevision = -1;
       this.collaborationActionSequence = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.2.1-beta",
+  "version": "2.3.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.2.1-beta",
+      "version": "2.3.0-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.2.1-beta",
+  "version": "2.3.0-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {
@@ -15,7 +15,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "test:fabric-drawing-pilot": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test scripts/tests/fabric-drawing-pilot-integration.test.js scripts/tests/fabric-drawing-pilot-benchmark.test.mjs scripts/tests/fabric-drawing-pilot-session.test.js scripts/tests/fabric-drawing-pilot-shortcuts.test.js scripts/tests/fabric-drawing-pilot-source.test.js scripts/tests/fabric-drawing-persistence-controller.test.js scripts/tests/mpv-fabric-overlay-runtime.test.js",
+    "test:fabric-drawing-pilot": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test scripts/tests/fabric-drawing-pilot-integration.test.js scripts/tests/fabric-drawing-pilot-benchmark.test.mjs scripts/tests/fabric-drawing-pilot-session.test.js scripts/tests/fabric-drawing-pilot-shortcuts.test.js scripts/tests/fabric-drawing-pilot-source.test.js scripts/tests/fabric-drawing-pilot-display-controller.test.js scripts/tests/fabric-drawing-persistence-controller.test.js scripts/tests/mpv-fabric-overlay-runtime.test.js",
     "test:fabric-drawing-persistence": "npm run build:review-file-cas-helper && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test --test-concurrency=1 scripts/tests/fabric-drawing-persistence-store.test.mjs scripts/tests/review-data-manager-save.test.js scripts/tests/review-save-version-token-source.test.js scripts/tests/review-save-version-token-ipc.test.js scripts/tests/lazy-bframe-creation-source.test.js scripts/tests/review-file-cas-helper.test.js scripts/tests/review-file-store-contract.test.js scripts/tests/review-file-store-cross-process.test.js scripts/tests/review-file-store-recovery.test.js",
     "diagnostics:fabric-drawing-pilot": "node scripts/run-fabric-drawing-pilot-diagnostics.js",
     "test:recent": "node --test scripts/tests/recent-files-store.test.js scripts/tests/recent-files-source.test.js",

--- a/preload/mpv-overlay-preload.js
+++ b/preload/mpv-overlay-preload.js
@@ -4,6 +4,16 @@ const PERSISTENCE_CHANNEL = 'mpv-overlay:fabric-drawing-persistence';
 const POINTER_PRESENCE_CHANNEL = 'mpv-overlay:pointer-presence';
 const COLLABORATION_ACTION_CHANNEL = 'mpv-overlay:collaboration-action';
 const COLLABORATION_DRAG_RESET_CHANNEL = 'mpv-overlay:collaboration-drag-reset';
+const DRAWING_POINTERDOWN_FRAME_REQUEST_CHANNEL =
+  'mpv-overlay:drawing-pointerdown-frame-request';
+const DRAWING_POINTERDOWN_FRAME_REQUEST_KEYS = Object.freeze([
+  'hostGeneration',
+  'videoGeneration',
+  'inputRevision',
+  'sessionId',
+  'pointerdownId',
+  'pointerdownAt'
+]);
 const MAX_TRANSITION_BYTES = 8 * 1024 * 1024;
 const MAX_COLLABORATION_POINTER_COORDINATE = 32768;
 const encoder = new TextEncoder();
@@ -44,12 +54,34 @@ function isExactPlainObject(value, expectedKeys) {
     if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
     const prototype = Object.getPrototypeOf(value);
     if (prototype !== Object.prototype && prototype !== null) return false;
-    const keys = Object.keys(value);
+    const keys = Reflect.ownKeys(value);
     return keys.length === expectedKeys.length &&
-      keys.every(key => expectedKeys.includes(key));
+      keys.every(key => typeof key === 'string' && expectedKeys.includes(key));
   } catch (_error) {
     return false;
   }
+}
+
+function normalizeDrawingPointerdownFrameRequest(value) {
+  if (!isExactPlainObject(value, DRAWING_POINTERDOWN_FRAME_REQUEST_KEYS) ||
+      !Number.isSafeInteger(value.hostGeneration) || value.hostGeneration <= 0 ||
+      !Number.isSafeInteger(value.videoGeneration) || value.videoGeneration <= 0 ||
+      !Number.isSafeInteger(value.inputRevision) || value.inputRevision <= 0 ||
+      typeof value.sessionId !== 'string' || value.sessionId.length === 0 ||
+      value.sessionId.length > 256 ||
+      typeof value.pointerdownId !== 'string' || value.pointerdownId.length === 0 ||
+      value.pointerdownId.length > 256 ||
+      !Number.isSafeInteger(value.pointerdownAt) || value.pointerdownAt < 0) {
+    return null;
+  }
+  return {
+    hostGeneration: value.hostGeneration,
+    videoGeneration: value.videoGeneration,
+    inputRevision: value.inputRevision,
+    sessionId: value.sessionId,
+    pointerdownId: value.pointerdownId,
+    pointerdownAt: value.pointerdownAt
+  };
 }
 
 function readOverlayViewportRect() {
@@ -521,5 +553,18 @@ contextBridge.exposeInMainWorld('mpvOverlayCollaborationActions', Object.freeze(
   },
   cancelActiveDrag() {
     return cancelActiveCollaborationDrag();
+  }
+}));
+
+contextBridge.exposeInMainWorld('mpvOverlayDrawingFrame', Object.freeze({
+  requestPointerdownFrame(value) {
+    const request = normalizeDrawingPointerdownFrameRequest(value);
+    if (!request) return false;
+    try {
+      ipcRenderer.send(DRAWING_POINTERDOWN_FRAME_REQUEST_CHANNEL, request);
+      return true;
+    } catch (_error) {
+      return false;
+    }
   }
 }));

--- a/preload/preload.js
+++ b/preload/preload.js
@@ -8,6 +8,16 @@ const { contextBridge, ipcRenderer } = require('electron');
 const MPV_OVERLAY_KEYBOARD_CHANNEL = 'mpv-overlay:keyboard-input';
 const MPV_OVERLAY_POINTER_PRESENCE_CHANNEL = 'mpv-overlay:pointer-presence';
 const MPV_OVERLAY_COLLABORATION_ACTION_CHANNEL = 'mpv-overlay:collaboration-action';
+const MPV_OVERLAY_DRAWING_POINTERDOWN_FRAME_CHANNEL =
+  'mpv-overlay:drawing-pointerdown-frame-request';
+const MPV_OVERLAY_DRAWING_POINTERDOWN_FRAME_KEYS = Object.freeze([
+  'hostGeneration',
+  'videoGeneration',
+  'inputRevision',
+  'sessionId',
+  'pointerdownId',
+  'pointerdownAt'
+]);
 const MPV_OVERLAY_COLLABORATION_ACTIONS = new Set([
   'collab.indicator-enter',
   'collab.indicator-leave',
@@ -126,6 +136,28 @@ function isExactPlainObject(value, keys) {
   } catch (_error) {
     return false;
   }
+}
+
+function normalizeMpvOverlayDrawingPointerdownFrame(value) {
+  if (!isExactPlainObject(value, MPV_OVERLAY_DRAWING_POINTERDOWN_FRAME_KEYS) ||
+      !Number.isSafeInteger(value.hostGeneration) || value.hostGeneration <= 0 ||
+      !Number.isSafeInteger(value.videoGeneration) || value.videoGeneration <= 0 ||
+      !Number.isSafeInteger(value.inputRevision) || value.inputRevision <= 0 ||
+      typeof value.sessionId !== 'string' || value.sessionId.length === 0 ||
+      value.sessionId.length > 256 ||
+      typeof value.pointerdownId !== 'string' || value.pointerdownId.length === 0 ||
+      value.pointerdownId.length > 256 ||
+      !Number.isSafeInteger(value.pointerdownAt) || value.pointerdownAt < 0) {
+    return null;
+  }
+  return {
+    hostGeneration: value.hostGeneration,
+    videoGeneration: value.videoGeneration,
+    inputRevision: value.inputRevision,
+    sessionId: value.sessionId,
+    pointerdownId: value.pointerdownId,
+    pointerdownAt: value.pointerdownAt
+  };
 }
 
 function normalizeMpvOverlayCollaborationActionPayload(action, payload) {
@@ -329,7 +361,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   mpvTriggerOverlayCollabRipple: (state) => ipcRenderer.invoke('mpv:trigger-overlay-collab-ripple', state),
   mpvSetOverlayDrawingInput: (request) => ipcRenderer.invoke('mpv:set-overlay-drawing-input', request),
   mpvUpdateOverlayDrawingTool: (request) => ipcRenderer.invoke('mpv:update-overlay-drawing-tool', request),
+  mpvUpdateOverlayDrawingFrame: (request) => ipcRenderer.invoke('mpv:update-overlay-drawing-frame', request),
   mpvApplyOverlayDrawingAction: (request) => ipcRenderer.invoke('mpv:apply-overlay-drawing-action', request),
+  mpvConfirmOverlayDrawingPointerdownFrame: (request) =>
+    ipcRenderer.invoke('mpv:confirm-overlay-drawing-pointerdown-frame', request),
+  mpvPresentOverlayDrawingFrame: (request) => ipcRenderer.invoke('mpv:present-overlay-drawing-frame', request),
   mpvGetOverlayDrawingDiagnostics: () => ipcRenderer.invoke('mpv:get-overlay-drawing-diagnostics'),
   mpvHydrateOverlayDrawingVideo: (request) => ipcRenderer.invoke('mpv:hydrate-overlay-drawing-video', request),
   mpvExportOverlayDrawingVideo: (request) => ipcRenderer.invoke('mpv:export-overlay-drawing-video', request),
@@ -350,6 +386,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
     };
     ipcRenderer.on(MPV_OVERLAY_POINTER_PRESENCE_CHANNEL, listener);
     return () => ipcRenderer.removeListener(MPV_OVERLAY_POINTER_PRESENCE_CHANNEL, listener);
+  },
+  onMpvOverlayDrawingPointerdownFrame: (callback) => {
+    if (typeof callback !== 'function') return () => {};
+    const listener = (_event, value) => {
+      const request = normalizeMpvOverlayDrawingPointerdownFrame(value);
+      if (request) callback(request);
+    };
+    ipcRenderer.on(MPV_OVERLAY_DRAWING_POINTERDOWN_FRAME_CHANNEL, listener);
+    return () => ipcRenderer.removeListener(
+      MPV_OVERLAY_DRAWING_POINTERDOWN_FRAME_CHANNEL,
+      listener
+    );
   },
   onMpvOverlayCollaborationAction: (callback) => {
     if (typeof callback !== 'function') return () => {};

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -1186,16 +1186,13 @@ async function initApp() {
   const MAX_UNDO_STACK = 50;
   let _isProcessingUndo = false;
   let globalHistoryRevision = 0;
+  let globalHistoryMutationBarrier = null;
 
   function advanceGlobalHistoryRevision() {
     globalHistoryRevision += 1;
   }
 
-  /**
-   * Undo 스택에 작업 추가
-   * @param {Object} action - { type, data, undo, redo }
-   */
-  function pushUndo(action) {
+  function pushUndoNow(action) {
     if (!action.timestamp) action.timestamp = Date.now();
     undoStack.push(action);
     if (undoStack.length > MAX_UNDO_STACK) {
@@ -1205,10 +1202,59 @@ async function initApp() {
     advanceGlobalHistoryRevision();
   }
 
+  function beginGlobalHistoryMutation() {
+    if (globalHistoryMutationBarrier) return null;
+    let resolveBarrier;
+    const barrier = {
+      promise: new Promise(resolve => { resolveBarrier = resolve; }),
+      queuedActions: [],
+      committed: false
+    };
+    globalHistoryMutationBarrier = barrier;
+    let released = false;
+    return {
+      commit(action) {
+        if (released || barrier.committed || globalHistoryMutationBarrier !== barrier) {
+          return false;
+        }
+        barrier.committed = true;
+        pushUndoNow(action);
+        return true;
+      },
+      release() {
+        if (released) return;
+        released = true;
+        for (const action of barrier.queuedActions.splice(0)) {
+          pushUndoNow(action);
+        }
+        if (globalHistoryMutationBarrier === barrier) {
+          globalHistoryMutationBarrier = null;
+        }
+        resolveBarrier();
+      }
+    };
+  }
+
+  /**
+   * Undo 스택에 작업 추가
+   * @param {Object} action - { type, data, undo, redo }
+   */
+  function pushUndo(action) {
+    const pendingHistoryMutation = globalHistoryMutationBarrier;
+    if (pendingHistoryMutation) {
+      if (!action.timestamp) action.timestamp = Date.now();
+      pendingHistoryMutation.queuedActions.push(action);
+      return;
+    }
+    pushUndoNow(action);
+  }
+
   /**
    * 글로벌 Undo 실행 (통합 타임라인)
    */
   async function globalUndo({ fromFabricFallback = false } = {}) {
+    const pendingHistoryMutation = globalHistoryMutationBarrier;
+    if (pendingHistoryMutation) await pendingHistoryMutation.promise;
     if (_isProcessingUndo || undoStack.length === 0) return false;
     _isProcessingUndo = true;
     const advanceHistoryRevision = () => {
@@ -1251,6 +1297,8 @@ async function initApp() {
    * 글로벌 Redo 실행 (통합 타임라인)
    */
   async function globalRedo({ fromFabricFallback = false } = {}) {
+    const pendingHistoryMutation = globalHistoryMutationBarrier;
+    if (pendingHistoryMutation) await pendingHistoryMutation.promise;
     if (_isProcessingUndo || redoStack.length === 0) return false;
     _isProcessingUndo = true;
     const advanceHistoryRevision = () => {
@@ -1641,6 +1689,7 @@ async function initApp() {
       commentManager.setCurrentFrame(currentFrame);
       void handleCutlistPlaybackFrame(currentFrame);
       refreshCurrentCutFromPlayback(currentFrame);
+      void fabricDrawingPilotController.syncDisplayFrame(currentFrame);
     }
 
     if (updatePresence && liveblocksManager.isConnected) {
@@ -1716,6 +1765,7 @@ async function initApp() {
 
   // 비디오 재생 상태 변경
   videoPlayer.addEventListener('play', () => {
+    syncCurrentFabricDrawingDisplayFrame({ force: true });
     elements.btnPlay.innerHTML = pauseIconSVG;
     drawingManager.setPlaying(true);
     timeline.setPlayingState(true);
@@ -2120,11 +2170,129 @@ async function initApp() {
     deleteDrawingLayer(selectedLayerIdForPopup);
   });
 
-  // 키프레임 이동
-  timeline.addEventListener('keyframesMove', (e) => {
-    // 파일럿 투영 레이어는 읽기 전용 — 드래그 이동이 레거시 undo 히스토리를 오염시키지 않게 차단
-    if (getFabricPilotTimelineLayers()) return;
-    const { keyframes, frameDelta, anchor } = e.detail;
+  let fabricPilotKeyframeMoveInProgress = false;
+
+  function classifyFabricPilotKeyframeMove(keyframes) {
+    if (!Array.isArray(keyframes) || keyframes.length === 0) return 'invalid';
+    const fabricCount = keyframes.filter(
+      keyframe => keyframe?.layerId === 'fabric-pilot-drawing-layer'
+    ).length;
+    if (fabricCount === 0) return 'legacy';
+    return fabricCount === keyframes.length ? 'fabric' : 'mixed';
+  }
+
+  async function moveFabricPilotKeyframes(keyframes, frameDelta, anchor) {
+    if (fabricPilotKeyframeMoveInProgress || _isProcessingUndo) return false;
+    const moves = keyframes.map(keyframe => ({
+      fromFrame: keyframe.fromFrame,
+      toFrame: keyframe.toFrame
+    }));
+    fabricPilotKeyframeMoveInProgress = true;
+    const globalHistoryMutation = beginGlobalHistoryMutation();
+    if (!globalHistoryMutation) {
+      fabricPilotKeyframeMoveInProgress = false;
+      return false;
+    }
+    let moveResult = null;
+    try {
+      const refreshed = await fabricDrawingPilotController.refreshPersistenceSource(() => {
+        moveResult = fabricDrawingPersistenceStore.moveKeyframes(moves);
+        return moveResult?.applied === true;
+      });
+      if (moveResult?.applied !== true || !moveResult.edit) {
+        return false;
+      }
+      const currentDocumentId = fabricDrawingPersistenceStore
+        .getHydrationDocument?.()?.documentId;
+      if (currentDocumentId !== moveResult.edit.documentId) {
+        log.warn('Fabric 키프레임 이동 후 문서 소유자가 바뀌어 결과 반영을 중단했습니다.');
+        return false;
+      }
+      if (refreshed !== true) {
+        // store 반영은 이미 끝났다. 이후 host 재수화/재활성화 실패를 이동 실패로
+        // 되돌리면 global undo 스택과 canonical 문서 상태가 서로 어긋난다.
+        log.warn('Fabric 키프레임 이동은 저장됐지만 화면 갱신이 지연되어 재동기화합니다.');
+        syncCurrentFabricDrawingDisplayFrame({ force: true });
+      }
+
+      const movedSelection = keyframes.map(keyframe => ({
+        layerId: keyframe.layerId,
+        frame: keyframe.toFrame
+      }));
+      timeline.setKeyframeSelection(movedSelection, { anchor });
+      renderActiveDrawingLayers();
+      showToast(`키프레임 ${frameDelta > 0 ? '+' : ''}${frameDelta} 프레임 이동`, 'info');
+
+      const applyHistoryEdit = async direction => {
+        let historyResult = null;
+        const historyRefreshed = await fabricDrawingPilotController.refreshPersistenceSource(() => {
+          historyResult = fabricDrawingPersistenceStore.applyKeyframeEdit(
+            moveResult.edit,
+            direction
+          );
+          return historyResult?.applied === true;
+        });
+        if (historyResult?.applied !== true) {
+          throw new Error(
+            `Fabric keyframe move ${direction} failed: ${historyResult?.reason || 'edit-rejected'}`
+          );
+        }
+        const historyDocumentId = fabricDrawingPersistenceStore
+          .getHydrationDocument?.()?.documentId;
+        if (historyDocumentId !== moveResult.edit.documentId) {
+          // canonical edit는 성공했으므로 global history 이동은 완료한다. 다만 그 사이
+          // 새 문서가 들어왔다면 옛 선택 상태를 새 타임라인에 덮어쓰지 않는다.
+          log.warn(`Fabric 키프레임 이동 ${direction} 후 문서 소유자가 바뀌어 화면만 재동기화합니다.`);
+          syncCurrentFabricDrawingDisplayFrame({ force: true });
+          return true;
+        }
+        if (historyRefreshed !== true) {
+          log.warn(`Fabric 키프레임 이동 ${direction}는 저장됐지만 화면 갱신이 지연되어 재동기화합니다.`);
+          syncCurrentFabricDrawingDisplayFrame({ force: true });
+        }
+        const historySelection = keyframes.map(keyframe => ({
+          layerId: keyframe.layerId,
+          frame: direction === 'undo' ? keyframe.fromFrame : keyframe.toFrame
+        }));
+        const historyAnchor = anchor
+          ? {
+            ...anchor,
+            frame: direction === 'undo' ? anchor.frame - frameDelta : anchor.frame
+          }
+          : null;
+        timeline.setKeyframeSelection(historySelection, { anchor: historyAnchor });
+        renderActiveDrawingLayers();
+        return true;
+      };
+      if (!globalHistoryMutation.commit({
+        type: 'FABRIC_KEYFRAME_MOVE',
+        data: { edit: moveResult.edit },
+        undo: () => applyHistoryEdit('undo'),
+        redo: () => applyHistoryEdit('redo')
+      })) {
+        return false;
+      }
+      return true;
+    } catch (error) {
+      log.warn('Fabric 키프레임 이동 실패', { error: error.message });
+      return false;
+    } finally {
+      globalHistoryMutation.release();
+      fabricPilotKeyframeMoveInProgress = false;
+    }
+  }
+
+  async function handleTimelineKeyframesMove(detail = {}) {
+    const { keyframes, frameDelta, anchor } = detail;
+    const route = classifyFabricPilotKeyframeMove(keyframes);
+    if (route === 'mixed') {
+      log.warn('Fabric/legacy 혼합 키프레임 이동을 차단했습니다.');
+      return false;
+    }
+    if (route === 'fabric') {
+      return moveFabricPilotKeyframes(keyframes, frameDelta, anchor);
+    }
+    if (route !== 'legacy') return false;
     if (drawingManager.moveKeyframes(keyframes)) {
       // 이동 성공 시 선택 상태 업데이트
       const movedSelection = keyframes.map(kf => ({
@@ -2134,7 +2302,15 @@ async function initApp() {
       timeline.setKeyframeSelection(movedSelection, { anchor });
       renderActiveDrawingLayers();
       showToast(`키프레임 ${frameDelta > 0 ? '+' : ''}${frameDelta} 프레임 이동`, 'info');
+      return true;
     }
+    return false;
+  }
+
+  // 키프레임 이동
+  timeline.addEventListener('keyframesMove', (e) => {
+    const { keyframes, frameDelta, anchor } = e.detail;
+    void handleTimelineKeyframesMove({ keyframes, frameDelta, anchor });
   });
 
   function deleteSelectedOrCurrentKeyframes() {
@@ -6231,12 +6407,22 @@ async function initApp() {
       color: '#4f8ef7',
       visible: true,
       locked: true,
+      timelineKeyframesMovable: true,
       opacity: 1,
       keyframes,
       getKeyframeRanges(totalFrames) {
-        return keyframes.map(kf => ({
+        const tailFrame = Math.max(0, Math.trunc(Number(totalFrames) || 0) - 1);
+        return keyframes.map((kf, index) => ({
           start: kf.frame,
-          end: kf.frame,
+          end: Math.max(
+            kf.frame,
+            Math.min(
+              tailFrame,
+              keyframes[index + 1]?.frame !== undefined
+                ? keyframes[index + 1].frame - 1
+                : tailFrame
+            )
+          ),
           keyframe: kf
         }));
       }
@@ -7374,6 +7560,10 @@ async function initApp() {
   let fabricDrawingViewportRevision = 0;
   let fabricDrawingViewportSignature = '';
   let resetMpvOverlayCollaborationDrag = () => {};
+  function syncCurrentFabricDrawingDisplayFrame(options) {
+    const currentFrame = Math.max(0, Math.trunc(Number(videoPlayer.currentFrame) || 0));
+    void fabricDrawingPilotController.syncDisplayFrame(currentFrame, options);
+  }
   const mpvOverlayLifecycle = createMpvOverlayLifecycle({
     onWarning: (error) => {
       log.warn('mpv 오버레이 동기화 실패, 호스트 복구를 시도합니다.', {
@@ -7412,6 +7602,7 @@ async function initApp() {
     requestAnimationFrame(() => {
       fabricPilotTimelineRenderQueued = false;
       renderActiveDrawingLayers();
+      syncCurrentFabricDrawingDisplayFrame();
     });
   });
   reviewDataManager.setFabricDrawingSourceRefreshHandler(
@@ -9726,10 +9917,6 @@ async function initApp() {
       elements.filePath.textContent = fileInfo.dir;
       elements.dropZone.classList.add('hidden');
 
-      if (playWhenMediaReady && shouldContinueVideoLoad()) {
-        await playVideoAfterMediaLoad({ silent: true });
-      }
-
       // 폴더 열기 / 다른 파일 열기 버튼 표시
       elements.btnOpenFolder.style.display = 'flex';
       elements.btnOpenOther.style.display = 'flex';
@@ -9822,6 +10009,21 @@ async function initApp() {
       }
       reviewDataManager.setFps(videoPlayer.fps);
 
+      if (!engineSwap && canContinueVideoLoad()) {
+        const fabricDrawingPilotApplies = useMpvPilot && !fileIsAudio &&
+          fabricDrawingPilotController.shouldOwnDrawingShortcut();
+        const fabricDrawingReady = await fabricDrawingPilotController.afterVideoReady({
+          ...getFabricDrawingPilotContext(),
+          loadToken
+        });
+        if (!canContinueVideoLoad()) return false;
+        if (fabricDrawingPilotApplies && fabricDrawingReady !== true) return false;
+      }
+
+      if (playWhenMediaReady && shouldContinueVideoLoad()) {
+        await playVideoAfterMediaLoad({ silent: true });
+      }
+
       // keepVersionContext가 false일 때만 manualVersions 복원
       // (true면 기존 버전 목록 유지)
       if (!keepVersionContext) {
@@ -9892,14 +10094,6 @@ async function initApp() {
           size: fileInfo.size,
           duration: videoPlayer.duration || 0
         });
-      }
-
-      if (!engineSwap && canContinueVideoLoad()) {
-        await fabricDrawingPilotController.afterVideoReady({
-          ...getFabricDrawingPilotContext(),
-          loadToken
-        });
-        if (!canContinueVideoLoad()) return false;
       }
 
       trace.end({ filePath, hasExistingData });
@@ -10310,6 +10504,9 @@ async function initApp() {
 
   function handleFabricDrawingPilotStateChange(nextState, snapshot) {
     fabricDrawingPilotStatusSnapshot = snapshot ? { ...snapshot } : null;
+    if (nextState === 'passive') {
+      syncCurrentFabricDrawingDisplayFrame();
+    }
     // persistence 우회/차단 사유가 바뀌는 순간을 파일 로그로 남긴다(이어붙이기 정지 진단용).
     const fabricPersistenceReason = snapshot?.persistenceFailureReason || null;
     if (fabricPersistenceReason !== lastLoggedFabricPersistenceReason) {

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -13127,6 +13127,7 @@ void main() {
       var DEFAULT_MAX_ACTIONS = 2048;
       var MAX_STROKE_POINTS = 2e4;
       var MAX_LASSO_POINTS = 1024;
+      var MAX_PENDING_POINTER_EVENTS = 1024;
       var DEFAULT_MAX_SELECTION_GEOMETRY_OPERATIONS = 25e4;
       var MAX_STROKE_GEOMETRY_CACHE_ENTRIES = 512;
       var MAX_STROKE_GEOMETRY_CACHE_WEIGHT = 25e4;
@@ -13221,6 +13222,66 @@ void main() {
       var PERSISTENCE_EXPORT_KEYS = Object.freeze(
         PERSISTENCE_HYDRATE_KEYS.filter((key) => key !== "keyframes")
       );
+      var PRESENTATION_REQUEST_KEYS = Object.freeze([
+        "hostGeneration",
+        "videoGeneration",
+        "presentationRevision",
+        "stableVideoIdentity",
+        "storeRevision",
+        "targetFrame",
+        "sourceFrame",
+        "sourceWidth",
+        "sourceHeight",
+        "canvasRect",
+        "viewportRevision",
+        "viewportTransform"
+      ]);
+      var PRESENTATION_CANVAS_RECT_KEYS = Object.freeze(["left", "top", "width", "height"]);
+      var PRESENTATION_VIEWPORT_TRANSFORM_KEYS = Object.freeze(["scale", "panX", "panY"]);
+      var ACTIVE_FRAME_REQUEST_KEYS = Object.freeze([
+        "hostGeneration",
+        "videoGeneration",
+        "inputRevision",
+        "sessionId",
+        "frameRevision",
+        "targetFrame"
+      ]);
+      var POINTERDOWN_FRAME_BASE_KEYS = Object.freeze([
+        "hostGeneration",
+        "videoGeneration",
+        "inputRevision",
+        "sessionId",
+        "pointerdownId",
+        "pointerdownAt"
+      ]);
+      var POINTERDOWN_FRAME_CONFIRMATION_KEYS = Object.freeze([
+        ...POINTERDOWN_FRAME_BASE_KEYS,
+        "targetFrame"
+      ]);
+      var POINTERDOWN_FRAME_CANCELLATION_KEYS = Object.freeze([
+        ...POINTERDOWN_FRAME_BASE_KEYS,
+        "cancelled"
+      ]);
+      var REPLAYED_POINTERDOWN = Symbol("baeframe-replayed-pointerdown");
+      var POINTER_EVENT_SNAPSHOT_FIELDS = Object.freeze([
+        "pointerId",
+        "pointerType",
+        "button",
+        "buttons",
+        "clientX",
+        "clientY",
+        "pressure",
+        "width",
+        "height",
+        "tiltX",
+        "tiltY",
+        "twist",
+        "isPrimary",
+        "ctrlKey",
+        "shiftKey",
+        "altKey",
+        "metaKey"
+      ]);
       var PERSISTENCE_KEYFRAME_KEYS = Object.freeze([
         "id",
         "frame",
@@ -13545,6 +13606,7 @@ void main() {
         let accessClock = 0;
         let latestVideoGeneration = -1;
         let latestPersistenceHostGeneration = -1;
+        let latestPersistenceVideoIdentity = null;
         let activeSession = null;
         let evictionCount = 0;
         let commandSequence = 0;
@@ -13614,7 +13676,7 @@ void main() {
             if (typeof activate !== "function") return;
             activate.call(drawingEngineObserver, {
               ...sceneDescriptor(scene, incomingSession),
-              mutationSequence: scene.mutationSequence
+              mutationSequence: scene.mutationSequence + (scene.provisional === true && scene.objects.size > 0 ? 1 : 0)
             }, activationObjectView(scene, alreadySeeded));
           } catch (_error) {
             recordObserverFailure(scene.sceneInstanceId);
@@ -13715,6 +13777,9 @@ void main() {
           }
           videoAccess.delete(stableVideoIdentity);
           persistenceByVideo.delete(stableVideoIdentity);
+          if (latestPersistenceVideoIdentity === stableVideoIdentity) {
+            latestPersistenceVideoIdentity = [...videoAccess.keys()].at(-1) || null;
+          }
           evictionCount += 1;
           notifyScenesDropped(droppedSceneInstanceIds);
         }
@@ -13939,8 +14004,29 @@ void main() {
           }
           return command;
         }
+        function materializeProvisionalScene(scene) {
+          if (scene?.provisional !== true) return;
+          scene.provisional = false;
+          scene.provisionalSourceFrame = null;
+          if (scene.objects.size === 0) return;
+          const objectIds = [...scene.objects.keys()];
+          const emptyObjects = /* @__PURE__ */ new Map();
+          noteMutation(scene);
+          touchVideo(scene.stableVideoIdentity);
+          notifyPersistenceTransition(scene, () => makeTransitionEvent(scene, {
+            origin: "live",
+            kind: "add-objects",
+            estimatedBytes: scene.estimatedBytes,
+            beforeState: makeObjectsState(emptyObjects, objectIds, []),
+            afterState: makeObjectsState(scene.objects, objectIds, objectIds),
+            baseTransforms: new Map(
+              [...scene.objects].map(([id, object]) => [id, clonePlain(object.transform || {})])
+            )
+          }));
+        }
         function commitStagedMutation(scene, change) {
-          if (!isSafeCount(scene.mutationSequence) || scene.mutationSequence >= Number.MAX_SAFE_INTEGER) {
+          const requiredMutationSequence = scene.provisional === true && scene.objects.size > 0 ? 2 : 1;
+          if (!isSafeCount(scene.mutationSequence) || scene.mutationSequence > Number.MAX_SAFE_INTEGER - requiredMutationSequence) {
             return { applied: false, reason: "mutation-sequence-overflow" };
           }
           const previousEstimatedBytes = scene.estimatedBytes;
@@ -13981,6 +14067,7 @@ void main() {
             return { applied: false, reason: recorded.reason || "history-record-failed" };
           }
           for (const stableVideoIdentity of plannedEvictions) evictVideo(stableVideoIdentity);
+          materializeProvisionalScene(scene);
           scene.historyEntries = { undo: projectedHistory.undo, redo: projectedHistory.redo };
           scene.objects = change.nextObjects;
           scene.selectedObjectIds = new Set(change.nextSelection || []);
@@ -14103,7 +14190,9 @@ void main() {
               mutationCount: 0,
               mutationSequence: frame.mutationSequence,
               estimatedBytes: frame.estimatedBytes,
-              drawingObserverSeeded: false
+              drawingObserverSeeded: false,
+              provisional: false,
+              provisionalSourceFrame: null
             });
           }
           const droppedSceneInstanceIds = [];
@@ -14130,6 +14219,7 @@ void main() {
             latestPersistenceHostGeneration,
             request.hostGeneration
           );
+          latestPersistenceVideoIdentity = request.stableVideoIdentity;
           touchVideo(request.stableVideoIdentity);
           for (const stableVideoIdentity of plannedEvictions) evictVideo(stableVideoIdentity);
           notifyScenesDropped(droppedSceneInstanceIds);
@@ -14152,7 +14242,7 @@ void main() {
             return { accepted: false, reason: "timeline-mismatch" };
           }
           try {
-            const scenesForVideo = [...scenes.values()].filter((scene) => scene.stableVideoIdentity === request.stableVideoIdentity).sort((left, right) => left.targetFrame - right.targetFrame).map((scene) => ({
+            const scenesForVideo = [...scenes.values()].filter((scene) => scene.stableVideoIdentity === request.stableVideoIdentity && scene.provisional !== true).sort((left, right) => left.targetFrame - right.targetFrame).map((scene) => ({
               sceneInstanceId: scene.sceneInstanceId,
               targetFrame: scene.targetFrame,
               sourceWidth: scene.sourceWidth,
@@ -14187,8 +14277,12 @@ void main() {
           const targetFrame = Number(session.targetFrame);
           const videoGeneration = Number(session.videoGeneration);
           const hostGeneration = Number(session.hostGeneration);
+          const sourceFrame = session.sourceFrame === null || session.sourceFrame === void 0 ? null : Number(session.sourceFrame);
           if (!Number.isInteger(targetFrame) || targetFrame < 0 || !Number.isInteger(videoGeneration) || videoGeneration < 0) {
             return { accepted: false, reason: "invalid-session-coordinates" };
+          }
+          if (sourceFrame !== null && (!Number.isSafeInteger(sourceFrame) || sourceFrame < 0 || sourceFrame > targetFrame)) {
+            return { accepted: false, reason: "invalid-session-source-frame" };
           }
           if (videoGeneration < latestVideoGeneration) {
             return { accepted: false, reason: "stale-video-generation" };
@@ -14200,7 +14294,28 @@ void main() {
           latestVideoGeneration = Math.max(latestVideoGeneration, videoGeneration);
           const sceneKey = makeSceneKey(session.stableVideoIdentity, targetFrame);
           const restored = scenes.has(sceneKey);
+          const sourceScene = sourceFrame === null ? null : scenes.get(makeSceneKey(session.stableVideoIdentity, sourceFrame));
+          if (!restored && sourceFrame !== null && (!sourceScene || sourceScene.provisional === true)) {
+            return { accepted: false, reason: "missing-source-scene" };
+          }
           if (!restored) {
+            const objects = new Map(
+              [...(sourceScene?.objects || /* @__PURE__ */ new Map()).entries()].map(([id, object]) => [id, clonePlain(object)])
+            );
+            const estimatedBytes = estimateObjectsBytes(objects);
+            let projectedBytes = calculateEstimatedBytes() + estimatedBytes;
+            let projectedVideoCount = videoAccess.size + (videoAccess.has(session.stableVideoIdentity) ? 0 : 1);
+            const plannedEvictions = [];
+            for (const candidate of videoAccess.keys()) {
+              if (projectedBytes <= maxBytes && projectedVideoCount <= maxVideos) break;
+              if (candidate === session.stableVideoIdentity) continue;
+              projectedBytes -= estimateVideoBytes(candidate);
+              projectedVideoCount -= 1;
+              plannedEvictions.push(candidate);
+            }
+            if (objects.size > maxObjects || projectedBytes > maxBytes || projectedVideoCount > maxVideos) {
+              return { accepted: false, reason: "scene-capacity-exceeded" };
+            }
             scenes.set(sceneKey, {
               key: sceneKey,
               sceneInstanceId: allocateSceneInstanceId(),
@@ -14208,7 +14323,7 @@ void main() {
               targetFrame,
               sourceWidth: sourceDimension(session.sourceWidth),
               sourceHeight: sourceDimension(session.sourceHeight),
-              objects: /* @__PURE__ */ new Map(),
+              objects,
               selectedObjectIds: /* @__PURE__ */ new Set(),
               history: createDrawingCommandHistory({
                 maxEntries: maxHistory,
@@ -14219,14 +14334,18 @@ void main() {
               dirty: false,
               mutationCount: 0,
               mutationSequence: 0,
-              estimatedBytes: 0,
-              drawingObserverSeeded: false
+              estimatedBytes,
+              drawingObserverSeeded: false,
+              provisional: true,
+              provisionalSourceFrame: sourceScene ? sourceFrame : null
             });
+            for (const stableVideoIdentity of plannedEvictions) evictVideo(stableVideoIdentity);
           }
           activeSession = {
             sessionId: session.sessionId,
             stableVideoIdentity: session.stableVideoIdentity,
             targetFrame,
+            sourceFrame: restored ? sourceFrame : sourceScene ? sourceFrame : null,
             sceneKey,
             videoGeneration,
             tool: session.tool === "select" ? "select" : "brush",
@@ -14237,7 +14356,24 @@ void main() {
           touchVideo(session.stableVideoIdentity);
           enforceLimits();
           notifySceneActivation(scene, session);
-          return { accepted: true, restored, sceneKey };
+          return {
+            accepted: true,
+            restored,
+            sceneKey,
+            provisional: scene.provisional === true,
+            sourceFrame: activeSession.sourceFrame
+          };
+        }
+        function replaceActiveSession(session) {
+          const previousScene = activeScene();
+          const activation = activateSession(session);
+          if (!activation.accepted) return activation;
+          previousScene?.selectedObjectIds.clear();
+          if (previousScene?.provisional === true && previousScene.key !== activeSession.sceneKey) {
+            scenes.delete(previousScene.key);
+            notifyScenesDropped([previousScene.sceneInstanceId]);
+          }
+          return activation;
         }
         function deactivateSession(sessionId) {
           if (!activeSession) return { accepted: true, active: false };
@@ -14246,6 +14382,10 @@ void main() {
           }
           const scene = activeScene();
           scene?.selectedObjectIds.clear();
+          if (scene?.provisional === true) {
+            scenes.delete(scene.key);
+            notifyScenesDropped([scene.sceneInstanceId]);
+          }
           activeSession = null;
           return { accepted: true, active: false };
         }
@@ -14592,6 +14732,86 @@ void main() {
         function getSceneSnapshot(stableVideoIdentity, targetFrame) {
           return snapshotScene(scenes.get(makeSceneKey(stableVideoIdentity, targetFrame)));
         }
+        function getPresentationScene(request = {}) {
+          const binding = persistenceByVideo.get(request.stableVideoIdentity);
+          if (!binding || request.stableVideoIdentity !== latestPersistenceVideoIdentity || request.hostGeneration !== latestPersistenceHostGeneration || request.videoGeneration !== latestVideoGeneration || binding.hostGeneration !== request.hostGeneration || binding.videoGeneration !== request.videoGeneration) {
+            return { accepted: false, reason: "stale-presentation-fence" };
+          }
+          if (request.targetFrame >= binding.totalFrames || request.sourceFrame !== null && request.sourceFrame >= binding.totalFrames) {
+            return { accepted: false, reason: "invalid-presentation-frame" };
+          }
+          const scene = resolveCommittedSceneAtFrame(
+            request.stableVideoIdentity,
+            request.targetFrame
+          );
+          if ((scene?.targetFrame ?? null) !== request.sourceFrame) {
+            return { accepted: false, reason: "stale-presentation-source" };
+          }
+          return {
+            accepted: true,
+            snapshot: snapshotScene(scene)
+          };
+        }
+        function resolveCommittedSceneAtFrame(stableVideoIdentity, targetFrame) {
+          let resolved = null;
+          for (const scene of scenes.values()) {
+            if (scene.stableVideoIdentity !== stableVideoIdentity || scene.provisional === true || scene.targetFrame > targetFrame || resolved && scene.targetFrame <= resolved.targetFrame) {
+              continue;
+            }
+            resolved = scene;
+          }
+          return resolved;
+        }
+        function getActiveFrameCandidate(targetFrame, options2 = {}) {
+          if (!activeSession || !Number.isSafeInteger(targetFrame) || targetFrame < 0) {
+            return { accepted: false, reason: "invalid-active-frame" };
+          }
+          const binding = persistenceByVideo.get(activeSession.stableVideoIdentity);
+          if (!binding || binding.videoGeneration !== activeSession.videoGeneration || targetFrame >= binding.totalFrames) {
+            return { accepted: false, reason: "stale-active-frame-session" };
+          }
+          const sourceScene = resolveCommittedSceneAtFrame(
+            activeSession.stableVideoIdentity,
+            targetFrame
+          );
+          return {
+            accepted: true,
+            sourceFrame: sourceScene?.targetFrame ?? null,
+            sceneInstanceId: sourceScene?.sceneInstanceId ?? null,
+            mutationSequence: sourceScene?.mutationSequence ?? 0,
+            ...options2.includeSnapshot === true ? { snapshot: snapshotScene(sourceScene) } : {}
+          };
+        }
+        function retargetActiveSession(session = {}) {
+          if (!activeSession || session.sessionId !== activeSession.sessionId) {
+            return { accepted: false, reason: "stale-session" };
+          }
+          const targetFrame = Number(session.targetFrame);
+          if (targetFrame === activeSession.targetFrame) {
+            return {
+              accepted: true,
+              restored: true,
+              sourceFrame: activeSession.sourceFrame,
+              targetFrame
+            };
+          }
+          const candidate = getActiveFrameCandidate(targetFrame);
+          if (!candidate.accepted) return candidate;
+          const previousSession = { ...activeSession };
+          const activation = replaceActiveSession({
+            ...session,
+            targetFrame,
+            sourceFrame: candidate.sourceFrame,
+            tool: previousSession.tool
+          });
+          if (!activation.accepted) return activation;
+          activeSession.toolRevision = previousSession.toolRevision;
+          return {
+            ...activation,
+            targetFrame,
+            sourceFrame: activeSession.sourceFrame
+          };
+        }
         function getActiveSceneSnapshot() {
           return snapshotScene(activeScene());
         }
@@ -14618,6 +14838,7 @@ void main() {
             persistenceVideoCount: persistenceByVideo.size,
             latestPersistenceHostGeneration,
             latestVideoGeneration,
+            latestPersistenceVideoIdentity,
             activeSessionId: activeSession?.sessionId || null,
             activeSceneKey: activeSession?.sceneKey || null,
             tool: activeSession?.tool || null,
@@ -14626,6 +14847,8 @@ void main() {
             selectionCount: scene?.selectedObjectIds.size || 0,
             mutationCount: scene?.mutationCount || 0,
             dirty: scene?.dirty || false,
+            provisional: scene?.provisional === true,
+            provisionalSourceFrame: scene?.provisionalSourceFrame ?? null,
             undoDepth: history.undoDepth,
             redoDepth: history.redoDepth,
             undoBytes: history.undoBytes,
@@ -14640,11 +14863,13 @@ void main() {
           scenes.clear();
           videoAccess.clear();
           persistenceByVideo.clear();
+          latestPersistenceVideoIdentity = null;
           activeSession = null;
           notifyScenesDropped(droppedSceneInstanceIds);
         }
         return {
           activateSession,
+          replaceActiveSession,
           deactivateSession,
           hydrateVideo,
           exportVideo,
@@ -14659,6 +14884,9 @@ void main() {
           updateTool,
           setLocalTool,
           getSceneSnapshot,
+          getPresentationScene,
+          getActiveFrameCandidate,
+          retargetActiveSession,
           getActiveSceneSnapshot,
           hasScene,
           getDiagnostics,
@@ -14738,6 +14966,9 @@ void main() {
             while (entries.size > maxEntries) entries.delete(entries.keys().next().value);
             return true;
           },
+          release(actionId) {
+            entries.delete(actionId);
+          },
           clear() {
             entries.clear();
           },
@@ -14762,6 +14993,28 @@ void main() {
         if (request.enabled && currentVideo >= 0 && videoGeneration > currentVideo) return false;
         return true;
       }
+      function validatePresentationRequest(request = {}) {
+        if (!hasExactKeys(request, PRESENTATION_REQUEST_KEYS) || !isSafeCount(request.hostGeneration) || !isSafeCount(request.videoGeneration) || !isSafeCount(request.presentationRevision) || !isBoundedPersistenceString(request.stableVideoIdentity) || !isSafeCount(request.storeRevision) || !isSafeCount(request.targetFrame) || !Number.isFinite(request.sourceWidth) || request.sourceWidth <= 0 || request.sourceWidth > MAX_PERSISTED_SOURCE_DIMENSION || !Number.isFinite(request.sourceHeight) || request.sourceHeight <= 0 || request.sourceHeight > MAX_PERSISTED_SOURCE_DIMENSION || !hasExactKeys(request.canvasRect, PRESENTATION_CANVAS_RECT_KEYS) || !PRESENTATION_CANVAS_RECT_KEYS.every((key) => Number.isFinite(request.canvasRect[key])) || request.canvasRect.width <= 0 || request.canvasRect.height <= 0 || request.canvasRect.width > MAX_PERSISTED_SOURCE_DIMENSION || request.canvasRect.height > MAX_PERSISTED_SOURCE_DIMENSION || !isSafeCount(request.viewportRevision) || !hasExactKeys(
+          request.viewportTransform,
+          PRESENTATION_VIEWPORT_TRANSFORM_KEYS
+        ) || !PRESENTATION_VIEWPORT_TRANSFORM_KEYS.every(
+          (key) => Number.isFinite(request.viewportTransform[key]) && Math.abs(request.viewportTransform[key]) <= MAX_PERSISTED_TRANSFORM_MAGNITUDE
+        ) || request.viewportTransform.scale <= 0) {
+          return false;
+        }
+        return request.sourceFrame === null || isSafeCount(request.sourceFrame) && request.sourceFrame <= request.targetFrame;
+      }
+      function validateActiveFrameRequest(request = {}) {
+        return hasExactKeys(request, ACTIVE_FRAME_REQUEST_KEYS) && isSafeCount(request.hostGeneration) && isSafeCount(request.videoGeneration) && isSafeCount(request.inputRevision) && isBoundedPersistenceString(request.sessionId) && isSafeCount(request.frameRevision) && request.frameRevision > 0 && isSafeCount(request.targetFrame);
+      }
+      function validatePointerdownFrameConfirmation(request = {}) {
+        const validBase = isSafeCount(request.hostGeneration) && request.hostGeneration > 0 && isSafeCount(request.videoGeneration) && request.videoGeneration > 0 && isSafeCount(request.inputRevision) && request.inputRevision > 0 && isBoundedPersistenceString(request.sessionId) && isBoundedPersistenceString(request.pointerdownId) && isSafeCount(request.pointerdownAt);
+        if (!validBase) return false;
+        if (hasExactKeys(request, POINTERDOWN_FRAME_CANCELLATION_KEYS)) {
+          return request.cancelled === true;
+        }
+        return hasExactKeys(request, POINTERDOWN_FRAME_CONFIRMATION_KEYS) && isSafeCount(request.targetFrame);
+      }
       function resolvePersistenceCommitObserver(options, windowRef) {
         if (typeof options.persistenceCommitObserver === "function") {
           return options.persistenceCommitObserver;
@@ -14779,10 +15032,22 @@ void main() {
         const performanceRef = options.performance || (typeof performance !== "undefined" ? performance : null);
         const queueMicrotaskRef = options.queueMicrotask || windowRef?.queueMicrotask?.bind(windowRef) || globalThis.queueMicrotask?.bind(globalThis) || ((callback) => Promise.resolve().then(callback));
         const now = () => typeof performanceRef?.now === "function" ? performanceRef.now() : Date.now();
+        const wallNow = typeof options.wallNow === "function" ? options.wallNow : () => {
+          const epochMilliseconds = Number(performanceRef?.timeOrigin) + Number(performanceRef?.now?.());
+          return Number.isFinite(epochMilliseconds) ? Math.floor(epochMilliseconds * 1e3) : Date.now() * 1e3;
+        };
         const devicePixelRatio = finiteNumber(options.devicePixelRatio ?? windowRef?.devicePixelRatio, 1) || 1;
         const metrics = options.metrics || createFabricDrawingPilotMetrics(options.metricsOptions);
         const drawingV3ShadowRequested = options.drawingV3ShadowEnabled === true;
         const persistenceCommitObserver = resolvePersistenceCommitObserver(options, windowRef);
+        const requestPointerdownFrame = typeof options.requestPointerdownFrame === "function" ? options.requestPointerdownFrame : (() => {
+          try {
+            const bridge = windowRef?.mpvOverlayDrawingFrame;
+            return typeof bridge?.requestPointerdownFrame === "function" ? bridge.requestPointerdownFrame.bind(bridge) : null;
+          } catch (_error) {
+            return null;
+          }
+        })();
         const customSceneStore = options.sceneStore || null;
         let drawingV3Adapter = null;
         let drawingV3ShadowStartupFailed = false;
@@ -14820,6 +15085,30 @@ void main() {
           DEFAULT_MAX_SELECTION_GEOMETRY_OPERATIONS
         );
         const tokenState = { hostGeneration: -1, videoGeneration: -1, inputRevision: -1 };
+        const presentationState = {
+          hostGeneration: -1,
+          videoGeneration: -1,
+          presentationRevision: -1,
+          stableVideoIdentity: null,
+          storeRevision: -1,
+          targetFrame: null,
+          sourceFrame: null
+        };
+        const activeFrameState = {
+          hostGeneration: -1,
+          videoGeneration: -1,
+          inputRevision: -1,
+          sessionId: null,
+          frameRevision: -1,
+          targetFrame: null,
+          sourceFrame: null,
+          sourceSceneInstanceId: null,
+          sourceMutationSequence: 0,
+          renderedSourceFrame: null,
+          renderedSceneInstanceId: null,
+          renderedMutationSequence: 0,
+          previewed: false
+        };
         const domListeners = [];
         const fabricListeners = [];
         let fabricModule = null;
@@ -14835,9 +15124,11 @@ void main() {
         let destroyed = false;
         let inputEnabled = false;
         let currentSession = null;
+        let passiveDisplaySession = null;
         let lastPaintedScene = null;
         let activeStroke = null;
         let activeLasso = null;
+        let pendingPointerdownFrame = null;
         let lastSelectionGesture = null;
         let pendingLassoSelection = null;
         let preservingPendingLassoSelectionEvent = false;
@@ -15448,6 +15739,251 @@ void main() {
             fabricCanvas.requestRenderAll();
           }
           updateObjectMetric();
+          rememberRenderedActiveScene();
+        }
+        function rememberRenderedActiveScene() {
+          if (!currentSession) return;
+          const candidate = sceneStore.getActiveFrameCandidate(currentSession.targetFrame);
+          if (!candidate?.accepted) return;
+          activeFrameState.renderedSourceFrame = candidate.sourceFrame;
+          activeFrameState.renderedSceneInstanceId = candidate.sceneInstanceId;
+          activeFrameState.renderedMutationSequence = candidate.mutationSequence;
+        }
+        function resetActiveFrameState(session = null) {
+          const candidate = session ? sceneStore.getActiveFrameCandidate(session.targetFrame) : null;
+          activeFrameState.hostGeneration = session?.hostGeneration ?? -1;
+          activeFrameState.videoGeneration = session?.videoGeneration ?? -1;
+          activeFrameState.inputRevision = session ? tokenState.inputRevision : -1;
+          activeFrameState.sessionId = session?.sessionId || null;
+          activeFrameState.frameRevision = -1;
+          activeFrameState.targetFrame = session?.targetFrame ?? null;
+          activeFrameState.sourceFrame = candidate?.accepted ? candidate.sourceFrame : session?.sourceFrame ?? null;
+          activeFrameState.sourceSceneInstanceId = candidate?.accepted ? candidate.sceneInstanceId : null;
+          activeFrameState.sourceMutationSequence = candidate?.accepted ? candidate.mutationSequence : 0;
+          activeFrameState.renderedSourceFrame = candidate?.accepted ? candidate.sourceFrame : session?.sourceFrame ?? null;
+          activeFrameState.renderedSceneInstanceId = candidate?.accepted ? candidate.sceneInstanceId : null;
+          activeFrameState.renderedMutationSequence = candidate?.accepted ? candidate.mutationSequence : 0;
+          activeFrameState.previewed = false;
+        }
+        function activeFrameInteractionInProgress() {
+          return !!(pendingPointerdownFrame || activeStroke || activeLasso || selectGesture || transformStart);
+        }
+        function renderedCandidateMatches(candidate) {
+          return candidate.sourceFrame === activeFrameState.renderedSourceFrame && candidate.sceneInstanceId === activeFrameState.renderedSceneInstanceId && candidate.mutationSequence === activeFrameState.renderedMutationSequence;
+        }
+        function renderArmedFramePreview(frameState = activeFrameState) {
+          if (!inputEnabled || !currentSession || !fabricCanvas || frameState.sessionId !== currentSession.sessionId) {
+            return { accepted: false, reason: "stale-active-frame" };
+          }
+          if (activeFrameInteractionInProgress()) {
+            return {
+              accepted: true,
+              deferred: true,
+              repainted: false,
+              previewed: activeFrameState.previewed,
+              sourceFrame: frameState.sourceFrame,
+              sourceSceneInstanceId: frameState.sourceSceneInstanceId,
+              sourceMutationSequence: frameState.sourceMutationSequence,
+              renderedSourceFrame: activeFrameState.renderedSourceFrame,
+              renderedSceneInstanceId: activeFrameState.renderedSceneInstanceId,
+              renderedMutationSequence: activeFrameState.renderedMutationSequence
+            };
+          }
+          const candidate = sceneStore.getActiveFrameCandidate(frameState.targetFrame);
+          if (!candidate?.accepted) return candidate;
+          const isPreview = frameState.targetFrame !== currentSession.targetFrame;
+          if (renderedCandidateMatches(candidate)) {
+            if (isPreview) {
+              if (pendingLassoSelection) abortPendingLassoSelection();
+              fabricCanvas.discardActiveObject();
+              sceneStore.selectObjects([]);
+              for (const object of fabricCanvas.getObjects()) {
+                object.set?.({ selectable: false, evented: false });
+              }
+            } else {
+              refreshSelectionInteractionPolicy();
+            }
+            return {
+              accepted: true,
+              deferred: false,
+              repainted: false,
+              previewed: isPreview,
+              sourceFrame: candidate.sourceFrame,
+              sourceSceneInstanceId: candidate.sceneInstanceId,
+              sourceMutationSequence: candidate.mutationSequence,
+              renderedSourceFrame: candidate.sourceFrame,
+              renderedSceneInstanceId: candidate.sceneInstanceId,
+              renderedMutationSequence: candidate.mutationSequence
+            };
+          }
+          let preparedCandidate;
+          let paths;
+          try {
+            preparedCandidate = sceneStore.getActiveFrameCandidate(frameState.targetFrame, {
+              includeSnapshot: true
+            });
+            if (!preparedCandidate?.accepted || preparedCandidate.sourceFrame !== candidate.sourceFrame || preparedCandidate.sceneInstanceId !== candidate.sceneInstanceId || preparedCandidate.mutationSequence !== candidate.mutationSequence) {
+              return { accepted: false, reason: "stale-active-frame-preview" };
+            }
+            paths = (preparedCandidate.snapshot?.objects || []).map((record) => makeFabricPath(record));
+            if (isPreview) {
+              for (const path of paths) path.set({ selectable: false, evented: false });
+            }
+          } catch (error) {
+            lastError = error.message;
+            metrics.recordSurfaceError();
+            return { accepted: false, reason: "active-frame-preview-failed" };
+          }
+          const previousObjects = [...fabricCanvas.getObjects()];
+          const previousActiveObject = fabricCanvas.getActiveObject?.() || null;
+          const previousSelection = sceneStore.getActiveSceneSnapshot()?.selectedObjectIds || [];
+          const previousPendingLassoSelection = pendingLassoSelection;
+          const previousObjectStates = previousObjects.map((object) => ({
+            object,
+            transform: captureTransform(object),
+            opacity: object.opacity,
+            selectable: object.selectable,
+            evented: object.evented,
+            perPixelTargetFind: object.perPixelTargetFind,
+            padding: object.padding,
+            hoverCursor: object.hoverCursor,
+            moveCursor: object.moveCursor,
+            pendingLasso: object.__baeframePendingLasso
+          }));
+          try {
+            if (pendingLassoSelection) abortPendingLassoSelection();
+            fabricCanvas.discardActiveObject();
+            sceneStore.selectObjects([]);
+            fabricCanvas.clear();
+            for (const path of paths) fabricCanvas.add(path);
+            if (!isPreview) refreshSelectionInteractionPolicy();
+            if (typeof fabricCanvas.renderAll === "function") fabricCanvas.renderAll();
+            else fabricCanvas.requestRenderAll();
+          } catch (error) {
+            pendingLassoSelection = previousPendingLassoSelection;
+            try {
+              fabricCanvas.clear();
+              for (const state of previousObjectStates) {
+                state.object.set?.({
+                  ...state.transform,
+                  opacity: state.opacity,
+                  selectable: state.selectable,
+                  evented: state.evented,
+                  perPixelTargetFind: state.perPixelTargetFind,
+                  padding: state.padding,
+                  hoverCursor: state.hoverCursor,
+                  moveCursor: state.moveCursor
+                });
+                state.object.__baeframePendingLasso = state.pendingLasso;
+                state.object.setCoords?.();
+                fabricCanvas.add(state.object);
+              }
+              if (previousActiveObject && typeof fabricCanvas.setActiveObject === "function") {
+                fabricCanvas.setActiveObject(previousActiveObject);
+              }
+            } catch (_rollbackError) {
+            }
+            try {
+              sceneStore.selectObjects(previousSelection);
+            } catch (_rollbackError) {
+            }
+            lastError = error.message;
+            metrics.recordSurfaceError();
+            return { accepted: false, reason: "active-frame-preview-failed" };
+          }
+          updateObjectMetric();
+          return {
+            accepted: true,
+            deferred: false,
+            repainted: true,
+            previewed: isPreview,
+            sourceFrame: preparedCandidate.sourceFrame,
+            sourceSceneInstanceId: preparedCandidate.sceneInstanceId,
+            sourceMutationSequence: preparedCandidate.mutationSequence,
+            renderedSourceFrame: preparedCandidate.sourceFrame,
+            renderedSceneInstanceId: preparedCandidate.sceneInstanceId,
+            renderedMutationSequence: preparedCandidate.mutationSequence
+          };
+        }
+        function publishActiveFramePreview(frameState, preview) {
+          activeFrameState.hostGeneration = frameState.hostGeneration;
+          activeFrameState.videoGeneration = frameState.videoGeneration;
+          activeFrameState.inputRevision = frameState.inputRevision;
+          activeFrameState.sessionId = frameState.sessionId;
+          activeFrameState.frameRevision = frameState.frameRevision;
+          activeFrameState.targetFrame = frameState.targetFrame;
+          activeFrameState.sourceFrame = preview.sourceFrame;
+          activeFrameState.sourceSceneInstanceId = preview.sourceSceneInstanceId;
+          activeFrameState.sourceMutationSequence = preview.sourceMutationSequence;
+          activeFrameState.renderedSourceFrame = preview.renderedSourceFrame;
+          activeFrameState.renderedSceneInstanceId = preview.renderedSceneInstanceId;
+          activeFrameState.renderedMutationSequence = preview.renderedMutationSequence;
+          activeFrameState.previewed = preview.previewed === true;
+          if (preview.deferred !== true) {
+            lastPaintedScene = preview.sourceFrame === null ? null : {
+              stableVideoIdentity: currentSession.stableVideoIdentity,
+              targetFrame: preview.sourceFrame
+            };
+            presentationState.hostGeneration = frameState.hostGeneration;
+            presentationState.videoGeneration = frameState.videoGeneration;
+            presentationState.stableVideoIdentity = currentSession.stableVideoIdentity;
+            presentationState.targetFrame = frameState.targetFrame;
+            presentationState.sourceFrame = preview.sourceFrame;
+            syncPersistenceBadge(frameState.targetFrame);
+          }
+        }
+        function retargetFrameForMutation(targetFrame) {
+          if (!inputEnabled || !currentSession || !Number.isSafeInteger(targetFrame) || targetFrame < 0) {
+            return { accepted: false, reason: "stale-active-frame" };
+          }
+          if (targetFrame === currentSession.targetFrame && activeFrameState.previewed !== true) {
+            return {
+              accepted: true,
+              restored: true,
+              targetFrame: currentSession.targetFrame,
+              sourceFrame: currentSession.sourceFrame
+            };
+          }
+          if (targetFrame !== currentSession.targetFrame && pendingLassoSelection) {
+            abortPendingLassoSelection();
+          }
+          const result = sceneStore.retargetActiveSession({
+            ...currentSession,
+            targetFrame
+          });
+          if (!result?.accepted) return result || { accepted: false, reason: "retarget-failed" };
+          currentSession.targetFrame = result.targetFrame;
+          currentSession.sourceFrame = result.sourceFrame;
+          if (activeFrameState.targetFrame === targetFrame) {
+            const candidate = sceneStore.getActiveFrameCandidate(targetFrame);
+            activeFrameState.sourceFrame = result.sourceFrame;
+            activeFrameState.sourceSceneInstanceId = candidate?.sceneInstanceId ?? null;
+            activeFrameState.sourceMutationSequence = candidate?.mutationSequence ?? 0;
+          }
+          activeFrameState.previewed = false;
+          renderActiveScene({ immediate: true });
+          setToolMode(currentSession.tool);
+          lastPaintedScene = {
+            stableVideoIdentity: currentSession.stableVideoIdentity,
+            targetFrame: currentSession.targetFrame
+          };
+          syncPersistenceBadge(currentSession.targetFrame);
+          return result;
+        }
+        function retargetArmedFrameForMutation() {
+          if (!inputEnabled || !currentSession || activeFrameState.hostGeneration !== tokenState.hostGeneration || activeFrameState.videoGeneration !== tokenState.videoGeneration || activeFrameState.inputRevision !== tokenState.inputRevision || activeFrameState.sessionId !== currentSession.sessionId || !Number.isSafeInteger(activeFrameState.targetFrame)) {
+            return { accepted: false, reason: "stale-active-frame" };
+          }
+          return retargetFrameForMutation(activeFrameState.targetFrame);
+        }
+        function settleArmedFramePreview() {
+          if (!inputEnabled || !currentSession || activeFrameInteractionInProgress() || activeFrameState.targetFrame === currentSession.targetFrame) {
+            return false;
+          }
+          const preview = renderArmedFramePreview(activeFrameState);
+          if (preview?.accepted !== true) return false;
+          publishActiveFramePreview(activeFrameState, preview);
+          return true;
         }
         function repaintLastPaintedScene(options2 = {}) {
           if (destroyed || !fabricCanvas || inputEnabled || !lastPaintedScene) return;
@@ -16984,6 +17520,7 @@ void main() {
             selectedCount: Array.isArray(result?.selectedObjectIds) ? result.selectedObjectIds.length : 0,
             reason: typeof result?.reason === "string" ? result.reason.slice(0, 128) : null
           };
+          settleArmedFramePreview();
           return result;
         }
         function pointerTargetsActiveSelection(event) {
@@ -17024,6 +17561,7 @@ void main() {
             lastError = error.message;
             metrics.recordSurfaceError();
             activeStroke = null;
+            settleArmedFramePreview();
             return { applied: false, reason: "stroke-path-error" };
           }
           const record = {
@@ -17037,10 +17575,14 @@ void main() {
           record.transform = captureTransform(path);
           const result = sceneStore.addStroke(record);
           activeStroke = null;
-          if (!result.applied) return result;
+          if (!result.applied) {
+            settleArmedFramePreview();
+            return result;
+          }
           fabricCanvas.add(path);
           fabricCanvas.requestRenderAll();
           updateObjectMetric();
+          settleArmedFramePreview();
           return result;
         }
         function releasePointerCapture(target, pointerId) {
@@ -17147,10 +17689,19 @@ void main() {
             transformStart = null;
             selectGesture = null;
             settleDeferredViewport(gesture.sessionId, gesture.inputRevision);
+            settleArmedFramePreview();
           });
         }
-        function onPointerDown(event) {
+        function beginPointerDown(event, retargetArmed = true) {
           if (!inputEnabled || event.button !== 0) return;
+          if (retargetArmed) {
+            const retargeted = retargetArmedFrameForMutation();
+            if (!retargeted?.accepted) {
+              event.preventDefault?.();
+              event.stopImmediatePropagation?.();
+              return;
+            }
+          }
           const tool = sceneStore.getDiagnostics().tool;
           if (tool === "brush") {
             if (activeStroke || selectGesture) return;
@@ -17230,7 +17781,164 @@ void main() {
           } catch (_error) {
           }
         }
+        function snapshotPointerEvent(event) {
+          const snapshot = { type: String(event.type || "") };
+          for (const field of POINTER_EVENT_SNAPSHOT_FIELDS) {
+            const value = event[field];
+            if (value !== void 0) snapshot[field] = value;
+          }
+          return snapshot;
+        }
+        function cancelPendingPointerdownFrame() {
+          const pending = pendingPointerdownFrame;
+          pendingPointerdownFrame = null;
+          if (!pending) return false;
+          releasePointerCapture(pending.target, pending.pointerId);
+          return true;
+        }
+        function consumePendingPointerEvent(event) {
+          const pending = pendingPointerdownFrame;
+          if (!pending || event.pointerId !== void 0 && event.pointerId !== pending.pointerId) {
+            return false;
+          }
+          event.preventDefault?.();
+          event.stopImmediatePropagation?.();
+          event.stopPropagation?.();
+          if (pending.events.length >= MAX_PENDING_POINTER_EVENTS) {
+            cancelPendingPointerdownFrame();
+            return true;
+          }
+          pending.events.push(snapshotPointerEvent(event));
+          return true;
+        }
+        function dispatchReplayedPointerEvent(target, snapshot) {
+          if (typeof target?.dispatchEvent === "function" && windowRef?.Event) {
+            const EventConstructor = typeof windowRef.PointerEvent === "function" ? windowRef.PointerEvent : windowRef.Event;
+            let event;
+            if (EventConstructor === windowRef.PointerEvent) {
+              event = new EventConstructor(snapshot.type, {
+                bubbles: true,
+                cancelable: true,
+                ...snapshot
+              });
+            } else {
+              event = new EventConstructor(snapshot.type, { bubbles: true, cancelable: true });
+              for (const [field, value] of Object.entries(snapshot)) {
+                if (field === "type") continue;
+                Object.defineProperty(event, field, { value });
+              }
+            }
+            Object.defineProperty(event, REPLAYED_POINTERDOWN, { value: true });
+            target.dispatchEvent(event);
+            return true;
+          }
+          if (typeof target?.dispatch === "function") {
+            target.dispatch(snapshot.type, { ...snapshot, [REPLAYED_POINTERDOWN]: true });
+            return true;
+          }
+          return false;
+        }
+        function onPointerDown(event) {
+          if (event?.[REPLAYED_POINTERDOWN] === true) {
+            beginPointerDown(event, false);
+            return;
+          }
+          if (!inputEnabled || event.button !== 0 || pendingPointerdownFrame || activeStroke || activeLasso || selectGesture) {
+            return;
+          }
+          if (!requestPointerdownFrame) {
+            beginPointerDown(event, true);
+            return;
+          }
+          const pointerdownAt = Number(wallNow());
+          if (!currentSession || !Number.isSafeInteger(pointerdownAt) || pointerdownAt < 0) {
+            event.preventDefault?.();
+            event.stopImmediatePropagation?.();
+            return;
+          }
+          const request = {
+            hostGeneration: tokenState.hostGeneration,
+            videoGeneration: tokenState.videoGeneration,
+            inputRevision: tokenState.inputRevision,
+            sessionId: currentSession.sessionId,
+            pointerdownId: createId("pointerdown"),
+            pointerdownAt
+          };
+          const target = event.currentTarget || fabricCanvas?.upperCanvasEl || canvasElement;
+          pendingPointerdownFrame = {
+            request,
+            pointerId: event.pointerId,
+            target,
+            events: [snapshotPointerEvent(event)]
+          };
+          try {
+            target?.setPointerCapture?.(event.pointerId);
+          } catch (_error) {
+          }
+          event.preventDefault?.();
+          event.stopImmediatePropagation?.();
+          event.stopPropagation?.();
+          try {
+            if (requestPointerdownFrame(request) !== true) cancelPendingPointerdownFrame();
+          } catch (_error) {
+            cancelPendingPointerdownFrame();
+          }
+        }
+        function confirmDrawingPointerdownFrame(request = {}) {
+          if (!validatePointerdownFrameConfirmation(request)) {
+            return { accepted: false, reason: "invalid-pointerdown-frame-confirmation" };
+          }
+          const pending = pendingPointerdownFrame;
+          if (!pending || !inputEnabled || !currentSession || request.hostGeneration !== tokenState.hostGeneration || request.videoGeneration !== tokenState.videoGeneration || request.inputRevision !== tokenState.inputRevision || request.sessionId !== currentSession.sessionId || request.pointerdownId !== pending.request.pointerdownId || request.pointerdownAt !== pending.request.pointerdownAt) {
+            return { accepted: false, reason: "stale-pointerdown-frame-confirmation" };
+          }
+          if (request.cancelled === true) {
+            cancelPendingPointerdownFrame();
+            return {
+              accepted: true,
+              cancelled: true,
+              hostGeneration: request.hostGeneration,
+              videoGeneration: request.videoGeneration,
+              inputRevision: request.inputRevision,
+              sessionId: request.sessionId,
+              pointerdownId: request.pointerdownId,
+              pointerdownAt: request.pointerdownAt
+            };
+          }
+          const previousFrameState = { ...activeFrameState };
+          const candidate = sceneStore.getActiveFrameCandidate(request.targetFrame);
+          if (!candidate?.accepted) {
+            cancelPendingPointerdownFrame();
+            return { accepted: false, reason: candidate?.reason || "retarget-failed" };
+          }
+          activeFrameState.targetFrame = request.targetFrame;
+          activeFrameState.sourceFrame = candidate.sourceFrame;
+          activeFrameState.sourceSceneInstanceId = candidate.sceneInstanceId;
+          activeFrameState.sourceMutationSequence = candidate.mutationSequence;
+          const retargeted = retargetFrameForMutation(request.targetFrame);
+          if (!retargeted?.accepted) {
+            Object.assign(activeFrameState, previousFrameState);
+            cancelPendingPointerdownFrame();
+            return { accepted: false, reason: retargeted?.reason || "retarget-failed" };
+          }
+          pendingPointerdownFrame = null;
+          for (const replayEvent of pending.events) {
+            if (!dispatchReplayedPointerEvent(pending.target, replayEvent)) {
+              cancelActiveStroke();
+              cancelActiveLasso();
+              cancelSelectInteraction();
+              releasePointerCapture(pending.target, pending.pointerId);
+              return { accepted: false, reason: "pointerdown-replay-failed" };
+            }
+          }
+          return {
+            accepted: true,
+            pointerdownId: request.pointerdownId,
+            targetFrame: request.targetFrame
+          };
+        }
         function onPointerMove(event) {
+          if (consumePendingPointerEvent(event)) return;
           if (activeLasso) {
             if (event.pointerId !== activeLasso.pointerId) return;
             appendLassoPoint(event);
@@ -17246,6 +17954,7 @@ void main() {
           event.preventDefault?.();
         }
         function onPointerUp(event) {
+          if (consumePendingPointerEvent(event)) return;
           if (activeLasso) {
             if (event.pointerId !== activeLasso.pointerId) return;
             const { sessionId, inputRevision } = activeLasso;
@@ -17272,6 +17981,13 @@ void main() {
           scheduleSelectGestureSettle(gesture);
         }
         function onPointerCancel(event) {
+          if (pendingPointerdownFrame) {
+            if (event.pointerId !== void 0 && event.pointerId !== pendingPointerdownFrame.pointerId) return;
+            event.preventDefault?.();
+            event.stopImmediatePropagation?.();
+            cancelPendingPointerdownFrame();
+            return;
+          }
           if (activeLasso) {
             if (event.pointerId !== void 0 && event.pointerId !== activeLasso.pointerId) return;
             if (event.type === "lostpointercapture" && activeLasso.phase === "settling") return;
@@ -17295,6 +18011,10 @@ void main() {
           cancelSelectInteraction(event);
         }
         function onDocumentPointerUp(event) {
+          if (pendingPointerdownFrame && event.pointerId === pendingPointerdownFrame.pointerId) {
+            consumePendingPointerEvent(event);
+            return;
+          }
           if (activeLasso && event.pointerId === activeLasso.pointerId) {
             onPointerUp(event);
             return;
@@ -17303,6 +18023,10 @@ void main() {
           onPointerUp(event);
         }
         function onDocumentPointerCancel(event) {
+          if (pendingPointerdownFrame && event.pointerId === pendingPointerdownFrame.pointerId) {
+            onPointerCancel(event);
+            return;
+          }
           if (activeLasso && event.pointerId === activeLasso.pointerId) {
             onPointerCancel(event);
             return;
@@ -17392,6 +18116,7 @@ void main() {
             const result2 = commitPendingLassoMove(target);
             transformStart = null;
             if (result2.applied) updateObjectMetric();
+            settleArmedFramePreview();
             return;
           }
           const children = typeof target.getObjects === "function" ? target.getObjects() : [target];
@@ -17420,20 +18145,22 @@ void main() {
           }
           if (!result.applied) {
             rollbackSelectTransform(event, false);
+            settleArmedFramePreview();
             return;
           }
           const shouldReleaseMultiSelection = result.applied && children.length > 1;
           transformStart = null;
           if (result.applied) updateObjectMetric();
           if (shouldReleaseMultiSelection) scheduleMovedMultiSelectionRelease(target, ids);
+          settleArmedFramePreview();
         }
         function configureCanvasEvents() {
           const pointerTarget = fabricCanvas.upperCanvasEl || canvasElement;
           addDomListener(pointerTarget, "pointerdown", onPointerDown, true);
-          addDomListener(pointerTarget, "pointermove", onPointerMove);
-          addDomListener(pointerTarget, "pointerup", onPointerUp);
-          addDomListener(pointerTarget, "pointercancel", onPointerCancel);
-          addDomListener(pointerTarget, "lostpointercapture", onPointerCancel);
+          addDomListener(pointerTarget, "pointermove", onPointerMove, true);
+          addDomListener(pointerTarget, "pointerup", onPointerUp, true);
+          addDomListener(pointerTarget, "pointercancel", onPointerCancel, true);
+          addDomListener(pointerTarget, "lostpointercapture", onPointerCancel, true);
           addDomListener(documentRef, "pointerup", onDocumentPointerUp);
           addDomListener(documentRef, "pointercancel", onDocumentPointerCancel);
           addDomListener(windowRef, "blur", onPointerCancel);
@@ -17526,10 +18253,30 @@ void main() {
           currentSession.viewportRevision = command.revision;
           applyViewport(currentSession);
         }
-        function validateSession(session) {
-          return !!session && typeof session.sessionId === "string" && session.sessionId.length > 0 && typeof session.stableVideoIdentity === "string" && session.stableVideoIdentity.length > 0 && Number.isInteger(Number(session.targetFrame)) && Number(session.targetFrame) >= 0 && finiteNumber(session.sourceWidth) > 0 && finiteNumber(session.sourceHeight) > 0 && finiteNumber(session.canvasRect?.width) > 0 && finiteNumber(session.canvasRect?.height) > 0;
+        function resetPassivePresentationState() {
+          passiveDisplaySession = null;
+          presentationState.hostGeneration = -1;
+          presentationState.videoGeneration = -1;
+          presentationState.presentationRevision = -1;
+          presentationState.stableVideoIdentity = null;
+          presentationState.storeRevision = -1;
+          presentationState.targetFrame = null;
+          presentationState.sourceFrame = null;
         }
-        function disableInput() {
+        function validateSession(session) {
+          const targetFrame = Number(session?.targetFrame);
+          const sourceFrame = session?.sourceFrame;
+          return !!session && typeof session.sessionId === "string" && session.sessionId.length > 0 && typeof session.stableVideoIdentity === "string" && session.stableVideoIdentity.length > 0 && Number.isInteger(targetFrame) && targetFrame >= 0 && (sourceFrame === void 0 || sourceFrame === null || Number.isSafeInteger(Number(sourceFrame)) && Number(sourceFrame) >= 0 && Number(sourceFrame) <= targetFrame) && finiteNumber(session.sourceWidth) > 0 && finiteNumber(session.sourceHeight) > 0 && finiteNumber(session.canvasRect?.width) > 0 && finiteNumber(session.canvasRect?.height) > 0;
+        }
+        function disableInput({ preservePassiveDisplay = true } = {}) {
+          const disabledSession = currentSession;
+          const disabledFrameState = { ...activeFrameState };
+          const previewWasDisplayed = disabledSession && disabledFrameState.sessionId === disabledSession.sessionId && disabledFrameState.previewed === true;
+          const disabledTargetFrame = previewWasDisplayed ? disabledFrameState.targetFrame : disabledSession?.targetFrame;
+          const disabledCandidate = disabledSession && Number.isSafeInteger(disabledTargetFrame) ? sceneStore.getActiveFrameCandidate(disabledTargetFrame) : null;
+          const disabledSourceFrame = disabledCandidate?.accepted === true ? disabledCandidate.sourceFrame : previewWasDisplayed ? disabledFrameState.sourceFrame : disabledSession?.sourceFrame ?? null;
+          const discardedProvisional = sceneStore.getDiagnostics().provisional === true;
+          cancelPendingPointerdownFrame();
           abortPendingLassoSelection();
           cancelActiveLasso();
           cancelSelectInteraction();
@@ -17542,7 +18289,45 @@ void main() {
           inputEnabled = false;
           currentSession = null;
           sceneStore.deactivateSession();
-          repaintLastPaintedScene();
+          resetActiveFrameState();
+          if (preservePassiveDisplay && disabledSession) {
+            passiveDisplaySession = {
+              hostGeneration: disabledSession.hostGeneration,
+              videoGeneration: disabledSession.videoGeneration,
+              stableVideoIdentity: disabledSession.stableVideoIdentity,
+              targetFrame: disabledTargetFrame,
+              sourceFrame: disabledSourceFrame,
+              sourceWidth: disabledSession.sourceWidth,
+              sourceHeight: disabledSession.sourceHeight,
+              canvasRect: { ...disabledSession.canvasRect },
+              viewportRevision: disabledSession.viewportRevision,
+              viewportTransform: { ...disabledSession.viewportTransform }
+            };
+            presentationState.hostGeneration = disabledSession.hostGeneration;
+            presentationState.videoGeneration = disabledSession.videoGeneration;
+            presentationState.stableVideoIdentity = disabledSession.stableVideoIdentity;
+            presentationState.targetFrame = passiveDisplaySession.targetFrame;
+            presentationState.sourceFrame = passiveDisplaySession.sourceFrame;
+          } else if (!preservePassiveDisplay) {
+            passiveDisplaySession = null;
+          }
+          if (previewWasDisplayed) {
+            lastPaintedScene = disabledSourceFrame === null ? null : {
+              stableVideoIdentity: disabledSession.stableVideoIdentity,
+              targetFrame: disabledSourceFrame
+            };
+          } else if (disabledCandidate?.accepted === true) {
+            lastPaintedScene = disabledSourceFrame === null ? null : {
+              stableVideoIdentity: disabledSession.stableVideoIdentity,
+              targetFrame: disabledSourceFrame
+            };
+          } else if (discardedProvisional && disabledSession) {
+            lastPaintedScene = disabledSession.sourceFrame === null ? null : {
+              stableVideoIdentity: disabledSession.stableVideoIdentity,
+              targetFrame: disabledSession.sourceFrame
+            };
+          }
+          if (!previewWasDisplayed) repaintLastPaintedScene();
           syncPersistenceBadge();
         }
         function releaseSurfaceResources() {
@@ -17577,12 +18362,14 @@ void main() {
           appliedSourceWidth = null;
           appliedSourceHeight = null;
           activeStroke = null;
+          pendingPointerdownFrame = null;
           pendingLassoSelection = null;
           transformStart = null;
           selectGesture = null;
           deferredViewport = null;
           inputEnabled = false;
           currentSession = null;
+          resetPassivePresentationState();
           viewportElement = null;
           canvasElement = null;
           toolbar = null;
@@ -17720,22 +18507,29 @@ void main() {
           if (request.enabled && !validateSession(request.session)) {
             return { accepted: false, reason: "invalid-session" };
           }
+          cancelPendingPointerdownFrame();
           abortPendingLassoSelection();
           if (activeStroke) cancelActiveStroke();
           if (activeLasso) cancelActiveLasso();
           if (selectGesture || transformStart || deferredViewport) cancelSelectInteraction();
           if (!request.enabled) {
+            const ownerChanged = Number(request.hostGeneration) !== tokenState.hostGeneration || Number(request.videoGeneration) !== tokenState.videoGeneration;
             tokenState.hostGeneration = Number(request.hostGeneration);
             tokenState.videoGeneration = Number(request.videoGeneration);
             tokenState.inputRevision = Number(request.inputRevision);
             const lastTool = currentSession?.tool === "select" ? "select" : "brush";
-            disableInput();
+            disableInput({ preservePassiveDisplay: !ownerChanged });
+            if (ownerChanged) {
+              resetPassivePresentationState();
+            }
+            resetActiveFrameState();
             metrics.recordToggleLatency(now() - startedAt);
             return { accepted: true, enabled: false, tool: lastTool };
           }
           const session = {
             ...clonePlain(request.session),
             targetFrame: Number(request.session.targetFrame),
+            sourceFrame: request.session.sourceFrame === null || request.session.sourceFrame === void 0 ? null : Number(request.session.sourceFrame),
             sourceWidth: Number(request.session.sourceWidth),
             sourceHeight: Number(request.session.sourceHeight),
             hostGeneration: Number(request.hostGeneration),
@@ -17744,15 +18538,23 @@ void main() {
             viewportTransform: normalizeViewportTransform(request.session.viewportTransform),
             tool: request.session.tool === "select" ? "select" : "brush"
           };
-          const activation = sceneStore.activateSession(session);
+          const activation = typeof sceneStore.replaceActiveSession === "function" ? sceneStore.replaceActiveSession(session) : sceneStore.activateSession(session);
           if (!activation.accepted) {
             metrics.recordStaleMessageDrop();
             return activation;
           }
+          session.sourceFrame = activation.sourceFrame;
           tokenState.hostGeneration = Number(request.hostGeneration);
           tokenState.videoGeneration = Number(request.videoGeneration);
           tokenState.inputRevision = Number(request.inputRevision);
           currentSession = session;
+          passiveDisplaySession = null;
+          resetActiveFrameState(session);
+          presentationState.hostGeneration = session.hostGeneration;
+          presentationState.videoGeneration = session.videoGeneration;
+          presentationState.stableVideoIdentity = session.stableVideoIdentity;
+          presentationState.targetFrame = session.targetFrame;
+          presentationState.sourceFrame = session.sourceFrame;
           applyViewport(session);
           renderActiveScene({ immediate: true });
           lastPaintedScene = {
@@ -17780,6 +18582,9 @@ void main() {
           try {
             const result = sceneStore.hydrateVideo(clonePlain(request));
             if (result?.accepted === true) {
+              if (passiveDisplaySession && passiveDisplaySession.stableVideoIdentity !== String(request?.stableVideoIdentity || "")) {
+                resetPassivePresentationState();
+              }
               if (lastPaintedScene && lastPaintedScene.stableVideoIdentity === String(request?.stableVideoIdentity || "")) {
                 repaintLastPaintedScene({ force: true, clearWhenMissing: true });
               } else if (lastPaintedScene) {
@@ -17795,6 +18600,124 @@ void main() {
           } catch (_error) {
             return { accepted: false, reason: "invalid-hydration-request" };
           }
+        }
+        function presentDrawingFrame(request = {}) {
+          if (destroyed || !prepared) {
+            return { accepted: false, reason: destroyed ? "destroyed" : "not-prepared" };
+          }
+          if (inputEnabled) return { accepted: false, reason: "input-enabled" };
+          if (!validatePresentationRequest(request)) {
+            return { accepted: false, reason: "invalid-presentation-request" };
+          }
+          if (request.presentationRevision <= presentationState.presentationRevision) {
+            return { accepted: false, reason: "stale-presentation-revision" };
+          }
+          if (tokenState.hostGeneration >= 0 && request.hostGeneration !== tokenState.hostGeneration || tokenState.videoGeneration >= 0 && request.videoGeneration !== tokenState.videoGeneration) {
+            return { accepted: false, reason: "stale-presentation-fence" };
+          }
+          if (typeof sceneStore.getPresentationScene !== "function") {
+            return { accepted: false, reason: "persistence-unavailable" };
+          }
+          let resolved;
+          try {
+            resolved = sceneStore.getPresentationScene(request);
+          } catch (_error) {
+            return { accepted: false, reason: "invalid-presentation-request" };
+          }
+          if (resolved?.accepted !== true) return resolved;
+          try {
+            const displaySession = {
+              hostGeneration: request.hostGeneration,
+              videoGeneration: request.videoGeneration,
+              stableVideoIdentity: request.stableVideoIdentity,
+              targetFrame: request.targetFrame,
+              sourceFrame: request.sourceFrame,
+              sourceWidth: request.sourceWidth,
+              sourceHeight: request.sourceHeight,
+              canvasRect: { ...request.canvasRect },
+              viewportRevision: request.viewportRevision,
+              viewportTransform: { ...request.viewportTransform }
+            };
+            applyViewport(displaySession);
+            const sameSource = presentationState.hostGeneration === request.hostGeneration && presentationState.videoGeneration === request.videoGeneration && presentationState.stableVideoIdentity === request.stableVideoIdentity && presentationState.storeRevision === request.storeRevision && presentationState.sourceFrame === request.sourceFrame;
+            const snapshot = resolved.snapshot;
+            const records = snapshot?.objects || [];
+            if (!sameSource) {
+              const paths = records.map((record) => makeFabricPath(record));
+              for (const path of paths) path.set({ selectable: false, evented: false });
+              fabricCanvas.clear();
+              for (const path of paths) fabricCanvas.add(path);
+            } else {
+              for (const object of fabricCanvas.getObjects()) {
+                object.set?.({ selectable: false, evented: false });
+              }
+            }
+            fabricCanvas.discardActiveObject();
+            if (typeof fabricCanvas.renderAll === "function") fabricCanvas.renderAll();
+            else fabricCanvas.requestRenderAll();
+            presentationState.hostGeneration = request.hostGeneration;
+            presentationState.videoGeneration = request.videoGeneration;
+            presentationState.presentationRevision = request.presentationRevision;
+            presentationState.stableVideoIdentity = request.stableVideoIdentity;
+            presentationState.storeRevision = request.storeRevision;
+            presentationState.targetFrame = request.targetFrame;
+            presentationState.sourceFrame = request.sourceFrame;
+            passiveDisplaySession = displaySession;
+            lastPaintedScene = request.sourceFrame === null ? null : {
+              stableVideoIdentity: request.stableVideoIdentity,
+              targetFrame: request.sourceFrame
+            };
+            return {
+              accepted: true,
+              targetFrame: request.targetFrame,
+              sourceFrame: request.sourceFrame
+            };
+          } catch (error) {
+            lastError = error.message;
+            metrics.recordSurfaceError();
+            return { accepted: false, reason: "presentation-render-failed" };
+          }
+        }
+        function updateDrawingFrame(request = {}) {
+          if (destroyed || !prepared) {
+            return { accepted: false, reason: destroyed ? "destroyed" : "not-prepared" };
+          }
+          if (!inputEnabled || !currentSession) {
+            return { accepted: false, reason: "input-disabled" };
+          }
+          if (!validateActiveFrameRequest(request)) {
+            return { accepted: false, reason: "invalid-active-frame-request" };
+          }
+          if (request.hostGeneration !== tokenState.hostGeneration || request.videoGeneration !== tokenState.videoGeneration || request.inputRevision !== tokenState.inputRevision || request.sessionId !== currentSession.sessionId) {
+            return { accepted: false, reason: "stale-active-frame-fence" };
+          }
+          if (request.frameRevision <= activeFrameState.frameRevision) {
+            return { accepted: false, reason: "stale-active-frame-revision" };
+          }
+          const candidate = sceneStore.getActiveFrameCandidate(request.targetFrame);
+          if (!candidate?.accepted) return candidate;
+          const stagedFrameState = {
+            hostGeneration: request.hostGeneration,
+            videoGeneration: request.videoGeneration,
+            inputRevision: request.inputRevision,
+            sessionId: request.sessionId,
+            frameRevision: request.frameRevision,
+            targetFrame: request.targetFrame,
+            sourceFrame: candidate.sourceFrame,
+            sourceSceneInstanceId: candidate.sceneInstanceId,
+            sourceMutationSequence: candidate.mutationSequence
+          };
+          const preview = renderArmedFramePreview(stagedFrameState);
+          if (!preview?.accepted) return preview;
+          publishActiveFramePreview(stagedFrameState, preview);
+          return {
+            accepted: true,
+            frameRevision: request.frameRevision,
+            targetFrame: request.targetFrame,
+            sourceFrame: preview.sourceFrame,
+            deferred: preview.deferred === true,
+            repainted: preview.repainted === true
+          };
         }
         function exportDrawingVideo(request = {}) {
           if (destroyed || !prepared) {
@@ -17813,14 +18736,15 @@ void main() {
           }
         }
         function updateViewport(command = {}) {
-          if (!inputEnabled || !currentSession) return { accepted: false, reason: "input-disabled" };
+          const viewportSession = inputEnabled ? currentSession : passiveDisplaySession;
+          if (!viewportSession) return { accepted: false, reason: "input-disabled" };
           const revision = Number(command.revision);
           const rect = command.canvasRect;
           if (!Number.isInteger(revision) || revision < 0 || !rect || finiteNumber(rect.width) <= 0 || finiteNumber(rect.height) <= 0) {
             return { accepted: false, reason: "invalid-viewport" };
           }
-          const pendingRevision = deferredViewport?.command?.revision ?? -1;
-          if (revision <= Math.max(currentSession.viewportRevision, pendingRevision)) {
+          const pendingRevision = inputEnabled ? deferredViewport?.command?.revision ?? -1 : -1;
+          if (revision <= Math.max(viewportSession.viewportRevision, pendingRevision)) {
             return { accepted: false, reason: "stale-viewport" };
           }
           const normalizedCommand = {
@@ -17833,6 +18757,13 @@ void main() {
             },
             ...normalizeViewportTransform(command)
           };
+          if (!inputEnabled) {
+            passiveDisplaySession.canvasRect = { ...normalizedCommand.canvasRect };
+            passiveDisplaySession.viewportTransform = normalizeViewportTransform(normalizedCommand);
+            passiveDisplaySession.viewportRevision = revision;
+            applyViewport(passiveDisplaySession);
+            return { accepted: true, revision };
+          }
           if (activeLasso || selectGesture || transformStart !== null) {
             deferredViewport = {
               sessionId: currentSession.sessionId,
@@ -17873,12 +18804,26 @@ void main() {
           if (!DRAWING_ACTIONS.has(action)) {
             return { applied: false, reason: "invalid-action" };
           }
+          const hasExplicitTarget = command.targetFrame !== void 0;
+          const targetFrame = hasExplicitTarget ? Number(command.targetFrame) : activeFrameState.targetFrame;
+          if (!Number.isSafeInteger(targetFrame) || targetFrame < 0) {
+            return { applied: false, reason: "invalid-action-target" };
+          }
           if (!actionDeduper.accept(command.actionId)) {
             metrics.recordDuplicateAction();
             return { applied: false, duplicate: true };
           }
+          const retargeted = hasExplicitTarget ? retargetFrameForMutation(targetFrame) : retargetArmedFrameForMutation();
+          if (!retargeted?.accepted) {
+            actionDeduper.release?.(command.actionId);
+            return { applied: false, reason: retargeted?.reason || "retarget-failed" };
+          }
           if (pendingLassoSelection) {
-            if (action === "delete-selection") return commitPendingLassoDelete();
+            if (action === "delete-selection") {
+              const result2 = commitPendingLassoDelete();
+              settleArmedFramePreview();
+              return result2;
+            }
             abortPendingLassoSelection();
           }
           if ((action === "undo" || action === "redo") && (selectGesture || transformStart)) {
@@ -17893,6 +18838,7 @@ void main() {
               sceneStore.selectObjects([]);
               setToolMode(currentSession?.tool || "brush");
               updateObjectMetric();
+              settleArmedFramePreview();
               return result;
             }
             const deletedIds = new Set(result.deletedIds);
@@ -17904,6 +18850,7 @@ void main() {
             fabricCanvas.requestRenderAll();
             updateObjectMetric();
           }
+          settleArmedFramePreview();
           return result;
         }
         function getDrawingV3Diagnostics() {
@@ -17929,10 +18876,19 @@ void main() {
             inputEnabled,
             devicePixelRatio,
             tokens: { ...tokenState },
+            presentationRevision: presentationState.presentationRevision,
+            presentedStableVideoIdentity: currentSession?.stableVideoIdentity ?? presentationState.stableVideoIdentity,
+            presentedStoreRevision: presentationState.storeRevision,
+            presentedTargetFrame: currentSession?.targetFrame ?? presentationState.targetFrame,
+            presentedSourceFrame: currentSession ? currentSession.sourceFrame : presentationState.sourceFrame,
+            activeFrameRevision: activeFrameState.frameRevision,
+            armedTargetFrame: activeFrameState.targetFrame,
+            armedSourceFrame: activeFrameState.sourceFrame,
+            provisional: scene.provisional === true,
             activeSessionId: scene.activeSessionId,
             activeSceneKey: scene.activeSceneKey,
             targetFrame: currentSession?.targetFrame ?? null,
-            viewportRevision: currentSession?.viewportRevision ?? null,
+            viewportRevision: currentSession?.viewportRevision ?? passiveDisplaySession?.viewportRevision ?? null,
             tool: scene.tool,
             selectionTarget,
             selectionShape,
@@ -17988,6 +18944,9 @@ void main() {
           prepare,
           setDrawingInput,
           hydrateDrawingVideo,
+          presentDrawingFrame,
+          updateDrawingFrame,
+          confirmDrawingPointerdownFrame,
           exportDrawingVideo,
           updateDrawingTool,
           updateViewport,

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -17985,6 +17985,9 @@ void main() {
         function onPointerCancel(event) {
           if (pendingPointerdownFrame) {
             if (event.pointerId !== void 0 && event.pointerId !== pendingPointerdownFrame.pointerId) return;
+            if (event.type === "lostpointercapture" && pendingPointerdownFrame.events.some((pendingEvent) => pendingEvent.type === "pointerup")) {
+              return;
+            }
             event.preventDefault?.();
             event.stopImmediatePropagation?.();
             cancelPendingPointerdownFrame();

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -17804,11 +17804,13 @@ void main() {
           event.preventDefault?.();
           event.stopImmediatePropagation?.();
           event.stopPropagation?.();
-          if (pending.events.length >= MAX_PENDING_POINTER_EVENTS) {
+          const coalesced = event.type === "pointermove" && typeof event.getCoalescedEvents === "function" ? event.getCoalescedEvents() : [];
+          const samples = coalesced.length > 0 ? coalesced : [event];
+          if (pending.events.length + samples.length > MAX_PENDING_POINTER_EVENTS) {
             cancelPendingPointerdownFrame();
             return true;
           }
-          pending.events.push(snapshotPointerEvent(event));
+          for (const sample of samples) pending.events.push(snapshotPointerEvent(sample));
           return true;
         }
         function dispatchReplayedPointerEvent(target, snapshot) {

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -13128,6 +13128,7 @@ void main() {
       var MAX_STROKE_POINTS = 2e4;
       var MAX_LASSO_POINTS = 1024;
       var MAX_PENDING_POINTER_EVENTS = 1024;
+      var POINTERDOWN_FRAME_CONFIRMATION_DEADLINE_MS = 3e3;
       var DEFAULT_MAX_SELECTION_GEOMETRY_OPERATIONS = 25e4;
       var MAX_STROKE_GEOMETRY_CACHE_ENTRIES = 512;
       var MAX_STROKE_GEOMETRY_CACHE_WEIGHT = 25e4;
@@ -15031,6 +15032,8 @@ void main() {
         const windowRef = options.window || (typeof window !== "undefined" ? window : null);
         const performanceRef = options.performance || (typeof performance !== "undefined" ? performance : null);
         const queueMicrotaskRef = options.queueMicrotask || windowRef?.queueMicrotask?.bind(windowRef) || globalThis.queueMicrotask?.bind(globalThis) || ((callback) => Promise.resolve().then(callback));
+        const setTimeoutRef = typeof options.setTimeout === "function" ? options.setTimeout : globalThis.setTimeout?.bind(globalThis);
+        const clearTimeoutRef = typeof options.clearTimeout === "function" ? options.clearTimeout : globalThis.clearTimeout?.bind(globalThis);
         const now = () => typeof performanceRef?.now === "function" ? performanceRef.now() : Date.now();
         const wallNow = typeof options.wallNow === "function" ? options.wallNow : () => {
           const epochMilliseconds = Number(performanceRef?.timeOrigin) + Number(performanceRef?.now?.());
@@ -17793,8 +17796,28 @@ void main() {
           const pending = pendingPointerdownFrame;
           pendingPointerdownFrame = null;
           if (!pending) return false;
+          if (pending.confirmationDeadline !== null) {
+            try {
+              clearTimeoutRef?.(pending.confirmationDeadline);
+            } catch (_error) {
+            }
+            pending.confirmationDeadline = null;
+          }
           releasePointerCapture(pending.target, pending.pointerId);
           return true;
+        }
+        function schedulePendingPointerdownFrameDeadline(pending) {
+          if (typeof setTimeoutRef !== "function") return false;
+          try {
+            pending.confirmationDeadline = setTimeoutRef(() => {
+              if (pendingPointerdownFrame !== pending) return;
+              pending.confirmationDeadline = null;
+              cancelPendingPointerdownFrame();
+            }, POINTERDOWN_FRAME_CONFIRMATION_DEADLINE_MS);
+            return true;
+          } catch (_error) {
+            return false;
+          }
         }
         function consumePendingPointerEvent(event) {
           const pending = pendingPointerdownFrame;
@@ -17871,8 +17894,10 @@ void main() {
             request,
             pointerId: event.pointerId,
             target,
-            events: [snapshotPointerEvent(event)]
+            events: [snapshotPointerEvent(event)],
+            confirmationDeadline: null
           };
+          const pending = pendingPointerdownFrame;
           try {
             target?.setPointerCapture?.(event.pointerId);
           } catch (_error) {
@@ -17881,7 +17906,11 @@ void main() {
           event.stopImmediatePropagation?.();
           event.stopPropagation?.();
           try {
-            if (requestPointerdownFrame(request) !== true) cancelPendingPointerdownFrame();
+            if (requestPointerdownFrame(request) !== true) {
+              cancelPendingPointerdownFrame();
+            } else if (pendingPointerdownFrame === pending && !schedulePendingPointerdownFrameDeadline(pending)) {
+              cancelPendingPointerdownFrame();
+            }
           } catch (_error) {
             cancelPendingPointerdownFrame();
           }
@@ -17924,6 +17953,13 @@ void main() {
             return { accepted: false, reason: retargeted?.reason || "retarget-failed" };
           }
           pendingPointerdownFrame = null;
+          if (pending.confirmationDeadline !== null) {
+            try {
+              clearTimeoutRef?.(pending.confirmationDeadline);
+            } catch (_error) {
+            }
+            pending.confirmationDeadline = null;
+          }
           for (const replayEvent of pending.events) {
             if (!dispatchReplayedPointerEvent(pending.target, replayEvent)) {
               cancelActiveStroke();
@@ -18336,6 +18372,7 @@ void main() {
           syncPersistenceBadge();
         }
         function releaseSurfaceResources() {
+          cancelPendingPointerdownFrame();
           cancelSelectInteraction();
           for (const { target, type, listener, listenerOptions } of domListeners.splice(0)) {
             try {
@@ -18367,7 +18404,6 @@ void main() {
           appliedSourceWidth = null;
           appliedSourceHeight = null;
           activeStroke = null;
-          pendingPointerdownFrame = null;
           pendingLassoSelection = null;
           transformStart = null;
           selectGesture = null;

--- a/renderer/scripts/modules/fabric-drawing-persistence-store.js
+++ b/renderer/scripts/modules/fabric-drawing-persistence-store.js
@@ -813,11 +813,11 @@ export function createFabricDrawingPersistenceStore(options = {}) {
     }
   }
 
-  function resolveKeyframeAtFrame(targetFrame) {
+  function resolveKeyframeIndexAtFrame(targetFrame) {
     if (state !== 'ready' || !documentValue ||
         !Number.isSafeInteger(targetFrame) || targetFrame < 0 ||
         targetFrame >= documentValue.totalFrames) {
-      return null;
+      return -1;
     }
 
     let lower = 0;
@@ -832,9 +832,17 @@ export function createFabricDrawingPersistenceStore(options = {}) {
         upper = middle - 1;
       }
     }
-    return resolvedIndex >= 0
-      ? clonePlain(documentValue.keyframes[resolvedIndex])
-      : null;
+    return resolvedIndex;
+  }
+
+  function resolveSourceFrameAtFrame(targetFrame) {
+    const resolvedIndex = resolveKeyframeIndexAtFrame(targetFrame);
+    return resolvedIndex >= 0 ? documentValue.keyframes[resolvedIndex].frame : null;
+  }
+
+  function resolveKeyframeAtFrame(targetFrame) {
+    const resolvedIndex = resolveKeyframeIndexAtFrame(targetFrame);
+    return resolvedIndex >= 0 ? clonePlain(documentValue.keyframes[resolvedIndex]) : null;
   }
 
   function snapshotKeyframesAtFrames(frames, keyframes = documentValue?.keyframes || []) {
@@ -1422,6 +1430,7 @@ export function createFabricDrawingPersistenceStore(options = {}) {
     importRootValue,
     reset,
     invalidate,
+    resolveSourceFrameAtFrame,
     resolveKeyframeAtFrame,
     moveKeyframes,
     applyKeyframeEdit,

--- a/renderer/scripts/modules/fabric-drawing-persistence-store.js
+++ b/renderer/scripts/modules/fabric-drawing-persistence-store.js
@@ -95,6 +95,17 @@ const OVERLAY_SCENE_KEYS = Object.freeze([
   'mutationSequence',
   'objects'
 ]);
+const KEYFRAME_MOVE_KEYS = Object.freeze(['fromFrame', 'toFrame']);
+const KEYFRAME_EDIT_KEYS = Object.freeze([
+  'schema',
+  'kind',
+  'documentId',
+  'before',
+  'after'
+]);
+const KEYFRAME_EDIT_SNAPSHOT_KEYS = Object.freeze(['frame', 'keyframe']);
+const KEYFRAME_EDIT_SCHEMA = 'baeframe-fabric-keyframe-edit';
+const KEYFRAME_EDIT_KIND = 'move-keyframes';
 const VALID_ORIGINS = new Set(['live', 'history']);
 const VALID_KINDS = new Set([
   'add-objects',
@@ -308,6 +319,21 @@ function isPositiveFinite(value) {
 
 function clonePlain(value) {
   return structuredClone(value);
+}
+
+function samePlainValue(left, right) {
+  if (left === right) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((item, index) => samePlainValue(item, right[index]));
+  }
+  if (!isPlainRecord(left) || !isPlainRecord(right)) return false;
+  const leftKeys = Reflect.ownKeys(left);
+  const rightKeys = Reflect.ownKeys(right);
+  return leftKeys.length === rightKeys.length &&
+    leftKeys.every(key => Object.hasOwn(right, key) && samePlainValue(left[key], right[key]));
 }
 
 function jsonBytes(value) {
@@ -787,6 +813,227 @@ export function createFabricDrawingPersistenceStore(options = {}) {
     }
   }
 
+  function resolveKeyframeAtFrame(targetFrame) {
+    if (state !== 'ready' || !documentValue ||
+        !Number.isSafeInteger(targetFrame) || targetFrame < 0 ||
+        targetFrame >= documentValue.totalFrames) {
+      return null;
+    }
+
+    let lower = 0;
+    let upper = documentValue.keyframes.length - 1;
+    let resolvedIndex = -1;
+    while (lower <= upper) {
+      const middle = Math.floor((lower + upper) / 2);
+      if (documentValue.keyframes[middle].frame <= targetFrame) {
+        resolvedIndex = middle;
+        lower = middle + 1;
+      } else {
+        upper = middle - 1;
+      }
+    }
+    return resolvedIndex >= 0
+      ? clonePlain(documentValue.keyframes[resolvedIndex])
+      : null;
+  }
+
+  function snapshotKeyframesAtFrames(frames, keyframes = documentValue?.keyframes || []) {
+    const keyframesByFrame = new Map(keyframes.map(keyframe => [keyframe.frame, keyframe]));
+    return frames.map(frame => ({
+      frame,
+      keyframe: keyframesByFrame.has(frame)
+        ? clonePlain(keyframesByFrame.get(frame))
+        : null
+    }));
+  }
+
+  function validateKeyframeEditSnapshots(snapshots) {
+    if (!isDenseArray(snapshots) || snapshots.length === 0) return false;
+    let previousFrame = -1;
+    for (const snapshot of snapshots) {
+      if (!hasExactKeys(snapshot, KEYFRAME_EDIT_SNAPSHOT_KEYS) ||
+          !Number.isSafeInteger(snapshot.frame) || snapshot.frame < 0 ||
+          snapshot.frame >= documentValue.totalFrames ||
+          snapshot.frame <= previousFrame) {
+        return false;
+      }
+      if (snapshot.keyframe !== null) {
+        const validation = validateKeyframes(
+          [snapshot.keyframe],
+          documentValue.totalFrames,
+          limits
+        );
+        if (!validation.valid || snapshot.keyframe.frame !== snapshot.frame) return false;
+      }
+      previousFrame = snapshot.frame;
+    }
+    return true;
+  }
+
+  function validateKeyframeEdit(edit) {
+    if (!hasExactKeys(edit, KEYFRAME_EDIT_KEYS) ||
+        edit.schema !== KEYFRAME_EDIT_SCHEMA ||
+        edit.kind !== KEYFRAME_EDIT_KIND ||
+        edit.documentId !== documentValue.documentId ||
+        !validateKeyframeEditSnapshots(edit.before) ||
+        !validateKeyframeEditSnapshots(edit.after) ||
+        edit.before.length !== edit.after.length) {
+      return false;
+    }
+    return edit.before.every((snapshot, index) => snapshot.frame === edit.after[index].frame);
+  }
+
+  function buildDocumentFromSnapshots(snapshots, revision) {
+    const keyframesByFrame = new Map(
+      documentValue.keyframes.map(keyframe => [keyframe.frame, keyframe])
+    );
+    snapshots.forEach(snapshot => {
+      if (snapshot.keyframe === null) keyframesByFrame.delete(snapshot.frame);
+      else keyframesByFrame.set(snapshot.frame, clonePlain(snapshot.keyframe));
+    });
+    return {
+      ...documentValue,
+      revision,
+      keyframes: [...keyframesByFrame.values()].sort((left, right) => left.frame - right.frame)
+    };
+  }
+
+  function commitKeyframeDocument(nextDocument, touchedFrames, change) {
+    documentValue = nextDocument;
+    issuedIds.add(documentValue.documentId);
+    for (const keyframe of documentValue.keyframes) {
+      issuedIds.add(keyframe.id);
+      for (const object of keyframe.objects) issuedIds.add(object.id);
+    }
+    rebuildByteAccounting(documentValue);
+    touchedFrames.forEach(frame => sceneInstances.delete(frame));
+    emitChange(change);
+  }
+
+  function moveKeyframes(moves) {
+    if (state !== 'ready' || !documentValue) {
+      return { applied: false, reason: 'store-incompatible' };
+    }
+    if (!isDenseArray(moves) || moves.length === 0 ||
+        !moves.every(move =>
+          hasExactKeys(move, KEYFRAME_MOVE_KEYS) &&
+          Number.isSafeInteger(move.fromFrame) &&
+          Number.isSafeInteger(move.toFrame))) {
+      return { applied: false, reason: 'invalid-moves' };
+    }
+    if (moves.some(move => move.fromFrame === move.toFrame)) {
+      return { applied: false, reason: 'no-op' };
+    }
+    if (moves.some(move =>
+      move.fromFrame < 0 || move.fromFrame >= documentValue.totalFrames ||
+      move.toFrame < 0 || move.toFrame >= documentValue.totalFrames)) {
+      return { applied: false, reason: 'frame-out-of-range' };
+    }
+
+    const sourceFrames = new Set(moves.map(move => move.fromFrame));
+    if (sourceFrames.size !== moves.length) {
+      return { applied: false, reason: 'duplicate-source-frame' };
+    }
+    const targetFrames = new Set(moves.map(move => move.toFrame));
+    if (targetFrames.size !== moves.length) {
+      return { applied: false, reason: 'duplicate-target-frame' };
+    }
+    const currentByFrame = new Map(
+      documentValue.keyframes.map(keyframe => [keyframe.frame, keyframe])
+    );
+    if (moves.some(move => !currentByFrame.has(move.fromFrame))) {
+      return { applied: false, reason: 'source-keyframe-not-found' };
+    }
+    if (documentValue.revision >= Number.MAX_SAFE_INTEGER) {
+      return { applied: false, reason: 'revision-overflow' };
+    }
+
+    const touchedFrames = [...new Set(moves.flatMap(move => [
+      move.fromFrame,
+      move.toFrame
+    ]))].sort((left, right) => left - right);
+    const before = snapshotKeyframesAtFrames(touchedFrames);
+    const sourceSnapshots = new Map(moves.map(move => [
+      move.fromFrame,
+      clonePlain(currentByFrame.get(move.fromFrame))
+    ]));
+    moves.forEach(move => currentByFrame.delete(move.fromFrame));
+    moves.forEach(move => {
+      currentByFrame.set(move.toFrame, {
+        ...sourceSnapshots.get(move.fromFrame),
+        frame: move.toFrame
+      });
+    });
+
+    const nextDocument = {
+      ...documentValue,
+      revision: documentValue.revision + 1,
+      keyframes: [...currentByFrame.values()].sort((left, right) => left.frame - right.frame)
+    };
+    const validation = validateRootValue(nextDocument, limits);
+    if (!validation.valid) return { applied: false, reason: validation.reason };
+
+    const after = snapshotKeyframesAtFrames(touchedFrames, nextDocument.keyframes);
+    const edit = {
+      schema: KEYFRAME_EDIT_SCHEMA,
+      kind: KEYFRAME_EDIT_KIND,
+      documentId: documentValue.documentId,
+      before,
+      after
+    };
+    commitKeyframeDocument(nextDocument, touchedFrames, {
+      kind: 'move-keyframes',
+      origin: 'timeline',
+      frame: null,
+      mutationSequence: null,
+      revision: nextDocument.revision
+    });
+    return {
+      applied: true,
+      revision: documentValue.revision,
+      edit
+    };
+  }
+
+  function applyKeyframeEdit(edit, direction) {
+    if (state !== 'ready' || !documentValue) {
+      return { applied: false, reason: 'store-incompatible' };
+    }
+    if (direction !== 'undo' && direction !== 'redo') {
+      return { applied: false, reason: 'invalid-direction' };
+    }
+    if (!validateKeyframeEdit(edit)) {
+      return { applied: false, reason: 'invalid-edit' };
+    }
+    if (documentValue.revision >= Number.MAX_SAFE_INTEGER) {
+      return { applied: false, reason: 'revision-overflow' };
+    }
+
+    const expected = direction === 'undo' ? edit.after : edit.before;
+    const replacement = direction === 'undo' ? edit.before : edit.after;
+    const touchedFrames = expected.map(snapshot => snapshot.frame);
+    const current = snapshotKeyframesAtFrames(touchedFrames);
+    if (!samePlainValue(current, expected)) {
+      return { applied: false, reason: 'edit-state-mismatch' };
+    }
+
+    const nextDocument = buildDocumentFromSnapshots(
+      replacement,
+      documentValue.revision + 1
+    );
+    const validation = validateRootValue(nextDocument, limits);
+    if (!validation.valid) return { applied: false, reason: validation.reason };
+
+    commitKeyframeDocument(nextDocument, touchedFrames, {
+      kind: 'apply-keyframe-edit',
+      origin: direction,
+      frame: null,
+      mutationSequence: null,
+      revision: nextDocument.revision
+    });
+    return { applied: true, revision: documentValue.revision };
+  }
+
   function applyTransition(event) {
     if (state !== 'ready' || !documentValue) {
       return eventFailure('store-incompatible');
@@ -1175,6 +1422,9 @@ export function createFabricDrawingPersistenceStore(options = {}) {
     importRootValue,
     reset,
     invalidate,
+    resolveKeyframeAtFrame,
+    moveKeyframes,
+    applyKeyframeEdit,
     applyTransition,
     replaceFromOverlay,
     exportRootValue,

--- a/renderer/scripts/modules/fabric-drawing-pilot-controller.js
+++ b/renderer/scripts/modules/fabric-drawing-pilot-controller.js
@@ -2089,8 +2089,16 @@ export function createFabricDrawingPilotController(options = {}) {
     }
 
     lastError = null;
-    pushActiveFrameObservation(session.targetFrame);
     setState('active');
+    const acceptedTargetFrame = Math.max(
+      0,
+      Math.trunc(Number(contextSnapshot().targetFrame) || 0)
+    );
+    if (acceptedTargetFrame === session.targetFrame) {
+      recordActiveFrameObservation(acceptedTargetFrame);
+    } else {
+      runDetached(syncActiveDrawingFrame(acceptedTargetFrame, { force: true }));
+    }
     if (desiredTool !== session.tool) {
       await sendTool(desiredTool);
     }

--- a/renderer/scripts/modules/fabric-drawing-pilot-controller.js
+++ b/renderer/scripts/modules/fabric-drawing-pilot-controller.js
@@ -1,6 +1,52 @@
 const DRAWING_PROTOCOL = 'baeframe-drawing-surface';
 const DRAWING_PROTOCOL_VERSION = 1;
 const CONTROLLER_DRAWING_ACTIONS = new Set(['delete-selection', 'undo', 'redo']);
+const ACTIVE_FRAME_MAX_IN_FLIGHT = 2;
+const ACTIVE_FRAME_OBSERVATION_LIMIT = 64;
+const POINTERDOWN_FRAME_REQUEST_KEYS = [
+  'hostGeneration',
+  'videoGeneration',
+  'inputRevision',
+  'sessionId',
+  'pointerdownId',
+  'pointerdownAt'
+];
+
+function exactKeys(value, expectedKeys) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return false;
+  const ownKeys = Reflect.ownKeys(value);
+  if (ownKeys.some(key => typeof key !== 'string')) return false;
+  const actualKeys = ownKeys.sort();
+  const sortedExpectedKeys = [...expectedKeys].sort();
+  return actualKeys.length === sortedExpectedKeys.length &&
+    actualKeys.every((key, index) => key === sortedExpectedKeys[index]);
+}
+
+function normalizePointerdownFrameRequest(value) {
+  if (!exactKeys(value, POINTERDOWN_FRAME_REQUEST_KEYS)) return null;
+  const hostGeneration = value.hostGeneration;
+  const videoGeneration = value.videoGeneration;
+  const inputRevision = value.inputRevision;
+  const pointerdownAt = value.pointerdownAt;
+  if (![hostGeneration, videoGeneration, inputRevision].every(
+    number => Number.isSafeInteger(number) && number > 0
+  ) || !Number.isSafeInteger(pointerdownAt) || pointerdownAt < 0 ||
+      typeof value.sessionId !== 'string' || value.sessionId.length < 1 ||
+      value.sessionId.length > 256 || typeof value.pointerdownId !== 'string' ||
+      value.pointerdownId.length < 1 || value.pointerdownId.length > 256) {
+    return null;
+  }
+  return {
+    hostGeneration,
+    videoGeneration,
+    inputRevision,
+    sessionId: value.sessionId,
+    pointerdownId: value.pointerdownId,
+    pointerdownAt
+  };
+}
 
 function copyRect(rect) {
   return rect && typeof rect === 'object' ? { ...rect } : null;
@@ -91,6 +137,16 @@ export function createFabricDrawingPilotController(options = {}) {
     typeof options.persistenceSessionIdFactory === 'function'
       ? options.persistenceSessionIdFactory
       : () => globalThis.crypto?.randomUUID?.() || uuid();
+  const wallNow = typeof options.wallNow === 'function'
+    ? options.wallNow
+    : () => {
+      const performanceValue = globalThis.performance;
+      const epochMilliseconds = Number(performanceValue?.timeOrigin) +
+        Number(performanceValue?.now?.());
+      return Number.isFinite(epochMilliseconds)
+        ? Math.floor(epochMilliseconds * 1000)
+        : Date.now() * 1000;
+    };
   // 오버레이 호스트 IPC 응답 데드라인. 호스트가 응답하지 않으면 게이트가 영구 pending이 되어
   // 이어붙이기 전환 전체가 침묵 정지하므로(2026-08-21), 경계에서 유한 시간으로 자른다.
   const persistenceIpcDeadlineMs =
@@ -141,6 +197,17 @@ export function createFabricDrawingPilotController(options = {}) {
   let persistenceFailureReason = null;
   let persistenceVideoContext = null;
   let persistenceBoundSourceEpoch = null;
+  let presentationRevision = 0;
+  let passivePresentationInFlight = null;
+  let passivePresentationTrailing = null;
+  let lastAcceptedPresentationSignature = null;
+  let activeFrameRevision = 0;
+  const activeFrameInFlight = new Set();
+  let activeFramePending = null;
+  let activeFrameDispatchScheduled = false;
+  let lastAcceptedActiveFrameSignature = null;
+  let activeFrameObservations = [];
+  let passivePresentationBlock = null;
 
   function contextSnapshot(overrides) {
     let current = {};
@@ -152,6 +219,525 @@ export function createFabricDrawingPilotController(options = {}) {
     return overrides && typeof overrides === 'object'
       ? { ...current, ...overrides }
       : { ...current };
+  }
+
+  function isPassivePresentationBlocked() {
+    return !!(
+      passivePresentationBlock &&
+      passivePresentationBlock.hostGeneration === hostGeneration &&
+      passivePresentationBlock.videoGeneration === videoGeneration &&
+      passivePresentationBlock.inputRevision === inputRevision
+    );
+  }
+
+  function releasePassivePresentationBlock(block) {
+    if (passivePresentationBlock !== block) return false;
+    passivePresentationBlock = null;
+    return true;
+  }
+
+  function readPersistenceRevision() {
+    let value = null;
+    try {
+      value = persistenceStore?.getRevision?.();
+      if (value === null || value === undefined) {
+        value = persistenceStore?.getStatus?.()?.revision;
+      }
+    } catch {
+      value = null;
+    }
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
+  }
+
+  function resolveSourceFrame(targetFrame) {
+    if (typeof persistenceStore?.resolveKeyframeAtFrame !== 'function') return null;
+    let keyframe = null;
+    try {
+      keyframe = persistenceStore.resolveKeyframeAtFrame(targetFrame);
+    } catch {
+      return null;
+    }
+    if (keyframe === null) return { sourceFrame: null };
+    const sourceFrame = Number(keyframe?.frame);
+    if (!Number.isSafeInteger(sourceFrame) || sourceFrame < 0 || sourceFrame > targetFrame) {
+      return null;
+    }
+    return { sourceFrame };
+  }
+
+  function readPassiveViewport(context) {
+    const sourceWidth = Number(context.sourceWidth);
+    const sourceHeight = Number(context.sourceHeight);
+    const rect = context.canvasRect;
+    const canvasRect = {
+      left: Number(rect?.left),
+      top: Number(rect?.top),
+      width: Number(rect?.width),
+      height: Number(rect?.height)
+    };
+    const viewportRevision = Number(context.viewportRevision);
+    const viewportTransform = copyViewportTransform(context.viewportTransform);
+    if (!Number.isFinite(sourceWidth) || sourceWidth <= 0 ||
+        !Number.isFinite(sourceHeight) || sourceHeight <= 0 ||
+        !Object.values(canvasRect).every(Number.isFinite) ||
+        canvasRect.width <= 0 || canvasRect.height <= 0 ||
+        !Number.isSafeInteger(viewportRevision) || viewportRevision < 0 ||
+        !Number.isFinite(viewportTransform.scale) || viewportTransform.scale <= 0 ||
+        !Number.isFinite(viewportTransform.panX) ||
+        !Number.isFinite(viewportTransform.panY)) {
+      return null;
+    }
+    return {
+      sourceWidth,
+      sourceHeight,
+      canvasRect,
+      viewportRevision,
+      viewportTransform
+    };
+  }
+
+  function createPassivePresentationEntry(targetFrame, { force = false } = {}) {
+    if (!pilotEnabled || state !== 'passive' || desiredInputEnabled ||
+        isPassivePresentationBlocked() ||
+        !videoReady || !hostGeneration || !videoGeneration) {
+      return null;
+    }
+    let presentFrame;
+    try {
+      presentFrame = electronAPI.mpvPresentOverlayDrawingFrame;
+    } catch {
+      presentFrame = null;
+    }
+    if (typeof presentFrame !== 'function') return null;
+    const context = contextSnapshot();
+    const stableVideoIdentity = String(context.stableVideoIdentity || '');
+    if (!validPilotContext(context) || !stableVideoIdentity ||
+        stableVideoIdentity !== confirmedVideoIdentity) {
+      return null;
+    }
+    const normalizedTargetFrame = Math.max(0, Math.trunc(Number(targetFrame) || 0));
+    const totalFrames = Number(context.totalFrames);
+    if (Number.isSafeInteger(totalFrames) && totalFrames > 0 &&
+        normalizedTargetFrame >= totalFrames) {
+      return null;
+    }
+    const resolved = resolveSourceFrame(normalizedTargetFrame);
+    const storeRevision = readPersistenceRevision();
+    const viewport = readPassiveViewport(context);
+    if (!resolved || storeRevision === null || !viewport ||
+        presentationRevision >= Number.MAX_SAFE_INTEGER) {
+      return null;
+    }
+    const signature = JSON.stringify([
+      hostGeneration,
+      videoGeneration,
+      stableVideoIdentity,
+      storeRevision,
+      resolved.sourceFrame,
+      viewport.sourceWidth,
+      viewport.sourceHeight,
+      viewport.canvasRect.left,
+      viewport.canvasRect.top,
+      viewport.canvasRect.width,
+      viewport.canvasRect.height,
+      viewport.viewportRevision,
+      viewport.viewportTransform.scale,
+      viewport.viewportTransform.panX,
+      viewport.viewportTransform.panY
+    ]);
+    if (!force) {
+      if (passivePresentationTrailing?.signature === signature) {
+        return { existingPromise: passivePresentationTrailing.promise };
+      }
+      if (passivePresentationInFlight?.signature === signature &&
+          !passivePresentationTrailing) {
+        return { existingPromise: passivePresentationInFlight.promise };
+      }
+      if (signature === lastAcceptedPresentationSignature &&
+          !passivePresentationInFlight) {
+        return { deduped: true };
+      }
+    }
+    presentationRevision += 1;
+    let resolveEntry;
+    const promise = new Promise(resolve => {
+      resolveEntry = resolve;
+    });
+    const request = {
+      hostGeneration,
+      videoGeneration,
+      presentationRevision,
+      stableVideoIdentity,
+      storeRevision,
+      targetFrame: normalizedTargetFrame,
+      sourceFrame: resolved.sourceFrame,
+      ...viewport
+    };
+    return {
+      force,
+      signature,
+      request,
+      presentFrame,
+      promise,
+      resolve: resolveEntry
+    };
+  }
+
+  function passivePresentationEntryIsCurrent(entry) {
+    const request = entry?.request;
+    if (!request || state !== 'passive' || desiredInputEnabled || !videoReady ||
+        request.hostGeneration !== hostGeneration ||
+        request.videoGeneration !== videoGeneration ||
+        request.presentationRevision !== presentationRevision ||
+        request.stableVideoIdentity !== confirmedVideoIdentity) {
+      return false;
+    }
+    const context = contextSnapshot();
+    const viewport = readPassiveViewport(context);
+    if (!validPilotContext(context) ||
+        String(context.stableVideoIdentity || '') !== request.stableVideoIdentity ||
+        readPersistenceRevision() !== request.storeRevision ||
+        !viewport ||
+        JSON.stringify(viewport) !== JSON.stringify({
+          sourceWidth: request.sourceWidth,
+          sourceHeight: request.sourceHeight,
+          canvasRect: request.canvasRect,
+          viewportRevision: request.viewportRevision,
+          viewportTransform: request.viewportTransform
+        })) {
+      return false;
+    }
+    const resolved = resolveSourceFrame(request.targetFrame);
+    return resolved !== null && resolved.sourceFrame === request.sourceFrame;
+  }
+
+  function responseMatchesPassivePresentation(response, request) {
+    return response?.success === true &&
+      response.accepted === true &&
+      response.presentationRevision === request.presentationRevision &&
+      response.targetFrame === request.targetFrame &&
+      response.sourceFrame === request.sourceFrame;
+  }
+
+  function runPassivePresentationEntry(entry) {
+    passivePresentationInFlight = entry;
+    void (async () => {
+      let accepted = false;
+      try {
+        const response = await entry.presentFrame(entry.request);
+        accepted = responseMatchesPassivePresentation(response, entry.request) &&
+          passivePresentationEntryIsCurrent(entry);
+        if (accepted) lastAcceptedPresentationSignature = entry.signature;
+      } catch {
+        accepted = false;
+      } finally {
+        if (passivePresentationInFlight === entry) {
+          passivePresentationInFlight = null;
+        }
+        entry.resolve(accepted);
+        const trailing = passivePresentationTrailing;
+        passivePresentationTrailing = null;
+        if (!trailing) return;
+        if (!passivePresentationEntryIsCurrent(trailing)) {
+          trailing.resolve(false);
+          return;
+        }
+        if (!trailing.force && trailing.signature === lastAcceptedPresentationSignature) {
+          trailing.resolve(true);
+          return;
+        }
+        runPassivePresentationEntry(trailing);
+      }
+    })();
+  }
+
+  function syncDisplayFrame(targetFrame, options = {}) {
+    if (state === 'active') return syncActiveDrawingFrame(targetFrame, options);
+    const entry = createPassivePresentationEntry(targetFrame, options);
+    if (!entry) return Promise.resolve(false);
+    if (entry.deduped) return Promise.resolve(true);
+    if (entry.existingPromise) return entry.existingPromise;
+    if (passivePresentationInFlight) {
+      if (passivePresentationTrailing) passivePresentationTrailing.resolve(false);
+      passivePresentationTrailing = entry;
+      return entry.promise;
+    }
+    runPassivePresentationEntry(entry);
+    return entry.promise;
+  }
+
+  function pushActiveFrameObservation(targetFrame, observedAt = wallNow()) {
+    if (!currentSession || !Number.isSafeInteger(targetFrame) || targetFrame < 0 ||
+        !Number.isSafeInteger(observedAt) || observedAt < 0) {
+      return false;
+    }
+    const observation = {
+      hostGeneration,
+      videoGeneration,
+      inputRevision,
+      sessionId: currentSession.sessionId,
+      targetFrame,
+      observedAt
+    };
+    const previous = activeFrameObservations.at(-1);
+    if (previous && previous.hostGeneration === observation.hostGeneration &&
+        previous.videoGeneration === observation.videoGeneration &&
+        previous.inputRevision === observation.inputRevision &&
+        previous.sessionId === observation.sessionId &&
+        previous.targetFrame === observation.targetFrame &&
+        previous.observedAt === observation.observedAt) {
+      return true;
+    }
+    activeFrameObservations.push(observation);
+    if (activeFrameObservations.length > ACTIVE_FRAME_OBSERVATION_LIMIT) {
+      activeFrameObservations.splice(
+        0,
+        activeFrameObservations.length - ACTIVE_FRAME_OBSERVATION_LIMIT
+      );
+    }
+    return true;
+  }
+
+  function recordActiveFrameObservation(targetFrame) {
+    if (state !== 'active' || !desiredInputEnabled || !currentSession || !videoReady) {
+      return false;
+    }
+    const context = contextSnapshot();
+    const normalizedTargetFrame = Math.max(0, Math.trunc(Number(targetFrame) || 0));
+    const totalFrames = Number(context.totalFrames);
+    if (!validPilotContext(context) ||
+        String(context.stableVideoIdentity || '') !== confirmedVideoIdentity ||
+        (Number.isSafeInteger(totalFrames) && totalFrames > 0 &&
+          normalizedTargetFrame >= totalFrames)) {
+      return false;
+    }
+    return pushActiveFrameObservation(normalizedTargetFrame);
+  }
+
+  function resolvePointerdownFrame(request) {
+    for (let index = activeFrameObservations.length - 1; index >= 0; index -= 1) {
+      const observation = activeFrameObservations[index];
+      if (observation.observedAt <= request.pointerdownAt &&
+          observation.hostGeneration === request.hostGeneration &&
+          observation.videoGeneration === request.videoGeneration &&
+          observation.inputRevision === request.inputRevision &&
+          observation.sessionId === request.sessionId) {
+        return observation.targetFrame;
+      }
+    }
+    return null;
+  }
+
+  async function cancelPointerdownFrame(request, confirmPointerdownFrame) {
+    try {
+      await withPersistenceIpcDeadline(
+        confirmPointerdownFrame({ ...request, cancelled: true }),
+        { success: false, accepted: false, reason: 'pointerdown-cancel-ipc-timeout' }
+      );
+    } catch { /* cancellation is best-effort and runtime-fenced */ }
+    return false;
+  }
+
+  async function handlePointerdownFrameRequest(value) {
+    const request = normalizePointerdownFrameRequest(value);
+    let confirmPointerdownFrame;
+    try {
+      confirmPointerdownFrame = electronAPI.mpvConfirmOverlayDrawingPointerdownFrame;
+    } catch {
+      confirmPointerdownFrame = null;
+    }
+    if (!request || typeof confirmPointerdownFrame !== 'function') {
+      return false;
+    }
+    if (state !== 'active' || !desiredInputEnabled || !currentSession ||
+        request.hostGeneration !== hostGeneration ||
+        request.videoGeneration !== videoGeneration ||
+        request.inputRevision !== inputRevision ||
+        request.sessionId !== currentSession.sessionId) {
+      return cancelPointerdownFrame(request, confirmPointerdownFrame);
+    }
+    const targetFrame = resolvePointerdownFrame(request);
+    if (!Number.isSafeInteger(targetFrame)) {
+      return cancelPointerdownFrame(request, confirmPointerdownFrame);
+    }
+    const confirmation = { ...request, targetFrame };
+    try {
+      const response = await withPersistenceIpcDeadline(
+        confirmPointerdownFrame(confirmation),
+        { success: false, accepted: false, reason: 'pointerdown-frame-ipc-timeout' }
+      );
+      const accepted = response?.success === true && response.accepted === true &&
+        response.pointerdownId === request.pointerdownId &&
+        response.targetFrame === targetFrame && state === 'active' &&
+        desiredInputEnabled && currentSession?.sessionId === request.sessionId &&
+        hostGeneration === request.hostGeneration &&
+        videoGeneration === request.videoGeneration &&
+        inputRevision === request.inputRevision;
+      return accepted
+        ? true
+        : cancelPointerdownFrame(request, confirmPointerdownFrame);
+    } catch {
+      return cancelPointerdownFrame(request, confirmPointerdownFrame);
+    }
+  }
+
+  function createActiveFrameEntry(targetFrame, { force = false } = {}) {
+    if (!pilotEnabled || state !== 'active' || !desiredInputEnabled ||
+        !currentSession || !videoReady || !hostGeneration || !videoGeneration) {
+      return null;
+    }
+    let updateFrame;
+    try {
+      updateFrame = electronAPI.mpvUpdateOverlayDrawingFrame;
+    } catch {
+      updateFrame = null;
+    }
+    if (typeof updateFrame !== 'function') return null;
+    const context = contextSnapshot();
+    if (!validPilotContext(context) ||
+        String(context.stableVideoIdentity || '') !== confirmedVideoIdentity) {
+      return null;
+    }
+    const normalizedTargetFrame = Math.max(0, Math.trunc(Number(targetFrame) || 0));
+    const totalFrames = Number(context.totalFrames);
+    if (Number.isSafeInteger(totalFrames) && totalFrames > 0 &&
+        normalizedTargetFrame >= totalFrames) {
+      return null;
+    }
+    const signature = JSON.stringify([
+      hostGeneration,
+      videoGeneration,
+      inputRevision,
+      currentSession.sessionId,
+      normalizedTargetFrame
+    ]);
+    if (!force) {
+      if (activeFramePending?.signature === signature) {
+        return { existingPromise: activeFramePending.promise };
+      }
+      const matchingInFlight = [...activeFrameInFlight]
+        .find(candidate => candidate.signature === signature);
+      if (matchingInFlight && !activeFramePending) {
+        return { existingPromise: matchingInFlight.promise };
+      }
+      if (signature === lastAcceptedActiveFrameSignature &&
+          activeFrameInFlight.size === 0 && !activeFramePending) {
+        return { deduped: true };
+      }
+    }
+    if (activeFrameRevision >= Number.MAX_SAFE_INTEGER) return null;
+    activeFrameRevision += 1;
+    let resolveEntry;
+    const promise = new Promise(resolve => {
+      resolveEntry = resolve;
+    });
+    let settled = false;
+    return {
+      force,
+      signature,
+      request: {
+        hostGeneration,
+        videoGeneration,
+        inputRevision,
+        sessionId: currentSession.sessionId,
+        frameRevision: activeFrameRevision,
+        targetFrame: normalizedTargetFrame
+      },
+      updateFrame,
+      promise,
+      resolve(value) {
+        if (settled) return;
+        settled = true;
+        resolveEntry(value);
+      }
+    };
+  }
+
+  function activeFrameEntryIsCurrent(entry) {
+    const request = entry?.request;
+    if (!request || state !== 'active' || !desiredInputEnabled || !currentSession ||
+        !videoReady || request.hostGeneration !== hostGeneration ||
+        request.videoGeneration !== videoGeneration ||
+        request.inputRevision !== inputRevision ||
+        request.sessionId !== currentSession.sessionId ||
+        request.frameRevision !== activeFrameRevision) {
+      return false;
+    }
+    const context = contextSnapshot();
+    return validPilotContext(context) &&
+      String(context.stableVideoIdentity || '') === confirmedVideoIdentity;
+  }
+
+  function runActiveFrameEntry(entry) {
+    activeFrameInFlight.add(entry);
+    void (async () => {
+      let accepted = false;
+      try {
+        const response = await withPersistenceIpcDeadline(
+          entry.updateFrame(entry.request),
+          {
+            success: false,
+            accepted: false,
+            frameRevision: entry.request.frameRevision,
+            targetFrame: entry.request.targetFrame,
+            reason: 'active-frame-ipc-timeout'
+          }
+        );
+        accepted = response?.success === true &&
+          response.accepted === true &&
+          response.frameRevision === entry.request.frameRevision &&
+          response.targetFrame === entry.request.targetFrame &&
+          activeFrameEntryIsCurrent(entry);
+        if (accepted) lastAcceptedActiveFrameSignature = entry.signature;
+      } catch {
+        accepted = false;
+      } finally {
+        activeFrameInFlight.delete(entry);
+        entry.resolve(accepted);
+        scheduleActiveFrameDispatch();
+      }
+    })();
+  }
+
+  function scheduleActiveFrameDispatch() {
+    if (activeFrameDispatchScheduled || !activeFramePending) return;
+    activeFrameDispatchScheduled = true;
+    queueMicrotask(() => {
+      activeFrameDispatchScheduled = false;
+      if (!activeFramePending ||
+          activeFrameInFlight.size >= ACTIVE_FRAME_MAX_IN_FLIGHT) {
+        return;
+      }
+      const pending = activeFramePending;
+      activeFramePending = null;
+      if (!activeFrameEntryIsCurrent(pending)) {
+        pending.resolve(false);
+        scheduleActiveFrameDispatch();
+        return;
+      }
+      if (!pending.force && pending.signature === lastAcceptedActiveFrameSignature) {
+        pending.resolve(true);
+        scheduleActiveFrameDispatch();
+        return;
+      }
+      runActiveFrameEntry(pending);
+    });
+  }
+
+  function syncActiveDrawingFrame(targetFrame, options = {}) {
+    recordActiveFrameObservation(targetFrame);
+    const entry = createActiveFrameEntry(targetFrame, options);
+    if (!entry) return Promise.resolve(false);
+    if (entry.deduped) return Promise.resolve(true);
+    if (entry.existingPromise) return entry.existingPromise;
+    if (activeFrameInFlight.size > 0) {
+      if (activeFramePending) activeFramePending.resolve(false);
+      activeFramePending = entry;
+      scheduleActiveFrameDispatch();
+      return entry.promise;
+    }
+    runActiveFrameEntry(entry);
+    return entry.promise;
   }
 
   function readHistoryRevision() {
@@ -183,6 +769,8 @@ export function createFabricDrawingPilotController(options = {}) {
       persistenceBlocked,
       persistenceFailureReason,
       persistenceSourceRefreshInProgress,
+      presentationRevision,
+      activeFrameRevision,
       persistenceQuitPrepared: persistenceQuitSuspension !== null,
       persistenceReady: persistenceStore === null ||
         (persistenceBridgeReady && persistenceSessionId !== null),
@@ -236,8 +824,33 @@ export function createFabricDrawingPilotController(options = {}) {
 
   function setState(nextState) {
     if (state === nextState) return;
+    if (nextState !== 'passive') invalidatePassivePresentationOwner();
+    if (nextState !== 'active') invalidateActiveFrameOwner();
     state = nextState;
     notifyStateChange();
+  }
+
+  function invalidatePassivePresentationOwner() {
+    presentationRevision += 1;
+    lastAcceptedPresentationSignature = null;
+    if (passivePresentationTrailing) {
+      passivePresentationTrailing.resolve(false);
+      passivePresentationTrailing = null;
+    }
+  }
+
+  function invalidateActiveFrameOwner() {
+    activeFrameRevision += 1;
+    lastAcceptedActiveFrameSignature = null;
+    activeFrameObservations = [];
+    if (activeFramePending) {
+      activeFramePending.resolve(false);
+      activeFramePending = null;
+    }
+    for (const entry of activeFrameInFlight) {
+      entry.resolve(false);
+    }
+    activeFrameInFlight.clear();
   }
 
   function syncExplicitResumeIntent() {
@@ -534,11 +1147,14 @@ export function createFabricDrawingPilotController(options = {}) {
 
   function buildSession(context) {
     const sessionId = uuid();
+    const targetFrame = Math.max(0, Math.trunc(Number(context.targetFrame) || 0));
+    const resolved = resolveSourceFrame(targetFrame);
     return {
       sessionId,
       persistenceSessionId,
       stableVideoIdentity: String(context.stableVideoIdentity || ''),
-      targetFrame: Math.max(0, Math.trunc(Number(context.targetFrame) || 0)),
+      targetFrame,
+      sourceFrame: resolved?.sourceFrame ?? null,
       sourceWidth: Number(context.sourceWidth),
       sourceHeight: Number(context.sourceHeight),
       canvasRect: copyRect(context.canvasRect),
@@ -582,6 +1198,13 @@ export function createFabricDrawingPilotController(options = {}) {
       return null;
     }
     const sessionId = currentSession.sessionId;
+    const context = contextSnapshot();
+    const targetFrame = Math.max(0, Math.trunc(Number(context.targetFrame) || 0));
+    const totalFrames = Number(context.totalFrames);
+    if (!validPilotContext(context) ||
+        (Number.isSafeInteger(totalFrames) && totalFrames > 0 && targetFrame >= totalFrames)) {
+      return null;
+    }
     const request = {
       ...makeEnvelope('drawing-action', { action }),
       hostGeneration,
@@ -589,7 +1212,8 @@ export function createFabricDrawingPilotController(options = {}) {
       inputRevision,
       sessionId,
       actionId: uuid(),
-      action
+      action,
+      targetFrame
     };
     return { ...request };
   }
@@ -1404,6 +2028,7 @@ export function createFabricDrawingPilotController(options = {}) {
     const context = contextSnapshot(contextOverrides);
     if (!validPilotContext(context) || !context.stableVideoIdentity) return false;
 
+    passivePresentationBlock = null;
     resumeRequested = false;
     const session = buildSession(context);
     currentSession = session;
@@ -1411,6 +2036,7 @@ export function createFabricDrawingPilotController(options = {}) {
       sessionId: session.sessionId,
       stableVideoIdentity: session.stableVideoIdentity,
       targetFrame: session.targetFrame,
+      sourceFrame: session.sourceFrame,
       sourceWidth: session.sourceWidth,
       sourceHeight: session.sourceHeight,
       canvasRect: copyRect(session.canvasRect),
@@ -1438,6 +2064,7 @@ export function createFabricDrawingPilotController(options = {}) {
     }
 
     lastError = null;
+    pushActiveFrameObservation(session.targetFrame);
     setState('active');
     if (desiredTool !== session.tool) {
       await sendTool(desiredTool);
@@ -1538,6 +2165,17 @@ export function createFabricDrawingPilotController(options = {}) {
         }
       }
       pilotEnabled = enabled;
+      let subscribePointerdownFrame;
+      try {
+        subscribePointerdownFrame = electronAPI.onMpvOverlayDrawingPointerdownFrame;
+      } catch {
+        subscribePointerdownFrame = null;
+      }
+      if (enabled && typeof subscribePointerdownFrame === 'function') {
+        try {
+          subscribePointerdownFrame(handlePointerdownFrameRequest);
+        } catch { /* optional pointerdown frame bridge */ }
+      }
       setState(enabled ? 'passive' : 'disabled');
       return enabled;
     })();
@@ -1757,23 +2395,41 @@ export function createFabricDrawingPilotController(options = {}) {
     return true;
   }
 
-  function disable() {
+  async function disable() {
     persistenceQuitSuspension = null;
     resumeRequested = false;
     syncExplicitResumeIntent();
     desiredInputEnabled = false;
     currentSession = null;
+    const presentationBlock = {
+      hostGeneration,
+      videoGeneration,
+      inputRevision
+    };
+    passivePresentationBlock = presentationBlock;
     setState(pilotEnabled ? 'passive' : 'disabled');
-    if (!pilotEnabled || !hostGeneration || !videoGeneration) return Promise.resolve(false);
+    if (!pilotEnabled || !hostGeneration || !videoGeneration) {
+      releasePassivePresentationBlock(presentationBlock);
+      return false;
+    }
 
     const request = makeInputRequest(false);
-    return invokeInput(request).then(async response => {
+    presentationBlock.inputRevision = request.inputRevision;
+    let shouldPresent = false;
+    try {
+      const response = await invokeInput(request);
       if (!isCurrentInputRequest(request)) return false;
       if (!isAcceptedInputResponse(response, false)) {
         return enterFailure(response?.error);
       }
+      shouldPresent = true;
       return true;
-    });
+    } finally {
+      const released = releasePassivePresentationBlock(presentationBlock);
+      if (released && shouldPresent && state === 'passive' && !desiredInputEnabled) {
+        runDetached(syncDisplayFrame(contextSnapshot().targetFrame, { force: true }));
+      }
+    }
   }
 
   function toggle() {
@@ -1940,6 +2596,7 @@ export function createFabricDrawingPilotController(options = {}) {
     flushPersistenceBeforeLeave,
     abandonPersistenceForVideoChange,
     refreshPersistenceSource,
+    syncDisplayFrame,
     preparePersistenceForQuit,
     resumeAfterQuitCancelled,
     shouldOwnDrawingShortcut,

--- a/renderer/scripts/modules/fabric-drawing-pilot-controller.js
+++ b/renderer/scripts/modules/fabric-drawing-pilot-controller.js
@@ -250,6 +250,21 @@ export function createFabricDrawingPilotController(options = {}) {
   }
 
   function resolveSourceFrame(targetFrame) {
+    if (typeof persistenceStore?.resolveSourceFrameAtFrame === 'function') {
+      let sourceFrame = null;
+      try {
+        sourceFrame = persistenceStore.resolveSourceFrameAtFrame(targetFrame);
+      } catch {
+        return null;
+      }
+      if (sourceFrame === null) return { sourceFrame: null };
+      const normalizedSourceFrame = Number(sourceFrame);
+      if (!Number.isSafeInteger(normalizedSourceFrame) || normalizedSourceFrame < 0 ||
+          normalizedSourceFrame > targetFrame) {
+        return null;
+      }
+      return { sourceFrame: normalizedSourceFrame };
+    }
     if (typeof persistenceStore?.resolveKeyframeAtFrame !== 'function') return null;
     let keyframe = null;
     try {
@@ -424,7 +439,17 @@ export function createFabricDrawingPilotController(options = {}) {
     void (async () => {
       let accepted = false;
       try {
-        const response = await entry.presentFrame(entry.request);
+        const response = await withPersistenceIpcDeadline(
+          entry.presentFrame(entry.request),
+          {
+            success: false,
+            accepted: false,
+            presentationRevision: entry.request.presentationRevision,
+            targetFrame: entry.request.targetFrame,
+            sourceFrame: entry.request.sourceFrame,
+            reason: 'passive-presentation-ipc-timeout'
+          }
+        );
         accepted = responseMatchesPassivePresentation(response, entry.request) &&
           passivePresentationEntryIsCurrent(entry);
         if (accepted) lastAcceptedPresentationSignature = entry.signature;

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -45,6 +45,7 @@ const DEFAULT_MAX_ACTIONS = 2048;
 const MAX_STROKE_POINTS = 20000;
 const MAX_LASSO_POINTS = 1024;
 const MAX_PENDING_POINTER_EVENTS = 1024;
+const POINTERDOWN_FRAME_CONFIRMATION_DEADLINE_MS = 3000;
 const DEFAULT_MAX_SELECTION_GEOMETRY_OPERATIONS = 250_000;
 const MAX_STROKE_GEOMETRY_CACHE_ENTRIES = 512;
 const MAX_STROKE_GEOMETRY_CACHE_WEIGHT = 250_000;
@@ -2267,6 +2268,12 @@ function createFabricOverlayRuntime(options = {}) {
     windowRef?.queueMicrotask?.bind(windowRef) ||
     globalThis.queueMicrotask?.bind(globalThis) ||
     (callback => Promise.resolve().then(callback));
+  const setTimeoutRef = typeof options.setTimeout === 'function'
+    ? options.setTimeout
+    : globalThis.setTimeout?.bind(globalThis);
+  const clearTimeoutRef = typeof options.clearTimeout === 'function'
+    ? options.clearTimeout
+    : globalThis.clearTimeout?.bind(globalThis);
   const now = () => typeof performanceRef?.now === 'function' ? performanceRef.now() : Date.now();
   const wallNow = typeof options.wallNow === 'function'
     ? options.wallNow
@@ -5375,8 +5382,28 @@ function createFabricOverlayRuntime(options = {}) {
     const pending = pendingPointerdownFrame;
     pendingPointerdownFrame = null;
     if (!pending) return false;
+    if (pending.confirmationDeadline !== null) {
+      try {
+        clearTimeoutRef?.(pending.confirmationDeadline);
+      } catch (_error) { /* deadline cleanup is best-effort */ }
+      pending.confirmationDeadline = null;
+    }
     releasePointerCapture(pending.target, pending.pointerId);
     return true;
+  }
+
+  function schedulePendingPointerdownFrameDeadline(pending) {
+    if (typeof setTimeoutRef !== 'function') return false;
+    try {
+      pending.confirmationDeadline = setTimeoutRef(() => {
+        if (pendingPointerdownFrame !== pending) return;
+        pending.confirmationDeadline = null;
+        cancelPendingPointerdownFrame();
+      }, POINTERDOWN_FRAME_CONFIRMATION_DEADLINE_MS);
+      return true;
+    } catch (_error) {
+      return false;
+    }
   }
 
   function consumePendingPointerEvent(event) {
@@ -5462,8 +5489,10 @@ function createFabricOverlayRuntime(options = {}) {
       request,
       pointerId: event.pointerId,
       target,
-      events: [snapshotPointerEvent(event)]
+      events: [snapshotPointerEvent(event)],
+      confirmationDeadline: null
     };
+    const pending = pendingPointerdownFrame;
     try {
       target?.setPointerCapture?.(event.pointerId);
     } catch (_error) { /* pointer capture is best-effort */ }
@@ -5471,7 +5500,12 @@ function createFabricOverlayRuntime(options = {}) {
     event.stopImmediatePropagation?.();
     event.stopPropagation?.();
     try {
-      if (requestPointerdownFrame(request) !== true) cancelPendingPointerdownFrame();
+      if (requestPointerdownFrame(request) !== true) {
+        cancelPendingPointerdownFrame();
+      } else if (pendingPointerdownFrame === pending &&
+          !schedulePendingPointerdownFrameDeadline(pending)) {
+        cancelPendingPointerdownFrame();
+      }
     } catch (_error) {
       cancelPendingPointerdownFrame();
     }
@@ -5521,6 +5555,12 @@ function createFabricOverlayRuntime(options = {}) {
       return { accepted: false, reason: retargeted?.reason || 'retarget-failed' };
     }
     pendingPointerdownFrame = null;
+    if (pending.confirmationDeadline !== null) {
+      try {
+        clearTimeoutRef?.(pending.confirmationDeadline);
+      } catch (_error) { /* deadline cleanup is best-effort */ }
+      pending.confirmationDeadline = null;
+    }
     for (const replayEvent of pending.events) {
       if (!dispatchReplayedPointerEvent(pending.target, replayEvent)) {
         cancelActiveStroke();
@@ -5988,6 +6028,7 @@ function createFabricOverlayRuntime(options = {}) {
   }
 
   function releaseSurfaceResources() {
+    cancelPendingPointerdownFrame();
     cancelSelectInteraction();
     for (const { target, type, listener, listenerOptions } of domListeners.splice(0)) {
       try {
@@ -6014,7 +6055,6 @@ function createFabricOverlayRuntime(options = {}) {
     appliedSourceWidth = null;
     appliedSourceHeight = null;
     activeStroke = null;
-    pendingPointerdownFrame = null;
     pendingLassoSelection = null;
     transformStart = null;
     selectGesture = null;

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -5586,6 +5586,10 @@ function createFabricOverlayRuntime(options = {}) {
     if (pendingPointerdownFrame) {
       if (event.pointerId !== undefined &&
           event.pointerId !== pendingPointerdownFrame.pointerId) return;
+      if (event.type === 'lostpointercapture' &&
+          pendingPointerdownFrame.events.some(pendingEvent => pendingEvent.type === 'pointerup')) {
+        return;
+      }
       event.preventDefault?.();
       event.stopImmediatePropagation?.();
       cancelPendingPointerdownFrame();

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -5387,11 +5387,16 @@ function createFabricOverlayRuntime(options = {}) {
     event.preventDefault?.();
     event.stopImmediatePropagation?.();
     event.stopPropagation?.();
-    if (pending.events.length >= MAX_PENDING_POINTER_EVENTS) {
+    const coalesced = event.type === 'pointermove' &&
+      typeof event.getCoalescedEvents === 'function'
+      ? event.getCoalescedEvents()
+      : [];
+    const samples = coalesced.length > 0 ? coalesced : [event];
+    if (pending.events.length + samples.length > MAX_PENDING_POINTER_EVENTS) {
       cancelPendingPointerdownFrame();
       return true;
     }
-    pending.events.push(snapshotPointerEvent(event));
+    for (const sample of samples) pending.events.push(snapshotPointerEvent(sample));
     return true;
   }
 

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -44,6 +44,7 @@ const DEFAULT_MAX_BYTES = 128 * 1024 * 1024;
 const DEFAULT_MAX_ACTIONS = 2048;
 const MAX_STROKE_POINTS = 20000;
 const MAX_LASSO_POINTS = 1024;
+const MAX_PENDING_POINTER_EVENTS = 1024;
 const DEFAULT_MAX_SELECTION_GEOMETRY_OPERATIONS = 250_000;
 const MAX_STROKE_GEOMETRY_CACHE_ENTRIES = 512;
 const MAX_STROKE_GEOMETRY_CACHE_WEIGHT = 250_000;
@@ -138,6 +139,66 @@ const PERSISTENCE_HYDRATE_KEYS = Object.freeze([
 const PERSISTENCE_EXPORT_KEYS = Object.freeze(
   PERSISTENCE_HYDRATE_KEYS.filter(key => key !== 'keyframes')
 );
+const PRESENTATION_REQUEST_KEYS = Object.freeze([
+  'hostGeneration',
+  'videoGeneration',
+  'presentationRevision',
+  'stableVideoIdentity',
+  'storeRevision',
+  'targetFrame',
+  'sourceFrame',
+  'sourceWidth',
+  'sourceHeight',
+  'canvasRect',
+  'viewportRevision',
+  'viewportTransform'
+]);
+const PRESENTATION_CANVAS_RECT_KEYS = Object.freeze(['left', 'top', 'width', 'height']);
+const PRESENTATION_VIEWPORT_TRANSFORM_KEYS = Object.freeze(['scale', 'panX', 'panY']);
+const ACTIVE_FRAME_REQUEST_KEYS = Object.freeze([
+  'hostGeneration',
+  'videoGeneration',
+  'inputRevision',
+  'sessionId',
+  'frameRevision',
+  'targetFrame'
+]);
+const POINTERDOWN_FRAME_BASE_KEYS = Object.freeze([
+  'hostGeneration',
+  'videoGeneration',
+  'inputRevision',
+  'sessionId',
+  'pointerdownId',
+  'pointerdownAt'
+]);
+const POINTERDOWN_FRAME_CONFIRMATION_KEYS = Object.freeze([
+  ...POINTERDOWN_FRAME_BASE_KEYS,
+  'targetFrame'
+]);
+const POINTERDOWN_FRAME_CANCELLATION_KEYS = Object.freeze([
+  ...POINTERDOWN_FRAME_BASE_KEYS,
+  'cancelled'
+]);
+const REPLAYED_POINTERDOWN = Symbol('baeframe-replayed-pointerdown');
+const POINTER_EVENT_SNAPSHOT_FIELDS = Object.freeze([
+  'pointerId',
+  'pointerType',
+  'button',
+  'buttons',
+  'clientX',
+  'clientY',
+  'pressure',
+  'width',
+  'height',
+  'tiltX',
+  'tiltY',
+  'twist',
+  'isPrimary',
+  'ctrlKey',
+  'shiftKey',
+  'altKey',
+  'metaKey'
+]);
 const PERSISTENCE_KEYFRAME_KEYS = Object.freeze([
   'id',
   'frame',
@@ -553,6 +614,7 @@ function createSessionSceneStore(options = {}) {
   let accessClock = 0;
   let latestVideoGeneration = -1;
   let latestPersistenceHostGeneration = -1;
+  let latestPersistenceVideoIdentity = null;
   let activeSession = null;
   let evictionCount = 0;
   let commandSequence = 0;
@@ -629,7 +691,8 @@ function createSessionSceneStore(options = {}) {
       if (typeof activate !== 'function') return;
       activate.call(drawingEngineObserver, {
         ...sceneDescriptor(scene, incomingSession),
-        mutationSequence: scene.mutationSequence
+        mutationSequence: scene.mutationSequence +
+          (scene.provisional === true && scene.objects.size > 0 ? 1 : 0)
       }, activationObjectView(scene, alreadySeeded));
     } catch (_error) {
       recordObserverFailure(scene.sceneInstanceId);
@@ -743,6 +806,9 @@ function createSessionSceneStore(options = {}) {
     }
     videoAccess.delete(stableVideoIdentity);
     persistenceByVideo.delete(stableVideoIdentity);
+    if (latestPersistenceVideoIdentity === stableVideoIdentity) {
+      latestPersistenceVideoIdentity = [...videoAccess.keys()].at(-1) || null;
+    }
     evictionCount += 1;
     notifyScenesDropped(droppedSceneInstanceIds);
   }
@@ -1001,9 +1067,32 @@ function createSessionSceneStore(options = {}) {
     return command;
   }
 
+  function materializeProvisionalScene(scene) {
+    if (scene?.provisional !== true) return;
+    scene.provisional = false;
+    scene.provisionalSourceFrame = null;
+    if (scene.objects.size === 0) return;
+
+    const objectIds = [...scene.objects.keys()];
+    const emptyObjects = new Map();
+    noteMutation(scene);
+    touchVideo(scene.stableVideoIdentity);
+    notifyPersistenceTransition(scene, () => makeTransitionEvent(scene, {
+      origin: 'live',
+      kind: 'add-objects',
+      estimatedBytes: scene.estimatedBytes,
+      beforeState: makeObjectsState(emptyObjects, objectIds, []),
+      afterState: makeObjectsState(scene.objects, objectIds, objectIds),
+      baseTransforms: new Map(
+        [...scene.objects].map(([id, object]) => [id, clonePlain(object.transform || {})])
+      )
+    }));
+  }
+
   function commitStagedMutation(scene, change) {
+    const requiredMutationSequence = scene.provisional === true && scene.objects.size > 0 ? 2 : 1;
     if (!isSafeCount(scene.mutationSequence) ||
-        scene.mutationSequence >= Number.MAX_SAFE_INTEGER) {
+        scene.mutationSequence > Number.MAX_SAFE_INTEGER - requiredMutationSequence) {
       return { applied: false, reason: 'mutation-sequence-overflow' };
     }
     const previousEstimatedBytes = scene.estimatedBytes;
@@ -1045,6 +1134,7 @@ function createSessionSceneStore(options = {}) {
     }
     for (const stableVideoIdentity of plannedEvictions) evictVideo(stableVideoIdentity);
 
+    materializeProvisionalScene(scene);
     scene.historyEntries = { undo: projectedHistory.undo, redo: projectedHistory.redo };
     scene.objects = change.nextObjects;
     scene.selectedObjectIds = new Set(change.nextSelection || []);
@@ -1200,7 +1290,9 @@ function createSessionSceneStore(options = {}) {
         mutationCount: 0,
         mutationSequence: frame.mutationSequence,
         estimatedBytes: frame.estimatedBytes,
-        drawingObserverSeeded: false
+        drawingObserverSeeded: false,
+        provisional: false,
+        provisionalSourceFrame: null
       });
     }
 
@@ -1228,6 +1320,7 @@ function createSessionSceneStore(options = {}) {
       latestPersistenceHostGeneration,
       request.hostGeneration
     );
+    latestPersistenceVideoIdentity = request.stableVideoIdentity;
     touchVideo(request.stableVideoIdentity);
     for (const stableVideoIdentity of plannedEvictions) evictVideo(stableVideoIdentity);
     notifyScenesDropped(droppedSceneInstanceIds);
@@ -1255,7 +1348,9 @@ function createSessionSceneStore(options = {}) {
 
     try {
       const scenesForVideo = [...scenes.values()]
-        .filter(scene => scene.stableVideoIdentity === request.stableVideoIdentity)
+        .filter(scene =>
+          scene.stableVideoIdentity === request.stableVideoIdentity &&
+          scene.provisional !== true)
         .sort((left, right) => left.targetFrame - right.targetFrame)
         .map(scene => ({
           sceneInstanceId: scene.sceneInstanceId,
@@ -1293,8 +1388,15 @@ function createSessionSceneStore(options = {}) {
     const targetFrame = Number(session.targetFrame);
     const videoGeneration = Number(session.videoGeneration);
     const hostGeneration = Number(session.hostGeneration);
+    const sourceFrame = session.sourceFrame === null || session.sourceFrame === undefined
+      ? null
+      : Number(session.sourceFrame);
     if (!Number.isInteger(targetFrame) || targetFrame < 0 || !Number.isInteger(videoGeneration) || videoGeneration < 0) {
       return { accepted: false, reason: 'invalid-session-coordinates' };
+    }
+    if (sourceFrame !== null &&
+        (!Number.isSafeInteger(sourceFrame) || sourceFrame < 0 || sourceFrame > targetFrame)) {
+      return { accepted: false, reason: 'invalid-session-source-frame' };
     }
     if (videoGeneration < latestVideoGeneration) {
       return { accepted: false, reason: 'stale-video-generation' };
@@ -1311,7 +1413,33 @@ function createSessionSceneStore(options = {}) {
     latestVideoGeneration = Math.max(latestVideoGeneration, videoGeneration);
     const sceneKey = makeSceneKey(session.stableVideoIdentity, targetFrame);
     const restored = scenes.has(sceneKey);
+    const sourceScene = sourceFrame === null
+      ? null
+      : scenes.get(makeSceneKey(session.stableVideoIdentity, sourceFrame));
+    if (!restored && sourceFrame !== null &&
+        (!sourceScene || sourceScene.provisional === true)) {
+      return { accepted: false, reason: 'missing-source-scene' };
+    }
     if (!restored) {
+      const objects = new Map(
+        [...(sourceScene?.objects || new Map()).entries()]
+          .map(([id, object]) => [id, clonePlain(object)])
+      );
+      const estimatedBytes = estimateObjectsBytes(objects);
+      let projectedBytes = calculateEstimatedBytes() + estimatedBytes;
+      let projectedVideoCount = videoAccess.size +
+        (videoAccess.has(session.stableVideoIdentity) ? 0 : 1);
+      const plannedEvictions = [];
+      for (const candidate of videoAccess.keys()) {
+        if (projectedBytes <= maxBytes && projectedVideoCount <= maxVideos) break;
+        if (candidate === session.stableVideoIdentity) continue;
+        projectedBytes -= estimateVideoBytes(candidate);
+        projectedVideoCount -= 1;
+        plannedEvictions.push(candidate);
+      }
+      if (objects.size > maxObjects || projectedBytes > maxBytes || projectedVideoCount > maxVideos) {
+        return { accepted: false, reason: 'scene-capacity-exceeded' };
+      }
       scenes.set(sceneKey, {
         key: sceneKey,
         sceneInstanceId: allocateSceneInstanceId(),
@@ -1319,7 +1447,7 @@ function createSessionSceneStore(options = {}) {
         targetFrame,
         sourceWidth: sourceDimension(session.sourceWidth),
         sourceHeight: sourceDimension(session.sourceHeight),
-        objects: new Map(),
+        objects,
         selectedObjectIds: new Set(),
         history: createDrawingCommandHistory({
           maxEntries: maxHistory,
@@ -1330,15 +1458,19 @@ function createSessionSceneStore(options = {}) {
         dirty: false,
         mutationCount: 0,
         mutationSequence: 0,
-        estimatedBytes: 0,
-        drawingObserverSeeded: false
+        estimatedBytes,
+        drawingObserverSeeded: false,
+        provisional: true,
+        provisionalSourceFrame: sourceScene ? sourceFrame : null
       });
+      for (const stableVideoIdentity of plannedEvictions) evictVideo(stableVideoIdentity);
     }
 
     activeSession = {
       sessionId: session.sessionId,
       stableVideoIdentity: session.stableVideoIdentity,
       targetFrame,
+      sourceFrame: restored ? sourceFrame : (sourceScene ? sourceFrame : null),
       sceneKey,
       videoGeneration,
       tool: session.tool === 'select' ? 'select' : 'brush',
@@ -1349,7 +1481,25 @@ function createSessionSceneStore(options = {}) {
     touchVideo(session.stableVideoIdentity);
     enforceLimits();
     notifySceneActivation(scene, session);
-    return { accepted: true, restored, sceneKey };
+    return {
+      accepted: true,
+      restored,
+      sceneKey,
+      provisional: scene.provisional === true,
+      sourceFrame: activeSession.sourceFrame
+    };
+  }
+
+  function replaceActiveSession(session) {
+    const previousScene = activeScene();
+    const activation = activateSession(session);
+    if (!activation.accepted) return activation;
+    previousScene?.selectedObjectIds.clear();
+    if (previousScene?.provisional === true && previousScene.key !== activeSession.sceneKey) {
+      scenes.delete(previousScene.key);
+      notifyScenesDropped([previousScene.sceneInstanceId]);
+    }
+    return activation;
   }
 
   function deactivateSession(sessionId) {
@@ -1359,6 +1509,10 @@ function createSessionSceneStore(options = {}) {
     }
     const scene = activeScene();
     scene?.selectedObjectIds.clear();
+    if (scene?.provisional === true) {
+      scenes.delete(scene.key);
+      notifyScenesDropped([scene.sceneInstanceId]);
+    }
     activeSession = null;
     return { accepted: true, active: false };
   }
@@ -1736,6 +1890,102 @@ function createSessionSceneStore(options = {}) {
     return snapshotScene(scenes.get(makeSceneKey(stableVideoIdentity, targetFrame)));
   }
 
+  function getPresentationScene(request = {}) {
+    const binding = persistenceByVideo.get(request.stableVideoIdentity);
+    if (!binding ||
+        request.stableVideoIdentity !== latestPersistenceVideoIdentity ||
+        request.hostGeneration !== latestPersistenceHostGeneration ||
+        request.videoGeneration !== latestVideoGeneration ||
+        binding.hostGeneration !== request.hostGeneration ||
+        binding.videoGeneration !== request.videoGeneration) {
+      return { accepted: false, reason: 'stale-presentation-fence' };
+    }
+    if (request.targetFrame >= binding.totalFrames ||
+        (request.sourceFrame !== null && request.sourceFrame >= binding.totalFrames)) {
+      return { accepted: false, reason: 'invalid-presentation-frame' };
+    }
+    const scene = resolveCommittedSceneAtFrame(
+      request.stableVideoIdentity,
+      request.targetFrame
+    );
+    if ((scene?.targetFrame ?? null) !== request.sourceFrame) {
+      return { accepted: false, reason: 'stale-presentation-source' };
+    }
+    return {
+      accepted: true,
+      snapshot: snapshotScene(scene)
+    };
+  }
+
+  function resolveCommittedSceneAtFrame(stableVideoIdentity, targetFrame) {
+    let resolved = null;
+    for (const scene of scenes.values()) {
+      if (scene.stableVideoIdentity !== stableVideoIdentity ||
+          scene.provisional === true ||
+          scene.targetFrame > targetFrame ||
+          (resolved && scene.targetFrame <= resolved.targetFrame)) {
+        continue;
+      }
+      resolved = scene;
+    }
+    return resolved;
+  }
+
+  function getActiveFrameCandidate(targetFrame, options = {}) {
+    if (!activeSession || !Number.isSafeInteger(targetFrame) || targetFrame < 0) {
+      return { accepted: false, reason: 'invalid-active-frame' };
+    }
+    const binding = persistenceByVideo.get(activeSession.stableVideoIdentity);
+    if (!binding ||
+        binding.videoGeneration !== activeSession.videoGeneration ||
+        targetFrame >= binding.totalFrames) {
+      return { accepted: false, reason: 'stale-active-frame-session' };
+    }
+    const sourceScene = resolveCommittedSceneAtFrame(
+      activeSession.stableVideoIdentity,
+      targetFrame
+    );
+    return {
+      accepted: true,
+      sourceFrame: sourceScene?.targetFrame ?? null,
+      sceneInstanceId: sourceScene?.sceneInstanceId ?? null,
+      mutationSequence: sourceScene?.mutationSequence ?? 0,
+      ...(options.includeSnapshot === true ? { snapshot: snapshotScene(sourceScene) } : {})
+    };
+  }
+
+  function retargetActiveSession(session = {}) {
+    if (!activeSession || session.sessionId !== activeSession.sessionId) {
+      return { accepted: false, reason: 'stale-session' };
+    }
+    const targetFrame = Number(session.targetFrame);
+    if (targetFrame === activeSession.targetFrame) {
+      return {
+        accepted: true,
+        restored: true,
+        sourceFrame: activeSession.sourceFrame,
+        targetFrame
+      };
+    }
+    const candidate = getActiveFrameCandidate(targetFrame);
+    if (!candidate.accepted) return candidate;
+
+    const previousSession = { ...activeSession };
+    const activation = replaceActiveSession({
+      ...session,
+      targetFrame,
+      sourceFrame: candidate.sourceFrame,
+      tool: previousSession.tool
+    });
+    if (!activation.accepted) return activation;
+    activeSession.toolRevision = previousSession.toolRevision;
+    return {
+      ...activation,
+      targetFrame,
+      sourceFrame: activeSession.sourceFrame
+    };
+  }
+
   function getActiveSceneSnapshot() {
     return snapshotScene(activeScene());
   }
@@ -1764,6 +2014,7 @@ function createSessionSceneStore(options = {}) {
       persistenceVideoCount: persistenceByVideo.size,
       latestPersistenceHostGeneration,
       latestVideoGeneration,
+      latestPersistenceVideoIdentity,
       activeSessionId: activeSession?.sessionId || null,
       activeSceneKey: activeSession?.sceneKey || null,
       tool: activeSession?.tool || null,
@@ -1772,6 +2023,8 @@ function createSessionSceneStore(options = {}) {
       selectionCount: scene?.selectedObjectIds.size || 0,
       mutationCount: scene?.mutationCount || 0,
       dirty: scene?.dirty || false,
+      provisional: scene?.provisional === true,
+      provisionalSourceFrame: scene?.provisionalSourceFrame ?? null,
       undoDepth: history.undoDepth,
       redoDepth: history.redoDepth,
       undoBytes: history.undoBytes,
@@ -1787,12 +2040,14 @@ function createSessionSceneStore(options = {}) {
     scenes.clear();
     videoAccess.clear();
     persistenceByVideo.clear();
+    latestPersistenceVideoIdentity = null;
     activeSession = null;
     notifyScenesDropped(droppedSceneInstanceIds);
   }
 
   return {
     activateSession,
+    replaceActiveSession,
     deactivateSession,
     hydrateVideo,
     exportVideo,
@@ -1807,6 +2062,9 @@ function createSessionSceneStore(options = {}) {
     updateTool,
     setLocalTool,
     getSceneSnapshot,
+    getPresentationScene,
+    getActiveFrameCandidate,
+    retargetActiveSession,
     getActiveSceneSnapshot,
     hasScene,
     getDiagnostics,
@@ -1895,6 +2153,10 @@ function createActionDeduper(options = {}) {
       return true;
     },
 
+    release(actionId) {
+      entries.delete(actionId);
+    },
+
     clear() {
       entries.clear();
     },
@@ -1923,6 +2185,66 @@ function shouldAcceptInputRequest(current = {}, request = {}) {
   return true;
 }
 
+function validatePresentationRequest(request = {}) {
+  if (!hasExactKeys(request, PRESENTATION_REQUEST_KEYS) ||
+      !isSafeCount(request.hostGeneration) ||
+      !isSafeCount(request.videoGeneration) ||
+      !isSafeCount(request.presentationRevision) ||
+      !isBoundedPersistenceString(request.stableVideoIdentity) ||
+      !isSafeCount(request.storeRevision) ||
+      !isSafeCount(request.targetFrame) ||
+      !Number.isFinite(request.sourceWidth) || request.sourceWidth <= 0 ||
+      request.sourceWidth > MAX_PERSISTED_SOURCE_DIMENSION ||
+      !Number.isFinite(request.sourceHeight) || request.sourceHeight <= 0 ||
+      request.sourceHeight > MAX_PERSISTED_SOURCE_DIMENSION ||
+      !hasExactKeys(request.canvasRect, PRESENTATION_CANVAS_RECT_KEYS) ||
+      !PRESENTATION_CANVAS_RECT_KEYS.every(key => Number.isFinite(request.canvasRect[key])) ||
+      request.canvasRect.width <= 0 || request.canvasRect.height <= 0 ||
+      request.canvasRect.width > MAX_PERSISTED_SOURCE_DIMENSION ||
+      request.canvasRect.height > MAX_PERSISTED_SOURCE_DIMENSION ||
+      !isSafeCount(request.viewportRevision) ||
+      !hasExactKeys(
+        request.viewportTransform,
+        PRESENTATION_VIEWPORT_TRANSFORM_KEYS
+      ) ||
+      !PRESENTATION_VIEWPORT_TRANSFORM_KEYS.every(
+        key => Number.isFinite(request.viewportTransform[key]) &&
+          Math.abs(request.viewportTransform[key]) <= MAX_PERSISTED_TRANSFORM_MAGNITUDE
+      ) ||
+      request.viewportTransform.scale <= 0) {
+    return false;
+  }
+  return request.sourceFrame === null ||
+    (isSafeCount(request.sourceFrame) && request.sourceFrame <= request.targetFrame);
+}
+
+function validateActiveFrameRequest(request = {}) {
+  return hasExactKeys(request, ACTIVE_FRAME_REQUEST_KEYS) &&
+    isSafeCount(request.hostGeneration) &&
+    isSafeCount(request.videoGeneration) &&
+    isSafeCount(request.inputRevision) &&
+    isBoundedPersistenceString(request.sessionId) &&
+    isSafeCount(request.frameRevision) &&
+    request.frameRevision > 0 &&
+    isSafeCount(request.targetFrame);
+}
+
+function validatePointerdownFrameConfirmation(request = {}) {
+  const validBase =
+    isSafeCount(request.hostGeneration) && request.hostGeneration > 0 &&
+    isSafeCount(request.videoGeneration) && request.videoGeneration > 0 &&
+    isSafeCount(request.inputRevision) && request.inputRevision > 0 &&
+    isBoundedPersistenceString(request.sessionId) &&
+    isBoundedPersistenceString(request.pointerdownId) &&
+    isSafeCount(request.pointerdownAt);
+  if (!validBase) return false;
+  if (hasExactKeys(request, POINTERDOWN_FRAME_CANCELLATION_KEYS)) {
+    return request.cancelled === true;
+  }
+  return hasExactKeys(request, POINTERDOWN_FRAME_CONFIRMATION_KEYS) &&
+    isSafeCount(request.targetFrame);
+}
+
 function resolvePersistenceCommitObserver(options, windowRef) {
   if (typeof options.persistenceCommitObserver === 'function') {
     return options.persistenceCommitObserver;
@@ -1946,10 +2268,31 @@ function createFabricOverlayRuntime(options = {}) {
     globalThis.queueMicrotask?.bind(globalThis) ||
     (callback => Promise.resolve().then(callback));
   const now = () => typeof performanceRef?.now === 'function' ? performanceRef.now() : Date.now();
+  const wallNow = typeof options.wallNow === 'function'
+    ? options.wallNow
+    : () => {
+      const epochMilliseconds = Number(performanceRef?.timeOrigin) +
+        Number(performanceRef?.now?.());
+      return Number.isFinite(epochMilliseconds)
+        ? Math.floor(epochMilliseconds * 1000)
+        : Date.now() * 1000;
+    };
   const devicePixelRatio = finiteNumber(options.devicePixelRatio ?? windowRef?.devicePixelRatio, 1) || 1;
   const metrics = options.metrics || createFabricDrawingPilotMetrics(options.metricsOptions);
   const drawingV3ShadowRequested = options.drawingV3ShadowEnabled === true;
   const persistenceCommitObserver = resolvePersistenceCommitObserver(options, windowRef);
+  const requestPointerdownFrame = typeof options.requestPointerdownFrame === 'function'
+    ? options.requestPointerdownFrame
+    : (() => {
+      try {
+        const bridge = windowRef?.mpvOverlayDrawingFrame;
+        return typeof bridge?.requestPointerdownFrame === 'function'
+          ? bridge.requestPointerdownFrame.bind(bridge)
+          : null;
+      } catch (_error) {
+        return null;
+      }
+    })();
   const customSceneStore = options.sceneStore || null;
   let drawingV3Adapter = null;
   let drawingV3ShadowStartupFailed = false;
@@ -1989,6 +2332,30 @@ function createFabricOverlayRuntime(options = {}) {
     DEFAULT_MAX_SELECTION_GEOMETRY_OPERATIONS
   );
   const tokenState = { hostGeneration: -1, videoGeneration: -1, inputRevision: -1 };
+  const presentationState = {
+    hostGeneration: -1,
+    videoGeneration: -1,
+    presentationRevision: -1,
+    stableVideoIdentity: null,
+    storeRevision: -1,
+    targetFrame: null,
+    sourceFrame: null
+  };
+  const activeFrameState = {
+    hostGeneration: -1,
+    videoGeneration: -1,
+    inputRevision: -1,
+    sessionId: null,
+    frameRevision: -1,
+    targetFrame: null,
+    sourceFrame: null,
+    sourceSceneInstanceId: null,
+    sourceMutationSequence: 0,
+    renderedSourceFrame: null,
+    renderedSceneInstanceId: null,
+    renderedMutationSequence: 0,
+    previewed: false
+  };
   const domListeners = [];
   const fabricListeners = [];
   let fabricModule = null;
@@ -2004,9 +2371,11 @@ function createFabricOverlayRuntime(options = {}) {
   let destroyed = false;
   let inputEnabled = false;
   let currentSession = null;
+  let passiveDisplaySession = null;
   let lastPaintedScene = null;
   let activeStroke = null;
   let activeLasso = null;
+  let pendingPointerdownFrame = null;
   let lastSelectionGesture = null;
   let pendingLassoSelection = null;
   let preservingPendingLassoSelectionEvent = false;
@@ -2676,6 +3045,289 @@ function createFabricOverlayRuntime(options = {}) {
       fabricCanvas.requestRenderAll();
     }
     updateObjectMetric();
+    rememberRenderedActiveScene();
+  }
+
+  function rememberRenderedActiveScene() {
+    if (!currentSession) return;
+    const candidate = sceneStore.getActiveFrameCandidate(currentSession.targetFrame);
+    if (!candidate?.accepted) return;
+    activeFrameState.renderedSourceFrame = candidate.sourceFrame;
+    activeFrameState.renderedSceneInstanceId = candidate.sceneInstanceId;
+    activeFrameState.renderedMutationSequence = candidate.mutationSequence;
+  }
+
+  function resetActiveFrameState(session = null) {
+    const candidate = session
+      ? sceneStore.getActiveFrameCandidate(session.targetFrame)
+      : null;
+    activeFrameState.hostGeneration = session?.hostGeneration ?? -1;
+    activeFrameState.videoGeneration = session?.videoGeneration ?? -1;
+    activeFrameState.inputRevision = session ? tokenState.inputRevision : -1;
+    activeFrameState.sessionId = session?.sessionId || null;
+    activeFrameState.frameRevision = -1;
+    activeFrameState.targetFrame = session?.targetFrame ?? null;
+    activeFrameState.sourceFrame = candidate?.accepted
+      ? candidate.sourceFrame
+      : session?.sourceFrame ?? null;
+    activeFrameState.sourceSceneInstanceId = candidate?.accepted
+      ? candidate.sceneInstanceId
+      : null;
+    activeFrameState.sourceMutationSequence = candidate?.accepted
+      ? candidate.mutationSequence
+      : 0;
+    activeFrameState.renderedSourceFrame = candidate?.accepted
+      ? candidate.sourceFrame
+      : session?.sourceFrame ?? null;
+    activeFrameState.renderedSceneInstanceId = candidate?.accepted
+      ? candidate.sceneInstanceId
+      : null;
+    activeFrameState.renderedMutationSequence = candidate?.accepted
+      ? candidate.mutationSequence
+      : 0;
+    activeFrameState.previewed = false;
+  }
+
+  function activeFrameInteractionInProgress() {
+    return !!(pendingPointerdownFrame || activeStroke || activeLasso || selectGesture || transformStart);
+  }
+
+  function renderedCandidateMatches(candidate) {
+    return candidate.sourceFrame === activeFrameState.renderedSourceFrame &&
+      candidate.sceneInstanceId === activeFrameState.renderedSceneInstanceId &&
+      candidate.mutationSequence === activeFrameState.renderedMutationSequence;
+  }
+
+  function renderArmedFramePreview(frameState = activeFrameState) {
+    if (!inputEnabled || !currentSession || !fabricCanvas ||
+        frameState.sessionId !== currentSession.sessionId) {
+      return { accepted: false, reason: 'stale-active-frame' };
+    }
+    if (activeFrameInteractionInProgress()) {
+      return {
+        accepted: true,
+        deferred: true,
+        repainted: false,
+        previewed: activeFrameState.previewed,
+        sourceFrame: frameState.sourceFrame,
+        sourceSceneInstanceId: frameState.sourceSceneInstanceId,
+        sourceMutationSequence: frameState.sourceMutationSequence,
+        renderedSourceFrame: activeFrameState.renderedSourceFrame,
+        renderedSceneInstanceId: activeFrameState.renderedSceneInstanceId,
+        renderedMutationSequence: activeFrameState.renderedMutationSequence
+      };
+    }
+    const candidate = sceneStore.getActiveFrameCandidate(frameState.targetFrame);
+    if (!candidate?.accepted) return candidate;
+    const isPreview = frameState.targetFrame !== currentSession.targetFrame;
+    if (renderedCandidateMatches(candidate)) {
+      if (isPreview) {
+        if (pendingLassoSelection) abortPendingLassoSelection();
+        fabricCanvas.discardActiveObject();
+        sceneStore.selectObjects([]);
+        for (const object of fabricCanvas.getObjects()) {
+          object.set?.({ selectable: false, evented: false });
+        }
+      } else {
+        refreshSelectionInteractionPolicy();
+      }
+      return {
+        accepted: true,
+        deferred: false,
+        repainted: false,
+        previewed: isPreview,
+        sourceFrame: candidate.sourceFrame,
+        sourceSceneInstanceId: candidate.sceneInstanceId,
+        sourceMutationSequence: candidate.mutationSequence,
+        renderedSourceFrame: candidate.sourceFrame,
+        renderedSceneInstanceId: candidate.sceneInstanceId,
+        renderedMutationSequence: candidate.mutationSequence
+      };
+    }
+
+    let preparedCandidate;
+    let paths;
+    try {
+      preparedCandidate = sceneStore.getActiveFrameCandidate(frameState.targetFrame, {
+        includeSnapshot: true
+      });
+      if (!preparedCandidate?.accepted ||
+          preparedCandidate.sourceFrame !== candidate.sourceFrame ||
+          preparedCandidate.sceneInstanceId !== candidate.sceneInstanceId ||
+          preparedCandidate.mutationSequence !== candidate.mutationSequence) {
+        return { accepted: false, reason: 'stale-active-frame-preview' };
+      }
+      paths = (preparedCandidate.snapshot?.objects || []).map(record => makeFabricPath(record));
+      if (isPreview) {
+        for (const path of paths) path.set({ selectable: false, evented: false });
+      }
+    } catch (error) {
+      lastError = error.message;
+      metrics.recordSurfaceError();
+      return { accepted: false, reason: 'active-frame-preview-failed' };
+    }
+
+    const previousObjects = [...fabricCanvas.getObjects()];
+    const previousActiveObject = fabricCanvas.getActiveObject?.() || null;
+    const previousSelection = sceneStore.getActiveSceneSnapshot()?.selectedObjectIds || [];
+    const previousPendingLassoSelection = pendingLassoSelection;
+    const previousObjectStates = previousObjects.map(object => ({
+      object,
+      transform: captureTransform(object),
+      opacity: object.opacity,
+      selectable: object.selectable,
+      evented: object.evented,
+      perPixelTargetFind: object.perPixelTargetFind,
+      padding: object.padding,
+      hoverCursor: object.hoverCursor,
+      moveCursor: object.moveCursor,
+      pendingLasso: object.__baeframePendingLasso
+    }));
+    try {
+      if (pendingLassoSelection) abortPendingLassoSelection();
+      fabricCanvas.discardActiveObject();
+      sceneStore.selectObjects([]);
+      fabricCanvas.clear();
+      for (const path of paths) fabricCanvas.add(path);
+      if (!isPreview) refreshSelectionInteractionPolicy();
+      if (typeof fabricCanvas.renderAll === 'function') fabricCanvas.renderAll();
+      else fabricCanvas.requestRenderAll();
+    } catch (error) {
+      pendingLassoSelection = previousPendingLassoSelection;
+      try {
+        fabricCanvas.clear();
+        for (const state of previousObjectStates) {
+          state.object.set?.({
+            ...state.transform,
+            opacity: state.opacity,
+            selectable: state.selectable,
+            evented: state.evented,
+            perPixelTargetFind: state.perPixelTargetFind,
+            padding: state.padding,
+            hoverCursor: state.hoverCursor,
+            moveCursor: state.moveCursor
+          });
+          state.object.__baeframePendingLasso = state.pendingLasso;
+          state.object.setCoords?.();
+          fabricCanvas.add(state.object);
+        }
+        if (previousActiveObject && typeof fabricCanvas.setActiveObject === 'function') {
+          fabricCanvas.setActiveObject(previousActiveObject);
+        }
+      } catch (_rollbackError) { /* best-effort visual rollback */ }
+      try {
+        sceneStore.selectObjects(previousSelection);
+      } catch (_rollbackError) { /* best-effort selection rollback */ }
+      lastError = error.message;
+      metrics.recordSurfaceError();
+      return { accepted: false, reason: 'active-frame-preview-failed' };
+    }
+    updateObjectMetric();
+    return {
+      accepted: true,
+      deferred: false,
+      repainted: true,
+      previewed: isPreview,
+      sourceFrame: preparedCandidate.sourceFrame,
+      sourceSceneInstanceId: preparedCandidate.sceneInstanceId,
+      sourceMutationSequence: preparedCandidate.mutationSequence,
+      renderedSourceFrame: preparedCandidate.sourceFrame,
+      renderedSceneInstanceId: preparedCandidate.sceneInstanceId,
+      renderedMutationSequence: preparedCandidate.mutationSequence
+    };
+  }
+
+  function publishActiveFramePreview(frameState, preview) {
+    activeFrameState.hostGeneration = frameState.hostGeneration;
+    activeFrameState.videoGeneration = frameState.videoGeneration;
+    activeFrameState.inputRevision = frameState.inputRevision;
+    activeFrameState.sessionId = frameState.sessionId;
+    activeFrameState.frameRevision = frameState.frameRevision;
+    activeFrameState.targetFrame = frameState.targetFrame;
+    activeFrameState.sourceFrame = preview.sourceFrame;
+    activeFrameState.sourceSceneInstanceId = preview.sourceSceneInstanceId;
+    activeFrameState.sourceMutationSequence = preview.sourceMutationSequence;
+    activeFrameState.renderedSourceFrame = preview.renderedSourceFrame;
+    activeFrameState.renderedSceneInstanceId = preview.renderedSceneInstanceId;
+    activeFrameState.renderedMutationSequence = preview.renderedMutationSequence;
+    activeFrameState.previewed = preview.previewed === true;
+    if (preview.deferred !== true) {
+      lastPaintedScene = preview.sourceFrame === null
+        ? null
+        : {
+          stableVideoIdentity: currentSession.stableVideoIdentity,
+          targetFrame: preview.sourceFrame
+        };
+      presentationState.hostGeneration = frameState.hostGeneration;
+      presentationState.videoGeneration = frameState.videoGeneration;
+      presentationState.stableVideoIdentity = currentSession.stableVideoIdentity;
+      presentationState.targetFrame = frameState.targetFrame;
+      presentationState.sourceFrame = preview.sourceFrame;
+      syncPersistenceBadge(frameState.targetFrame);
+    }
+  }
+
+  function retargetFrameForMutation(targetFrame) {
+    if (!inputEnabled || !currentSession || !Number.isSafeInteger(targetFrame) || targetFrame < 0) {
+      return { accepted: false, reason: 'stale-active-frame' };
+    }
+    if (targetFrame === currentSession.targetFrame &&
+        activeFrameState.previewed !== true) {
+      return {
+        accepted: true,
+        restored: true,
+        targetFrame: currentSession.targetFrame,
+        sourceFrame: currentSession.sourceFrame
+      };
+    }
+    if (targetFrame !== currentSession.targetFrame && pendingLassoSelection) {
+      abortPendingLassoSelection();
+    }
+    const result = sceneStore.retargetActiveSession({
+      ...currentSession,
+      targetFrame
+    });
+    if (!result?.accepted) return result || { accepted: false, reason: 'retarget-failed' };
+    currentSession.targetFrame = result.targetFrame;
+    currentSession.sourceFrame = result.sourceFrame;
+    if (activeFrameState.targetFrame === targetFrame) {
+      const candidate = sceneStore.getActiveFrameCandidate(targetFrame);
+      activeFrameState.sourceFrame = result.sourceFrame;
+      activeFrameState.sourceSceneInstanceId = candidate?.sceneInstanceId ?? null;
+      activeFrameState.sourceMutationSequence = candidate?.mutationSequence ?? 0;
+    }
+    activeFrameState.previewed = false;
+    renderActiveScene({ immediate: true });
+    setToolMode(currentSession.tool);
+    lastPaintedScene = {
+      stableVideoIdentity: currentSession.stableVideoIdentity,
+      targetFrame: currentSession.targetFrame
+    };
+    syncPersistenceBadge(currentSession.targetFrame);
+    return result;
+  }
+
+  function retargetArmedFrameForMutation() {
+    if (!inputEnabled || !currentSession ||
+        activeFrameState.hostGeneration !== tokenState.hostGeneration ||
+        activeFrameState.videoGeneration !== tokenState.videoGeneration ||
+        activeFrameState.inputRevision !== tokenState.inputRevision ||
+        activeFrameState.sessionId !== currentSession.sessionId ||
+        !Number.isSafeInteger(activeFrameState.targetFrame)) {
+      return { accepted: false, reason: 'stale-active-frame' };
+    }
+    return retargetFrameForMutation(activeFrameState.targetFrame);
+  }
+
+  function settleArmedFramePreview() {
+    if (!inputEnabled || !currentSession || activeFrameInteractionInProgress() ||
+        activeFrameState.targetFrame === currentSession.targetFrame) {
+      return false;
+    }
+    const preview = renderArmedFramePreview(activeFrameState);
+    if (preview?.accepted !== true) return false;
+    publishActiveFramePreview(activeFrameState, preview);
+    return true;
   }
 
   function repaintLastPaintedScene(options = {}) {
@@ -4438,6 +5090,7 @@ function createFabricOverlayRuntime(options = {}) {
         : 0,
       reason: typeof result?.reason === 'string' ? result.reason.slice(0, 128) : null
     };
+    settleArmedFramePreview();
     return result;
   }
 
@@ -4479,6 +5132,7 @@ function createFabricOverlayRuntime(options = {}) {
       lastError = error.message;
       metrics.recordSurfaceError();
       activeStroke = null;
+      settleArmedFramePreview();
       return { applied: false, reason: 'stroke-path-error' };
     }
     const record = {
@@ -4492,10 +5146,14 @@ function createFabricOverlayRuntime(options = {}) {
     record.transform = captureTransform(path);
     const result = sceneStore.addStroke(record);
     activeStroke = null;
-    if (!result.applied) return result;
+    if (!result.applied) {
+      settleArmedFramePreview();
+      return result;
+    }
     fabricCanvas.add(path);
     fabricCanvas.requestRenderAll();
     updateObjectMetric();
+    settleArmedFramePreview();
     return result;
   }
 
@@ -4609,11 +5267,20 @@ function createFabricOverlayRuntime(options = {}) {
       transformStart = null;
       selectGesture = null;
       settleDeferredViewport(gesture.sessionId, gesture.inputRevision);
+      settleArmedFramePreview();
     });
   }
 
-  function onPointerDown(event) {
+  function beginPointerDown(event, retargetArmed = true) {
     if (!inputEnabled || event.button !== 0) return;
+    if (retargetArmed) {
+      const retargeted = retargetArmedFrameForMutation();
+      if (!retargeted?.accepted) {
+        event.preventDefault?.();
+        event.stopImmediatePropagation?.();
+        return;
+      }
+    }
     const tool = sceneStore.getDiagnostics().tool;
     if (tool === 'brush') {
       if (activeStroke || selectGesture) return;
@@ -4695,7 +5362,178 @@ function createFabricOverlayRuntime(options = {}) {
     } catch (_error) { /* pointer capture is best-effort */ }
   }
 
+  function snapshotPointerEvent(event) {
+    const snapshot = { type: String(event.type || '') };
+    for (const field of POINTER_EVENT_SNAPSHOT_FIELDS) {
+      const value = event[field];
+      if (value !== undefined) snapshot[field] = value;
+    }
+    return snapshot;
+  }
+
+  function cancelPendingPointerdownFrame() {
+    const pending = pendingPointerdownFrame;
+    pendingPointerdownFrame = null;
+    if (!pending) return false;
+    releasePointerCapture(pending.target, pending.pointerId);
+    return true;
+  }
+
+  function consumePendingPointerEvent(event) {
+    const pending = pendingPointerdownFrame;
+    if (!pending || (event.pointerId !== undefined && event.pointerId !== pending.pointerId)) {
+      return false;
+    }
+    event.preventDefault?.();
+    event.stopImmediatePropagation?.();
+    event.stopPropagation?.();
+    if (pending.events.length >= MAX_PENDING_POINTER_EVENTS) {
+      cancelPendingPointerdownFrame();
+      return true;
+    }
+    pending.events.push(snapshotPointerEvent(event));
+    return true;
+  }
+
+  function dispatchReplayedPointerEvent(target, snapshot) {
+    if (typeof target?.dispatchEvent === 'function' && windowRef?.Event) {
+      const EventConstructor = typeof windowRef.PointerEvent === 'function'
+        ? windowRef.PointerEvent
+        : windowRef.Event;
+      let event;
+      if (EventConstructor === windowRef.PointerEvent) {
+        event = new EventConstructor(snapshot.type, {
+          bubbles: true,
+          cancelable: true,
+          ...snapshot
+        });
+      } else {
+        event = new EventConstructor(snapshot.type, { bubbles: true, cancelable: true });
+        for (const [field, value] of Object.entries(snapshot)) {
+          if (field === 'type') continue;
+          Object.defineProperty(event, field, { value });
+        }
+      }
+      Object.defineProperty(event, REPLAYED_POINTERDOWN, { value: true });
+      target.dispatchEvent(event);
+      return true;
+    }
+    if (typeof target?.dispatch === 'function') {
+      target.dispatch(snapshot.type, { ...snapshot, [REPLAYED_POINTERDOWN]: true });
+      return true;
+    }
+    return false;
+  }
+
+  function onPointerDown(event) {
+    if (event?.[REPLAYED_POINTERDOWN] === true) {
+      beginPointerDown(event, false);
+      return;
+    }
+    if (!inputEnabled || event.button !== 0 || pendingPointerdownFrame ||
+        activeStroke || activeLasso || selectGesture) {
+      return;
+    }
+    if (!requestPointerdownFrame) {
+      beginPointerDown(event, true);
+      return;
+    }
+    const pointerdownAt = Number(wallNow());
+    if (!currentSession || !Number.isSafeInteger(pointerdownAt) || pointerdownAt < 0) {
+      event.preventDefault?.();
+      event.stopImmediatePropagation?.();
+      return;
+    }
+    const request = {
+      hostGeneration: tokenState.hostGeneration,
+      videoGeneration: tokenState.videoGeneration,
+      inputRevision: tokenState.inputRevision,
+      sessionId: currentSession.sessionId,
+      pointerdownId: createId('pointerdown'),
+      pointerdownAt
+    };
+    const target = event.currentTarget || fabricCanvas?.upperCanvasEl || canvasElement;
+    pendingPointerdownFrame = {
+      request,
+      pointerId: event.pointerId,
+      target,
+      events: [snapshotPointerEvent(event)]
+    };
+    try {
+      target?.setPointerCapture?.(event.pointerId);
+    } catch (_error) { /* pointer capture is best-effort */ }
+    event.preventDefault?.();
+    event.stopImmediatePropagation?.();
+    event.stopPropagation?.();
+    try {
+      if (requestPointerdownFrame(request) !== true) cancelPendingPointerdownFrame();
+    } catch (_error) {
+      cancelPendingPointerdownFrame();
+    }
+  }
+
+  function confirmDrawingPointerdownFrame(request = {}) {
+    if (!validatePointerdownFrameConfirmation(request)) {
+      return { accepted: false, reason: 'invalid-pointerdown-frame-confirmation' };
+    }
+    const pending = pendingPointerdownFrame;
+    if (!pending || !inputEnabled || !currentSession ||
+        request.hostGeneration !== tokenState.hostGeneration ||
+        request.videoGeneration !== tokenState.videoGeneration ||
+        request.inputRevision !== tokenState.inputRevision ||
+        request.sessionId !== currentSession.sessionId ||
+        request.pointerdownId !== pending.request.pointerdownId ||
+        request.pointerdownAt !== pending.request.pointerdownAt) {
+      return { accepted: false, reason: 'stale-pointerdown-frame-confirmation' };
+    }
+    if (request.cancelled === true) {
+      cancelPendingPointerdownFrame();
+      return {
+        accepted: true,
+        cancelled: true,
+        hostGeneration: request.hostGeneration,
+        videoGeneration: request.videoGeneration,
+        inputRevision: request.inputRevision,
+        sessionId: request.sessionId,
+        pointerdownId: request.pointerdownId,
+        pointerdownAt: request.pointerdownAt
+      };
+    }
+    const previousFrameState = { ...activeFrameState };
+    const candidate = sceneStore.getActiveFrameCandidate(request.targetFrame);
+    if (!candidate?.accepted) {
+      cancelPendingPointerdownFrame();
+      return { accepted: false, reason: candidate?.reason || 'retarget-failed' };
+    }
+    activeFrameState.targetFrame = request.targetFrame;
+    activeFrameState.sourceFrame = candidate.sourceFrame;
+    activeFrameState.sourceSceneInstanceId = candidate.sceneInstanceId;
+    activeFrameState.sourceMutationSequence = candidate.mutationSequence;
+    const retargeted = retargetFrameForMutation(request.targetFrame);
+    if (!retargeted?.accepted) {
+      Object.assign(activeFrameState, previousFrameState);
+      cancelPendingPointerdownFrame();
+      return { accepted: false, reason: retargeted?.reason || 'retarget-failed' };
+    }
+    pendingPointerdownFrame = null;
+    for (const replayEvent of pending.events) {
+      if (!dispatchReplayedPointerEvent(pending.target, replayEvent)) {
+        cancelActiveStroke();
+        cancelActiveLasso();
+        cancelSelectInteraction();
+        releasePointerCapture(pending.target, pending.pointerId);
+        return { accepted: false, reason: 'pointerdown-replay-failed' };
+      }
+    }
+    return {
+      accepted: true,
+      pointerdownId: request.pointerdownId,
+      targetFrame: request.targetFrame
+    };
+  }
+
   function onPointerMove(event) {
+    if (consumePendingPointerEvent(event)) return;
     if (activeLasso) {
       if (event.pointerId !== activeLasso.pointerId) return;
       appendLassoPoint(event);
@@ -4712,6 +5550,7 @@ function createFabricOverlayRuntime(options = {}) {
   }
 
   function onPointerUp(event) {
+    if (consumePendingPointerEvent(event)) return;
     if (activeLasso) {
       if (event.pointerId !== activeLasso.pointerId) return;
       const { sessionId, inputRevision } = activeLasso;
@@ -4739,6 +5578,14 @@ function createFabricOverlayRuntime(options = {}) {
   }
 
   function onPointerCancel(event) {
+    if (pendingPointerdownFrame) {
+      if (event.pointerId !== undefined &&
+          event.pointerId !== pendingPointerdownFrame.pointerId) return;
+      event.preventDefault?.();
+      event.stopImmediatePropagation?.();
+      cancelPendingPointerdownFrame();
+      return;
+    }
     if (activeLasso) {
       if (event.pointerId !== undefined && event.pointerId !== activeLasso.pointerId) return;
       if (event.type === 'lostpointercapture' && activeLasso.phase === 'settling') return;
@@ -4765,6 +5612,10 @@ function createFabricOverlayRuntime(options = {}) {
   }
 
   function onDocumentPointerUp(event) {
+    if (pendingPointerdownFrame && event.pointerId === pendingPointerdownFrame.pointerId) {
+      consumePendingPointerEvent(event);
+      return;
+    }
     if (activeLasso && event.pointerId === activeLasso.pointerId) {
       onPointerUp(event);
       return;
@@ -4774,6 +5625,10 @@ function createFabricOverlayRuntime(options = {}) {
   }
 
   function onDocumentPointerCancel(event) {
+    if (pendingPointerdownFrame && event.pointerId === pendingPointerdownFrame.pointerId) {
+      onPointerCancel(event);
+      return;
+    }
     if (activeLasso && event.pointerId === activeLasso.pointerId) {
       onPointerCancel(event);
       return;
@@ -4871,6 +5726,7 @@ function createFabricOverlayRuntime(options = {}) {
       const result = commitPendingLassoMove(target);
       transformStart = null;
       if (result.applied) updateObjectMetric();
+      settleArmedFramePreview();
       return;
     }
     const children = typeof target.getObjects === 'function' ? target.getObjects() : [target];
@@ -4899,21 +5755,23 @@ function createFabricOverlayRuntime(options = {}) {
     }
     if (!result.applied) {
       rollbackSelectTransform(event, false);
+      settleArmedFramePreview();
       return;
     }
     const shouldReleaseMultiSelection = result.applied && children.length > 1;
     transformStart = null;
     if (result.applied) updateObjectMetric();
     if (shouldReleaseMultiSelection) scheduleMovedMultiSelectionRelease(target, ids);
+    settleArmedFramePreview();
   }
 
   function configureCanvasEvents() {
     const pointerTarget = fabricCanvas.upperCanvasEl || canvasElement;
     addDomListener(pointerTarget, 'pointerdown', onPointerDown, true);
-    addDomListener(pointerTarget, 'pointermove', onPointerMove);
-    addDomListener(pointerTarget, 'pointerup', onPointerUp);
-    addDomListener(pointerTarget, 'pointercancel', onPointerCancel);
-    addDomListener(pointerTarget, 'lostpointercapture', onPointerCancel);
+    addDomListener(pointerTarget, 'pointermove', onPointerMove, true);
+    addDomListener(pointerTarget, 'pointerup', onPointerUp, true);
+    addDomListener(pointerTarget, 'pointercancel', onPointerCancel, true);
+    addDomListener(pointerTarget, 'lostpointercapture', onPointerCancel, true);
     addDomListener(documentRef, 'pointerup', onDocumentPointerUp);
     addDomListener(documentRef, 'pointercancel', onDocumentPointerCancel);
     addDomListener(windowRef, 'blur', onPointerCancel);
@@ -5016,16 +5874,50 @@ function createFabricOverlayRuntime(options = {}) {
     applyViewport(currentSession);
   }
 
+  function resetPassivePresentationState() {
+    passiveDisplaySession = null;
+    presentationState.hostGeneration = -1;
+    presentationState.videoGeneration = -1;
+    presentationState.presentationRevision = -1;
+    presentationState.stableVideoIdentity = null;
+    presentationState.storeRevision = -1;
+    presentationState.targetFrame = null;
+    presentationState.sourceFrame = null;
+  }
+
   function validateSession(session) {
+    const targetFrame = Number(session?.targetFrame);
+    const sourceFrame = session?.sourceFrame;
     return !!session &&
       typeof session.sessionId === 'string' && session.sessionId.length > 0 &&
       typeof session.stableVideoIdentity === 'string' && session.stableVideoIdentity.length > 0 &&
-      Number.isInteger(Number(session.targetFrame)) && Number(session.targetFrame) >= 0 &&
+      Number.isInteger(targetFrame) && targetFrame >= 0 &&
+      (sourceFrame === undefined || sourceFrame === null ||
+        (Number.isSafeInteger(Number(sourceFrame)) && Number(sourceFrame) >= 0 &&
+         Number(sourceFrame) <= targetFrame)) &&
       finiteNumber(session.sourceWidth) > 0 && finiteNumber(session.sourceHeight) > 0 &&
       finiteNumber(session.canvasRect?.width) > 0 && finiteNumber(session.canvasRect?.height) > 0;
   }
 
-  function disableInput() {
+  function disableInput({ preservePassiveDisplay = true } = {}) {
+    const disabledSession = currentSession;
+    const disabledFrameState = { ...activeFrameState };
+    const previewWasDisplayed = disabledSession &&
+      disabledFrameState.sessionId === disabledSession.sessionId &&
+      disabledFrameState.previewed === true;
+    const disabledTargetFrame = previewWasDisplayed
+      ? disabledFrameState.targetFrame
+      : disabledSession?.targetFrame;
+    const disabledCandidate = disabledSession && Number.isSafeInteger(disabledTargetFrame)
+      ? sceneStore.getActiveFrameCandidate(disabledTargetFrame)
+      : null;
+    const disabledSourceFrame = disabledCandidate?.accepted === true
+      ? disabledCandidate.sourceFrame
+      : previewWasDisplayed
+        ? disabledFrameState.sourceFrame
+        : disabledSession?.sourceFrame ?? null;
+    const discardedProvisional = sceneStore.getDiagnostics().provisional === true;
+    cancelPendingPointerdownFrame();
     abortPendingLassoSelection();
     cancelActiveLasso();
     cancelSelectInteraction();
@@ -5038,7 +5930,51 @@ function createFabricOverlayRuntime(options = {}) {
     inputEnabled = false;
     currentSession = null;
     sceneStore.deactivateSession();
-    repaintLastPaintedScene();
+    resetActiveFrameState();
+    if (preservePassiveDisplay && disabledSession) {
+      passiveDisplaySession = {
+        hostGeneration: disabledSession.hostGeneration,
+        videoGeneration: disabledSession.videoGeneration,
+        stableVideoIdentity: disabledSession.stableVideoIdentity,
+        targetFrame: disabledTargetFrame,
+        sourceFrame: disabledSourceFrame,
+        sourceWidth: disabledSession.sourceWidth,
+        sourceHeight: disabledSession.sourceHeight,
+        canvasRect: { ...disabledSession.canvasRect },
+        viewportRevision: disabledSession.viewportRevision,
+        viewportTransform: { ...disabledSession.viewportTransform }
+      };
+      presentationState.hostGeneration = disabledSession.hostGeneration;
+      presentationState.videoGeneration = disabledSession.videoGeneration;
+      presentationState.stableVideoIdentity = disabledSession.stableVideoIdentity;
+      presentationState.targetFrame = passiveDisplaySession.targetFrame;
+      presentationState.sourceFrame = passiveDisplaySession.sourceFrame;
+    } else if (!preservePassiveDisplay) {
+      passiveDisplaySession = null;
+    }
+    if (previewWasDisplayed) {
+      lastPaintedScene = disabledSourceFrame === null
+        ? null
+        : {
+          stableVideoIdentity: disabledSession.stableVideoIdentity,
+          targetFrame: disabledSourceFrame
+        };
+    } else if (disabledCandidate?.accepted === true) {
+      lastPaintedScene = disabledSourceFrame === null
+        ? null
+        : {
+          stableVideoIdentity: disabledSession.stableVideoIdentity,
+          targetFrame: disabledSourceFrame
+        };
+    } else if (discardedProvisional && disabledSession) {
+      lastPaintedScene = disabledSession.sourceFrame === null
+        ? null
+        : {
+          stableVideoIdentity: disabledSession.stableVideoIdentity,
+          targetFrame: disabledSession.sourceFrame
+        };
+    }
+    if (!previewWasDisplayed) repaintLastPaintedScene();
     syncPersistenceBadge();
   }
 
@@ -5069,12 +6005,14 @@ function createFabricOverlayRuntime(options = {}) {
     appliedSourceWidth = null;
     appliedSourceHeight = null;
     activeStroke = null;
+    pendingPointerdownFrame = null;
     pendingLassoSelection = null;
     transformStart = null;
     selectGesture = null;
     deferredViewport = null;
     inputEnabled = false;
     currentSession = null;
+    resetPassivePresentationState();
     viewportElement = null;
     canvasElement = null;
     toolbar = null;
@@ -5219,17 +6157,24 @@ function createFabricOverlayRuntime(options = {}) {
       return { accepted: false, reason: 'invalid-session' };
     }
 
+    cancelPendingPointerdownFrame();
     abortPendingLassoSelection();
     if (activeStroke) cancelActiveStroke();
     if (activeLasso) cancelActiveLasso();
     if (selectGesture || transformStart || deferredViewport) cancelSelectInteraction();
 
     if (!request.enabled) {
+      const ownerChanged = Number(request.hostGeneration) !== tokenState.hostGeneration ||
+        Number(request.videoGeneration) !== tokenState.videoGeneration;
       tokenState.hostGeneration = Number(request.hostGeneration);
       tokenState.videoGeneration = Number(request.videoGeneration);
       tokenState.inputRevision = Number(request.inputRevision);
       const lastTool = currentSession?.tool === 'select' ? 'select' : 'brush';
-      disableInput();
+      disableInput({ preservePassiveDisplay: !ownerChanged });
+      if (ownerChanged) {
+        resetPassivePresentationState();
+      }
+      resetActiveFrameState();
       metrics.recordToggleLatency(now() - startedAt);
       return { accepted: true, enabled: false, tool: lastTool };
     }
@@ -5237,6 +6182,9 @@ function createFabricOverlayRuntime(options = {}) {
     const session = {
       ...clonePlain(request.session),
       targetFrame: Number(request.session.targetFrame),
+      sourceFrame: request.session.sourceFrame === null || request.session.sourceFrame === undefined
+        ? null
+        : Number(request.session.sourceFrame),
       sourceWidth: Number(request.session.sourceWidth),
       sourceHeight: Number(request.session.sourceHeight),
       hostGeneration: Number(request.hostGeneration),
@@ -5245,15 +6193,25 @@ function createFabricOverlayRuntime(options = {}) {
       viewportTransform: normalizeViewportTransform(request.session.viewportTransform),
       tool: request.session.tool === 'select' ? 'select' : 'brush'
     };
-    const activation = sceneStore.activateSession(session);
+    const activation = typeof sceneStore.replaceActiveSession === 'function'
+      ? sceneStore.replaceActiveSession(session)
+      : sceneStore.activateSession(session);
     if (!activation.accepted) {
       metrics.recordStaleMessageDrop();
       return activation;
     }
+    session.sourceFrame = activation.sourceFrame;
     tokenState.hostGeneration = Number(request.hostGeneration);
     tokenState.videoGeneration = Number(request.videoGeneration);
     tokenState.inputRevision = Number(request.inputRevision);
     currentSession = session;
+    passiveDisplaySession = null;
+    resetActiveFrameState(session);
+    presentationState.hostGeneration = session.hostGeneration;
+    presentationState.videoGeneration = session.videoGeneration;
+    presentationState.stableVideoIdentity = session.stableVideoIdentity;
+    presentationState.targetFrame = session.targetFrame;
+    presentationState.sourceFrame = session.sourceFrame;
     applyViewport(session);
     renderActiveScene({ immediate: true });
     lastPaintedScene = {
@@ -5282,6 +6240,11 @@ function createFabricOverlayRuntime(options = {}) {
     try {
       const result = sceneStore.hydrateVideo(clonePlain(request));
       if (result?.accepted === true) {
+        if (passiveDisplaySession &&
+            passiveDisplaySession.stableVideoIdentity !==
+              String(request?.stableVideoIdentity || '')) {
+          resetPassivePresentationState();
+        }
         if (lastPaintedScene &&
             lastPaintedScene.stableVideoIdentity === String(request?.stableVideoIdentity || '')) {
           // 수화는 같은 objectId를 유지한 채 내용(pathData·transform)만 바꿀 수 있으므로
@@ -5304,6 +6267,142 @@ function createFabricOverlayRuntime(options = {}) {
     }
   }
 
+  function presentDrawingFrame(request = {}) {
+    if (destroyed || !prepared) {
+      return { accepted: false, reason: destroyed ? 'destroyed' : 'not-prepared' };
+    }
+    if (inputEnabled) return { accepted: false, reason: 'input-enabled' };
+    if (!validatePresentationRequest(request)) {
+      return { accepted: false, reason: 'invalid-presentation-request' };
+    }
+    if (request.presentationRevision <= presentationState.presentationRevision) {
+      return { accepted: false, reason: 'stale-presentation-revision' };
+    }
+    if ((tokenState.hostGeneration >= 0 &&
+         request.hostGeneration !== tokenState.hostGeneration) ||
+        (tokenState.videoGeneration >= 0 &&
+         request.videoGeneration !== tokenState.videoGeneration)) {
+      return { accepted: false, reason: 'stale-presentation-fence' };
+    }
+    if (typeof sceneStore.getPresentationScene !== 'function') {
+      return { accepted: false, reason: 'persistence-unavailable' };
+    }
+
+    let resolved;
+    try {
+      resolved = sceneStore.getPresentationScene(request);
+    } catch (_error) {
+      return { accepted: false, reason: 'invalid-presentation-request' };
+    }
+    if (resolved?.accepted !== true) return resolved;
+
+    try {
+      const displaySession = {
+        hostGeneration: request.hostGeneration,
+        videoGeneration: request.videoGeneration,
+        stableVideoIdentity: request.stableVideoIdentity,
+        targetFrame: request.targetFrame,
+        sourceFrame: request.sourceFrame,
+        sourceWidth: request.sourceWidth,
+        sourceHeight: request.sourceHeight,
+        canvasRect: { ...request.canvasRect },
+        viewportRevision: request.viewportRevision,
+        viewportTransform: { ...request.viewportTransform }
+      };
+      applyViewport(displaySession);
+      const sameSource = presentationState.hostGeneration === request.hostGeneration &&
+        presentationState.videoGeneration === request.videoGeneration &&
+        presentationState.stableVideoIdentity === request.stableVideoIdentity &&
+        presentationState.storeRevision === request.storeRevision &&
+        presentationState.sourceFrame === request.sourceFrame;
+      const snapshot = resolved.snapshot;
+      const records = snapshot?.objects || [];
+      if (!sameSource) {
+        const paths = records.map(record => makeFabricPath(record));
+        for (const path of paths) path.set({ selectable: false, evented: false });
+        fabricCanvas.clear();
+        for (const path of paths) fabricCanvas.add(path);
+      } else {
+        for (const object of fabricCanvas.getObjects()) {
+          object.set?.({ selectable: false, evented: false });
+        }
+      }
+      fabricCanvas.discardActiveObject();
+      if (typeof fabricCanvas.renderAll === 'function') fabricCanvas.renderAll();
+      else fabricCanvas.requestRenderAll();
+
+      presentationState.hostGeneration = request.hostGeneration;
+      presentationState.videoGeneration = request.videoGeneration;
+      presentationState.presentationRevision = request.presentationRevision;
+      presentationState.stableVideoIdentity = request.stableVideoIdentity;
+      presentationState.storeRevision = request.storeRevision;
+      presentationState.targetFrame = request.targetFrame;
+      presentationState.sourceFrame = request.sourceFrame;
+      passiveDisplaySession = displaySession;
+      lastPaintedScene = request.sourceFrame === null
+        ? null
+        : {
+          stableVideoIdentity: request.stableVideoIdentity,
+          targetFrame: request.sourceFrame
+        };
+      return {
+        accepted: true,
+        targetFrame: request.targetFrame,
+        sourceFrame: request.sourceFrame
+      };
+    } catch (error) {
+      lastError = error.message;
+      metrics.recordSurfaceError();
+      return { accepted: false, reason: 'presentation-render-failed' };
+    }
+  }
+
+  function updateDrawingFrame(request = {}) {
+    if (destroyed || !prepared) {
+      return { accepted: false, reason: destroyed ? 'destroyed' : 'not-prepared' };
+    }
+    if (!inputEnabled || !currentSession) {
+      return { accepted: false, reason: 'input-disabled' };
+    }
+    if (!validateActiveFrameRequest(request)) {
+      return { accepted: false, reason: 'invalid-active-frame-request' };
+    }
+    if (request.hostGeneration !== tokenState.hostGeneration ||
+        request.videoGeneration !== tokenState.videoGeneration ||
+        request.inputRevision !== tokenState.inputRevision ||
+        request.sessionId !== currentSession.sessionId) {
+      return { accepted: false, reason: 'stale-active-frame-fence' };
+    }
+    if (request.frameRevision <= activeFrameState.frameRevision) {
+      return { accepted: false, reason: 'stale-active-frame-revision' };
+    }
+    const candidate = sceneStore.getActiveFrameCandidate(request.targetFrame);
+    if (!candidate?.accepted) return candidate;
+
+    const stagedFrameState = {
+      hostGeneration: request.hostGeneration,
+      videoGeneration: request.videoGeneration,
+      inputRevision: request.inputRevision,
+      sessionId: request.sessionId,
+      frameRevision: request.frameRevision,
+      targetFrame: request.targetFrame,
+      sourceFrame: candidate.sourceFrame,
+      sourceSceneInstanceId: candidate.sceneInstanceId,
+      sourceMutationSequence: candidate.mutationSequence
+    };
+    const preview = renderArmedFramePreview(stagedFrameState);
+    if (!preview?.accepted) return preview;
+    publishActiveFramePreview(stagedFrameState, preview);
+    return {
+      accepted: true,
+      frameRevision: request.frameRevision,
+      targetFrame: request.targetFrame,
+      sourceFrame: preview.sourceFrame,
+      deferred: preview.deferred === true,
+      repainted: preview.repainted === true
+    };
+  }
+
   function exportDrawingVideo(request = {}) {
     if (destroyed || !prepared) {
       return {
@@ -5322,15 +6421,16 @@ function createFabricOverlayRuntime(options = {}) {
   }
 
   function updateViewport(command = {}) {
-    if (!inputEnabled || !currentSession) return { accepted: false, reason: 'input-disabled' };
+    const viewportSession = inputEnabled ? currentSession : passiveDisplaySession;
+    if (!viewportSession) return { accepted: false, reason: 'input-disabled' };
     const revision = Number(command.revision);
     const rect = command.canvasRect;
     if (!Number.isInteger(revision) || revision < 0 ||
         !rect || finiteNumber(rect.width) <= 0 || finiteNumber(rect.height) <= 0) {
       return { accepted: false, reason: 'invalid-viewport' };
     }
-    const pendingRevision = deferredViewport?.command?.revision ?? -1;
-    if (revision <= Math.max(currentSession.viewportRevision, pendingRevision)) {
+    const pendingRevision = inputEnabled ? deferredViewport?.command?.revision ?? -1 : -1;
+    if (revision <= Math.max(viewportSession.viewportRevision, pendingRevision)) {
       return { accepted: false, reason: 'stale-viewport' };
     }
 
@@ -5344,6 +6444,13 @@ function createFabricOverlayRuntime(options = {}) {
       },
       ...normalizeViewportTransform(command)
     };
+    if (!inputEnabled) {
+      passiveDisplaySession.canvasRect = { ...normalizedCommand.canvasRect };
+      passiveDisplaySession.viewportTransform = normalizeViewportTransform(normalizedCommand);
+      passiveDisplaySession.viewportRevision = revision;
+      applyViewport(passiveDisplaySession);
+      return { accepted: true, revision };
+    }
     if (activeLasso || selectGesture || transformStart !== null) {
       deferredViewport = {
         sessionId: currentSession.sessionId,
@@ -5388,12 +6495,28 @@ function createFabricOverlayRuntime(options = {}) {
     if (!DRAWING_ACTIONS.has(action)) {
       return { applied: false, reason: 'invalid-action' };
     }
+    const hasExplicitTarget = command.targetFrame !== undefined;
+    const targetFrame = hasExplicitTarget ? Number(command.targetFrame) : activeFrameState.targetFrame;
+    if (!Number.isSafeInteger(targetFrame) || targetFrame < 0) {
+      return { applied: false, reason: 'invalid-action-target' };
+    }
     if (!actionDeduper.accept(command.actionId)) {
       metrics.recordDuplicateAction();
       return { applied: false, duplicate: true };
     }
+    const retargeted = hasExplicitTarget
+      ? retargetFrameForMutation(targetFrame)
+      : retargetArmedFrameForMutation();
+    if (!retargeted?.accepted) {
+      actionDeduper.release?.(command.actionId);
+      return { applied: false, reason: retargeted?.reason || 'retarget-failed' };
+    }
     if (pendingLassoSelection) {
-      if (action === 'delete-selection') return commitPendingLassoDelete();
+      if (action === 'delete-selection') {
+        const result = commitPendingLassoDelete();
+        settleArmedFramePreview();
+        return result;
+      }
       abortPendingLassoSelection();
     }
     if ((action === 'undo' || action === 'redo') && (selectGesture || transformStart)) {
@@ -5415,6 +6538,7 @@ function createFabricOverlayRuntime(options = {}) {
         sceneStore.selectObjects([]);
         setToolMode(currentSession?.tool || 'brush');
         updateObjectMetric();
+        settleArmedFramePreview();
         return result;
       }
       const deletedIds = new Set(result.deletedIds);
@@ -5426,6 +6550,7 @@ function createFabricOverlayRuntime(options = {}) {
       fabricCanvas.requestRenderAll();
       updateObjectMetric();
     }
+    settleArmedFramePreview();
     return result;
   }
 
@@ -5453,10 +6578,23 @@ function createFabricOverlayRuntime(options = {}) {
       inputEnabled,
       devicePixelRatio,
       tokens: { ...tokenState },
+      presentationRevision: presentationState.presentationRevision,
+      presentedStableVideoIdentity: currentSession?.stableVideoIdentity ??
+        presentationState.stableVideoIdentity,
+      presentedStoreRevision: presentationState.storeRevision,
+      presentedTargetFrame: currentSession?.targetFrame ?? presentationState.targetFrame,
+      presentedSourceFrame: currentSession
+        ? currentSession.sourceFrame
+        : presentationState.sourceFrame,
+      activeFrameRevision: activeFrameState.frameRevision,
+      armedTargetFrame: activeFrameState.targetFrame,
+      armedSourceFrame: activeFrameState.sourceFrame,
+      provisional: scene.provisional === true,
       activeSessionId: scene.activeSessionId,
       activeSceneKey: scene.activeSceneKey,
       targetFrame: currentSession?.targetFrame ?? null,
-      viewportRevision: currentSession?.viewportRevision ?? null,
+      viewportRevision: currentSession?.viewportRevision ??
+        passiveDisplaySession?.viewportRevision ?? null,
       tool: scene.tool,
       selectionTarget,
       selectionShape,
@@ -5517,6 +6655,9 @@ function createFabricOverlayRuntime(options = {}) {
     prepare,
     setDrawingInput,
     hydrateDrawingVideo,
+    presentDrawingFrame,
+    updateDrawingFrame,
+    confirmDrawingPointerdownFrame,
     exportDrawingVideo,
     updateDrawingTool,
     updateViewport,

--- a/renderer/scripts/modules/timeline.js
+++ b/renderer/scripts/modules/timeline.js
@@ -105,6 +105,8 @@ export class Timeline extends EventTarget {
     this.dragGhostItems = [];
     this.dragSourceElements = [];
     this.dragGhostKeyframes = [];
+    this._drawingLayerRenderRevision = 0;
+    this.dragDrawingLayerRenderRevision = null;
 
     // 다중 선택 상태
     this.selectedKeyframes = [];  // [ { layerId, frame } ]
@@ -1434,6 +1436,7 @@ export class Timeline extends EventTarget {
   renderDrawingLayers(layers, activeLayerId) {
     if (!this.tracksContainer || !this.layerHeaders) return;
 
+    this._drawingLayerRenderRevision += 1;
     this._lastDrawingLayers = layers;
     this._lastDrawingActiveLayerId = activeLayerId;
 
@@ -1736,6 +1739,7 @@ export class Timeline extends EventTarget {
    * 키프레임 드래그 시작
    */
   _startKeyframeDrag(e, layerId, frame, clipElement) {
+    if (!this._isKeyframeLayerMovable(layerId, frame)) return;
     this.isDraggingKeyframe = true;
     this.draggedKeyframe = { layerId, frame, element: clipElement };
     this.dragStartX = e.clientX;
@@ -1748,6 +1752,8 @@ export class Timeline extends EventTarget {
     if (!isSelected && !e.ctrlKey && !e.metaKey) {
       this._selectKeyframe(layerId, frame, false);
     }
+
+    this.dragDrawingLayerRenderRevision = this._drawingLayerRenderRevision;
 
     // 고스트 요소 생성
     this._createDragGhost(e, frame);
@@ -1801,6 +1807,8 @@ export class Timeline extends EventTarget {
 
     const targetFrame = parseInt(this.dragGhost?.dataset.targetFrame || this.dragStartFrame);
     const frameDelta = targetFrame - this.dragStartFrame;
+    const isCurrentDrawingLayerRender =
+      this.dragDrawingLayerRenderRevision === this._drawingLayerRenderRevision;
 
     // 원본 키프레임 투명도 복원
     this.dragSourceElements.forEach(element => {
@@ -1824,18 +1832,21 @@ export class Timeline extends EventTarget {
     document.body.style.cursor = 'default';
 
     // 이동량이 있으면 이벤트 발생
-    if (frameDelta !== 0) {
+    if (frameDelta !== 0 && isCurrentDrawingLayerRender) {
       // 선택된 모든 키프레임 이동
-      const keyframesToMove = this.dragGhostKeyframes.map(kf => ({
-        layerId: kf.layerId,
-        fromFrame: kf.frame,
-        toFrame: kf.frame + frameDelta
-      }));
-      const selectionAnchor = this.draggedKeyframe
-        ? {
-          layerId: this.draggedKeyframe.layerId,
-          frame: this.draggedKeyframe.frame + frameDelta
-        }
+      const keyframesToMove = this.dragGhostKeyframes
+        .filter(kf => this._isKeyframeLayerMovable(kf.layerId, kf.frame))
+        .map(kf => ({
+          layerId: kf.layerId,
+          fromFrame: kf.frame,
+          toFrame: kf.frame + frameDelta
+        }));
+      const anchorMove = keyframesToMove.find(keyframe =>
+        keyframe.layerId === this.draggedKeyframe?.layerId &&
+        keyframe.fromFrame === this.draggedKeyframe?.frame
+      );
+      const selectionAnchor = anchorMove
+        ? { layerId: anchorMove.layerId, frame: anchorMove.toFrame }
         : null;
 
       if (keyframesToMove.length > 0) {
@@ -1846,6 +1857,7 @@ export class Timeline extends EventTarget {
 
     this.dragGhostKeyframes = [];
     this.draggedKeyframe = null;
+    this.dragDrawingLayerRenderRevision = null;
   }
 
   /**
@@ -1918,13 +1930,24 @@ export class Timeline extends EventTarget {
     const keyframes = isDraggedKeyframeSelected && this.selectedKeyframes.length > 0
       ? this.selectedKeyframes.map(keyframe => ({ ...keyframe }))
       : [{ layerId, frame }];
-    return keyframes.filter(keyframe => this._isKeyframeLayerMovable(keyframe.layerId));
+    return keyframes.filter(keyframe =>
+      this._isKeyframeLayerMovable(keyframe.layerId, keyframe.frame)
+    );
   }
 
-  _isKeyframeLayerMovable(layerId) {
-    if (!Array.isArray(this._lastDrawingLayers)) return true;
+  _isKeyframeLayerMovable(layerId, frame = null) {
+    if (!Array.isArray(this._lastDrawingLayers)) return false;
     const layer = this._lastDrawingLayers.find(item => item.id === layerId);
-    return layer?.locked !== true;
+    if (!layer) return false;
+    const hasFrame = frame !== null &&
+      frame !== undefined &&
+      Number.isFinite(Number(frame));
+    if (hasFrame &&
+        (!Array.isArray(layer.keyframes) ||
+         !layer.keyframes.some(keyframe => Number(keyframe?.frame) === Number(frame)))) {
+      return false;
+    }
+    return layer.locked !== true || layer.timelineKeyframesMovable === true;
   }
 
   _clampKeyframeDragDelta(frameDelta) {

--- a/scripts/tests/fabric-drawing-persistence-controller.test.js
+++ b/scripts/tests/fabric-drawing-persistence-controller.test.js
@@ -1994,3 +1994,216 @@ test('a rejected source refresh preserves quit suspension resume intent', async 
   assert.equal(await harness.controller.resumeAfterQuitCancelled(), true);
   assert.equal(harness.controller.getState(), 'active');
 });
+
+function makeKeyframe(frame, id, objectIds = [], overrides = {}) {
+  return {
+    id,
+    frame,
+    sourceWidth: 1920,
+    sourceHeight: 1080,
+    mutationSequence: frame + 1,
+    objects: objectIds.map(makeRecord),
+    ...overrides
+  };
+}
+
+function createStoreWithKeyframes(keyframes, options = {}) {
+  const store = createFabricDrawingPersistenceStore({
+    createId: prefix => `${prefix}-generated`,
+    ...options
+  });
+  const imported = store.importRootValue(makeRoot({
+    revision: options.revision ?? 1,
+    keyframes
+  }), {
+    fps: 24,
+    totalFrames: 240,
+    stableVideoIdentity: 'C:/shot/scene-001.mov'
+  });
+  assert.equal(imported.accepted, true);
+  return store;
+}
+
+test('hold resolver returns the last exact or held keyframe while preserving an empty hold break', () => {
+  const store = createStoreWithKeyframes([
+    makeKeyframe(100, 'keyframe-100', ['stroke-100']),
+    makeKeyframe(150, 'keyframe-150'),
+    makeKeyframe(200, 'keyframe-200', ['stroke-200'])
+  ]);
+
+  assert.equal(store.resolveKeyframeAtFrame(99), null);
+  assert.equal(store.resolveKeyframeAtFrame(-1), null);
+  assert.equal(store.resolveKeyframeAtFrame(240), null);
+  assert.equal(store.resolveKeyframeAtFrame(100.5), null);
+  assert.deepEqual(
+    { frame: store.resolveKeyframeAtFrame(100).frame, ids: store.resolveKeyframeAtFrame(100).objects.map(item => item.id) },
+    { frame: 100, ids: ['stroke-100'] }
+  );
+  assert.deepEqual(
+    { frame: store.resolveKeyframeAtFrame(149).frame, ids: store.resolveKeyframeAtFrame(149).objects.map(item => item.id) },
+    { frame: 100, ids: ['stroke-100'] }
+  );
+  assert.deepEqual(
+    { frame: store.resolveKeyframeAtFrame(150).frame, objects: store.resolveKeyframeAtFrame(150).objects },
+    { frame: 150, objects: [] }
+  );
+  assert.deepEqual(
+    { frame: store.resolveKeyframeAtFrame(199).frame, objects: store.resolveKeyframeAtFrame(199).objects },
+    { frame: 150, objects: [] }
+  );
+  assert.deepEqual(
+    { frame: store.resolveKeyframeAtFrame(200).frame, ids: store.resolveKeyframeAtFrame(200).objects.map(item => item.id) },
+    { frame: 200, ids: ['stroke-200'] }
+  );
+
+  const resolvedClone = store.resolveKeyframeAtFrame(149);
+  resolvedClone.objects[0].style.color = '#000000';
+  assert.equal(store.resolveKeyframeAtFrame(149).objects[0].style.color, '#ff4757');
+  assert.equal(createFabricDrawingPersistenceStore().resolveKeyframeAtFrame(0), null);
+});
+
+test('single keyframe move preserves the source snapshot and emits one revision', () => {
+  const source = makeKeyframe(10, 'keyframe-10', ['stroke-10'], {
+    sourceWidth: 1280,
+    sourceHeight: 720,
+    mutationSequence: 77
+  });
+  const store = createStoreWithKeyframes([source]);
+  const changes = [];
+  store.subscribe(change => changes.push(change));
+
+  const result = store.moveKeyframes([{ fromFrame: 10, toFrame: 15 }]);
+
+  assert.equal(result.applied, true);
+  assert.equal(result.revision, 2);
+  assert.deepEqual(Object.keys(result.edit), [
+    'schema',
+    'kind',
+    'documentId',
+    'before',
+    'after'
+  ]);
+  assert.deepEqual(result.edit.before.map(item => item.frame), [10, 15]);
+  assert.deepEqual(result.edit.after.map(item => item.frame), [10, 15]);
+  assert.deepEqual(store.exportRootValue().keyframes, [{ ...source, frame: 15 }]);
+  assert.equal(store.getStatus().objectCount, 1);
+  assert.deepEqual(changes.map(change => change.revision), [2]);
+});
+
+test('multi-keyframe move uses the starting snapshot for overlap and overwrites destinations atomically', () => {
+  const frame100 = makeKeyframe(100, 'keyframe-100', ['stroke-100']);
+  const frame200 = makeKeyframe(200, 'keyframe-200', ['stroke-200']);
+  const overwritten = makeKeyframe(220, 'keyframe-220', ['stroke-overwritten']);
+  const store = createStoreWithKeyframes([frame100, frame200, overwritten]);
+  const changes = [];
+  store.subscribe(change => changes.push(change));
+
+  const result = store.moveKeyframes([
+    { fromFrame: 100, toFrame: 200 },
+    { fromFrame: 200, toFrame: 220 }
+  ]);
+
+  assert.equal(result.applied, true);
+  assert.deepEqual(
+    store.exportRootValue().keyframes.map(keyframe => ({
+      frame: keyframe.frame,
+      id: keyframe.id,
+      objectIds: keyframe.objects.map(object => object.id)
+    })),
+    [
+      { frame: 200, id: 'keyframe-100', objectIds: ['stroke-100'] },
+      { frame: 220, id: 'keyframe-200', objectIds: ['stroke-200'] }
+    ]
+  );
+  assert.deepEqual(result.edit.before.map(item => item.frame), [100, 200, 220]);
+  assert.deepEqual(result.edit.after.map(item => item.frame), [100, 200, 220]);
+  assert.equal(store.getStatus().objectCount, 2);
+  assert.equal(changes.length, 1);
+});
+
+test('invalid keyframe move batches leave the document, revision, and events untouched', () => {
+  const invalidBatches = [
+    [{ fromFrame: 10, toFrame: 240 }],
+    [{ fromFrame: 10, toFrame: 11 }, { fromFrame: 99, toFrame: 12 }],
+    [{ fromFrame: 10, toFrame: 11 }, { fromFrame: 10, toFrame: 12 }],
+    [{ fromFrame: 10, toFrame: 12 }, { fromFrame: 20, toFrame: 12 }],
+    [{ fromFrame: 10, toFrame: 10 }]
+  ];
+
+  invalidBatches.forEach(moves => {
+    const store = createStoreWithKeyframes([
+      makeKeyframe(10, 'keyframe-10', ['stroke-10']),
+      makeKeyframe(20, 'keyframe-20', ['stroke-20'])
+    ]);
+    const before = store.exportRootValue();
+    const changes = [];
+    store.subscribe(change => changes.push(change));
+
+    assert.equal(store.moveKeyframes(moves).applied, false);
+    assert.deepEqual(store.exportRootValue(), before);
+    assert.equal(store.getRevision(), before.revision);
+    assert.equal(changes.length, 0);
+  });
+
+  const overflowStore = createStoreWithKeyframes([
+    makeKeyframe(10, 'keyframe-10', ['stroke-10'])
+  ], { revision: Number.MAX_SAFE_INTEGER });
+  const overflowBefore = overflowStore.exportRootValue();
+  assert.deepEqual(
+    overflowStore.moveKeyframes([{ fromFrame: 10, toFrame: 11 }]),
+    { applied: false, reason: 'revision-overflow' }
+  );
+  assert.deepEqual(overflowStore.exportRootValue(), overflowBefore);
+});
+
+test('keyframe move edit restores an overwritten destination on undo and can redo the move', () => {
+  const original10 = makeKeyframe(10, 'keyframe-10', ['stroke-10']);
+  const original20 = makeKeyframe(20, 'keyframe-20', ['stroke-20']);
+  const store = createStoreWithKeyframes([original10, original20]);
+  const changes = [];
+  store.subscribe(change => changes.push(change));
+
+  const moved = store.moveKeyframes([{ fromFrame: 10, toFrame: 20 }]);
+  assert.equal(moved.applied, true);
+  assert.deepEqual(
+    store.exportRootValue().keyframes.map(keyframe => keyframe.id),
+    ['keyframe-10']
+  );
+
+  assert.deepEqual(store.applyKeyframeEdit(moved.edit, 'undo'), {
+    applied: true,
+    revision: 3
+  });
+  assert.deepEqual(store.exportRootValue().keyframes, [original10, original20]);
+
+  assert.deepEqual(store.applyKeyframeEdit(moved.edit, 'redo'), {
+    applied: true,
+    revision: 4
+  });
+  assert.deepEqual(store.exportRootValue().keyframes, [{ ...original10, frame: 20 }]);
+  assert.deepEqual(changes.map(change => change.revision), [2, 3, 4]);
+});
+
+test('keyframe edit rejects wrong documents, malformed tokens, and changed touched frames atomically', () => {
+  const store = createStoreWithKeyframes([
+    makeKeyframe(10, 'keyframe-10', ['stroke-10']),
+    makeKeyframe(20, 'keyframe-20', ['stroke-20'])
+  ]);
+  const firstMove = store.moveKeyframes([{ fromFrame: 10, toFrame: 20 }]);
+  assert.equal(firstMove.applied, true);
+  const secondMove = store.moveKeyframes([{ fromFrame: 20, toFrame: 21 }]);
+  assert.equal(secondMove.applied, true);
+  const beforeRejectedEdits = store.exportRootValue();
+
+  assert.equal(store.applyKeyframeEdit(firstMove.edit, 'undo').applied, false);
+  assert.equal(store.applyKeyframeEdit({
+    ...firstMove.edit,
+    documentId: 'another-document'
+  }, 'undo').applied, false);
+  assert.equal(store.applyKeyframeEdit({
+    ...firstMove.edit,
+    unexpected: true
+  }, 'undo').applied, false);
+  assert.equal(store.applyKeyframeEdit(firstMove.edit, 'sideways').applied, false);
+  assert.deepEqual(store.exportRootValue(), beforeRejectedEdits);
+});

--- a/scripts/tests/fabric-drawing-persistence-store.test.mjs
+++ b/scripts/tests/fabric-drawing-persistence-store.test.mjs
@@ -159,6 +159,44 @@ test('reset creates an empty canonical document without reporting a user change'
   assert.deepEqual(changes, []);
 });
 
+test('source-frame resolver preserves empty hold breaks without cloning keyframe payloads', async () => {
+  const { createFabricDrawingPersistenceStore } = await loadModule();
+  const store = createFabricDrawingPersistenceStore();
+  assert.equal(store.importRootValue(rootValue({
+    keyframes: [
+      keyframe(100, [record('held-source')]),
+      keyframe(150, []),
+      keyframe(200, [record('next-source')])
+    ]
+  }), META).accepted, true);
+  assert.equal(typeof store.resolveSourceFrameAtFrame, 'function');
+
+  const originalStructuredClone = globalThis.structuredClone;
+  let structuredCloneCalls = 0;
+  globalThis.structuredClone = () => {
+    structuredCloneCalls += 1;
+    throw new Error('source-frame resolution must not clone object payloads');
+  };
+  try {
+    assert.equal(store.resolveSourceFrameAtFrame(99), null);
+    assert.equal(store.resolveSourceFrameAtFrame(100), 100);
+    assert.equal(store.resolveSourceFrameAtFrame(149), 100);
+    assert.equal(store.resolveSourceFrameAtFrame(150), 150);
+    assert.equal(store.resolveSourceFrameAtFrame(199), 150);
+    assert.equal(store.resolveSourceFrameAtFrame(200), 200);
+    assert.equal(store.resolveSourceFrameAtFrame(-1), null);
+    assert.equal(store.resolveSourceFrameAtFrame(240), null);
+    assert.equal(store.resolveSourceFrameAtFrame(100.5), null);
+    assert.equal(structuredCloneCalls, 0);
+  } finally {
+    globalThis.structuredClone = originalStructuredClone;
+  }
+
+  const emptyBreak = store.resolveKeyframeAtFrame(199);
+  assert.equal(emptyBreak.frame, 150);
+  assert.deepEqual(emptyBreak.objects, []);
+});
+
 test('source epoch changes only when a review root is installed or invalidated', async () => {
   const { createFabricDrawingPersistenceStore } = await loadModule();
   const store = createFabricDrawingPersistenceStore();

--- a/scripts/tests/fabric-drawing-pilot-display-controller.test.js
+++ b/scripts/tests/fabric-drawing-pilot-display-controller.test.js
@@ -1,0 +1,783 @@
+const { before, test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const controllerPath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'renderer',
+  'scripts',
+  'modules',
+  'fabric-drawing-pilot-controller.js'
+);
+
+let createFabricDrawingPilotController;
+
+before(async () => {
+  ({ createFabricDrawingPilotController } = await import(pathToFileURL(controllerPath).href));
+});
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function clone(value) {
+  return value === null || value === undefined
+    ? value
+    : JSON.parse(JSON.stringify(value));
+}
+
+function createHarness(options = {}) {
+  let id = 0;
+  let revision = 4;
+  let wallTime = options.wallTime ?? 100;
+  let context = {
+    isMpvActive: true,
+    isAudio: false,
+    stableVideoIdentity: 'C:/shots/display.mov',
+    targetFrame: 99,
+    sourceWidth: 1920,
+    sourceHeight: 1080,
+    canvasRect: { left: 0, top: 0, width: 960, height: 540 },
+    viewportRevision: 1,
+    viewportTransform: { scale: 1, panX: 0, panY: 0 },
+    fps: 24,
+    totalFrames: 240,
+    ...options.context
+  };
+  const keyframes = [
+    { id: 'kf-100', frame: 100, sourceWidth: 1920, sourceHeight: 1080, mutationSequence: 1, objects: [{ id: 'held' }] },
+    { id: 'kf-150', frame: 150, sourceWidth: 1920, sourceHeight: 1080, mutationSequence: 2, objects: [] },
+    { id: 'kf-200', frame: 200, sourceWidth: 1920, sourceHeight: 1080, mutationSequence: 3, objects: [{ id: 'next' }] }
+  ];
+  const calls = {
+    input: [],
+    hydrate: [],
+    present: [],
+    frame: [],
+    pointerdownConfirm: [],
+    action: []
+  };
+  let pointerdownFrameListener = null;
+  let runtimeSnapshot = null;
+  const rootValue = () => ({
+    storageSchema: 'baeframe-drawings-v3',
+    storageVersion: 1,
+    engine: 'fabric',
+    documentId: 'display-document',
+    revision,
+    fps: context.fps,
+    totalFrames: context.totalFrames,
+    keyframes: clone(keyframes)
+  });
+  const persistenceStore = {
+    getStatus: () => ({ state: 'ready', compatible: true, revision }),
+    exportRootValue: rootValue,
+    importRootValue: () => ({ accepted: true, compatible: true, revision }),
+    getSourceEpoch: () => 1,
+    getHydrationDocument: () => ({
+      documentId: 'display-document',
+      revision,
+      fps: context.fps,
+      totalFrames: context.totalFrames,
+      keyframes: clone(keyframes)
+    }),
+    replaceFromOverlay: () => ({ accepted: true, changed: false, revision }),
+    applyTransition: () => ({ applied: true, revision }),
+    resolveKeyframeAtFrame(targetFrame) {
+      const source = [...keyframes]
+        .reverse()
+        .find(keyframe => keyframe.frame <= targetFrame);
+      return clone(source || null);
+    },
+    getRevision: () => revision
+  };
+  const electronAPI = {
+    getFabricDrawingPilotState: async () => true,
+    onFabricDrawingPersistenceEvent: () => () => {},
+    onMpvOverlayDrawingPointerdownFrame(callback) {
+      pointerdownFrameListener = callback;
+      return () => {
+        if (pointerdownFrameListener === callback) pointerdownFrameListener = null;
+      };
+    },
+    async mpvSetOverlayDrawingInput(request) {
+      calls.input.push(request);
+      if (options.onInput) return options.onInput(request, calls.input.length - 1);
+      return { success: true, accepted: true, enabled: request.enabled };
+    },
+    async mpvHydrateOverlayDrawingVideo(request) {
+      calls.hydrate.push(request);
+      runtimeSnapshot = {
+        hostGeneration: request.hostGeneration,
+        videoGeneration: request.videoGeneration,
+        persistenceSessionId: request.persistenceSessionId,
+        stableVideoIdentity: request.stableVideoIdentity,
+        fps: request.fps,
+        totalFrames: request.totalFrames,
+        scenes: request.keyframes.map(keyframe => ({
+          sceneInstanceId: `display-scene-${keyframe.frame}`,
+          targetFrame: keyframe.frame,
+          sourceWidth: keyframe.sourceWidth,
+          sourceHeight: keyframe.sourceHeight,
+          mutationSequence: keyframe.mutationSequence,
+          objects: clone(keyframe.objects)
+        }))
+      };
+      return { success: true, accepted: true, sceneCount: request.keyframes.length, objectCount: 2 };
+    },
+    async mpvExportOverlayDrawingVideo() {
+      return { success: true, accepted: true, snapshot: clone(runtimeSnapshot) };
+    },
+    async mpvPresentOverlayDrawingFrame(request) {
+      calls.present.push(request);
+      if (options.onPresent) return options.onPresent(request, calls.present.length - 1);
+      return {
+        success: true,
+        accepted: true,
+        presentationRevision: request.presentationRevision,
+        targetFrame: request.targetFrame,
+        sourceFrame: request.sourceFrame
+      };
+    },
+    async mpvUpdateOverlayDrawingFrame(request) {
+      calls.frame.push(request);
+      if (options.onFrame) return options.onFrame(request, calls.frame.length - 1);
+      return {
+        success: true,
+        accepted: true,
+        frameRevision: request.frameRevision,
+        targetFrame: request.targetFrame
+      };
+    },
+    async mpvConfirmOverlayDrawingPointerdownFrame(request) {
+      calls.pointerdownConfirm.push(request);
+      if (options.onPointerdownConfirm) {
+        return options.onPointerdownConfirm(request, calls.pointerdownConfirm.length - 1);
+      }
+      return {
+        success: true,
+        accepted: true,
+        pointerdownId: request.pointerdownId,
+        targetFrame: request.targetFrame
+      };
+    },
+    async mpvApplyOverlayDrawingAction(request) {
+      calls.action.push(request);
+      if (options.onAction) return options.onAction(request, calls.action.length - 1);
+      return { success: true, applied: true, deletedCount: 1 };
+    }
+  };
+  const controller = createFabricDrawingPilotController({
+    electronAPI,
+    getContext: () => context,
+    onStateChange: (state, snapshot) => options.onStateChange?.(state, snapshot, controller),
+    persistenceStore,
+    persistenceSessionIdFactory: () => 'display-persistence-session',
+    uuid: () => `display-request-${++id}`,
+    wallNow: () => wallTime,
+    ...(options.persistenceIpcDeadlineMs
+      ? { persistenceIpcDeadlineMs: options.persistenceIpcDeadlineMs }
+      : {})
+  });
+
+  return {
+    calls,
+    controller,
+    persistenceStore,
+    setContext(patch) {
+      context = { ...context, ...patch };
+    },
+    setWallTime(value) {
+      wallTime = value;
+    },
+    setRevision(nextRevision) {
+      revision = nextRevision;
+    },
+    setKeyframes(nextKeyframes) {
+      keyframes.splice(0, keyframes.length, ...clone(nextKeyframes));
+    },
+    emitPointerdownFrame(request) {
+      return pointerdownFrameListener?.(request);
+    }
+  };
+}
+
+async function preparePassive(harness) {
+  assert.equal(await harness.controller.initialize(), true);
+  assert.equal(await harness.controller.adoptOverlayCapability({
+    passiveReady: true,
+    hostGeneration: 1
+  }), true);
+  assert.equal(await harness.controller.afterVideoReady({ loadToken: 'display-load' }), true);
+  assert.equal(harness.controller.getState(), 'passive');
+}
+
+test('passive display resolves held sources and resends the same source when viewport geometry changes', async () => {
+  const harness = createHarness();
+  await preparePassive(harness);
+
+  assert.equal(await harness.controller.syncDisplayFrame(99), true);
+  assert.equal(await harness.controller.syncDisplayFrame(100), true);
+  assert.equal(await harness.controller.syncDisplayFrame(101), true);
+  assert.equal(await harness.controller.syncDisplayFrame(149), true);
+  harness.setContext({
+    canvasRect: { left: 12, top: 18, width: 900, height: 506.25 },
+    viewportRevision: 2,
+    viewportTransform: { scale: 1.25, panX: 14, panY: -8 }
+  });
+  assert.equal(await harness.controller.syncDisplayFrame(149), true);
+  assert.equal(await harness.controller.syncDisplayFrame(150), true);
+
+  assert.deepEqual(
+    harness.calls.present.map(request => ({
+      targetFrame: request.targetFrame,
+      sourceFrame: request.sourceFrame,
+      storeRevision: request.storeRevision,
+      sourceWidth: request.sourceWidth,
+      sourceHeight: request.sourceHeight,
+      canvasRect: request.canvasRect,
+      viewportRevision: request.viewportRevision,
+      viewportTransform: request.viewportTransform
+    })),
+    [
+      {
+        targetFrame: 99, sourceFrame: null, storeRevision: 4,
+        sourceWidth: 1920, sourceHeight: 1080,
+        canvasRect: { left: 0, top: 0, width: 960, height: 540 },
+        viewportRevision: 1,
+        viewportTransform: { scale: 1, panX: 0, panY: 0 }
+      },
+      {
+        targetFrame: 100, sourceFrame: 100, storeRevision: 4,
+        sourceWidth: 1920, sourceHeight: 1080,
+        canvasRect: { left: 0, top: 0, width: 960, height: 540 },
+        viewportRevision: 1,
+        viewportTransform: { scale: 1, panX: 0, panY: 0 }
+      },
+      {
+        targetFrame: 149, sourceFrame: 100, storeRevision: 4,
+        sourceWidth: 1920, sourceHeight: 1080,
+        canvasRect: { left: 12, top: 18, width: 900, height: 506.25 },
+        viewportRevision: 2,
+        viewportTransform: { scale: 1.25, panX: 14, panY: -8 }
+      },
+      {
+        targetFrame: 150, sourceFrame: 150, storeRevision: 4,
+        sourceWidth: 1920, sourceHeight: 1080,
+        canvasRect: { left: 12, top: 18, width: 900, height: 506.25 },
+        viewportRevision: 2,
+        viewportTransform: { scale: 1.25, panX: 14, panY: -8 }
+      }
+    ]
+  );
+
+  harness.setRevision(5);
+  assert.equal(await harness.controller.syncDisplayFrame(151), true);
+  assert.equal(harness.calls.present.at(-1).targetFrame, 151);
+  assert.equal(harness.calls.present.at(-1).sourceFrame, 150);
+  assert.equal(harness.calls.present.at(-1).storeRevision, 5);
+});
+
+test('passive display serializes one request and keeps only the newest trailing source', async () => {
+  const first = deferred();
+  const harness = createHarness({
+    onPresent(request, index) {
+      if (index === 0) return first.promise;
+      return {
+        success: true,
+        accepted: true,
+        presentationRevision: request.presentationRevision,
+        targetFrame: request.targetFrame,
+        sourceFrame: request.sourceFrame
+      };
+    }
+  });
+  await preparePassive(harness);
+
+  const firstResult = harness.controller.syncDisplayFrame(100);
+  const discardedTrailing = harness.controller.syncDisplayFrame(150);
+  const newestTrailing = harness.controller.syncDisplayFrame(200);
+
+  assert.equal(harness.calls.present.length, 1);
+  assert.equal(await discardedTrailing, false);
+  first.resolve({
+    success: true,
+    accepted: true,
+    presentationRevision: harness.calls.present[0].presentationRevision,
+    targetFrame: 100,
+    sourceFrame: 100
+  });
+
+  assert.equal(await firstResult, false);
+  assert.equal(await newestTrailing, true);
+  assert.deepEqual(harness.calls.present.map(request => request.sourceFrame), [100, 200]);
+});
+
+test('seeking A to B and back to in-flight A replaces the stale B trailing request', async () => {
+  const first = deferred();
+  const harness = createHarness({
+    onPresent(request, index) {
+      if (index === 0) return first.promise;
+      return {
+        success: true,
+        accepted: true,
+        presentationRevision: request.presentationRevision,
+        targetFrame: request.targetFrame,
+        sourceFrame: request.sourceFrame
+      };
+    }
+  });
+  await preparePassive(harness);
+
+  const firstA = harness.controller.syncDisplayFrame(100);
+  const staleB = harness.controller.syncDisplayFrame(200);
+  const latestA = harness.controller.syncDisplayFrame(101);
+
+  assert.equal(await staleB, false);
+  first.resolve({
+    success: true,
+    accepted: true,
+    presentationRevision: harness.calls.present[0].presentationRevision,
+    targetFrame: 100,
+    sourceFrame: 100
+  });
+  assert.equal(await firstA, false);
+  assert.equal(await latestA, true);
+  assert.deepEqual(harness.calls.present.map(request => request.sourceFrame), [100, 100]);
+  assert.equal(harness.calls.present.at(-1).targetFrame, 101);
+});
+
+test('active state syncs the latest playhead as an edit candidate while B-off force-presents it', async () => {
+  const harness = createHarness({ context: { targetFrame: 101 } });
+  await preparePassive(harness);
+
+  assert.equal(await harness.controller.toggle(), true);
+  const enableRequest = harness.calls.input.at(-1);
+  assert.equal(enableRequest.enabled, true);
+  assert.equal(enableRequest.session.targetFrame, 101);
+  assert.equal(enableRequest.session.sourceFrame, 100);
+
+  harness.setContext({ targetFrame: 200 });
+  assert.equal(await harness.controller.syncDisplayFrame(200), true);
+  assert.equal(harness.calls.present.length, 0);
+  assert.equal(harness.calls.frame.length, 1);
+  assert.deepEqual(Object.keys(harness.calls.frame[0]).sort(), [
+    'frameRevision',
+    'hostGeneration',
+    'inputRevision',
+    'sessionId',
+    'targetFrame',
+    'videoGeneration'
+  ]);
+  assert.equal(harness.calls.frame[0].targetFrame, 200);
+
+  assert.equal(await harness.controller.disable(), true);
+  assert.equal(harness.controller.getState(), 'passive');
+  assert.equal(harness.calls.present.length, 1);
+  assert.equal(harness.calls.present[0].targetFrame, 200);
+  assert.equal(harness.calls.present[0].sourceFrame, 200);
+
+  await harness.controller.beforeVideoChange('next-load');
+  assert.equal(harness.controller.getState(), 'recovering');
+  assert.equal(await harness.controller.syncDisplayFrame(100), false);
+  assert.equal(harness.calls.present.length, 1);
+});
+
+test('active frame sync sends a coalesced latest target concurrently without waiting for an older invoke', async () => {
+  const first = deferred();
+  const harness = createHarness({
+    context: { targetFrame: 10 },
+    onFrame(request, index) {
+      if (index === 0) return first.promise;
+      return {
+        success: true,
+        accepted: true,
+        frameRevision: request.frameRevision,
+        targetFrame: request.targetFrame
+      };
+    }
+  });
+  await preparePassive(harness);
+  assert.equal(await harness.controller.toggle(), true);
+
+  const frame20 = harness.controller.syncDisplayFrame(20);
+  const discarded21 = harness.controller.syncDisplayFrame(21);
+  const latest22 = harness.controller.syncDisplayFrame(22);
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(harness.calls.frame.map(request => request.targetFrame), [20, 22]);
+  assert.equal(await discarded21, false);
+  assert.equal(await latest22, true);
+
+  const firstRequest = harness.calls.frame[0];
+  first.resolve({
+    success: true,
+    accepted: true,
+    frameRevision: firstRequest.frameRevision,
+    targetFrame: firstRequest.targetFrame
+  });
+  assert.equal(await frame20, false);
+});
+
+test('active frame sync stays bounded and a replacement session sends without waiting for a stale owner', async () => {
+  const first = deferred();
+  const second = deferred();
+  const harness = createHarness({
+    context: { targetFrame: 10 },
+    onFrame(request, index) {
+      if (index === 0) return first.promise;
+      if (index === 1) return second.promise;
+      return {
+        success: true,
+        accepted: true,
+        frameRevision: request.frameRevision,
+        targetFrame: request.targetFrame
+      };
+    }
+  });
+  await preparePassive(harness);
+  assert.equal(await harness.controller.toggle(), true);
+
+  const frame20 = harness.controller.syncDisplayFrame(20);
+  const replaced = [];
+  for (let targetFrame = 21; targetFrame <= 120; targetFrame += 1) {
+    replaced.push(harness.controller.syncDisplayFrame(targetFrame));
+  }
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(harness.calls.frame.map(request => request.targetFrame), [20, 120]);
+  assert.equal(await replaced[0], false);
+
+  harness.setContext({ targetFrame: 30 });
+  assert.equal(await harness.controller.disable(), true);
+  assert.equal(await harness.controller.toggle(), true);
+  const replacementOwner = harness.controller.syncDisplayFrame(30);
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(harness.calls.frame.length, 3, 'the new session must not wait for stale unresolved invokes');
+  assert.notEqual(harness.calls.frame[2].sessionId, harness.calls.frame[0].sessionId);
+  assert.equal(await replacementOwner, true);
+
+  first.resolve({
+    success: true,
+    accepted: true,
+    frameRevision: harness.calls.frame[0].frameRevision,
+    targetFrame: harness.calls.frame[0].targetFrame
+  });
+  second.resolve({
+    success: true,
+    accepted: true,
+    frameRevision: harness.calls.frame[1].frameRevision,
+    targetFrame: harness.calls.frame[1].targetFrame
+  });
+  assert.equal(await frame20, false);
+  assert.equal(await replaced.at(-1), false);
+});
+
+test('two unresolved active frame invokes time out locally so the newest pending frame can advance', async () => {
+  const harness = createHarness({
+    context: { targetFrame: 10 },
+    persistenceIpcDeadlineMs: 10,
+    onFrame(request, index) {
+      if (index < 2) return new Promise(() => {});
+      return {
+        success: true,
+        accepted: true,
+        frameRevision: request.frameRevision,
+        targetFrame: request.targetFrame
+      };
+    }
+  });
+  await preparePassive(harness);
+  assert.equal(await harness.controller.toggle(), true);
+
+  void harness.controller.syncDisplayFrame(20);
+  void harness.controller.syncDisplayFrame(21);
+  await new Promise(resolve => setImmediate(resolve));
+  const newest = harness.controller.syncDisplayFrame(22);
+  const result = await Promise.race([
+    newest,
+    new Promise(resolve => setTimeout(() => resolve('test-timeout'), 150))
+  ]);
+  assert.equal(result, true);
+  assert.deepEqual(harness.calls.frame.map(request => request.targetFrame), [20, 21, 22]);
+});
+
+test('an unresolved burst coalesces to one newest target after the local deadline', async () => {
+  const harness = createHarness({
+    context: { targetFrame: 10 },
+    persistenceIpcDeadlineMs: 10,
+    onFrame: () => new Promise(() => {})
+  });
+  await preparePassive(harness);
+  assert.equal(await harness.controller.toggle(), true);
+
+  void harness.controller.syncDisplayFrame(20);
+  void harness.controller.syncDisplayFrame(21);
+  await new Promise(resolve => setImmediate(resolve));
+  for (let targetFrame = 22; targetFrame <= 120; targetFrame += 1) {
+    void harness.controller.syncDisplayFrame(targetFrame);
+  }
+  await new Promise(resolve => setTimeout(resolve, 80));
+  assert.deepEqual(harness.calls.frame.map(request => request.targetFrame), [20, 21, 120]);
+});
+
+test('drawing actions capture the keypress frame and do not wait for a forced preview update', async () => {
+  const harness = createHarness({ context: { targetFrame: 20 } });
+  await preparePassive(harness);
+  assert.equal(await harness.controller.toggle(), true);
+
+  const action = harness.controller.applyDrawingAction('delete-selection');
+  harness.setContext({ targetFrame: 21 });
+  assert.equal(await action, true);
+  assert.equal(harness.calls.frame.length, 0);
+  assert.equal(harness.calls.action.length, 1);
+  assert.equal(harness.calls.action[0].targetFrame, 20);
+});
+
+test('pointerdown handshake confirms the current renderer frame and drops a stale session request', async () => {
+  const harness = createHarness({ context: { targetFrame: 10 } });
+  await preparePassive(harness);
+  assert.equal(await harness.controller.toggle(), true);
+  const session = harness.calls.input.at(-1).session;
+
+  harness.setWallTime(200);
+  harness.setContext({ targetFrame: 20 });
+  assert.equal(await harness.controller.syncDisplayFrame(20), true);
+  harness.setWallTime(300);
+  harness.setContext({ targetFrame: 21 });
+  assert.equal(await harness.controller.syncDisplayFrame(21), true);
+
+  assert.equal(await harness.emitPointerdownFrame({
+    hostGeneration: 1,
+    videoGeneration: 1,
+    inputRevision: 2,
+    sessionId: session.sessionId,
+    pointerdownId: 'pointerdown-current-1',
+    pointerdownAt: 250
+  }), true);
+  assert.deepEqual(harness.calls.pointerdownConfirm, [{
+    hostGeneration: 1,
+    videoGeneration: 1,
+    inputRevision: 2,
+    sessionId: session.sessionId,
+    pointerdownId: 'pointerdown-current-1',
+    pointerdownAt: 250,
+    targetFrame: 20
+  }]);
+
+  const staleRequest = {
+    hostGeneration: 1,
+    videoGeneration: 1,
+    inputRevision: 2,
+    sessionId: 'stale-session',
+    pointerdownId: 'pointerdown-stale-1',
+    pointerdownAt: 250
+  };
+  assert.equal(await harness.emitPointerdownFrame(staleRequest), false);
+  assert.deepEqual(harness.calls.pointerdownConfirm[1], {
+    ...staleRequest,
+    cancelled: true
+  });
+});
+
+for (const failure of ['rejected', 'timeout', 'throw']) {
+  test(`pointerdown ${failure} sends a fenced negative acknowledgement`, async () => {
+    const harness = createHarness({
+      context: { targetFrame: 20 },
+      persistenceIpcDeadlineMs: 10,
+      onPointerdownConfirm(request) {
+        if (request.cancelled === true) {
+          return {
+            success: true,
+            accepted: true,
+            cancelled: true,
+            hostGeneration: request.hostGeneration,
+            videoGeneration: request.videoGeneration,
+            inputRevision: request.inputRevision,
+            sessionId: request.sessionId,
+            pointerdownId: request.pointerdownId,
+            pointerdownAt: request.pointerdownAt
+          };
+        }
+        if (failure === 'timeout') return new Promise(() => {});
+        if (failure === 'throw') throw new Error('pointerdown confirmation failed');
+        return { success: false, accepted: false, reason: 'confirmation-rejected' };
+      }
+    });
+    await preparePassive(harness);
+    assert.equal(await harness.controller.toggle(), true);
+    const session = harness.calls.input.at(-1).session;
+    harness.setWallTime(200);
+    assert.equal(await harness.controller.syncDisplayFrame(20), true);
+
+    const request = {
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 2,
+      sessionId: session.sessionId,
+      pointerdownId: `pointerdown-${failure}`,
+      pointerdownAt: 200
+    };
+    assert.equal(await harness.emitPointerdownFrame(request), false);
+    assert.deepEqual(harness.calls.pointerdownConfirm, [
+      { ...request, targetFrame: 20 },
+      { ...request, cancelled: true }
+    ]);
+  });
+}
+
+test('B-off blocks passive state-hook presentation until the disable acknowledgement', async () => {
+  const disableGate = deferred();
+  let holdDisable = false;
+  let stateHookSync = null;
+  const harness = createHarness({
+    context: { targetFrame: 20 },
+    onInput(request) {
+      if (holdDisable && request.enabled === false) return disableGate.promise;
+      return { success: true, accepted: true, enabled: request.enabled };
+    },
+    onStateChange(state, snapshot, controller) {
+      if (state === 'passive' && snapshot.inputRevision === 2) {
+        stateHookSync = controller.syncDisplayFrame(20);
+      }
+    }
+  });
+  await preparePassive(harness);
+  assert.equal(await harness.controller.toggle(), true);
+  holdDisable = true;
+
+  const disabling = harness.controller.disable();
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(await stateHookSync, false);
+  assert.equal(harness.calls.present.length, 0);
+
+  disableGate.resolve({ success: true, accepted: true, enabled: false });
+  assert.equal(await disabling, true);
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(harness.calls.present.length, 1);
+  assert.equal(harness.calls.present[0].targetFrame, 20);
+});
+
+test('an early B-off without a host cannot permanently block a later passive owner', async () => {
+  const harness = createHarness({ context: { targetFrame: 100 } });
+  assert.equal(await harness.controller.initialize(), true);
+  assert.equal(await harness.controller.disable(), false);
+
+  assert.equal(await harness.controller.adoptOverlayCapability({
+    passiveReady: true,
+    hostGeneration: 1
+  }), true);
+  assert.equal(await harness.controller.afterVideoReady({ loadToken: 'display-load' }), true);
+  assert.equal(await harness.controller.syncDisplayFrame(100, { force: true }), true);
+  assert.equal(harness.calls.present.at(-1).hostGeneration, 1);
+});
+
+test('a stale disable owner neither blocks nor releases the replacement passive owner', async () => {
+  const staleDisable = deferred();
+  let holdStaleDisable = false;
+  const harness = createHarness({
+    context: { targetFrame: 100 },
+    onInput(request) {
+      if (holdStaleDisable && request.hostGeneration === 1 && request.enabled === false) {
+        return staleDisable.promise;
+      }
+      return { success: true, accepted: true, enabled: request.enabled };
+    }
+  });
+  await preparePassive(harness);
+  assert.equal(await harness.controller.toggle(), true);
+
+  holdStaleDisable = true;
+  const disabling = harness.controller.disable();
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(await harness.controller.adoptOverlayCapability({
+    passiveReady: true,
+    hostGeneration: 2
+  }), true);
+  const beforeReplacementPresent = harness.calls.present.length;
+  assert.equal(await harness.controller.syncDisplayFrame(100, { force: true }), true);
+  assert.equal(harness.calls.present.length, beforeReplacementPresent + 1);
+  assert.equal(harness.calls.present.at(-1).hostGeneration, 2);
+
+  staleDisable.resolve({ success: true, accepted: true, enabled: false });
+  assert.equal(await disabling, false);
+  assert.equal(await harness.controller.syncDisplayFrame(101, { force: true }), true);
+  assert.equal(harness.calls.present.at(-1).hostGeneration, 2);
+});
+
+test('active frame sync drops a stale owner response on disable', async () => {
+  const stale = deferred();
+  const staleHarness = createHarness({
+    context: { targetFrame: 10 },
+    onFrame: () => stale.promise
+  });
+  await preparePassive(staleHarness);
+  assert.equal(await staleHarness.controller.toggle(), true);
+
+  const staleResult = staleHarness.controller.syncDisplayFrame(30);
+  const staleRequest = staleHarness.calls.frame[0];
+  const disabling = staleHarness.controller.disable();
+  stale.resolve({
+    success: true,
+    accepted: true,
+    frameRevision: staleRequest.frameRevision,
+    targetFrame: staleRequest.targetFrame
+  });
+  assert.equal(await staleResult, false);
+  assert.equal(await disabling, true);
+});
+
+test('a presentation response is discarded when its host owner changes while in flight', async () => {
+  const held = deferred();
+  const harness = createHarness({ onPresent: () => held.promise });
+  await preparePassive(harness);
+
+  const pending = harness.controller.syncDisplayFrame(100);
+  const request = harness.calls.present[0];
+  const recovery = harness.controller.adoptOverlayCapability({
+    passiveReady: true,
+    hostGeneration: 2
+  });
+  held.resolve({
+    success: true,
+    accepted: true,
+    presentationRevision: request.presentationRevision,
+    targetFrame: request.targetFrame,
+    sourceFrame: request.sourceFrame
+  });
+
+  assert.equal(await pending, false);
+  assert.equal(await recovery, true);
+});
+
+test('an in-flight presentation is discarded when the store revision and held source change', async () => {
+  const held = deferred();
+  const harness = createHarness({ onPresent: () => held.promise });
+  await preparePassive(harness);
+
+  const pending = harness.controller.syncDisplayFrame(149);
+  const request = harness.calls.present[0];
+  assert.equal(request.storeRevision, 4);
+  assert.equal(request.sourceFrame, 100);
+
+  harness.setRevision(5);
+  harness.setKeyframes([
+    { id: 'kf-120', frame: 120, sourceWidth: 1920, sourceHeight: 1080, mutationSequence: 4, objects: [{ id: 'new-hold' }] }
+  ]);
+  held.resolve({
+    success: true,
+    accepted: true,
+    presentationRevision: request.presentationRevision,
+    targetFrame: request.targetFrame,
+    sourceFrame: request.sourceFrame
+  });
+
+  assert.equal(await pending, false);
+});

--- a/scripts/tests/fabric-drawing-pilot-display-controller.test.js
+++ b/scripts/tests/fabric-drawing-pilot-display-controller.test.js
@@ -64,7 +64,9 @@ function createHarness(options = {}) {
     present: [],
     frame: [],
     pointerdownConfirm: [],
-    action: []
+    action: [],
+    sourceFrameResolution: [],
+    keyframeResolution: []
   };
   let pointerdownFrameListener = null;
   let runtimeSnapshot = null;
@@ -92,7 +94,18 @@ function createHarness(options = {}) {
     }),
     replaceFromOverlay: () => ({ accepted: true, changed: false, revision }),
     applyTransition: () => ({ applied: true, revision }),
+    resolveSourceFrameAtFrame(targetFrame) {
+      calls.sourceFrameResolution.push(targetFrame);
+      const source = [...keyframes]
+        .reverse()
+        .find(keyframe => keyframe.frame <= targetFrame);
+      return source?.frame ?? null;
+    },
     resolveKeyframeAtFrame(targetFrame) {
+      calls.keyframeResolution.push(targetFrame);
+      if (options.rejectFullKeyframeResolution) {
+        throw new Error('passive display must not clone the full keyframe payload');
+      }
       const source = [...keyframes]
         .reverse()
         .find(keyframe => keyframe.frame <= targetFrame);
@@ -287,6 +300,16 @@ test('passive display resolves held sources and resends the same source when vie
   assert.equal(harness.calls.present.at(-1).storeRevision, 5);
 });
 
+test('passive display resolves only the source frame without cloning held scene payloads', async () => {
+  const harness = createHarness({ rejectFullKeyframeResolution: true });
+  await preparePassive(harness);
+
+  assert.equal(await harness.controller.syncDisplayFrame(149), true);
+  assert.equal(harness.calls.present.at(-1)?.sourceFrame, 100);
+  assert.deepEqual(harness.calls.sourceFrameResolution, [149, 149]);
+  assert.deepEqual(harness.calls.keyframeResolution, []);
+});
+
 test('passive display serializes one request and keeps only the newest trailing source', async () => {
   const first = deferred();
   const harness = createHarness({
@@ -320,6 +343,53 @@ test('passive display serializes one request and keeps only the newest trailing 
   assert.equal(await firstResult, false);
   assert.equal(await newestTrailing, true);
   assert.deepEqual(harness.calls.present.map(request => request.sourceFrame), [100, 200]);
+});
+
+test('an unresolved passive presentation times out and releases the newest trailing frame', async () => {
+  const first = deferred();
+  const harness = createHarness({
+    persistenceIpcDeadlineMs: 10,
+    onPresent(request, index) {
+      if (index === 0) return first.promise;
+      return {
+        success: true,
+        accepted: true,
+        presentationRevision: request.presentationRevision,
+        targetFrame: request.targetFrame,
+        sourceFrame: request.sourceFrame
+      };
+    }
+  });
+  await preparePassive(harness);
+
+  const firstResult = harness.controller.syncDisplayFrame(100);
+  const discardedTrailing = harness.controller.syncDisplayFrame(150);
+  const newestTrailing = harness.controller.syncDisplayFrame(200);
+  assert.equal(await discardedTrailing, false);
+  assert.deepEqual(harness.calls.present.map(request => request.targetFrame), [100]);
+
+  const settled = await Promise.race([
+    Promise.all([firstResult, newestTrailing]),
+    new Promise(resolve => setTimeout(() => resolve('test-timeout'), 150))
+  ]);
+  assert.deepEqual(settled, [false, true]);
+  assert.deepEqual(harness.calls.present.map(request => request.targetFrame), [100, 200]);
+
+  await new Promise(resolve => setTimeout(resolve, 30));
+  assert.equal(harness.calls.present.length, 2, 'a timed-out request must not start a retry loop');
+
+  const firstRequest = harness.calls.present[0];
+  first.resolve({
+    success: true,
+    accepted: true,
+    presentationRevision: firstRequest.presentationRevision,
+    targetFrame: firstRequest.targetFrame,
+    sourceFrame: firstRequest.sourceFrame
+  });
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(await harness.controller.syncDisplayFrame(100), true);
+  assert.deepEqual(harness.calls.present.map(request => request.targetFrame), [100, 200, 100]);
 });
 
 test('seeking A to B and back to in-flight A replaces the stale B trailing request', async () => {

--- a/scripts/tests/fabric-drawing-pilot-display-controller.test.js
+++ b/scripts/tests/fabric-drawing-pilot-display-controller.test.js
@@ -657,6 +657,49 @@ test('pointerdown handshake confirms the current renderer frame and drops a stal
   });
 });
 
+test('B-on activation samples the live frame after a delayed input acknowledgement', async () => {
+  const enableGate = deferred();
+  const harness = createHarness({
+    context: { targetFrame: 10 },
+    onInput(request) {
+      if (request.enabled === true) return enableGate.promise;
+      return { success: true, accepted: true, enabled: false };
+    }
+  });
+  await preparePassive(harness);
+
+  const enabling = harness.controller.toggle();
+  await new Promise(resolve => setImmediate(resolve));
+  const enableRequest = harness.calls.input.at(-1);
+  assert.equal(enableRequest.enabled, true);
+
+  harness.setWallTime(200);
+  harness.setContext({ targetFrame: 20 });
+  assert.equal(await harness.controller.syncDisplayFrame(20), false);
+
+  enableGate.resolve({ success: true, accepted: true, enabled: true });
+  assert.equal(await enabling, true);
+  assert.deepEqual(
+    harness.calls.frame.map(request => request.targetFrame),
+    [20],
+    'the accepted runtime session must immediately preview the live frame'
+  );
+
+  const pointerdown = {
+    hostGeneration: enableRequest.hostGeneration,
+    videoGeneration: enableRequest.videoGeneration,
+    inputRevision: enableRequest.inputRevision,
+    sessionId: enableRequest.session.sessionId,
+    pointerdownId: 'pointerdown-after-delayed-enable',
+    pointerdownAt: 200
+  };
+  assert.equal(await harness.emitPointerdownFrame(pointerdown), true);
+  assert.deepEqual(harness.calls.pointerdownConfirm.at(-1), {
+    ...pointerdown,
+    targetFrame: 20
+  });
+});
+
 for (const failure of ['rejected', 'timeout', 'throw']) {
   test(`pointerdown ${failure} sends a fenced negative acknowledgement`, async () => {
     const harness = createHarness({

--- a/scripts/tests/fabric-drawing-pilot-integration.test.js
+++ b/scripts/tests/fabric-drawing-pilot-integration.test.js
@@ -12,6 +12,10 @@ const controllerPath = path.join(
   rootDir,
   'renderer/scripts/modules/fabric-drawing-pilot-controller.js'
 );
+const persistenceStorePath = path.join(
+  rootDir,
+  'renderer/scripts/modules/fabric-drawing-persistence-store.js'
+);
 const diagnosticsRunnerPath = path.join(rootDir, 'scripts/run-fabric-drawing-pilot-diagnostics.js');
 const {
   createFabricOverlayRuntime
@@ -24,9 +28,13 @@ const { validateDiagnostics, runCli } = require('../run-fabric-drawing-pilot-dia
 const appPackage = require('../../package.json');
 
 let createFabricDrawingPilotController;
+let createFabricDrawingPersistenceStore;
 
 before(async () => {
   ({ createFabricDrawingPilotController } = await import(pathToFileURL(controllerPath).href));
+  ({ createFabricDrawingPersistenceStore } = await import(
+    pathToFileURL(persistenceStorePath).href
+  ));
 });
 
 class FakeElement {
@@ -313,7 +321,8 @@ function createRuntimeControllerHarness(runtimeOptions = {}) {
     timelineMutation: 0,
     input: 0,
     tool: 0,
-    action: 0
+    action: 0,
+    frame: 0
   };
   const playbackCanaries = {
     owner: { identity: 'mpv-playback-owner-1' },
@@ -350,6 +359,14 @@ function createRuntimeControllerHarness(runtimeOptions = {}) {
         success: result.accepted === true,
         accepted: result.accepted === true,
         tool: result.tool
+      };
+    },
+    async mpvUpdateOverlayDrawingFrame(request) {
+      ledger.frame += 1;
+      const result = runtime.updateDrawingFrame(request);
+      return {
+        success: result.accepted === true,
+        ...result
       };
     },
     async mpvApplyOverlayDrawingAction(request) {
@@ -394,6 +411,253 @@ function createRuntimeControllerHarness(runtimeOptions = {}) {
     playbackCanaries,
     root,
     runtime
+  };
+}
+
+function makePassivePlaybackRecord(id, color) {
+  return {
+    id,
+    type: 'stroke',
+    pathData: 'M 0 0 Q 5 10 10 10 Z',
+    sourcePoints: [
+      { x: 0, y: 0, pressure: 0.25, time: 0, pointerType: 'pen' },
+      { x: 10, y: 10, pressure: 0.75, time: 8, pointerType: 'pen' }
+    ],
+    strokeCaps: { start: true, end: true },
+    style: { color, size: 7.5, opacity: 0.65 },
+    transform: {
+      left: 0,
+      top: 0,
+      scaleX: 1,
+      scaleY: 1,
+      angle: 0,
+      skewX: 0,
+      skewY: 0,
+      flipX: false,
+      flipY: false
+    }
+  };
+}
+
+function createPassivePlaybackIntegrationHarness() {
+  FakeCanvas.instances = [];
+  const events = [];
+  const windows = [];
+  const inputRequests = [];
+  const presentationRequests = [];
+  const presentationResponses = [];
+  const bundleSource = '/* bounded passive playback integration bundle */';
+  const stableVideoIdentity = 'C:/shots/passive-playback.mov';
+  const documentRef = new FakeDocument();
+  const root = documentRef.createElement('div');
+  const runtime = createFabricOverlayRuntime({
+    fabric: { Canvas: FakeCanvas, Path: FakePath },
+    document: documentRef,
+    now: () => 1
+  });
+  const persistenceStore = createFabricDrawingPersistenceStore({
+    createId: (() => {
+      let id = 0;
+      return (prefix) => `${prefix}-passive-${++id}`;
+    })()
+  });
+  const imported = persistenceStore.importRootValue({
+    storageSchema: 'baeframe-fabric-scenes',
+    storageVersion: '1.0.0',
+    engine: 'fabric-7',
+    documentId: 'passive-playback-document',
+    revision: 7,
+    fps: 24,
+    totalFrames: 240,
+    keyframes: [
+      {
+        id: 'keyframe-100',
+        frame: 100,
+        sourceWidth: 1920,
+        sourceHeight: 1080,
+        mutationSequence: 1,
+        objects: [makePassivePlaybackRecord('A', '#ff4757')]
+      },
+      {
+        id: 'keyframe-150-empty',
+        frame: 150,
+        sourceWidth: 1920,
+        sourceHeight: 1080,
+        mutationSequence: 2,
+        objects: []
+      },
+      {
+        id: 'keyframe-200',
+        frame: 200,
+        sourceWidth: 1920,
+        sourceHeight: 1080,
+        mutationSequence: 3,
+        objects: [makePassivePlaybackRecord('B', '#2ed573')]
+      }
+    ]
+  }, {
+    fps: 24,
+    totalFrames: 240,
+    stableVideoIdentity
+  });
+  assert.equal(imported.accepted, true);
+  assert.equal(imported.compatible, true);
+
+  const fakeMainWindow = {
+    isDestroyed: () => false,
+    isMinimized: () => false,
+    getContentBounds: () => ({ x: 100, y: 80, width: 1200, height: 800 }),
+    on() {},
+    off() {},
+    webContents: {
+      isDestroyed: () => false,
+      send() {}
+    }
+  };
+
+  class FakeBrowserWindow {
+    constructor(options) {
+      this.options = options;
+      this.destroyed = false;
+      this.listeners = new Map();
+      this.webContentsListeners = new Map();
+      this.webContents = {
+        on: (eventName, handler) => {
+          this.webContentsListeners.set(eventName, handler);
+        },
+        executeJavaScript: async (script) => {
+          if (script.includes('__mpvFabricOverlayBootstrap')) return true;
+          if (script.includes("typeof window.__applyMpvOverlayState === 'function'")) {
+            return true;
+          }
+          if (script === bundleSource) return true;
+          if (script.includes(".prepare(document.getElementById('root'))")) {
+            return runtime.prepare(root);
+          }
+          const methodMatch = script.match(
+            /^window\.__mpvFabricOverlay\.([A-Za-z0-9]+)\((.*)\);$/
+          );
+          if (!methodMatch) return undefined;
+          const [, methodName, argument] = methodMatch;
+          const method = runtime[methodName];
+          if (typeof method !== 'function') return undefined;
+          return argument ? method(JSON.parse(argument)) : method();
+        },
+        invalidate: () => events.push(['invalidate'])
+      };
+      windows.push(this);
+      events.push(['construct']);
+    }
+
+    loadURL() {
+      events.push(['loadURL']);
+      return Promise.resolve();
+    }
+
+    setBounds() {
+      events.push(['setBounds']);
+    }
+
+    setIgnoreMouseEvents(value) {
+      events.push(['setIgnoreMouseEvents', value]);
+    }
+
+    setFocusable(value) {
+      events.push(['setFocusable', value]);
+    }
+
+    showInactive() {
+      events.push(['show']);
+    }
+
+    hide() {
+      events.push(['hide']);
+    }
+
+    moveTop() {
+      events.push(['moveTop']);
+    }
+
+    isDestroyed() {
+      return this.destroyed;
+    }
+
+    on(eventName, handler) {
+      this.listeners.set(eventName, handler);
+    }
+
+    destroy() {
+      this.destroyed = true;
+      events.push(['destroy']);
+    }
+  }
+
+  const host = new MPVOverlayHost({
+    BrowserWindow: FakeBrowserWindow,
+    getMainWindow: () => fakeMainWindow,
+    fabricBundlePath: 'fixed/passive-playback-bundle.js',
+    readFile: async () => bundleSource
+  });
+  const context = {
+    isMpvActive: true,
+    isAudio: false,
+    stableVideoIdentity,
+    targetFrame: 99,
+    sourceWidth: 1920,
+    sourceHeight: 1080,
+    canvasRect: { left: 0, top: 0, width: 960, height: 540 },
+    viewportRevision: 1,
+    viewportTransform: { scale: 1, panX: 0, panY: 0 },
+    fps: 24,
+    totalFrames: 240
+  };
+  const electronAPI = {
+    async getFabricDrawingPilotState() {
+      return true;
+    },
+    onFabricDrawingPersistenceEvent() {
+      return () => {};
+    },
+    async mpvSetOverlayDrawingInput(request) {
+      inputRequests.push(structuredClone(request));
+      return host.setDrawingInput(request);
+    },
+    async mpvHydrateOverlayDrawingVideo(request) {
+      return host.hydrateDrawingVideo(request);
+    },
+    async mpvExportOverlayDrawingVideo(request) {
+      return host.exportDrawingVideo(request);
+    },
+    async mpvPresentOverlayDrawingFrame(request) {
+      presentationRequests.push(structuredClone(request));
+      const response = await host.presentDrawingFrame(request);
+      presentationResponses.push(structuredClone(response));
+      return response;
+    }
+  };
+  const controller = createFabricDrawingPilotController({
+    electronAPI,
+    getContext: () => context,
+    persistenceStore,
+    persistenceSessionIdFactory: () => 'passive-playback-persistence-session',
+    uuid: (() => {
+      let id = 0;
+      return () => `passive-playback-${++id}`;
+    })()
+  });
+
+  return {
+    controller,
+    events,
+    host,
+    inputRequests,
+    objectIds: () => (
+      FakeCanvas.instances.at(-1)?.getObjects().map(object => object.__baeframeObjectId) || []
+    ),
+    presentationRequests,
+    presentationResponses,
+    runtime,
+    windows
   };
 }
 
@@ -719,6 +983,104 @@ test('controller history shortcuts round-trip a real Fabric stroke without persi
   assert.equal(harness.runtime.getDiagnostics().lastError, null);
 });
 
+test('passive playback without enabling B presents held and empty keyframes through controller host and runtime', async () => {
+  const harness = createPassivePlaybackIntegrationHarness();
+  const ensured = await harness.host.ensure({ x: 0, y: 0, width: 960, height: 540 });
+  assert.equal(ensured.success, true);
+  assert.equal(ensured.drawingCapability.passiveReady, true);
+
+  assert.equal(await harness.controller.initialize(), true);
+  assert.equal(
+    await harness.controller.adoptOverlayCapability(ensured.drawingCapability),
+    true
+  );
+  assert.equal(
+    await harness.controller.afterVideoReady({ loadToken: 'passive-playback-load' }),
+    true
+  );
+  assert.equal(harness.controller.getState(), 'passive');
+  const invalidationsBeforePlayback = harness.events.filter(
+    ([name]) => name === 'invalidate'
+  ).length;
+  const moveTopBeforePlayback = harness.events.filter(
+    ([name]) => name === 'moveTop'
+  ).length;
+  const eventIndexBeforePlayback = harness.events.length;
+
+  const forwardFrames = [99, 100, 149, 150, 199, 200];
+  const forwardObjectIds = [];
+  for (const frame of forwardFrames) {
+    assert.equal(
+      await harness.controller.syncDisplayFrame(frame),
+      true,
+      JSON.stringify(harness.presentationResponses.at(-1))
+    );
+    forwardObjectIds.push(harness.objectIds());
+  }
+  assert.deepEqual(forwardObjectIds, [[], ['A'], ['A'], [], [], ['B']]);
+
+  const reverseFrames = [199, 149, 99];
+  const reverseObjectIds = [];
+  for (const frame of reverseFrames) {
+    assert.equal(await harness.controller.syncDisplayFrame(frame), true);
+    reverseObjectIds.push(harness.objectIds());
+  }
+  assert.deepEqual(
+    [...forwardObjectIds, ...reverseObjectIds],
+    [[], ['A'], ['A'], [], [], ['B'], [], ['A'], []]
+  );
+  const expectedPresentedFrames = [
+    { targetFrame: 99, sourceFrame: null },
+    { targetFrame: 100, sourceFrame: 100 },
+    { targetFrame: 150, sourceFrame: 150 },
+    { targetFrame: 200, sourceFrame: 200 },
+    { targetFrame: 199, sourceFrame: 150 },
+    { targetFrame: 149, sourceFrame: 100 },
+    { targetFrame: 99, sourceFrame: null }
+  ];
+  assert.deepEqual(
+    harness.presentationRequests.map(request => ({
+      targetFrame: request.targetFrame,
+      sourceFrame: request.sourceFrame
+    })),
+    expectedPresentedFrames,
+    'same-source holds at 149 and 199 are controller-deduped without changing the canvas'
+  );
+
+  assert.equal(
+    harness.inputRequests.filter(request => request.enabled === true).length,
+    0,
+    'passive playback must never request B/input enable'
+  );
+  assert.equal(harness.inputRequests.every(request => request.enabled === false), true);
+  assert.equal(harness.controller.getState(), 'passive');
+  assert.equal(harness.runtime.getDiagnostics().state, 'passive');
+  assert.equal(harness.runtime.getDiagnostics().inputEnabled, false);
+  assert.equal(harness.windows.length, 1);
+  assert.equal(
+    harness.events.filter(([name]) => name === 'moveTop').length - moveTopBeforePlayback,
+    expectedPresentedFrames.length,
+    'each accepted passive frame is restacked above the sibling video host'
+  );
+  assert.equal(
+    harness.events.filter(([name]) => name === 'invalidate').length -
+      invalidationsBeforePlayback,
+    expectedPresentedFrames.length,
+    'each accepted host presentation invalidates exactly one frame'
+  );
+  assert.deepEqual(
+    harness.events
+      .slice(eventIndexBeforePlayback)
+      .filter(([name]) => name === 'moveTop' || name === 'invalidate')
+      .map(([name]) => name),
+    Array.from(
+      { length: expectedPresentedFrames.length },
+      () => ['moveTop', 'invalidate']
+    ).flat(),
+    'the host restacks before invalidating every accepted passive frame'
+  );
+});
+
 test('synthetic controller/runtime boundary restores native stack order and preserves all other canaries', async (t) => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'baeframe-fabric-drawing-'));
   t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
@@ -887,6 +1249,7 @@ test('synthetic controller/runtime boundary restores native stack order and pres
   });
   assert.equal(harness.ledger.input, 101, 'one setup disable plus exactly 100 controller toggles');
   assert.equal(harness.ledger.tool, 1, 'V crosses the real controller/runtime bridge once');
+  assert.equal(harness.ledger.frame, 0, 'Delete must not force a preview that clears selection');
   assert.equal(harness.ledger.action, 1, 'Delete crosses the real controller/runtime bridge once');
   assert.equal(
     runtimeMutationEvidence >= 4,
@@ -1259,7 +1622,7 @@ test('CLI reads raw JSON, emits only the bounded summary, and exits 1 for violat
 test('package exposes focused Fabric pilot test and diagnostics commands', () => {
   assert.equal(
     appPackage.scripts['test:fabric-drawing-pilot'],
-    'node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test scripts/tests/fabric-drawing-pilot-integration.test.js scripts/tests/fabric-drawing-pilot-benchmark.test.mjs scripts/tests/fabric-drawing-pilot-session.test.js scripts/tests/fabric-drawing-pilot-shortcuts.test.js scripts/tests/fabric-drawing-pilot-source.test.js scripts/tests/fabric-drawing-persistence-controller.test.js scripts/tests/mpv-fabric-overlay-runtime.test.js'
+    'node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test scripts/tests/fabric-drawing-pilot-integration.test.js scripts/tests/fabric-drawing-pilot-benchmark.test.mjs scripts/tests/fabric-drawing-pilot-session.test.js scripts/tests/fabric-drawing-pilot-shortcuts.test.js scripts/tests/fabric-drawing-pilot-source.test.js scripts/tests/fabric-drawing-pilot-display-controller.test.js scripts/tests/fabric-drawing-persistence-controller.test.js scripts/tests/mpv-fabric-overlay-runtime.test.js'
   );
   assert.equal(
     appPackage.scripts['test:fabric-drawing-persistence'],

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -314,7 +314,7 @@ test('Fabric 툴바 표시는 페이드 없이 한 프레임에 완성된다', (
   assert.equal(iifeSource.includes('opacity 100ms ease'), false);
 });
 
-test('파일럿 드로잉은 타임라인에 읽기 전용으로 투영된다', () => {
+test('파일럿 드로잉은 타임라인에 이동 가능한 합성 행으로 투영된다', () => {
   assert.match(appSource, /function getFabricPilotTimelineLayers\(\)/);
   assert.match(appSource, /function renderActiveDrawingLayers\(\)/);
   assert.match(appSource, /fabricDrawingPersistenceStore\.subscribe\(\(\) => \{/);
@@ -328,11 +328,9 @@ test('파일럿 드로잉은 타임라인에 읽기 전용으로 투영된다', 
     appSource,
     /scheduleMpvOverlayStateSync\(\{ force: true \}\);\n\s+renderActiveDrawingLayers\(\);\n\s+if \(!engaged && !wasEngaged\) \{/
   );
-  // 투영 레이어 드래그·삭제 차단
-  assert.match(
-    appSource,
-    /keyframesMove', \(e\) => \{[\s\S]{0,400}?if \(getFabricPilotTimelineLayers\(\)\) return;/
-  );
+  // 투영 레이어 드래그는 Fabric store 경로로 보내고, 삭제 보호는 유지한다.
+  assert.match(appSource, /async function moveFabricPilotKeyframes\(/);
+  assert.match(appSource, /async function handleTimelineKeyframesMove\(/);
   assert.match(
     appSource,
     /function deleteSelectedOrCurrentKeyframes\(\) \{[\s\S]{0,400}?if \(getFabricPilotTimelineLayers\(\)\) return false;/
@@ -612,7 +610,7 @@ test('집계 타임라인에서는 현재 영상의 로컬 드로잉 투영을 �
   assert.equal(getProjection(), null);
 });
 
-test('파일럿 투영 범위는 저장된 장면의 단일 프레임만 표시한다', () => {
+test('파일럿 투영 범위는 다음 exact 키프레임 직전과 영상 꼬리까지 hold한다', () => {
   const projectionSource = appSource.match(
     /function getFabricPilotTimelineLayers\(\) \{[\s\S]*?\n  \}\n\n  let lastFabricPilotTimeline/
   )?.[0]?.replace(/\n\n  let lastFabricPilotTimeline$/, '');
@@ -634,7 +632,7 @@ test('파일럿 투영 범위는 저장된 장면의 단일 프레임만 표시�
       getHydrationDocument: () => ({
         keyframes: [
           { frame: 10, objects: [{}] },
-          { frame: 20, objects: [{}] }
+          { frame: 20, objects: [] }
         ]
       })
     },
@@ -653,9 +651,527 @@ test('파일럿 투영 범위는 저장된 장면의 단일 프레임만 표시�
   assert.deepEqual(
     layer.getKeyframeRanges(100).map(range => ({ start: range.start, end: range.end })),
     [
-      { start: 10, end: 10 },
-      { start: 20, end: 20 }
+      { start: 10, end: 19 },
+      { start: 20, end: 99 }
     ]
+  );
+  assert.equal(layer.keyframes[0].isEmpty, false);
+  assert.equal(layer.keyframes[1].isEmpty, true);
+  assert.equal(layer.locked, true);
+  assert.equal(layer.timelineKeyframesMovable, true);
+});
+
+test('Fabric 키프레임 이동은 controller refresh 안에서 store만 바꾸고 선택과 전역 undo를 갱신한다', async () => {
+  const moveSource = appSource.match(
+    /async function moveFabricPilotKeyframes\(keyframes, frameDelta, anchor\) \{[\s\S]*?\n  \}\n\n  async function handleTimelineKeyframesMove/
+  )?.[0]?.replace(/\n\n  async function handleTimelineKeyframesMove$/, '');
+  assert.ok(moveSource, 'Fabric keyframe move source should be extractable');
+
+  const edit = {
+    schema: 'baeframe-fabric-keyframe-edit',
+    kind: 'move-keyframes',
+    documentId: 'app-move-document',
+    before: [{ frame: 10, keyframe: { frame: 10 } }, { frame: 20, keyframe: null }],
+    after: [{ frame: 10, keyframe: null }, { frame: 20, keyframe: { frame: 20 } }]
+  };
+  let holdRefresh = true;
+  let failRefreshTail = false;
+  let releaseRefresh;
+  const heldRefresh = new Promise(resolve => {
+    releaseRefresh = resolve;
+  });
+  const storeCalls = [];
+  let applyAccepted = true;
+  let currentDocumentId = edit.documentId;
+  const store = {
+    moveKeyframes(moves) {
+      storeCalls.push(['move', moves]);
+      return { applied: true, revision: 5, edit };
+    },
+    applyKeyframeEdit(receivedEdit, direction) {
+      storeCalls.push(['history', receivedEdit, direction]);
+      return applyAccepted
+        ? { applied: true, revision: direction === 'undo' ? 6 : 7 }
+        : { applied: false, reason: 'edit-state-mismatch' };
+    },
+    getHydrationDocument: () => currentDocumentId
+      ? { documentId: currentDocumentId }
+      : null
+  };
+  const controller = {
+    async refreshPersistenceSource(installSource) {
+      if (holdRefresh) {
+        await heldRefresh;
+        return false;
+      }
+      const installed = (await installSource()) !== false;
+      return failRefreshTail ? false : installed;
+    }
+  };
+  const selections = [];
+  const timelineHarness = {
+    setKeyframeSelection(selection, options) {
+      selections.push({ selection, options });
+    }
+  };
+  const toasts = [];
+  const warnings = [];
+  const displaySyncs = [];
+  const actions = [];
+  let renders = 0;
+  const moveFabricPilotKeyframes = new Function(
+    'fabricDrawingPilotController',
+    'fabricDrawingPersistenceStore',
+    'timeline',
+    'renderActiveDrawingLayers',
+    'showToast',
+    'pushUndo',
+    'fabricPilotKeyframeMoveInProgress',
+    '_isProcessingUndo',
+    'beginGlobalHistoryMutation',
+    'syncCurrentFabricDrawingDisplayFrame',
+    'log',
+    `${moveSource}\nreturn moveFabricPilotKeyframes;`
+  )(
+    controller,
+    store,
+    timelineHarness,
+    () => { renders += 1; },
+    (message, level) => toasts.push([message, level]),
+    action => actions.push(action),
+    false,
+    false,
+    () => ({
+      commit: action => {
+        actions.push(action);
+        return true;
+      },
+      release() {}
+    }),
+    options => displaySyncs.push(options),
+    { warn: (...args) => warnings.push(args) }
+  );
+  const keyframes = [{
+    layerId: 'fabric-pilot-drawing-layer',
+    fromFrame: 10,
+    toFrame: 20
+  }];
+  const anchor = { layerId: 'fabric-pilot-drawing-layer', frame: 20 };
+
+  const heldMove = moveFabricPilotKeyframes(keyframes, 10, anchor);
+  assert.equal(await moveFabricPilotKeyframes(keyframes, 10, anchor), false);
+  holdRefresh = false;
+  releaseRefresh();
+  assert.equal(await heldMove, false);
+
+  // installSource/store commit 이후 host re-enable tail만 실패해도 canonical move는 성공이다.
+  failRefreshTail = true;
+  assert.equal(await moveFabricPilotKeyframes(keyframes, 10, anchor), true);
+  assert.deepEqual(storeCalls[0], ['move', [{ fromFrame: 10, toFrame: 20 }]]);
+  assert.deepEqual(selections[0], {
+    selection: [{ layerId: 'fabric-pilot-drawing-layer', frame: 20 }],
+    options: { anchor }
+  });
+  assert.equal(renders, 1);
+  assert.deepEqual(toasts, [['키프레임 +10 프레임 이동', 'info']]);
+  assert.equal(actions.length, 1);
+  assert.equal(actions[0].type, 'FABRIC_KEYFRAME_MOVE');
+  assert.equal(warnings.length, 1);
+  assert.deepEqual(displaySyncs, [{ force: true }]);
+
+  // undo도 store commit 이후 refresh tail 실패 때문에 global history가 되감기면 안 된다.
+  await actions[0].undo();
+  assert.equal(warnings.length, 2);
+  assert.deepEqual(displaySyncs, [{ force: true }, { force: true }]);
+  failRefreshTail = false;
+  await actions[0].redo();
+  assert.deepEqual(storeCalls.slice(1).map(call => call[2]), ['undo', 'redo']);
+
+  applyAccepted = false;
+  await assert.rejects(actions[0].undo(), /Fabric keyframe move undo failed/);
+
+  currentDocumentId = null;
+  const actionCountBeforeOwnerLoss = actions.length;
+  assert.equal(await moveFabricPilotKeyframes(keyframes, 10, anchor), false);
+  assert.equal(actions.length, actionCountBeforeOwnerLoss);
+
+  // history edit가 old owner에 적용된 직후 source가 바뀌면 stack 이동은 성공하되
+  // old selection/render를 새 문서에 덮어쓰지 않는다.
+  applyAccepted = true;
+  const selectionCountBeforeHistoryOwnerLoss = selections.length;
+  const renderCountBeforeHistoryOwnerLoss = renders;
+  assert.equal(await actions[0].undo(), true);
+  assert.equal(selections.length, selectionCountBeforeHistoryOwnerLoss);
+  assert.equal(renders, renderCountBeforeHistoryOwnerLoss);
+});
+
+test('Fabric 이동 tail 중 추가된 후속 action은 이동 뒤에 순서대로 Undo된다', async () => {
+  const historyBlock = appSource.match(
+    /  \/\/ ====== 글로벌 Undo\/Redo 시스템 ======\n([\s\S]*?)\n  \/\/ 마커 컨테이너 생성/
+  )?.[1];
+  const moveSource = appSource.match(
+    /async function moveFabricPilotKeyframes\(keyframes, frameDelta, anchor\) \{[\s\S]*?\n  \}\n\n  async function handleTimelineKeyframesMove/
+  )?.[0]?.replace(/\n\n  async function handleTimelineKeyframesMove$/, '');
+  assert.ok(historyBlock, 'global history block should be extractable');
+  assert.ok(moveSource, 'Fabric keyframe move source should be extractable');
+
+  const deferred = () => {
+    let resolve;
+    const promise = new Promise(resolvePromise => { resolve = resolvePromise; });
+    return { promise, resolve };
+  };
+  const committed = deferred();
+  const refreshTail = deferred();
+  const ownerLossCommitted = deferred();
+  const ownerLossRefreshTail = deferred();
+  let refreshCount = 0;
+  const edit = {
+    schema: 'baeframe-fabric-keyframe-edit',
+    kind: 'move-keyframes',
+    documentId: 'atomic-move-document'
+  };
+  const storeCalls = [];
+  let currentDocumentId = edit.documentId;
+  const store = {
+    moveKeyframes(moves) {
+      storeCalls.push(['move', moves]);
+      return { applied: true, edit };
+    },
+    applyKeyframeEdit(receivedEdit, direction) {
+      storeCalls.push(['history', receivedEdit, direction]);
+      return { applied: true };
+    },
+    getHydrationDocument: () => currentDocumentId
+      ? { documentId: currentDocumentId }
+      : null
+  };
+  const controller = {
+    async refreshPersistenceSource(installSource) {
+      refreshCount += 1;
+      const installed = (await installSource()) !== false;
+      if (refreshCount === 1) {
+        committed.resolve();
+        await refreshTail.promise;
+      } else if (refreshCount === 3) {
+        ownerLossCommitted.resolve();
+        await ownerLossRefreshTail.promise;
+      }
+      return installed;
+    }
+  };
+  const createHarness = new Function(
+    'drawingManager',
+    'log',
+    'showToast',
+    'fabricDrawingPilotController',
+    'fabricDrawingPersistenceStore',
+    'timeline',
+    'renderActiveDrawingLayers',
+    'fabricPilotKeyframeMoveInProgress',
+    'syncCurrentFabricDrawingDisplayFrame',
+    `${historyBlock}\n${moveSource}\nreturn {
+      pushUndo,
+      globalUndo,
+      moveFabricPilotKeyframes,
+      getUndoStack: () => [...undoStack],
+      getRedoStack: () => [...redoStack]
+    };`
+  );
+  const harness = createHarness(
+    { _createSnapshot() {}, _restoreSnapshot() {}, _emit() {} },
+    { error() {}, warn() {} },
+    () => {},
+    controller,
+    store,
+    { setKeyframeSelection() {} },
+    () => {},
+    false,
+    () => {}
+  );
+  let previousUndoCount = 0;
+  const previousAction = {
+    type: 'PREVIOUS_ACTION',
+    undo: async () => { previousUndoCount += 1; },
+    redo: async () => {}
+  };
+  harness.pushUndo(previousAction);
+
+  const keyframes = [{
+    layerId: 'fabric-pilot-drawing-layer',
+    fromFrame: 10,
+    toFrame: 20
+  }];
+  const move = harness.moveFabricPilotKeyframes(
+    keyframes,
+    10,
+    { layerId: 'fabric-pilot-drawing-layer', frame: 20 }
+  );
+  await committed.promise;
+
+  let laterUndoCount = 0;
+  const laterAction = {
+    type: 'LATER_EXTERNAL_ACTION',
+    undo: async () => { laterUndoCount += 1; },
+    redo: async () => {}
+  };
+  harness.pushUndo(laterAction);
+
+  let undoSettled = false;
+  const undoDuringRefreshTail = harness.globalUndo().then(result => {
+    undoSettled = true;
+    return result;
+  });
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(undoSettled, false, 'Undo must wait until the committed move owns a history action');
+  assert.equal(previousUndoCount, 0, 'the prior action must stay untouched during the move tail');
+
+  refreshTail.resolve();
+  assert.equal(await move, true);
+  assert.equal(await undoDuringRefreshTail, true);
+  assert.equal(previousUndoCount, 0);
+  assert.equal(laterUndoCount, 1, 'the later external action must be undone before the move');
+  assert.deepEqual(storeCalls.map(call => [call[0], call[2]]), [
+    ['move', undefined]
+  ]);
+
+  assert.equal(await harness.globalUndo(), true);
+  assert.deepEqual(storeCalls.map(call => [call[0], call[2]]), [
+    ['move', undefined],
+    ['history', 'undo']
+  ]);
+  assert.deepEqual(harness.getUndoStack(), [previousAction]);
+  assert.deepEqual(
+    harness.getRedoStack().map(action => action.type),
+    ['LATER_EXTERNAL_ACTION', 'FABRIC_KEYFRAME_MOVE']
+  );
+
+  currentDocumentId = null;
+  let ownerLossExternalUndoCount = 0;
+  const ownerLossMove = harness.moveFabricPilotKeyframes(
+    keyframes,
+    10,
+    { layerId: 'fabric-pilot-drawing-layer', frame: 20 }
+  );
+  await ownerLossCommitted.promise;
+  const ownerLossExternalAction = {
+    type: 'OWNER_LOSS_EXTERNAL_ACTION',
+    undo: async () => { ownerLossExternalUndoCount += 1; },
+    redo: async () => {}
+  };
+  harness.pushUndo(ownerLossExternalAction);
+  const undoAfterOwnerLoss = harness.globalUndo();
+  ownerLossRefreshTail.resolve();
+
+  assert.equal(await ownerLossMove, false);
+  assert.equal(await undoAfterOwnerLoss, true);
+  assert.equal(ownerLossExternalUndoCount, 1);
+  assert.deepEqual(harness.getUndoStack(), [previousAction]);
+  assert.deepEqual(
+    harness.getRedoStack().map(action => action.type),
+    ['OWNER_LOSS_EXTERNAL_ACTION']
+  );
+});
+
+test('전역 Undo가 진행 중이면 Fabric 이동은 store를 commit하지 않고 기존 action을 보존한다', async () => {
+  const historyBlock = appSource.match(
+    /  \/\/ ====== 글로벌 Undo\/Redo 시스템 ======\n([\s\S]*?)\n  \/\/ 마커 컨테이너 생성/
+  )?.[1];
+  const moveSource = appSource.match(
+    /async function moveFabricPilotKeyframes\(keyframes, frameDelta, anchor\) \{[\s\S]*?\n  \}\n\n  async function handleTimelineKeyframesMove/
+  )?.[0]?.replace(/\n\n  async function handleTimelineKeyframesMove$/, '');
+  assert.ok(historyBlock, 'global history block should be extractable');
+  assert.ok(moveSource, 'Fabric keyframe move source should be extractable');
+
+  let rejectUndo;
+  let notifyUndoStarted;
+  const undoStarted = new Promise(resolve => { notifyUndoStarted = resolve; });
+  const heldUndo = new Promise((_resolve, reject) => { rejectUndo = reject; });
+  const edit = {
+    schema: 'baeframe-fabric-keyframe-edit',
+    kind: 'move-keyframes',
+    documentId: 'inverse-race-document'
+  };
+  const storeCalls = [];
+  const store = {
+    moveKeyframes(moves) {
+      storeCalls.push(['move', moves]);
+      return { applied: true, edit };
+    },
+    applyKeyframeEdit() {
+      storeCalls.push(['history']);
+      return { applied: true };
+    },
+    getHydrationDocument: () => ({ documentId: edit.documentId })
+  };
+  const createHarness = new Function(
+    'drawingManager',
+    'log',
+    'showToast',
+    'fabricDrawingPilotController',
+    'fabricDrawingPersistenceStore',
+    'timeline',
+    'renderActiveDrawingLayers',
+    'fabricPilotKeyframeMoveInProgress',
+    'syncCurrentFabricDrawingDisplayFrame',
+    `${historyBlock}\n${moveSource}\nreturn {
+      pushUndo,
+      globalUndo,
+      moveFabricPilotKeyframes,
+      getUndoStack: () => [...undoStack],
+      getRedoStack: () => [...redoStack]
+    };`
+  );
+  const harness = createHarness(
+    { _createSnapshot() {}, _restoreSnapshot() {}, _emit() {} },
+    { error() {}, warn() {} },
+    () => {},
+    { refreshPersistenceSource: async installSource => (await installSource()) !== false },
+    store,
+    { setKeyframeSelection() {} },
+    () => {},
+    false,
+    () => {}
+  );
+  const previousAction = {
+    type: 'PREVIOUS_ACTION',
+    undo: () => {
+      notifyUndoStarted();
+      return heldUndo;
+    },
+    redo: async () => {}
+  };
+  harness.pushUndo(previousAction);
+
+  const inFlightUndo = harness.globalUndo();
+  await undoStarted;
+  const moveResult = await harness.moveFabricPilotKeyframes(
+    [{
+      layerId: 'fabric-pilot-drawing-layer',
+      fromFrame: 10,
+      toFrame: 20
+    }],
+    10,
+    { layerId: 'fabric-pilot-drawing-layer', frame: 20 }
+  );
+  rejectUndo(new Error('expected in-flight undo failure'));
+
+  assert.equal(await inFlightUndo, false);
+  assert.equal(moveResult, false);
+  assert.deepEqual(storeCalls, []);
+  assert.deepEqual(harness.getUndoStack(), [previousAction]);
+  assert.deepEqual(harness.getRedoStack(), []);
+});
+
+test('timeline move router sends only the synthetic layer to Fabric and preserves the legacy route', async () => {
+  const handlerSource = appSource.match(
+    /async function handleTimelineKeyframesMove\(detail = \{\}\) \{[\s\S]*?\n  \}\n\n  \/\/ 키프레임 이동\n  timeline\.addEventListener\('keyframesMove'/
+  )?.[0]?.replace(/\n\n  \/\/ 키프레임 이동\n  timeline\.addEventListener\('keyframesMove'$/, '');
+  assert.ok(handlerSource, 'timeline keyframe move handler should be extractable');
+
+  const routes = [];
+  const selections = [];
+  const warnings = [];
+  const handler = new Function(
+    'classifyFabricPilotKeyframeMove',
+    'moveFabricPilotKeyframes',
+    'drawingManager',
+    'timeline',
+    'renderActiveDrawingLayers',
+    'showToast',
+    'log',
+    `${handlerSource}\nreturn handleTimelineKeyframesMove;`
+  )(
+    keyframes => {
+      const fabricCount = keyframes.filter(
+        keyframe => keyframe.layerId === 'fabric-pilot-drawing-layer'
+      ).length;
+      if (fabricCount === 0) return 'legacy';
+      return fabricCount === keyframes.length ? 'fabric' : 'mixed';
+    },
+    async (...args) => {
+      routes.push(['fabric', ...args]);
+      return true;
+    },
+    {
+      moveKeyframes(keyframes) {
+        routes.push(['legacy', keyframes]);
+        return true;
+      }
+    },
+    {
+      setKeyframeSelection(selection, options) {
+        selections.push({ selection, options });
+      }
+    },
+    () => routes.push(['render']),
+    (message, level) => routes.push(['toast', message, level]),
+    { warn: (...args) => warnings.push(args) }
+  );
+
+  const fabricMove = [{
+    layerId: 'fabric-pilot-drawing-layer',
+    fromFrame: 10,
+    toFrame: 20
+  }];
+  assert.equal(await handler({ keyframes: fabricMove, frameDelta: 10, anchor: null }), true);
+  assert.equal(routes.some(([route]) => route === 'legacy'), false);
+
+  routes.length = 0;
+  const mixedMove = [
+    fabricMove[0],
+    { layerId: 'legacy-layer', fromFrame: 30, toFrame: 40 }
+  ];
+  assert.equal(await handler({ keyframes: mixedMove, frameDelta: 10, anchor: null }), false);
+  assert.deepEqual(routes, []);
+  assert.equal(warnings.length, 1);
+
+  routes.length = 0;
+  const legacyMove = [{ layerId: 'legacy-layer', fromFrame: 2, toFrame: 4 }];
+  const legacyAnchor = { layerId: 'legacy-layer', frame: 4 };
+  assert.equal(await handler({
+    keyframes: legacyMove,
+    frameDelta: 2,
+    anchor: legacyAnchor
+  }), true);
+  assert.deepEqual(routes[0], ['legacy', legacyMove]);
+  assert.deepEqual(selections.at(-1), {
+    selection: [{ layerId: 'legacy-layer', frame: 4 }],
+    options: { anchor: legacyAnchor }
+  });
+});
+
+test('primary play handler force-syncs the current Fabric display frame exactly once at start', () => {
+  const playHandlerSource = appSource.match(
+    /\/\/ 비디오 재생 상태 변경\n  videoPlayer\.addEventListener\('play', \(\) => \{([\s\S]*?)\n  \}\);\n\n  videoPlayer\.addEventListener\('pause'/
+  )?.[1] || '';
+  assert.ok(playHandlerSource, 'primary video play handler source should be extractable');
+
+  const displaySyncCalls = playHandlerSource.match(
+    /syncCurrentFabricDrawingDisplayFrame\([^;]*\);/g
+  ) || [];
+  assert.equal(displaySyncCalls.length, 1);
+  assert.match(
+    playHandlerSource,
+    /^\s*syncCurrentFabricDrawingDisplayFrame\(\{ force: true \}\);/
+  );
+});
+
+test('playback frame consumers and passive landings request the current Fabric display frame', () => {
+  const playbackSyncSource = appSource.match(
+    /function syncPlaybackPositionUI\(currentTime, currentFrame, options = \{\}\) \{[\s\S]*?\n  \}\n\n  function syncCompositionLayerPlaybackState/
+  )?.[0] || '';
+  assert.match(
+    playbackSyncSource,
+    /if \(shouldSyncFrameConsumers\) \{[\s\S]*?fabricDrawingPilotController\.syncDisplayFrame\(currentFrame\)/
+  );
+  assert.match(
+    appSource,
+    /fabricDrawingPersistenceStore\.subscribe\(\(\) => \{[\s\S]*?syncCurrentFabricDrawingDisplayFrame\(\)/
+  );
+  assert.match(
+    appSource,
+    /function handleFabricDrawingPilotStateChange\(nextState, snapshot\) \{[\s\S]*?if \(nextState === 'passive'\)[\s\S]*?syncCurrentFabricDrawingDisplayFrame\(\)/
   );
 });
 

--- a/scripts/tests/fabric-drawing-scene-observer.test.js
+++ b/scripts/tests/fabric-drawing-scene-observer.test.js
@@ -869,6 +869,9 @@ test('warm source dimension mismatch quarantines only the shadow projection', ()
   });
 
   assert.equal(store.activateSession(session()).accepted, true);
+  // 저장되지 않은 빈 target은 copy-on-write 임시 장면이므로 deactivate 때 폐기된다.
+  // warm signature 계약은 실제 변경으로 materialize된 같은 장면에서 검증한다.
+  assert.equal(store.addStroke(stroke('materialized-before-resize')).applied, true);
   assert.equal(store.deactivateSession('session-a').accepted, true);
   assert.equal(store.activateSession(session({
     sessionId: 'session-resized-source',
@@ -877,7 +880,7 @@ test('warm source dimension mismatch quarantines only the shadow projection', ()
   assert.equal(adapter.getSceneProjection('scene-dimensions'), null);
   assert.equal(adapter.getDiagnostics('scene-dimensions').lastReason, 'seed-signature-changed');
   assert.equal(store.addStroke(stroke('primary-still-works')).applied, true);
-  assert.equal(store.getActiveSceneSnapshot().objects.length, 1);
+  assert.equal(store.getActiveSceneSnapshot().objects.length, 2);
 });
 
 test('a final enqueue exception immediately hides the real shadow without rolling back Fabric', () => {

--- a/scripts/tests/keyframe-drag-ghost-source.test.js
+++ b/scripts/tests/keyframe-drag-ghost-source.test.js
@@ -1,7 +1,8 @@
-const { test } = require('node:test');
+const { before, test } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const { pathToFileURL } = require('node:url');
 
 const rootDir = path.resolve(__dirname, '../..');
 const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
@@ -10,6 +11,14 @@ const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer
 const userSettingsSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/user-settings.js'), 'utf8'));
 const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
 const mainCss = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/styles/main.css'), 'utf8'));
+let Timeline;
+
+before(async () => {
+  ({ Timeline } = await import(pathToFileURL(path.join(
+    rootDir,
+    'renderer/scripts/modules/timeline.js'
+  )).href));
+});
 
 test('keyframe drag ghost renders as an exact one-frame cell', () => {
   assert.match(timelineSource, /keyframe-drag-ghost-cell/);
@@ -38,10 +47,16 @@ test('keyframe drag ghost previews every selected keyframe while dragging', () =
   assert.match(timelineSource, /parseInt\(ghostCell\.dataset\.sourceFrame \|\| '0', 10\) \+ frameDelta/);
   assert.match(timelineSource, /this\.dragSourceElements\.forEach\(element => \{/);
   assert.match(timelineSource, /this\.dragGhostItems\.forEach\(ghost => ghost\.remove\(\)\)/);
-  assert.match(timelineSource, /const keyframesToMove = this\.dragGhostKeyframes\.map\(kf => \(/);
+  assert.match(
+    timelineSource,
+    /const keyframesToMove = this\.dragGhostKeyframes\s*\.filter\(kf => this\._isKeyframeLayerMovable\(kf\.layerId, kf\.frame\)\)\s*\.map\(kf => \(/
+  );
+  const movePayloadIndex = timelineSource.indexOf(
+    'const keyframesToMove = this.dragGhostKeyframes'
+  );
   assert.ok(
-    timelineSource.indexOf('const keyframesToMove = this.dragGhostKeyframes.map') <
-      timelineSource.indexOf('this.dragGhostKeyframes = [];', timelineSource.indexOf('const keyframesToMove = this.dragGhostKeyframes.map')),
+    movePayloadIndex >= 0 &&
+      movePayloadIndex < timelineSource.indexOf('this.dragGhostKeyframes = [];', movePayloadIndex),
     'drag ghost keyframes must be cleared after move payload creation'
   );
 });
@@ -57,11 +72,162 @@ test('keyframe drag ghost clamps group delta before preview and move emit', () =
   assert.match(timelineSource, /this\.dragGhost\.dataset\.targetFrame = targetFrame;/);
 });
 
-test('keyframe drag ghost excludes locked layers from preview, clamp, and move emit', () => {
-  assert.match(timelineSource, /_isKeyframeLayerMovable\(layerId\)/);
-  assert.match(timelineSource, /return keyframes\.filter\(keyframe => this\._isKeyframeLayerMovable\(keyframe\.layerId\)\);/);
-  assert.match(timelineSource, /const layer = this\._lastDrawingLayers\.find\(item => item\.id === layerId\);/);
-  assert.match(timelineSource, /return layer\?\.locked !== true;/);
+test('keyframe drag allows the explicit locked synthetic exception while ordinary locked layers stay blocked', () => {
+  const timeline = Object.create(Timeline.prototype);
+  timeline._lastDrawingLayers = [
+    {
+      id: 'fabric-synthetic',
+      locked: true,
+      timelineKeyframesMovable: true,
+      keyframes: [{ frame: 10 }, { frame: 20 }]
+    },
+    {
+      id: 'ordinary-locked',
+      locked: true,
+      keyframes: [{ frame: 30 }]
+    },
+    {
+      id: 'ordinary-unlocked',
+      locked: false,
+      keyframes: [{ frame: 40 }]
+    }
+  ];
+  timeline.selectedKeyframes = [
+    { layerId: 'fabric-synthetic', frame: 10 },
+    { layerId: 'fabric-synthetic', frame: 20 },
+    { layerId: 'ordinary-locked', frame: 30 },
+    { layerId: 'ordinary-unlocked', frame: 40 }
+  ];
+
+  assert.equal(timeline._isKeyframeLayerMovable('fabric-synthetic', 10), true);
+  assert.equal(timeline._isKeyframeLayerMovable('ordinary-locked', 30), false);
+  assert.deepEqual(timeline._getDragGhostKeyframes('fabric-synthetic', 10), [
+    { layerId: 'fabric-synthetic', frame: 10 },
+    { layerId: 'fabric-synthetic', frame: 20 },
+    { layerId: 'ordinary-unlocked', frame: 40 }
+  ]);
+});
+
+test('keyframe drag payload excludes stale selections outside the current rendered markers', () => {
+  const timeline = Object.create(Timeline.prototype);
+  timeline._lastDrawingLayers = [{
+    id: 'fabric-synthetic',
+    locked: true,
+    timelineKeyframesMovable: true,
+    keyframes: [{ frame: 10 }, { frame: 20 }]
+  }];
+  timeline.selectedKeyframes = [
+    { layerId: 'fabric-synthetic', frame: 10 },
+    { layerId: 'fabric-synthetic', frame: 99 },
+    { layerId: 'stale-layer', frame: 10 }
+  ];
+
+  assert.deepEqual(timeline._getDragGhostKeyframes('fabric-synthetic', 10), [
+    { layerId: 'fabric-synthetic', frame: 10 }
+  ]);
+  assert.equal(timeline._isKeyframeLayerMovable('stale-layer', 10), false);
+  timeline._lastDrawingLayers = null;
+  assert.equal(timeline._isKeyframeLayerMovable('fabric-synthetic', 10), false);
+});
+
+test('keyframe drag finish drops a selection that became stale during the drag', () => {
+  const timeline = Object.create(Timeline.prototype);
+  timeline._lastDrawingLayers = [{
+    id: 'fabric-synthetic',
+    locked: true,
+    timelineKeyframesMovable: true,
+    keyframes: [{ frame: 20 }]
+  }];
+  timeline.draggedKeyframe = { layerId: 'stale-layer', frame: 10 };
+  timeline.dragStartFrame = 10;
+  timeline.dragGhost = {
+    dataset: { targetFrame: '15' },
+    remove() {}
+  };
+  timeline.dragGhostItems = [];
+  timeline.dragSourceElements = [];
+  timeline.dragTooltip = null;
+  timeline.dragGhostKeyframes = [
+    { layerId: 'stale-layer', frame: 10 },
+    { layerId: 'fabric-synthetic', frame: 20 }
+  ];
+  const emitted = [];
+  timeline._emit = (name, detail) => emitted.push({ name, detail });
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  globalThis.document = { body: { style: {} } };
+  globalThis.window = {};
+  try {
+    timeline._finishKeyframeDrag({});
+  } finally {
+    if (previousDocument === undefined) delete globalThis.document;
+    else globalThis.document = previousDocument;
+    if (previousWindow === undefined) delete globalThis.window;
+    else globalThis.window = previousWindow;
+  }
+
+  assert.deepEqual(emitted, [{
+    name: 'keyframesMove',
+    detail: {
+      keyframes: [{
+        layerId: 'fabric-synthetic',
+        fromFrame: 20,
+        toFrame: 25
+      }],
+      frameDelta: 5,
+      anchor: null
+    }
+  }]);
+});
+
+test('keyframe drag finish drops the old gesture after drawing layers rerender with the same marker identity', () => {
+  const timeline = Object.create(Timeline.prototype);
+  timeline._lastDrawingLayers = [{
+    id: 'fabric-synthetic',
+    locked: true,
+    timelineKeyframesMovable: true,
+    keyframes: [{ frame: 10 }]
+  }];
+  timeline._drawingLayerRenderRevision = 4;
+  timeline.dragDrawingLayerRenderRevision = 4;
+  timeline.tracksContainer = { querySelectorAll: () => [] };
+  timeline.layerHeaders = { querySelectorAll: () => [] };
+  timeline._renderLayerHeader = () => {};
+  timeline._renderLayerTrack = () => {};
+  timeline._syncFrameGridContainerMetrics = () => {};
+  timeline.renderDrawingLayers([{
+    id: 'fabric-synthetic',
+    locked: true,
+    timelineKeyframesMovable: true,
+    keyframes: [{ frame: 10 }]
+  }], null);
+
+  timeline.draggedKeyframe = { layerId: 'fabric-synthetic', frame: 10 };
+  timeline.dragStartFrame = 10;
+  timeline.dragGhost = {
+    dataset: { targetFrame: '15' },
+    remove() {}
+  };
+  timeline.dragGhostItems = [];
+  timeline.dragSourceElements = [];
+  timeline.dragTooltip = null;
+  timeline.dragGhostKeyframes = [{ layerId: 'fabric-synthetic', frame: 10 }];
+  const emitted = [];
+  timeline._emit = (name, detail) => emitted.push({ name, detail });
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  globalThis.document = { body: { style: {} } };
+  globalThis.window = {};
+  try {
+    timeline._finishKeyframeDrag({});
+  } finally {
+    if (previousDocument === undefined) delete globalThis.document;
+    else globalThis.document = previousDocument;
+    if (previousWindow === undefined) delete globalThis.window;
+    else globalThis.window = previousWindow;
+  }
+
+  assert.deepEqual(emitted, []);
 });
 
 test('frame cell mode is stored and wired through the timeline toolbar', () => {

--- a/scripts/tests/keyframe-multi-select-source.test.js
+++ b/scripts/tests/keyframe-multi-select-source.test.js
@@ -99,7 +99,9 @@ test('selected keyframe moves are ordered by drag direction to keep adjacent mov
 test('moved keyframes refresh selection through the timeline setter', () => {
   assert.match(timelineSource, /setKeyframeSelection\(selection, options = \{\}\) \{/);
   assert.match(timelineSource, /this\._setKeyframeSelection\(selection, options\);/);
-  assert.match(timelineSource, /const selectionAnchor = this\.draggedKeyframe/);
+  assert.match(timelineSource, /const anchorMove = keyframesToMove\.find\(keyframe =>/);
+  assert.match(timelineSource, /keyframe\.layerId === this\.draggedKeyframe\?\.layerId/);
+  assert.match(timelineSource, /const selectionAnchor = anchorMove/);
   assert.match(timelineSource, /this\._emit\('keyframesMove', \{ keyframes: keyframesToMove, frameDelta, anchor: selectionAnchor \}\)/);
   assert.match(appSource, /const \{ keyframes, frameDelta, anchor \} = e\.detail;/);
   assert.match(appSource, /const movedSelection = keyframes\.map\(kf => \(\{/);

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -11914,6 +11914,132 @@ test('pointerdown confirmation pins the controller-captured frame instead of an 
   runtime.destroy();
 });
 
+test('pending pointerdown replays every coalesced move sample before its buffered pointerup', () => {
+  const pointerdownRequests = [];
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 0, objects: []
+  }], {
+    runtimeOptions: {
+      requestPointerdownFrame(request) {
+        pointerdownRequests.push(request);
+        return true;
+      }
+    }
+  });
+  const { runtime, canvas } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+
+  canvas.upperCanvasEl.dispatch('pointerdown', {
+    pointerId: 1907,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.3
+  });
+  canvas.upperCanvasEl.dispatch('pointermove', {
+    pointerId: 1907,
+    pointerType: 'pen',
+    buttons: 1,
+    clientX: 999,
+    clientY: 999,
+    pressure: 1,
+    getCoalescedEvents: () => [
+      {
+        type: 'pointermove', pointerId: 1907, pointerType: 'pen', buttons: 1,
+        clientX: 20, clientY: 30, pressure: 0.2
+      },
+      {
+        type: 'pointermove', pointerId: 1907, pointerType: 'pen', buttons: 1,
+        clientX: 40, clientY: 50, pressure: 0.8
+      }
+    ]
+  });
+  canvas.upperCanvasEl.dispatch('pointerup', {
+    pointerId: 1907,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 0,
+    clientX: 60,
+    clientY: 70,
+    pressure: 0.4
+  });
+
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    targetFrame: 10
+  }).accepted, true);
+  const stroke = runtime.exportDrawingVideo(makePersistenceExport())
+    .snapshot.scenes[0].objects[0];
+  assert.deepEqual(
+    stroke.sourcePoints.map(({ x, y, pressure }) => ({ x, y, pressure })),
+    [
+      { x: 20, y: 40, pressure: 0.3 },
+      { x: 40, y: 60, pressure: 0.2 },
+      { x: 80, y: 100, pressure: 0.8 },
+      { x: 120, y: 140, pressure: 0.4 }
+    ]
+  );
+  runtime.destroy();
+});
+
+test('a coalesced pending move cannot exceed the existing pointer event buffer limit', () => {
+  const pointerdownRequests = [];
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 0, objects: []
+  }], {
+    runtimeOptions: {
+      requestPointerdownFrame(request) {
+        pointerdownRequests.push(request);
+        return true;
+      }
+    }
+  });
+  const { runtime, canvas } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+
+  canvas.upperCanvasEl.dispatch('pointerdown', {
+    pointerId: 1908,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.3
+  });
+  canvas.upperCanvasEl.dispatch('pointermove', {
+    pointerId: 1908,
+    pointerType: 'pen',
+    buttons: 1,
+    clientX: 20,
+    clientY: 30,
+    pressure: 0.4,
+    getCoalescedEvents: () => Array.from({ length: 1024 }, (_value, index) => ({
+      type: 'pointermove',
+      pointerId: 1908,
+      pointerType: 'pen',
+      buttons: 1,
+      clientX: 20 + index,
+      clientY: 30 + index,
+      pressure: 0.4
+    }))
+  });
+
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    targetFrame: 10
+  }).accepted, false);
+  assert.deepEqual(canvas.upperCanvasEl.pointerReleaseRequests, [1908]);
+  assert.equal(
+    runtime.exportDrawingVideo(makePersistenceExport()).snapshot.scenes[0].objects.length,
+    0
+  );
+  runtime.destroy();
+});
+
 test('a fenced negative pointerdown acknowledgement releases input while stale cancel leaves the next gesture intact', () => {
   const pointerdownRequests = [];
   const source = makeHistoryStroke('pointerdown-cancel-source');

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -12040,6 +12040,116 @@ test('a coalesced pending move cannot exceed the existing pointer event buffer l
   runtime.destroy();
 });
 
+test('implicit capture loss after buffered pointerup preserves the fenced pending gesture', () => {
+  const pointerdownRequests = [];
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 0, objects: []
+  }], {
+    runtimeOptions: {
+      requestPointerdownFrame(request) {
+        pointerdownRequests.push(request);
+        return true;
+      }
+    }
+  });
+  const { runtime, canvas } = harness;
+  const pointerTarget = canvas.upperCanvasEl;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+
+  pointerTarget.dispatch('pointerdown', {
+    pointerId: 1909,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.3
+  });
+  assert.equal(pointerdownRequests.length, 1);
+  pointerTarget.dispatch('lostpointercapture', {
+    pointerId: 9999,
+    pointerType: 'pen'
+  });
+  pointerTarget.dispatch('pointerup', {
+    pointerId: 1909,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 0,
+    clientX: 30,
+    clientY: 40,
+    pressure: 0.7
+  });
+  pointerTarget.capturedPointerIds.delete(1909);
+  pointerTarget.dispatch('lostpointercapture', {
+    pointerId: 1909,
+    pointerType: 'pen'
+  });
+
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    sessionId: 'wrong-session',
+    targetFrame: 10
+  }).accepted, false);
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    targetFrame: 10
+  }).accepted, true);
+  const stroke = runtime.exportDrawingVideo(makePersistenceExport())
+    .snapshot.scenes[0].objects[0];
+  assert.deepEqual(
+    stroke.sourcePoints.map(({ x, y, pressure }) => ({ x, y, pressure })),
+    [
+      { x: 20, y: 40, pressure: 0.3 },
+      { x: 60, y: 80, pressure: 0.7 }
+    ]
+  );
+  runtime.destroy();
+});
+
+test('capture loss before any buffered pointerup still cancels the pending gesture', () => {
+  const pointerdownRequests = [];
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 0, objects: []
+  }], {
+    runtimeOptions: {
+      requestPointerdownFrame(request) {
+        pointerdownRequests.push(request);
+        return true;
+      }
+    }
+  });
+  const { runtime, canvas } = harness;
+  const pointerTarget = canvas.upperCanvasEl;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+
+  pointerTarget.dispatch('pointerdown', {
+    pointerId: 1910,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.3
+  });
+  pointerTarget.capturedPointerIds.delete(1910);
+  pointerTarget.dispatch('lostpointercapture', {
+    pointerId: 1910,
+    pointerType: 'pen'
+  });
+
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    targetFrame: 10
+  }).accepted, false);
+  assert.equal(
+    runtime.exportDrawingVideo(makePersistenceExport()).snapshot.scenes[0].objects.length,
+    0
+  );
+  runtime.destroy();
+});
+
 test('a fenced negative pointerdown acknowledgement releases input while stale cancel leaves the next gesture intact', () => {
   const pointerdownRequests = [];
   const source = makeHistoryStroke('pointerdown-cancel-source');

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -11792,6 +11792,34 @@ function createPresentationHarness(keyframes, options = {}) {
   };
 }
 
+function createManualTimerHarness() {
+  const scheduled = [];
+  let nextId = 0;
+  return {
+    scheduled,
+    setTimeout(callback, delay) {
+      const timer = {
+        id: ++nextId,
+        callback,
+        delay,
+        cleared: false,
+        fired: false
+      };
+      scheduled.push(timer);
+      return timer;
+    },
+    clearTimeout(timer) {
+      if (timer) timer.cleared = true;
+    },
+    fire(timer, { includeCleared = false } = {}) {
+      if (!timer || timer.fired || (timer.cleared && !includeCleared)) return false;
+      timer.fired = true;
+      timer.callback();
+      return true;
+    }
+  };
+}
+
 test('pointerdown confirmation pins the controller-captured frame instead of an older delivered candidate', () => {
   const pointerdownRequests = [];
   const source = makeHistoryStroke('pointerdown-handshake-source');
@@ -12148,6 +12176,249 @@ test('capture loss before any buffered pointerup still cancels the pending gestu
     0
   );
   runtime.destroy();
+});
+
+test('unanswered pointerdown frame request times out and releases the next gesture', () => {
+  const pointerdownRequests = [];
+  const timerHarness = createManualTimerHarness();
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 0, objects: []
+  }], {
+    runtimeOptions: {
+      requestPointerdownFrame(request) {
+        pointerdownRequests.push(request);
+        return true;
+      },
+      setTimeout: timerHarness.setTimeout,
+      clearTimeout: timerHarness.clearTimeout
+    }
+  });
+  const { runtime, canvas } = harness;
+  const pointerTarget = canvas.upperCanvasEl;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+
+  pointerTarget.dispatch('pointerdown', {
+    pointerId: 1911,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.3
+  });
+  pointerTarget.dispatch('pointerup', {
+    pointerId: 1911,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 0,
+    clientX: 30,
+    clientY: 40,
+    pressure: 0.7
+  });
+  pointerTarget.dispatch('lostpointercapture', {
+    pointerId: 1911,
+    pointerType: 'pen'
+  });
+
+  assert.equal(pointerdownRequests.length, 1);
+  assert.equal(timerHarness.scheduled.length, 1);
+  assert.equal(timerHarness.scheduled[0].delay, 3000);
+  assert.equal(timerHarness.fire(timerHarness.scheduled[0]), true);
+  assert.equal(pointerTarget.capturedPointerIds.has(1911), false);
+  assert.deepEqual(pointerTarget.pointerReleaseRequests, [1911]);
+
+  pointerTarget.dispatch('pointerdown', {
+    pointerId: 1912,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 50,
+    clientY: 60,
+    pressure: 0.4
+  });
+  pointerTarget.dispatch('pointerup', {
+    pointerId: 1912,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 0,
+    clientX: 70,
+    clientY: 80,
+    pressure: 0.6
+  });
+  assert.equal(pointerdownRequests.length, 2, 'the deadline releases the pending input lock');
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    targetFrame: 10
+  }).accepted, false, 'a late confirmation cannot claim the newer pending gesture');
+  assert.equal(
+    runtime.exportDrawingVideo(makePersistenceExport()).snapshot.scenes[0].objects.length,
+    0,
+    'the late confirmation cannot materialize a stroke'
+  );
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[1],
+    targetFrame: 10
+  }).accepted, true);
+  assert.equal(
+    runtime.exportDrawingVideo(makePersistenceExport()).snapshot.scenes[0].objects.length,
+    1,
+    'the newer gesture remains confirmable'
+  );
+  runtime.destroy();
+});
+
+test('pointerdown frame confirmation before the deadline clears its timer and commits once', () => {
+  const pointerdownRequests = [];
+  const timerHarness = createManualTimerHarness();
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 0, objects: []
+  }], {
+    runtimeOptions: {
+      requestPointerdownFrame(request) {
+        pointerdownRequests.push(request);
+        return true;
+      },
+      setTimeout: timerHarness.setTimeout,
+      clearTimeout: timerHarness.clearTimeout
+    }
+  });
+  const { runtime, canvas } = harness;
+  const pointerTarget = canvas.upperCanvasEl;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+
+  pointerTarget.dispatch('pointerdown', {
+    pointerId: 1913,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.3
+  });
+  pointerTarget.dispatch('pointerup', {
+    pointerId: 1913,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 0,
+    clientX: 30,
+    clientY: 40,
+    pressure: 0.7
+  });
+
+  assert.equal(timerHarness.scheduled.length, 1);
+  const deadline = timerHarness.scheduled[0];
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    sessionId: 'wrong-session',
+    cancelled: true
+  }).accepted, false, 'a wrong-session cancel cannot clear the pending request');
+  assert.equal(deadline.cleared, false);
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    targetFrame: 10
+  }).accepted, true);
+  assert.equal(deadline.cleared, true, 'successful confirmation clears the local deadline');
+  assert.equal(
+    runtime.exportDrawingVideo(makePersistenceExport()).snapshot.scenes[0].objects.length,
+    1
+  );
+  assert.equal(timerHarness.fire(deadline, { includeCleared: true }), true);
+  assert.equal(
+    runtime.exportDrawingVideo(makePersistenceExport()).snapshot.scenes[0].objects.length,
+    1,
+    'a stale cleared callback cannot alter the committed gesture'
+  );
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    cancelled: true
+  }).accepted, false, 'a stale cancel remains fenced after confirmation');
+  runtime.destroy();
+});
+
+test('pointerdown frame deadline is cleared by disable, session replacement, and destroy', () => {
+  const createPendingHarness = pointerId => {
+    const pointerdownRequests = [];
+    const timerHarness = createManualTimerHarness();
+    const harness = createPresentationHarness([{
+      id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 0, objects: []
+    }], {
+      runtimeOptions: {
+        requestPointerdownFrame(request) {
+          pointerdownRequests.push(request);
+          return true;
+        },
+        setTimeout: timerHarness.setTimeout,
+        clearTimeout: timerHarness.clearTimeout
+      }
+    });
+    assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+    harness.canvas.upperCanvasEl.dispatch('pointerdown', {
+      pointerId,
+      pointerType: 'pen',
+      button: 0,
+      buttons: 1,
+      clientX: 10,
+      clientY: 20,
+      pressure: 0.3
+    });
+    assert.equal(pointerdownRequests.length, 1);
+    assert.equal(timerHarness.scheduled.length, 1);
+    return { ...harness, pointerdownRequests, timerHarness };
+  };
+
+  const disabled = createPendingHarness(1914);
+  const disabledDeadline = disabled.timerHarness.scheduled[0];
+  assert.equal(disabled.runtime.setDrawingInput({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 2,
+    enabled: false
+  }).accepted, true);
+  assert.equal(disabledDeadline.cleared, true);
+  assert.equal(disabled.timerHarness.fire(disabledDeadline, { includeCleared: true }), true);
+  assert.equal(disabled.runtime.confirmDrawingPointerdownFrame({
+    ...disabled.pointerdownRequests[0],
+    targetFrame: 10
+  }).accepted, false);
+  disabled.runtime.destroy();
+
+  const replaced = createPendingHarness(1915);
+  const replacedDeadline = replaced.timerHarness.scheduled[0];
+  assert.equal(replaced.enableHeldFrame(10, 10, 'brush', 2).accepted, true);
+  assert.equal(replacedDeadline.cleared, true);
+  assert.equal(replaced.timerHarness.fire(replacedDeadline, { includeCleared: true }), true);
+  replaced.canvas.upperCanvasEl.dispatch('pointerdown', {
+    pointerId: 1916,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 30,
+    clientY: 40,
+    pressure: 0.4
+  });
+  assert.equal(replaced.pointerdownRequests.length, 2, 'the replacement session remains usable');
+  assert.equal(replaced.runtime.confirmDrawingPointerdownFrame({
+    ...replaced.pointerdownRequests[0],
+    cancelled: true
+  }).accepted, false, 'the replaced session request stays fenced');
+  assert.equal(replaced.runtime.confirmDrawingPointerdownFrame({
+    ...replaced.pointerdownRequests[1],
+    cancelled: true
+  }).accepted, true);
+  replaced.runtime.destroy();
+
+  const destroyed = createPendingHarness(1917);
+  const destroyedDeadline = destroyed.timerHarness.scheduled[0];
+  assert.equal(destroyed.runtime.destroy().destroyed, true);
+  assert.equal(destroyedDeadline.cleared, true);
+  assert.equal(destroyed.timerHarness.fire(destroyedDeadline, { includeCleared: true }), true);
+  assert.equal(destroyed.runtime.confirmDrawingPointerdownFrame({
+    ...destroyed.pointerdownRequests[0],
+    targetFrame: 10
+  }).accepted, false);
 });
 
 test('a fenced negative pointerdown acknowledgement releases input while stale cancel leaves the next gesture intact', () => {

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -209,6 +209,8 @@ class FakeCanvas {
     this.listeners = new Map();
     this.dimensionCalls = [];
     this.calcOffsetCalls = 0;
+    this.renderAllCalls = 0;
+    this.requestRenderAllCalls = 0;
     this.disposed = false;
     FakeCanvas.instances.push(this);
   }
@@ -258,6 +260,12 @@ class FakeCanvas {
     this.activeObject = null;
   }
 
+  setActiveObject(object) {
+    this.activeObject = object;
+    this.activeObjects = object ? [object] : [];
+    return object;
+  }
+
   setTargetFindTolerance(value) {
     this.targetFindTolerance = Math.round(value);
   }
@@ -287,7 +295,13 @@ class FakeCanvas {
     this.calcOffsetCalls += 1;
   }
 
-  requestRenderAll() {}
+  renderAll() {
+    this.renderAllCalls += 1;
+  }
+
+  requestRenderAll() {
+    this.requestRenderAllCalls += 1;
+  }
 
   dispose() {
     this.disposed = true;
@@ -5522,7 +5536,8 @@ test('partial lasso Delete commits one command and round-trips exact ID path and
     const deleted = harness.runtime.applyDrawingAction({
       sessionId: 'real-fabric-session',
       actionId: 'partial-lasso-delete',
-      action: 'delete-selection'
+      action: 'delete-selection',
+      targetFrame: 0
     });
 
     const holed = harness.sceneStore.getActiveSceneSnapshot();
@@ -8266,12 +8281,15 @@ test('pure exports load without constructing a DOM or Fabric canvas', () => {
 
   assert.deepEqual(Object.keys(runtime).sort(), [
     'applyDrawingAction',
+    'confirmDrawingPointerdownFrame',
     'destroy',
     'exportDrawingVideo',
     'getDiagnostics',
     'hydrateDrawingVideo',
     'prepare',
+    'presentDrawingFrame',
     'setDrawingInput',
+    'updateDrawingFrame',
     'updateDrawingTool',
     'updateViewport'
   ]);
@@ -11705,4 +11723,1468 @@ test('lastPaintedScene이 없는 초기 상태의 disable은 예외 없이 완�
     inputRevision: 1,
     enabled: false
   }).accepted, true);
+});
+
+function createPresentationHarness(keyframes, options = {}) {
+  FakeCanvas.instances = [];
+  const document = new FakeDocument();
+  const root = document.createElement('div');
+  const persistenceTransitions = [];
+  const runtime = createFabricOverlayRuntime({
+    fabric: { Canvas: FakeCanvas, Path: FakePath },
+    document,
+    ...(options.runtimeOptions || {}),
+    persistenceCommitObserver(event) {
+      persistenceTransitions.push(event);
+    }
+  });
+  assert.equal(runtime.prepare(root).prepared, true);
+  assert.equal(runtime.hydrateDrawingVideo(makePersistenceHydration({ keyframes })).accepted, true);
+  const canvas = FakeCanvas.instances[0];
+  const present = (presentationRevision, targetFrame, sourceFrame, overrides = {}) =>
+    runtime.presentDrawingFrame({
+      hostGeneration: 3,
+      videoGeneration: 7,
+      presentationRevision,
+      stableVideoIdentity: 'runtime-video',
+      storeRevision: 11,
+      targetFrame,
+      sourceFrame,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      canvasRect: { left: 0, top: 0, width: 960, height: 540 },
+      viewportRevision: 1,
+      viewportTransform: { scale: 1, panX: 0, panY: 0 },
+      ...overrides
+    });
+  const enableHeldFrame = (targetFrame, sourceFrame, tool = 'brush', inputRevision = 1) =>
+    runtime.setDrawingInput(makeInput({
+      hostGeneration: 3,
+      videoGeneration: 7,
+      inputRevision,
+      session: {
+        ...makeInput().session,
+        sessionId: `held-session-${targetFrame}-${inputRevision}`,
+        targetFrame,
+        sourceFrame,
+        tool
+      }
+    }));
+  const updateFrame = (frameRevision, targetFrame, overrides = {}) =>
+    runtime.updateDrawingFrame({
+      hostGeneration: 3,
+      videoGeneration: 7,
+      inputRevision: 1,
+      sessionId: 'active-frame-session',
+      frameRevision,
+      targetFrame,
+      ...overrides
+    });
+  return {
+    runtime,
+    root,
+    canvas,
+    persistenceTransitions,
+    present,
+    enableHeldFrame,
+    updateFrame,
+    options
+  };
+}
+
+test('pointerdown confirmation pins the controller-captured frame instead of an older delivered candidate', () => {
+  const pointerdownRequests = [];
+  const source = makeHistoryStroke('pointerdown-handshake-source');
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 2, objects: [source]
+  }], {
+    runtimeOptions: {
+      requestPointerdownFrame(request) {
+        pointerdownRequests.push(request);
+        return true;
+      }
+    }
+  });
+  const { runtime, canvas } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+  assert.equal(runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'held-session-10-1',
+    frameRevision: 1,
+    targetFrame: 20
+  }).accepted, true);
+
+  canvas.upperCanvasEl.dispatch('pointerdown', {
+    pointerId: 1901,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.3,
+    timeStamp: 1
+  });
+  assert.equal(pointerdownRequests.length, 1);
+  assert.equal(runtime.getDiagnostics().targetFrame, 10, 'no old-frame COW before confirmation');
+  assert.deepEqual(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    targetFrame: 21
+  }), {
+    accepted: true,
+    pointerdownId: pointerdownRequests[0].pointerdownId,
+    targetFrame: 21
+  });
+  assert.deepEqual(runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'held-session-10-1',
+    frameRevision: 2,
+    targetFrame: 22
+  }), {
+    accepted: true,
+    frameRevision: 2,
+    targetFrame: 22,
+    sourceFrame: 10,
+    deferred: true,
+    repainted: false
+  });
+  canvas.upperCanvasEl.dispatch('pointermove', {
+    pointerId: 1901,
+    pointerType: 'pen',
+    buttons: 1,
+    clientX: 30,
+    clientY: 40,
+    pressure: 0.5,
+    timeStamp: 2
+  });
+  canvas.upperCanvasEl.dispatch('pointerup', {
+    pointerId: 1901,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 0,
+    clientX: 40,
+    clientY: 50,
+    pressure: 0.4,
+    timeStamp: 3
+  });
+
+  let snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10, 21]);
+  assert.deepEqual(snapshot.scenes[0].objects, [source]);
+  assert.equal(snapshot.scenes[1].objects.length, 2);
+  assert.equal(runtime.getDiagnostics().targetFrame, 21);
+  assert.equal(runtime.getDiagnostics().armedTargetFrame, 22);
+
+  canvas.upperCanvasEl.dispatch('pointerdown', {
+    pointerId: 1902,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 50,
+    clientY: 60,
+    pressure: 0.3,
+    timeStamp: 4
+  });
+  assert.equal(pointerdownRequests.length, 2);
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    targetFrame: 21
+  }).accepted, false, 'a prior pointerdown cannot confirm the next gesture');
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[1],
+    targetFrame: 22
+  }).accepted, true);
+  canvas.upperCanvasEl.dispatch('pointerup', {
+    pointerId: 1902,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 0,
+    clientX: 70,
+    clientY: 80,
+    pressure: 0.4,
+    timeStamp: 5
+  });
+  snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10, 21, 22]);
+  assert.equal(snapshot.scenes[2].objects.length, 3);
+  runtime.destroy();
+});
+
+test('a fenced negative pointerdown acknowledgement releases input while stale cancel leaves the next gesture intact', () => {
+  const pointerdownRequests = [];
+  const source = makeHistoryStroke('pointerdown-cancel-source');
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 1, objects: [source]
+  }], {
+    runtimeOptions: {
+      requestPointerdownFrame(request) {
+        pointerdownRequests.push(request);
+        return true;
+      }
+    }
+  });
+  const { runtime, canvas } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+
+  canvas.upperCanvasEl.dispatch('pointerdown', {
+    pointerId: 1905,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.3
+  });
+  assert.equal(pointerdownRequests.length, 1);
+  const firstRequest = pointerdownRequests[0];
+  assert.deepEqual(runtime.confirmDrawingPointerdownFrame({
+    ...firstRequest,
+    cancelled: true
+  }), {
+    accepted: true,
+    cancelled: true,
+    hostGeneration: firstRequest.hostGeneration,
+    videoGeneration: firstRequest.videoGeneration,
+    inputRevision: firstRequest.inputRevision,
+    sessionId: firstRequest.sessionId,
+    pointerdownId: firstRequest.pointerdownId,
+    pointerdownAt: firstRequest.pointerdownAt
+  });
+
+  canvas.upperCanvasEl.dispatch('pointerdown', {
+    pointerId: 1906,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 30,
+    clientY: 40,
+    pressure: 0.4
+  });
+  assert.equal(pointerdownRequests.length, 2, 'negative acknowledgement releases the input lock');
+  const secondRequest = pointerdownRequests[1];
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...firstRequest,
+    cancelled: true
+  }).accepted, false, 'a stale cancel cannot clear a newer pending pointerdown');
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...secondRequest,
+    targetFrame: 10
+  }).accepted, true, 'the newer gesture remains confirmable');
+  canvas.upperCanvasEl.dispatch('pointerup', {
+    pointerId: 1906,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 0,
+    clientX: 40,
+    clientY: 50,
+    pressure: 0.4
+  });
+  runtime.destroy();
+});
+
+test('B-off drops a pending pointerdown confirmation without materializing its armed frame', () => {
+  const pointerdownRequests = [];
+  const source = makeHistoryStroke('pointerdown-disable-source');
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 1, objects: [source]
+  }], {
+    runtimeOptions: {
+      requestPointerdownFrame(request) {
+        pointerdownRequests.push(request);
+        return true;
+      }
+    }
+  });
+  const { runtime, canvas } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+  assert.equal(runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'held-session-10-1',
+    frameRevision: 1,
+    targetFrame: 20
+  }).accepted, true);
+  canvas.upperCanvasEl.dispatch('pointerdown', {
+    pointerId: 1904,
+    pointerType: 'pen',
+    button: 0,
+    buttons: 1,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.3
+  });
+  assert.equal(pointerdownRequests.length, 1);
+  assert.equal(runtime.setDrawingInput({
+    hostGeneration: 3, videoGeneration: 7, inputRevision: 2, enabled: false
+  }).accepted, true);
+  assert.equal(runtime.confirmDrawingPointerdownFrame({
+    ...pointerdownRequests[0],
+    targetFrame: 20
+  }).accepted, false);
+  assert.deepEqual(
+    runtime.exportDrawingVideo(makePersistenceExport()).snapshot.scenes.map(scene => scene.targetFrame),
+    [10]
+  );
+  assert.equal(runtime.getDiagnostics().cache.sceneCount, 1);
+  runtime.destroy();
+});
+
+test('passive presentation applies viewport geometry and B-off viewport updates without mutating scenes', () => {
+  const source = makeHistoryStroke('passive-viewport');
+  const harness = createPresentationHarness([{
+    id: 'keyframe-100', frame: 100, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 1, objects: [source]
+  }]);
+  const { runtime, root, canvas, present, persistenceTransitions } = harness;
+  const before = structuredClone(runtime.exportDrawingVideo(makePersistenceExport()).snapshot);
+  const viewport = root.querySelectorAllByClass('mpv-fabric-pilot-viewport')[0];
+
+  assert.deepEqual(present(1, 100, 100, {
+    sourceWidth: 2048,
+    sourceHeight: 1152,
+    canvasRect: { left: 12, top: 18, width: 900, height: 506.25 },
+    viewportRevision: 3,
+    viewportTransform: { scale: 1.25, panX: 14, panY: -8 }
+  }), { accepted: true, targetFrame: 100, sourceFrame: 100 });
+  assert.deepEqual(canvas.dimensionCalls.slice(-2), [
+    { dimensions: { width: 2048, height: 1152 }, options: { backstoreOnly: true } },
+    { dimensions: { width: 900, height: 506.25 }, options: { cssOnly: true } }
+  ]);
+  assert.equal(viewport.style.left, '12px');
+  assert.equal(viewport.style.top, '18px');
+  assert.equal(viewport.style.transform, 'scale(1.25) translate(14px, -8px)');
+  assert.equal(runtime.getDiagnostics().viewportRevision, 3);
+
+  const shownObject = canvas.getObjects()[0];
+  assert.deepEqual(runtime.updateViewport({
+    revision: 4,
+    canvasRect: { left: 20, top: 30, width: 800, height: 450 },
+    scale: 1.5,
+    panX: -6,
+    panY: 10
+  }), { accepted: true, revision: 4 });
+  assert.equal(canvas.getObjects()[0], shownObject);
+  assert.equal(viewport.style.left, '20px');
+  assert.equal(viewport.style.top, '30px');
+  assert.equal(viewport.style.transform, 'scale(1.5) translate(-6px, 10px)');
+  assert.equal(runtime.getDiagnostics().viewportRevision, 4);
+  assert.deepEqual(runtime.updateViewport({
+    revision: 4,
+    canvasRect: { left: 0, top: 0, width: 640, height: 360 },
+    scale: 1,
+    panX: 0,
+    panY: 0
+  }), { accepted: false, reason: 'stale-viewport' });
+  assert.deepEqual(runtime.exportDrawingVideo(makePersistenceExport()).snapshot, before);
+  assert.equal(persistenceTransitions.length, 0);
+  runtime.destroy();
+});
+
+test('passive viewport ownership survives same-video disable and resets on identity, generation, and release boundaries', () => {
+  const makeHarness = () => createPresentationHarness([{
+    id: 'keyframe-100', frame: 100, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 1, objects: [makeHistoryStroke('passive-boundary')]
+  }]);
+  const viewportUpdate = revision => ({
+    revision,
+    canvasRect: { left: 5, top: 6, width: 800, height: 450 },
+    scale: 1.1,
+    panX: 2,
+    panY: -3
+  });
+
+  const sameOwner = makeHarness();
+  assert.equal(sameOwner.runtime.setDrawingInput({
+    hostGeneration: 3, videoGeneration: 7, inputRevision: 1, enabled: false
+  }).accepted, true);
+  assert.equal(sameOwner.present(1, 100, 100).accepted, true);
+  assert.equal(sameOwner.runtime.setDrawingInput({
+    hostGeneration: 3, videoGeneration: 7, inputRevision: 2, enabled: false
+  }).accepted, true);
+  assert.deepEqual(sameOwner.runtime.updateViewport(viewportUpdate(2)), {
+    accepted: true, revision: 2
+  });
+  assert.equal(sameOwner.runtime.setDrawingInput({
+    hostGeneration: 3, videoGeneration: 8, inputRevision: 3, enabled: false
+  }).accepted, true);
+  assert.deepEqual(sameOwner.runtime.updateViewport(viewportUpdate(3)), {
+    accepted: false, reason: 'input-disabled'
+  });
+  sameOwner.runtime.destroy();
+
+  const identity = makeHarness();
+  assert.equal(identity.present(1, 100, 100).accepted, true);
+  assert.equal(identity.runtime.hydrateDrawingVideo(makePersistenceHydration({
+    stableVideoIdentity: 'replacement-video',
+    keyframes: []
+  })).accepted, true);
+  assert.deepEqual(identity.runtime.updateViewport(viewportUpdate(2)), {
+    accepted: false, reason: 'input-disabled'
+  });
+  identity.runtime.destroy();
+
+  const released = makeHarness();
+  assert.equal(released.present(1, 100, 100).accepted, true);
+  released.runtime.destroy();
+  assert.deepEqual(released.runtime.updateViewport(viewportUpdate(2)), {
+    accepted: false, reason: 'input-disabled'
+  });
+});
+
+test('passive frame presentation follows exact, held, empty-break, and reverse-seek sources without mutation', () => {
+  const exact100 = makeHistoryStroke('scene-100');
+  const exact200 = makeHistoryStroke('scene-200', { style: { color: '#18a058' } });
+  const harness = createPresentationHarness([
+    {
+      id: 'keyframe-100', frame: 100, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 4, objects: [exact100]
+    },
+    {
+      id: 'keyframe-150-empty', frame: 150, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 5, objects: []
+    },
+    {
+      id: 'keyframe-200', frame: 200, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 6, objects: [exact200]
+    }
+  ]);
+  const { runtime, canvas, present } = harness;
+  const beforeExport = structuredClone(runtime.exportDrawingVideo(makePersistenceExport()).snapshot);
+  const beforeDiagnostics = runtime.getDiagnostics();
+
+  assert.deepEqual(present(1, 99, null), {
+    accepted: true, targetFrame: 99, sourceFrame: null
+  });
+  assert.equal(canvas.getObjects().length, 0);
+
+  assert.deepEqual(present(2, 100, 100), {
+    accepted: true, targetFrame: 100, sourceFrame: 100
+  });
+  assert.deepEqual(canvas.getObjects().map(object => object.__baeframeObjectId), ['scene-100']);
+  assert.equal(canvas.getObjects()[0].selectable, false);
+  assert.equal(canvas.getObjects()[0].evented, false);
+  const heldObject = canvas.getObjects()[0];
+  const renderCount = canvas.renderAllCalls;
+
+  assert.deepEqual(present(3, 101, 100), {
+    accepted: true, targetFrame: 101, sourceFrame: 100
+  });
+  assert.equal(canvas.getObjects()[0], heldObject, 'same source must reuse the existing Fabric object');
+  assert.equal(canvas.renderAllCalls, renderCount + 1, 'accepted presentation renders synchronously');
+
+  assert.deepEqual(present(4, 150, 150), {
+    accepted: true, targetFrame: 150, sourceFrame: 150
+  });
+  assert.equal(canvas.getObjects().length, 0, 'empty exact keyframe breaks the previous hold');
+  assert.deepEqual(present(5, 199, 150), {
+    accepted: true, targetFrame: 199, sourceFrame: 150
+  });
+  assert.equal(canvas.getObjects().length, 0);
+
+  assert.deepEqual(present(6, 200, 200), {
+    accepted: true, targetFrame: 200, sourceFrame: 200
+  });
+  assert.deepEqual(canvas.getObjects().map(object => object.__baeframeObjectId), ['scene-200']);
+  assert.deepEqual(present(7, 101, 100), {
+    accepted: true, targetFrame: 101, sourceFrame: 100
+  });
+  assert.deepEqual(canvas.getObjects().map(object => object.__baeframeObjectId), ['scene-100']);
+  assert.deepEqual(present(8, 99, null), {
+    accepted: true, targetFrame: 99, sourceFrame: null
+  });
+  assert.equal(canvas.getObjects().length, 0);
+
+  assert.deepEqual(runtime.exportDrawingVideo(makePersistenceExport()).snapshot, beforeExport);
+  const afterDiagnostics = runtime.getDiagnostics();
+  assert.equal(afterDiagnostics.mutationCount, beforeDiagnostics.mutationCount);
+  assert.equal(afterDiagnostics.undoDepth, beforeDiagnostics.undoDepth);
+  assert.equal(afterDiagnostics.redoDepth, beforeDiagnostics.redoDepth);
+  assert.equal(afterDiagnostics.presentedTargetFrame, 99);
+  assert.equal(afterDiagnostics.presentedSourceFrame, null);
+  assert.equal(afterDiagnostics.presentedStoreRevision, 11);
+  assert.equal(afterDiagnostics.provisional, false);
+  runtime.destroy();
+});
+
+test('frame presentation is passive-only and rejects stale revisions, identities, and invalid source frames', () => {
+  const harness = createPresentationHarness([{
+    id: 'keyframe-100', frame: 100, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 1, objects: [makeHistoryStroke('presentation-fence')]
+  }]);
+  const { runtime, canvas, present, enableHeldFrame } = harness;
+
+  assert.equal(present(1, 100, 100).accepted, true);
+  const shownObject = canvas.getObjects()[0];
+  assert.deepEqual(present(1, 101, 100), {
+    accepted: false, reason: 'stale-presentation-revision'
+  });
+  assert.equal(canvas.getObjects()[0], shownObject);
+  assert.equal(present(2, 99, 100).accepted, false, 'source after target is invalid');
+  assert.equal(present(2, 100, 100, { stableVideoIdentity: 'other-video' }).accepted, false);
+
+  assert.equal(enableHeldFrame(101, 100).accepted, true);
+  assert.deepEqual(present(2, 101, 100), {
+    accepted: false, reason: 'input-enabled'
+  });
+  assert.equal(runtime.setDrawingInput({
+    hostGeneration: 3, videoGeneration: 7, inputRevision: 2, enabled: false
+  }).accepted, true);
+  assert.equal(runtime.setDrawingInput({
+    hostGeneration: 4, videoGeneration: 8, inputRevision: 3, enabled: false
+  }).accepted, true);
+  assert.deepEqual(present(2, 100, 100), {
+    accepted: false, reason: 'stale-presentation-fence'
+  });
+  runtime.destroy();
+});
+
+test('held frame first stroke materializes the target while preserving the source and undo base', () => {
+  const source = makeHistoryStroke('held-source');
+  const harness = createPresentationHarness([{
+    id: 'keyframe-100', frame: 100, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 7, objects: [source]
+  }]);
+  const { runtime, canvas, persistenceTransitions, enableHeldFrame } = harness;
+  const before = structuredClone(runtime.exportDrawingVideo(makePersistenceExport()).snapshot);
+
+  assert.deepEqual(enableHeldFrame(101, 100), {
+    accepted: true, enabled: true, restored: false
+  });
+  assert.deepEqual(canvas.getObjects().map(object => object.__baeframeObjectId), ['held-source']);
+  assert.equal(runtime.getDiagnostics().provisional, true);
+  assert.equal(runtime.getDiagnostics().presentedTargetFrame, 101);
+  assert.equal(runtime.getDiagnostics().presentedSourceFrame, 100);
+  assert.deepEqual(runtime.exportDrawingVideo(makePersistenceExport()).snapshot, before);
+  assert.equal(persistenceTransitions.length, 0);
+
+  drawStroke(canvas.upperCanvasEl, 1201);
+  const afterStroke = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(afterStroke.scenes.map(scene => scene.targetFrame), [100, 101]);
+  assert.deepEqual(afterStroke.scenes[0].objects, [source], 'source keyframe stays immutable');
+  assert.equal(afterStroke.scenes[1].objects.length, 2);
+  assert.equal(afterStroke.scenes[1].objects[0].id, 'held-source');
+  assert.equal(runtime.getDiagnostics().provisional, false);
+  assert.deepEqual(persistenceTransitions.map(event => ({
+    targetFrame: event.scene.targetFrame,
+    mutationSequence: event.mutationSequence,
+    kind: event.kind
+  })), [
+    { targetFrame: 101, mutationSequence: 1, kind: 'add-objects' },
+    { targetFrame: 101, mutationSequence: 2, kind: 'add-objects' }
+  ]);
+
+  assert.equal(runtime.applyDrawingAction({
+    sessionId: 'held-session-101-1', actionId: 'undo-held-stroke', action: 'undo'
+  }).applied, true);
+  const afterUndo = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(afterUndo.scenes[0].objects, [source]);
+  assert.deepEqual(afterUndo.scenes[1].objects, [source], 'undo returns to the held base at target');
+  runtime.destroy();
+});
+
+test('held materialization keeps the Drawing V3 shadow sequence aligned without duplicate base insertion', () => {
+  FakeCanvas.instances = [];
+  const observed = createObservedDrawingV3Adapter();
+  const document = new FakeDocument();
+  const root = document.createElement('div');
+  const runtime = createFabricOverlayRuntime({
+    fabric: { Canvas: FakeCanvas, Path: FakePath },
+    document,
+    drawingV3ShadowEnabled: true,
+    drawingV3AdapterFactory: () => observed.observer
+  });
+  assert.equal(runtime.prepare(root).prepared, true);
+  const source = makeHistoryStroke('held-shadow-source');
+  assert.equal(runtime.hydrateDrawingVideo(makePersistenceHydration({
+    keyframes: [{
+      id: 'keyframe-100', frame: 100, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 5, objects: [source]
+    }]
+  })).accepted, true);
+  assert.equal(runtime.setDrawingInput(makeInput({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    session: {
+      ...makeInput().session,
+      sessionId: 'held-shadow-session',
+      targetFrame: 101,
+      sourceFrame: 100
+    }
+  })).accepted, true);
+
+  drawStroke(FakeCanvas.instances[0].upperCanvasEl, 1203);
+  observed.flushAll();
+  const projection = getObservedProjection(observed);
+  assert.equal(projection.headSequence, 2);
+  assert.deepEqual(
+    projection.document.layers[0].keyframes[0].objects.map(object => object.id),
+    FakeCanvas.instances[0].getObjects().map(object => object.__baeframeObjectId)
+  );
+  const diagnostics = runtime.getDiagnostics();
+  assert.equal(diagnostics.drawingV3Shadow.gapCount, 0);
+  assert.equal(diagnostics.drawingV3Shadow.divergenceCount, 0);
+  runtime.destroy();
+});
+
+test('held frame first transform and clear materialize only the target scene', async t => {
+  await t.test('transform', () => {
+    const source = makeHistoryStroke('held-transform-source');
+    const harness = createPresentationHarness([{
+      id: 'keyframe-100', frame: 100, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 3, objects: [source]
+    }]);
+    const { runtime, canvas, persistenceTransitions, enableHeldFrame } = harness;
+    assert.equal(enableHeldFrame(101, 100, 'select').accepted, true);
+    const path = canvas.getObjects()[0];
+    canvas.activeObject = path;
+    canvas.activeObjects = [path];
+    canvas.emit('selection:created', { selected: [path] });
+    canvas.emit('before:transform', { transform: { target: path } });
+    path.left = 18;
+    canvas.emit('object:modified', { target: path });
+
+    const snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+    assert.equal(snapshot.scenes[0].objects[0].transform.left, 0);
+    assert.equal(snapshot.scenes[1].objects[0].transform.left, 18);
+    assert.deepEqual(persistenceTransitions.map(event => event.kind), [
+      'add-objects', 'transform-objects'
+    ]);
+    runtime.destroy();
+  });
+
+  await t.test('clear', () => {
+    const source = makeHistoryStroke('held-clear-source');
+    const harness = createPresentationHarness([{
+      id: 'keyframe-100', frame: 100, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 3, objects: [source]
+    }]);
+    const { runtime, persistenceTransitions, enableHeldFrame } = harness;
+    assert.equal(enableHeldFrame(101, 100).accepted, true);
+    assert.equal(runtime.applyDrawingAction({
+      sessionId: 'held-session-101-1', actionId: 'clear-held-frame', action: 'clear-session'
+    }).applied, true);
+
+    const snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+    assert.deepEqual(snapshot.scenes[0].objects, [source]);
+    assert.deepEqual(snapshot.scenes[1].objects, []);
+    assert.deepEqual(persistenceTransitions.map(event => event.kind), [
+      'add-objects', 'clear-keyframe'
+    ]);
+    runtime.destroy();
+  });
+});
+
+test('no-edit disable discards held provisional state and an empty held source waits for a real object', () => {
+  const source = makeHistoryStroke('held-no-edit-source');
+  const noEdit = createPresentationHarness([{
+    id: 'keyframe-100', frame: 100, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 2, objects: [source]
+  }]);
+  const noEditBefore = structuredClone(noEdit.runtime.exportDrawingVideo(makePersistenceExport()).snapshot);
+  assert.equal(noEdit.enableHeldFrame(101, 100).accepted, true);
+  assert.equal(noEdit.runtime.getDiagnostics().provisional, true);
+  assert.equal(noEdit.runtime.setDrawingInput({
+    hostGeneration: 3, videoGeneration: 7, inputRevision: 2, enabled: false
+  }).accepted, true);
+  assert.equal(noEdit.runtime.getDiagnostics().provisional, false);
+  assert.deepEqual(noEdit.runtime.exportDrawingVideo(makePersistenceExport()).snapshot, noEditBefore);
+  assert.equal(noEdit.persistenceTransitions.length, 0);
+  assert.equal(noEdit.runtime.hydrateDrawingVideo(makePersistenceHydration({
+    keyframes: [{
+      id: 'keyframe-100-refreshed', frame: 100, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 3,
+      objects: [makeHistoryStroke('held-no-edit-source', { transform: { left: 25 } })]
+    }]
+  })).accepted, true);
+  assert.deepEqual(
+    noEdit.canvas.getObjects().map(object => [object.__baeframeObjectId, object.left]),
+    [['held-no-edit-source', 25]],
+    'passive rehydrate repaints the held source after provisional target disposal'
+  );
+  noEdit.runtime.destroy();
+
+  const emptyHeld = createPresentationHarness([{
+    id: 'keyframe-150-empty', frame: 150, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 4, objects: []
+  }]);
+  const emptyBefore = structuredClone(emptyHeld.runtime.exportDrawingVideo(makePersistenceExport()).snapshot);
+  assert.equal(emptyHeld.enableHeldFrame(151, 150).accepted, true);
+  assert.equal(emptyHeld.canvas.getObjects().length, 0);
+  assert.deepEqual(emptyHeld.runtime.exportDrawingVideo(makePersistenceExport()).snapshot, emptyBefore);
+  drawStroke(emptyHeld.canvas.upperCanvasEl, 1202);
+
+  const emptyAfter = emptyHeld.runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(emptyAfter.scenes.map(scene => scene.targetFrame), [150, 151]);
+  assert.deepEqual(emptyAfter.scenes[0].objects, []);
+  assert.equal(emptyAfter.scenes[1].objects.length, 1);
+  assert.deepEqual(emptyHeld.persistenceTransitions.map(event => ({
+    targetFrame: event.scene.targetFrame,
+    mutationSequence: event.mutationSequence,
+    kind: event.kind
+  })), [{ targetFrame: 151, mutationSequence: 1, kind: 'add-objects' }]);
+  emptyHeld.runtime.destroy();
+});
+
+test('active playback previews runtime-local held sources without mutation and retargets each gesture at pointerdown', () => {
+  const source10 = makeHistoryStroke('source-10');
+  const source15 = makeHistoryStroke('source-15', { style: { color: '#26de81' } });
+  const harness = createPresentationHarness([
+    {
+      id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 2, objects: [source10]
+    },
+    {
+      id: 'keyframe-15', frame: 15, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 3, objects: [source15]
+    }
+  ]);
+  const { runtime, canvas, persistenceTransitions } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+  const sessionId = 'held-session-10-1';
+  const update = (frameRevision, targetFrame, overrides = {}) => runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId,
+    frameRevision,
+    targetFrame,
+    ...overrides
+  });
+  const before = structuredClone(runtime.exportDrawingVideo(makePersistenceExport()).snapshot);
+  const beforeDiagnostics = runtime.getDiagnostics();
+
+  for (let frameRevision = 1; frameRevision <= 300; frameRevision += 1) {
+    const targetFrame = 11 + ((frameRevision - 1) % 9);
+    assert.equal(update(frameRevision, targetFrame).accepted, true);
+  }
+  assert.equal(update(301, 19).accepted, true);
+  assert.deepEqual(
+    canvas.getObjects().map(object => object.__baeframeObjectId),
+    ['source-15'],
+    'an intermediate real keyframe becomes the held read-only preview'
+  );
+  assert.equal(canvas.getObjects()[0].selectable, false);
+  assert.deepEqual(runtime.exportDrawingVideo(makePersistenceExport()).snapshot, before);
+  assert.equal(persistenceTransitions.length, 0);
+  const afterPlayback = runtime.getDiagnostics();
+  assert.equal(afterPlayback.cache.sceneCount, beforeDiagnostics.cache.sceneCount);
+  assert.equal(afterPlayback.undoDepth, beforeDiagnostics.undoDepth);
+  assert.equal(afterPlayback.redoDepth, beforeDiagnostics.redoDepth);
+
+  assert.equal(update(302, 20).accepted, true);
+  canvas.upperCanvasEl.dispatch('pointerdown', {
+    pointerId: 1501,
+    pointerType: 'pen',
+    button: 0,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.3,
+    timeStamp: 1
+  });
+  assert.equal(runtime.getDiagnostics().targetFrame, 20);
+  assert.equal(update(303, 21).accepted, true, 'a newer frame may arm while the stroke is active');
+  canvas.upperCanvasEl.dispatch('pointermove', {
+    pointerId: 1501,
+    pointerType: 'pen',
+    button: 0,
+    clientX: 30,
+    clientY: 40,
+    pressure: 0.5,
+    timeStamp: 2
+  });
+  canvas.upperCanvasEl.dispatch('pointerup', {
+    pointerId: 1501,
+    pointerType: 'pen',
+    button: 0,
+    clientX: 40,
+    clientY: 50,
+    pressure: 0.4,
+    timeStamp: 3
+  });
+
+  let snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10, 15, 20]);
+  assert.deepEqual(snapshot.scenes[0].objects, [source10]);
+  assert.deepEqual(snapshot.scenes[1].objects, [source15]);
+  assert.equal(snapshot.scenes[2].objects.length, 2);
+  assert.equal(runtime.getDiagnostics().targetFrame, 20, 'the whole stroke stays pinned to pointerdown');
+  assert.equal(runtime.getDiagnostics().armedTargetFrame, 21);
+
+  drawStroke(canvas.upperCanvasEl, 1502);
+  snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10, 15, 20, 21]);
+  assert.equal(snapshot.scenes[3].objects.length, 3);
+  assert.equal(runtime.getDiagnostics().targetFrame, 21);
+  assert.equal(persistenceTransitions.every(event => [20, 21].includes(event.scene.targetFrame)), true);
+  runtime.destroy();
+});
+
+test('active frame candidates are fenced by the current input session and are dropped on disable', () => {
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 1, objects: [makeHistoryStroke('frame-fence')]
+  }]);
+  const { runtime } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+  const request = {
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'held-session-10-1',
+    frameRevision: 1,
+    targetFrame: 20
+  };
+  assert.equal(runtime.updateDrawingFrame(request).accepted, true);
+  assert.equal(runtime.updateDrawingFrame({ ...request, targetFrame: 21 }).accepted, false);
+  assert.equal(runtime.updateDrawingFrame({ ...request, frameRevision: 2, sessionId: 'stale' }).accepted, false);
+  assert.equal(runtime.setDrawingInput({
+    hostGeneration: 3, videoGeneration: 7, inputRevision: 2, enabled: false
+  }).accepted, true);
+  assert.equal(runtime.updateDrawingFrame({
+    ...request, inputRevision: 2, frameRevision: 1
+  }).accepted, false);
+  assert.equal(runtime.getDiagnostics().armedTargetFrame, null);
+  runtime.destroy();
+});
+
+test('toolbar clear undo and redo retarget the armed frame without changing the held source keyframe', () => {
+  const source = makeHistoryStroke('toolbar-source');
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 2, objects: [source]
+  }]);
+  const { runtime } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+  assert.equal(runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'held-session-10-1',
+    frameRevision: 1,
+    targetFrame: 20
+  }).accepted, true);
+
+  assert.equal(runtime.applyDrawingAction({
+    sessionId: 'held-session-10-1', actionId: 'clear-armed-20', action: 'clear-session'
+  }).applied, true);
+  let snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10, 20]);
+  assert.deepEqual(snapshot.scenes[0].objects, [source]);
+  assert.deepEqual(snapshot.scenes[1].objects, []);
+
+  assert.equal(runtime.applyDrawingAction({
+    sessionId: 'held-session-10-1', actionId: 'undo-clear-armed-20', action: 'undo'
+  }).applied, true);
+  snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes[1].objects, [source]);
+  assert.equal(runtime.applyDrawingAction({
+    sessionId: 'held-session-10-1', actionId: 'redo-clear-armed-20', action: 'redo'
+  }).applied, true);
+  snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes[1].objects, []);
+  runtime.destroy();
+});
+
+test('select pointerdown retargets before transform hit-testing and writes only the armed frame', () => {
+  const source = makeHistoryStroke('select-source');
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 2, objects: [source]
+  }]);
+  const { runtime, canvas } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'select', 1).accepted, true);
+  assert.equal(runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'held-session-10-1',
+    frameRevision: 1,
+    targetFrame: 20
+  }).accepted, true);
+
+  canvas.upperCanvasEl.dispatch('pointerdown', {
+    pointerId: 1601,
+    pointerType: 'mouse',
+    button: 0,
+    clientX: 10,
+    clientY: 20,
+    pressure: 0.5,
+    timeStamp: 1
+  });
+  const path = canvas.getObjects()[0];
+  canvas.activeObject = path;
+  canvas.activeObjects = [path];
+  canvas.emit('selection:created', { selected: [path] });
+  canvas.emit('before:transform', { transform: { target: path } });
+  path.left = 25;
+  canvas.emit('object:modified', { target: path });
+
+  const snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10, 20]);
+  assert.equal(snapshot.scenes[0].objects[0].transform.left, 0);
+  assert.equal(snapshot.scenes[1].objects[0].transform.left, 25);
+  assert.equal(runtime.getDiagnostics().targetFrame, 20);
+  runtime.destroy();
+});
+
+test('pointer and toolbar mutations fail closed when an armed frame cannot be materialized', () => {
+  FakeCanvas.instances = [];
+  const document = new FakeDocument();
+  const root = document.createElement('div');
+  const transitions = [];
+  const runtime = createFabricOverlayRuntime({
+    fabric: { Canvas: FakeCanvas, Path: FakePath },
+    document,
+    sceneStoreOptions: {
+      maxBytes: 15,
+      estimateObjectBytes: () => 10
+    },
+    persistenceCommitObserver: event => transitions.push(event)
+  });
+  assert.equal(runtime.prepare(root).prepared, true);
+  const source = makeHistoryStroke('capacity-source');
+  assert.equal(runtime.hydrateDrawingVideo(makePersistenceHydration({
+    keyframes: [{
+      id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 1, objects: [source]
+    }]
+  })).accepted, true);
+  assert.equal(runtime.setDrawingInput(makeInput({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    session: {
+      ...makeInput().session,
+      sessionId: 'capacity-session',
+      targetFrame: 10,
+      sourceFrame: 10
+    }
+  })).accepted, true);
+  assert.equal(runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'capacity-session',
+    frameRevision: 1,
+    targetFrame: 20
+  }).accepted, true);
+
+  drawStroke(FakeCanvas.instances[0].upperCanvasEl, 1701);
+  assert.equal(runtime.applyDrawingAction({
+    sessionId: 'capacity-session', actionId: 'capacity-clear', action: 'clear-session'
+  }).applied, false);
+  const snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10]);
+  assert.deepEqual(snapshot.scenes[0].objects, [source]);
+  assert.equal(transitions.length, 0);
+  assert.equal(runtime.getDiagnostics().targetFrame, 10);
+  runtime.destroy();
+});
+
+test('enabled session replacement drops only the old provisional scene and preserves it on failure', async t => {
+  await t.test('successful replacement', () => {
+    const source = makeHistoryStroke('replacement-source');
+    const harness = createPresentationHarness([{
+      id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 1, objects: [source]
+    }]);
+    const { runtime } = harness;
+    assert.equal(harness.enableHeldFrame(11, 10, 'brush', 1).accepted, true);
+    assert.equal(runtime.getDiagnostics().cache.sceneCount, 2);
+
+    assert.equal(runtime.setDrawingInput(makeInput({
+      hostGeneration: 3,
+      videoGeneration: 7,
+      inputRevision: 2,
+      session: {
+        ...makeInput().session,
+        sessionId: 'replacement-session-20',
+        targetFrame: 20,
+        sourceFrame: 10
+      }
+    })).accepted, true);
+    const diagnostics = runtime.getDiagnostics();
+    assert.equal(diagnostics.activeSessionId, 'replacement-session-20');
+    assert.equal(diagnostics.targetFrame, 20);
+    assert.equal(diagnostics.cache.sceneCount, 2);
+    runtime.destroy();
+  });
+
+  await t.test('failed replacement', () => {
+    FakeCanvas.instances = [];
+    const document = new FakeDocument();
+    const root = document.createElement('div');
+    const runtime = createFabricOverlayRuntime({
+      fabric: { Canvas: FakeCanvas, Path: FakePath },
+      document,
+      sceneStoreOptions: {
+        maxBytes: 25,
+        estimateObjectBytes: () => 10
+      }
+    });
+    assert.equal(runtime.prepare(root).prepared, true);
+    assert.equal(runtime.hydrateDrawingVideo(makePersistenceHydration({
+      keyframes: [{
+        id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+        mutationSequence: 1, objects: [makeHistoryStroke('replacement-capacity')]
+      }]
+    })).accepted, true);
+    assert.equal(runtime.setDrawingInput(makeInput({
+      hostGeneration: 3,
+      videoGeneration: 7,
+      inputRevision: 1,
+      session: {
+        ...makeInput().session,
+        sessionId: 'replacement-old-session',
+        targetFrame: 11,
+        sourceFrame: 10
+      }
+    })).accepted, true);
+    const before = runtime.getDiagnostics();
+
+    assert.deepEqual(runtime.setDrawingInput(makeInput({
+      hostGeneration: 3,
+      videoGeneration: 7,
+      inputRevision: 2,
+      session: {
+        ...makeInput().session,
+        sessionId: 'replacement-failed-session',
+        targetFrame: 20,
+        sourceFrame: 10
+      }
+    })), { accepted: false, reason: 'scene-capacity-exceeded' });
+    const after = runtime.getDiagnostics();
+    assert.equal(after.activeSessionId, before.activeSessionId);
+    assert.equal(after.targetFrame, before.targetFrame);
+    assert.equal(after.cache.sceneCount, before.cache.sceneCount);
+    assert.equal(after.provisional, true);
+    runtime.destroy();
+  });
+});
+
+test('active preview skips same-version held sources and repaints when source or mutation changes', () => {
+  const harness = createPresentationHarness([
+    {
+      id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 1, objects: [makeHistoryStroke('preview-source-10')]
+    },
+    {
+      id: 'keyframe-15', frame: 15, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 1, objects: [makeHistoryStroke('preview-source-15')]
+    }
+  ]);
+  const { runtime, canvas } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+  const firstObject = canvas.getObjects()[0];
+  const renderAllBefore = canvas.renderAllCalls;
+  const requestedBefore = canvas.requestRenderAllCalls;
+  const update = (frameRevision, targetFrame) => runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'held-session-10-1',
+    frameRevision,
+    targetFrame
+  });
+
+  assert.equal(update(1, 11).repainted, false);
+  assert.equal(update(2, 12).repainted, false);
+  assert.equal(canvas.getObjects()[0], firstObject);
+  assert.equal(canvas.renderAllCalls, renderAllBefore);
+  assert.equal(canvas.requestRenderAllCalls, requestedBefore);
+  assert.equal(update(3, 15).repainted, true);
+  assert.deepEqual(canvas.getObjects().map(object => object.__baeframeObjectId), ['preview-source-15']);
+  assert.equal(canvas.renderAllCalls, renderAllBefore + 1);
+  runtime.destroy();
+
+  const mutated = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 1, objects: [makeHistoryStroke('preview-mutated-source')]
+  }]);
+  assert.equal(mutated.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+  drawStroke(mutated.canvas.upperCanvasEl, 1801);
+  const afterCommitRenders = mutated.canvas.renderAllCalls;
+  assert.equal(mutated.runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'held-session-10-1',
+    frameRevision: 1,
+    targetFrame: 11
+  }).repainted, true, 'a local commit changes the same source signature');
+  assert.equal(mutated.canvas.renderAllCalls, afterCommitRenders + 1);
+  mutated.runtime.destroy();
+});
+
+test('failed active preview rendering leaves the prior armed frame and canvas intact', () => {
+  class ThrowingPreviewPath extends FakePath {
+    constructor(pathData, options) {
+      if (pathData === 'THROW_PREVIEW') throw new Error('synthetic preview render failure');
+      super(pathData, options);
+    }
+  }
+  FakeCanvas.instances = [];
+  const document = new FakeDocument();
+  const root = document.createElement('div');
+  const runtime = createFabricOverlayRuntime({
+    fabric: { Canvas: FakeCanvas, Path: ThrowingPreviewPath },
+    document
+  });
+  assert.equal(runtime.prepare(root).prepared, true);
+  assert.equal(runtime.hydrateDrawingVideo(makePersistenceHydration({
+    keyframes: [
+      {
+        id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+        mutationSequence: 1, objects: [makeHistoryStroke('preview-safe')]
+      },
+      {
+        id: 'keyframe-15', frame: 15, sourceWidth: 1920, sourceHeight: 1080,
+        mutationSequence: 1,
+        objects: [makeHistoryStroke('preview-throws', { pathData: 'THROW_PREVIEW' })]
+      }
+    ]
+  })).accepted, true);
+  assert.equal(runtime.setDrawingInput(makeInput({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    session: {
+      ...makeInput().session,
+      sessionId: 'preview-rollback-session',
+      targetFrame: 10,
+      sourceFrame: 10
+    }
+  })).accepted, true);
+  const canvas = FakeCanvas.instances[0];
+  const shownObject = canvas.getObjects()[0];
+
+  assert.deepEqual(runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'preview-rollback-session',
+    frameRevision: 1,
+    targetFrame: 15
+  }), { accepted: false, reason: 'active-frame-preview-failed' });
+  assert.equal(runtime.getDiagnostics().armedTargetFrame, 10);
+  assert.equal(runtime.getDiagnostics().activeFrameRevision, -1);
+  assert.equal(canvas.getObjects()[0], shownObject);
+  runtime.destroy();
+});
+
+test('canvas add failure rolls active preview objects and scene selection back atomically', () => {
+  class ThrowingAddCanvas extends FakeCanvas {
+    add(object) {
+      if (object?.__baeframeObjectId === this.failObjectId) {
+        throw new Error('synthetic canvas add failure');
+      }
+      return super.add(object);
+    }
+  }
+  FakeCanvas.instances = [];
+  const document = new FakeDocument();
+  const root = document.createElement('div');
+  const runtime = createFabricOverlayRuntime({
+    fabric: { Canvas: ThrowingAddCanvas, Path: FakePath },
+    document
+  });
+  assert.equal(runtime.prepare(root).prepared, true);
+  assert.equal(runtime.hydrateDrawingVideo(makePersistenceHydration({
+    keyframes: [
+      {
+        id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+        mutationSequence: 1, objects: [makeHistoryStroke('rollback-old')]
+      },
+      {
+        id: 'keyframe-15', frame: 15, sourceWidth: 1920, sourceHeight: 1080,
+        mutationSequence: 1, objects: [makeHistoryStroke('rollback-new')]
+      }
+    ]
+  })).accepted, true);
+  assert.equal(runtime.setDrawingInput(makeInput({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    session: {
+      ...makeInput().session,
+      sessionId: 'canvas-rollback-session',
+      targetFrame: 10,
+      sourceFrame: 10,
+      tool: 'select'
+    }
+  })).accepted, true);
+  const canvas = FakeCanvas.instances[0];
+  const selected = canvas.getObjects()[0];
+  canvas.setActiveObject(selected);
+  canvas.emit('selection:created', { selected: [selected], deselected: [] });
+  assert.equal(runtime.getDiagnostics().selectionCount, 1);
+  canvas.failObjectId = 'rollback-new';
+
+  assert.deepEqual(runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'canvas-rollback-session',
+    frameRevision: 1,
+    targetFrame: 15
+  }), { accepted: false, reason: 'active-frame-preview-failed' });
+  assert.deepEqual(canvas.getObjects().map(object => object.__baeframeObjectId), ['rollback-old']);
+  assert.equal(canvas.getActiveObject(), selected);
+  assert.equal(runtime.getDiagnostics().selectionCount, 1);
+  assert.equal(runtime.getDiagnostics().armedTargetFrame, 10);
+  runtime.destroy();
+});
+
+test('source-changing preview failure restores the same pending partial-lasso proxy and delete path', async () => {
+  const sceneStore = createSessionSceneStore();
+  assert.equal(sceneStore.hydrateVideo(makePersistenceHydration({
+    hostGeneration: 1,
+    videoGeneration: 1,
+    stableVideoIdentity: 'real-fabric-video',
+    keyframes: [{
+      id: 'preview-keyframe-10',
+      frame: 10,
+      sourceWidth: 200,
+      sourceHeight: 200,
+      mutationSequence: 1,
+      objects: [makeHistoryStroke('pending-preview-source-10')]
+    }]
+  })).accepted, true);
+  const harness = createRealFabricHarness({ sceneStore });
+  try {
+    stageCrossingLasso(harness, 1902);
+    const pendingBefore = pendingLassoObjects(harness.canvas);
+    assert.equal(pendingBefore.length, 1);
+    const activeBefore = harness.canvas.getActiveObjects();
+    const selectionBefore = harness.sceneStore.getActiveSceneSnapshot().selectedObjectIds;
+    const historyBefore = lassoHistoryState(harness.runtime);
+    const realAdd = harness.canvas.add.bind(harness.canvas);
+    harness.canvas.add = (...objects) => {
+      if (objects.some(object => object?.__baeframeObjectId === 'pending-preview-source-10')) {
+        throw new Error('synthetic pending preview add failure');
+      }
+      return realAdd(...objects);
+    };
+
+    assert.deepEqual(harness.runtime.updateDrawingFrame({
+      hostGeneration: 1,
+      videoGeneration: 1,
+      inputRevision: 1,
+      sessionId: 'real-fabric-session',
+      frameRevision: 1,
+      targetFrame: 10
+    }), { accepted: false, reason: 'active-frame-preview-failed' });
+    harness.canvas.add = realAdd;
+
+    assert.deepEqual(pendingLassoObjects(harness.canvas), pendingBefore);
+    assert.deepEqual(harness.canvas.getActiveObjects(), activeBefore);
+    assert.deepEqual(
+      harness.sceneStore.getActiveSceneSnapshot().selectedObjectIds,
+      selectionBefore
+    );
+    assert.deepEqual(lassoHistoryState(harness.runtime), historyBefore);
+    const deletion = harness.runtime.applyDrawingAction({
+      sessionId: 'real-fabric-session',
+      actionId: 'delete-after-pending-preview-rollback',
+      action: 'delete-selection',
+      targetFrame: 0
+    });
+    assert.equal(deletion.applied, true);
+    assert.equal(pendingLassoObjects(harness.canvas).length, 0);
+  } finally {
+    await harness.destroy();
+  }
+});
+
+test('B-off preserves the active held or blank preview when passive force-present fails', async t => {
+  await t.test('held source', () => {
+    const harness = createPresentationHarness([
+      {
+        id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+        mutationSequence: 1, objects: [makeHistoryStroke('disable-source-10')]
+      },
+      {
+        id: 'keyframe-15', frame: 15, sourceWidth: 1920, sourceHeight: 1080,
+        mutationSequence: 1, objects: [makeHistoryStroke('disable-source-15')]
+      }
+    ]);
+    const { runtime, canvas } = harness;
+    assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+    assert.equal(runtime.updateDrawingFrame({
+      hostGeneration: 3,
+      videoGeneration: 7,
+      inputRevision: 1,
+      sessionId: 'held-session-10-1',
+      frameRevision: 1,
+      targetFrame: 16
+    }).accepted, true);
+    assert.deepEqual(canvas.getObjects().map(object => object.__baeframeObjectId), ['disable-source-15']);
+    assert.equal(runtime.setDrawingInput({
+      hostGeneration: 3, videoGeneration: 7, inputRevision: 2, enabled: false
+    }).accepted, true);
+    assert.equal(harness.present(1, 16, 15, { stableVideoIdentity: 'wrong-video' }).accepted, false);
+    assert.deepEqual(canvas.getObjects().map(object => object.__baeframeObjectId), ['disable-source-15']);
+    assert.equal(runtime.getDiagnostics().presentedTargetFrame, 16);
+    assert.equal(runtime.getDiagnostics().presentedSourceFrame, 15);
+    runtime.destroy();
+  });
+
+  await t.test('blank hold', () => {
+    const harness = createPresentationHarness([{
+      id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 1, objects: [makeHistoryStroke('disable-blank-source')]
+    }]);
+    const { runtime, canvas } = harness;
+    assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+    assert.equal(runtime.updateDrawingFrame({
+      hostGeneration: 3,
+      videoGeneration: 7,
+      inputRevision: 1,
+      sessionId: 'held-session-10-1',
+      frameRevision: 1,
+      targetFrame: 5
+    }).accepted, true);
+    assert.equal(canvas.getObjects().length, 0);
+    assert.equal(runtime.setDrawingInput({
+      hostGeneration: 3, videoGeneration: 7, inputRevision: 2, enabled: false
+    }).accepted, true);
+    assert.equal(harness.present(1, 5, null, { stableVideoIdentity: 'wrong-video' }).accepted, false);
+    assert.equal(canvas.getObjects().length, 0);
+    assert.equal(runtime.getDiagnostics().presentedTargetFrame, 5);
+    assert.equal(runtime.getDiagnostics().presentedSourceFrame, null);
+    runtime.destroy();
+  });
+});
+
+test('B-off rejects a stale persisted source after a just-committed local stroke', () => {
+  const source10 = makeHistoryStroke('disable-lag-source-10');
+  const harness = createPresentationHarness([{
+    id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+    mutationSequence: 1, objects: [source10]
+  }]);
+  const { runtime, canvas } = harness;
+  assert.equal(harness.enableHeldFrame(20, 10, 'brush', 1).accepted, true);
+  drawStroke(canvas.upperCanvasEl, 1903);
+  const committedIds = canvas.getObjects().map(object => object.__baeframeObjectId);
+  assert.equal(committedIds.length, 2);
+  assert.equal(runtime.setDrawingInput({
+    hostGeneration: 3, videoGeneration: 7, inputRevision: 2, enabled: false
+  }).accepted, true);
+
+  assert.deepEqual(harness.present(1, 20, 10), {
+    accepted: false,
+    reason: 'stale-presentation-source'
+  });
+  assert.deepEqual(
+    canvas.getObjects().map(object => object.__baeframeObjectId),
+    committedIds
+  );
+  assert.equal(runtime.getDiagnostics().presentedTargetFrame, 20);
+  assert.equal(runtime.getDiagnostics().presentedSourceFrame, 20);
+  assert.deepEqual(
+    runtime.exportDrawingVideo(makePersistenceExport()).snapshot.scenes.map(scene => scene.targetFrame),
+    [10, 20]
+  );
+  runtime.destroy();
+});
+
+test('controller action targets its captured frame while duplicate actions never retarget', () => {
+  const source10 = makeHistoryStroke('action-source-10');
+  const source15 = makeHistoryStroke('action-source-15');
+  const harness = createPresentationHarness([
+    {
+      id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 1, objects: [source10]
+    },
+    {
+      id: 'keyframe-15', frame: 15, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 1, objects: [source15]
+    }
+  ]);
+  const { runtime } = harness;
+  assert.equal(harness.enableHeldFrame(10, 10, 'brush', 1).accepted, true);
+  assert.equal(runtime.updateDrawingFrame({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    sessionId: 'held-session-10-1',
+    frameRevision: 1,
+    targetFrame: 20
+  }).accepted, true);
+  assert.equal(runtime.applyDrawingAction({
+    sessionId: 'held-session-10-1',
+    actionId: 'captured-frame-clear',
+    action: 'clear-session',
+    targetFrame: 10
+  }).applied, true);
+  let snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10, 15]);
+  assert.deepEqual(snapshot.scenes[0].objects, []);
+  assert.deepEqual(snapshot.scenes[1].objects, [source15]);
+
+  const beforeDuplicate = runtime.getDiagnostics();
+  assert.deepEqual(runtime.applyDrawingAction({
+    sessionId: 'held-session-10-1',
+    actionId: 'captured-frame-clear',
+    action: 'clear-session',
+    targetFrame: 20
+  }), { applied: false, duplicate: true });
+  const afterDuplicate = runtime.getDiagnostics();
+  assert.equal(afterDuplicate.targetFrame, beforeDuplicate.targetFrame);
+  assert.equal(afterDuplicate.cache.sceneCount, beforeDuplicate.cache.sceneCount);
+  snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10, 15]);
+  runtime.destroy();
+});
+
+test('a failed explicit action retarget releases its action id for a safe retry', () => {
+  FakeCanvas.instances = [];
+  const document = new FakeDocument();
+  const root = document.createElement('div');
+  const runtime = createFabricOverlayRuntime({
+    fabric: { Canvas: FakeCanvas, Path: FakePath },
+    document,
+    sceneStoreOptions: {
+      maxBytes: 15,
+      estimateObjectBytes: () => 10
+    }
+  });
+  assert.equal(runtime.prepare(root).prepared, true);
+  assert.equal(runtime.hydrateDrawingVideo(makePersistenceHydration({
+    keyframes: [{
+      id: 'keyframe-10', frame: 10, sourceWidth: 1920, sourceHeight: 1080,
+      mutationSequence: 1, objects: [makeHistoryStroke('action-retry-source')]
+    }]
+  })).accepted, true);
+  assert.equal(runtime.setDrawingInput(makeInput({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 1,
+    session: {
+      ...makeInput().session,
+      sessionId: 'action-retry-session',
+      targetFrame: 10,
+      sourceFrame: 10
+    }
+  })).accepted, true);
+  assert.equal(runtime.applyDrawingAction({
+    sessionId: 'action-retry-session',
+    actionId: 'retry-after-retarget-failure',
+    action: 'clear-session',
+    targetFrame: 20
+  }).applied, false);
+  assert.deepEqual(runtime.applyDrawingAction({
+    sessionId: 'action-retry-session',
+    actionId: 'retry-after-retarget-failure',
+    action: 'clear-session',
+    targetFrame: 10
+  }), { applied: false, reason: 'history-capacity-exceeded' });
+  runtime.destroy();
 });

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -599,6 +599,64 @@ function makePersistenceExport(hostGeneration, overrides = {}) {
   return request;
 }
 
+function makeDrawingPresentation(hostGeneration, overrides = {}) {
+  return {
+    hostGeneration,
+    videoGeneration: 7,
+    presentationRevision: 1,
+    stableVideoIdentity: 'C:/shots/host-video.mov',
+    storeRevision: 3,
+    targetFrame: 24,
+    sourceFrame: 12,
+    sourceWidth: 1920,
+    sourceHeight: 1080,
+    canvasRect: { left: 8, top: 12, width: 960, height: 540 },
+    viewportRevision: 4,
+    viewportTransform: { scale: 1.25, panX: 16, panY: -9 },
+    ...overrides
+  };
+}
+
+function makeDrawingFrameUpdate(hostGeneration, overrides = {}) {
+  return {
+    hostGeneration,
+    videoGeneration: 7,
+    inputRevision: 2,
+    sessionId: 'active-frame-session',
+    frameRevision: 1,
+    targetFrame: 20,
+    ...overrides
+  };
+}
+
+function makeDrawingPointerdownFrameRequest(hostGeneration, overrides = {}) {
+  return {
+    hostGeneration,
+    videoGeneration: 7,
+    inputRevision: 2,
+    sessionId: 'pointerdown-frame-session',
+    pointerdownId: 'pointerdown-frame-1',
+    pointerdownAt: 1234,
+    ...overrides
+  };
+}
+
+function makeDrawingPointerdownFrameConfirmation(hostGeneration, overrides = {}) {
+  return {
+    ...makeDrawingPointerdownFrameRequest(hostGeneration),
+    targetFrame: 42,
+    ...overrides
+  };
+}
+
+function makeDrawingPointerdownFrameCancellation(hostGeneration, overrides = {}) {
+  return {
+    ...makeDrawingPointerdownFrameRequest(hostGeneration),
+    cancelled: true,
+    ...overrides
+  };
+}
+
 function makePersistenceTransform(overrides = {}) {
   return {
     left: 0,
@@ -746,6 +804,7 @@ test('exposes the MPV overlay Fabric drawing host capability API', () => {
   assert.equal(typeof host.getDrawingCapability, 'function');
   assert.equal(typeof host.setDrawingInput, 'function');
   assert.equal(typeof host.updateDrawingTool, 'function');
+  assert.equal(typeof host.updateDrawingFrame, 'function');
   assert.equal(typeof host.applyDrawingAction, 'function');
   assert.equal(typeof host.getDrawingDiagnostics, 'function');
   assert.equal(typeof host.configureDrawingV3Shadow, 'function');
@@ -2875,6 +2934,29 @@ test('drawing action response forwards history-empty reason', async () => {
   assert.equal(result.success, false);
 });
 
+test('drawing actions preserve the controller-captured target frame through the host queue', async () => {
+  const payloads = [];
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (!script.includes('.applyDrawingAction(')) return undefined;
+      payloads.push(readFabricMethodPayload(script, 'applyDrawingAction'));
+      return { applied: true, deletedCount: 1 };
+    }
+  });
+  const tokens = await activateDrawingHost(harness, {
+    videoGeneration: 8,
+    sessionId: 'session-captured-action-frame'
+  });
+  assert.equal((await harness.host.applyDrawingAction({
+    ...tokens,
+    action: 'delete-selection',
+    actionId: 'captured-action-frame-1',
+    targetFrame: 42
+  })).applied, true);
+  assert.equal(payloads.length, 1);
+  assert.equal(payloads[0].targetFrame, 42);
+});
+
 test('overlay history relay does not await or invoke host Fabric history', async () => {
   const delayedHistory = createDeferred();
   let hostHistoryCallCount = 0;
@@ -4506,6 +4588,717 @@ test('standard mpv suite includes the hidden Fabric toolbar Chromium layout regr
   assert.match(
     packageJson.scripts['test:mpv'],
     /mpv-fabric-overlay-toolbar-layout\.test\.js/
+  );
+});
+
+test('current overlay pointerdown request relays only the exact active drawing session to main', async () => {
+  const harness = createDrawingHostHarness();
+  const tokens = await activateDrawingHost(harness, {
+    videoGeneration: 7,
+    sessionId: 'pointerdown-frame-session'
+  });
+  const currentEvent = { sender: harness.windows[0].webContents };
+  const request = makeDrawingPointerdownFrameRequest(tokens.hostGeneration);
+  harness.events.length = 0;
+
+  assert.deepEqual(
+    harness.host.forwardDrawingPointerdownFrameRequest(currentEvent, request),
+    { success: true, accepted: true }
+  );
+  assert.deepEqual(harness.events, [[
+    'mainWindow.send',
+    'mpv-overlay:drawing-pointerdown-frame-request',
+    request
+  ]]);
+  assert.notEqual(harness.events[0][2], request);
+
+  for (const invalid of [
+    makeDrawingPointerdownFrameRequest(tokens.hostGeneration, { sessionId: 'stale' }),
+    makeDrawingPointerdownFrameRequest(tokens.hostGeneration, { hostGeneration: 0 }),
+    makeDrawingPointerdownFrameRequest(tokens.hostGeneration, { pointerdownAt: 1.5 }),
+    makeDrawingPointerdownFrameRequest(tokens.hostGeneration, { pointerdownId: '' }),
+    { ...request, injected: true }
+  ]) {
+    assert.equal(
+      harness.host.forwardDrawingPointerdownFrameRequest(currentEvent, invalid).accepted,
+      false
+    );
+  }
+  assert.equal(
+    harness.host.forwardDrawingPointerdownFrameRequest({ sender: {} }, request).accepted,
+    false
+  );
+  assert.equal(
+    harness.events.filter(([name]) => name === 'mainWindow.send').length,
+    1
+  );
+
+  await harness.host.setDrawingInput(makeDrawingInput(tokens.hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 3,
+    enabled: false
+  }));
+  assert.equal(
+    harness.host.forwardDrawingPointerdownFrameRequest(currentEvent, {
+      ...request,
+      inputRevision: 3
+    }).accepted,
+    false
+  );
+});
+
+test('pointerdown frame confirmation reaches runtime only for the exact current active session', async () => {
+  const confirmations = [];
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (!script.includes('.confirmDrawingPointerdownFrame(')) return undefined;
+      const request = readFabricMethodPayload(script, 'confirmDrawingPointerdownFrame');
+      confirmations.push(request);
+      return {
+        accepted: true,
+        pointerdownId: request.pointerdownId,
+        targetFrame: request.targetFrame
+      };
+    }
+  });
+  const tokens = await activateDrawingHost(harness, {
+    videoGeneration: 7,
+    sessionId: 'pointerdown-frame-session'
+  });
+  const confirmation = makeDrawingPointerdownFrameConfirmation(tokens.hostGeneration);
+
+  assert.deepEqual(await harness.host.confirmDrawingPointerdownFrame(confirmation), {
+    success: true,
+    accepted: true,
+    pointerdownId: 'pointerdown-frame-1',
+    targetFrame: 42
+  });
+  assert.deepEqual(confirmations, [confirmation]);
+
+  for (const invalid of [
+    { ...confirmation, injected: true },
+    makeDrawingPointerdownFrameConfirmation(tokens.hostGeneration, { targetFrame: -1 }),
+    makeDrawingPointerdownFrameConfirmation(tokens.hostGeneration, { sessionId: 'stale' }),
+    makeDrawingPointerdownFrameConfirmation(tokens.hostGeneration, { pointerdownId: '' })
+  ]) {
+    assert.equal((await harness.host.confirmDrawingPointerdownFrame(invalid)).accepted, false);
+  }
+  assert.equal(confirmations.length, 1);
+});
+
+test('pointerdown frame cancellation reaches runtime and requires the exact echoed owner and time', async () => {
+  const cancellations = [];
+  let responseOverrides = {};
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (!script.includes('.confirmDrawingPointerdownFrame(')) return undefined;
+      const request = readFabricMethodPayload(script, 'confirmDrawingPointerdownFrame');
+      cancellations.push(request);
+      return {
+        accepted: true,
+        cancelled: true,
+        hostGeneration: request.hostGeneration,
+        videoGeneration: request.videoGeneration,
+        inputRevision: request.inputRevision,
+        sessionId: request.sessionId,
+        pointerdownId: request.pointerdownId,
+        pointerdownAt: request.pointerdownAt,
+        ...responseOverrides
+      };
+    }
+  });
+  const tokens = await activateDrawingHost(harness, {
+    videoGeneration: 7,
+    sessionId: 'pointerdown-frame-session'
+  });
+  const cancellation = makeDrawingPointerdownFrameCancellation(tokens.hostGeneration);
+
+  assert.deepEqual(await harness.host.confirmDrawingPointerdownFrame(cancellation), {
+    success: true,
+    accepted: true,
+    cancelled: true,
+    hostGeneration: tokens.hostGeneration,
+    videoGeneration: 7,
+    inputRevision: 2,
+    sessionId: 'pointerdown-frame-session',
+    pointerdownId: 'pointerdown-frame-1',
+    pointerdownAt: 1234
+  });
+  assert.deepEqual(cancellations, [cancellation]);
+
+  for (const mismatch of [
+    { hostGeneration: tokens.hostGeneration + 1 },
+    { videoGeneration: 8 },
+    { inputRevision: 3 },
+    { sessionId: 'other-session' },
+    { pointerdownId: 'other-pointerdown' },
+    { pointerdownAt: 1235 },
+    { cancelled: false }
+  ]) {
+    responseOverrides = mismatch;
+    assert.deepEqual(await harness.host.confirmDrawingPointerdownFrame(cancellation), {
+      success: false,
+      accepted: false,
+      reason: 'drawing-pointerdown-frame-cancel-rejected'
+    });
+  }
+  assert.equal(cancellations.length, 8);
+});
+
+test('pointerdown frame cancellation rejects non-exact tags and stale owners without runtime side effects', async () => {
+  let runtimeCalls = 0;
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.confirmDrawingPointerdownFrame(')) runtimeCalls += 1;
+      return { accepted: true };
+    }
+  });
+  const tokens = await activateDrawingHost(harness, {
+    videoGeneration: 7,
+    sessionId: 'pointerdown-frame-session'
+  });
+  const base = makeDrawingPointerdownFrameCancellation(tokens.hostGeneration);
+
+  for (const invalid of [
+    { ...base, cancelled: false },
+    { ...base, targetFrame: 42 },
+    { ...base, injected: true },
+    makeDrawingPointerdownFrameCancellation(tokens.hostGeneration, { pointerdownAt: -1 }),
+    makeDrawingPointerdownFrameCancellation(tokens.hostGeneration, { sessionId: 'stale' }),
+    makeDrawingPointerdownFrameCancellation(tokens.hostGeneration, { pointerdownId: '' })
+  ]) {
+    assert.equal((await harness.host.confirmDrawingPointerdownFrame(invalid)).accepted, false);
+  }
+  assert.equal(runtimeCalls, 0);
+});
+
+test('late pointerdown cancellation response is rejected after input ownership changes', async () => {
+  const delayed = createDeferred();
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.confirmDrawingPointerdownFrame(')) return delayed.promise;
+      return undefined;
+    }
+  });
+  const tokens = await activateDrawingHost(harness, {
+    videoGeneration: 7,
+    sessionId: 'pointerdown-frame-session'
+  });
+  const cancellation = makeDrawingPointerdownFrameCancellation(tokens.hostGeneration);
+  const pending = harness.host.confirmDrawingPointerdownFrame(cancellation);
+  await new Promise(resolve => setImmediate(resolve));
+  await harness.host.setDrawingInput(makeDrawingInput(tokens.hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 3,
+    enabled: false
+  }));
+  delayed.resolve({
+    accepted: true,
+    cancelled: true,
+    hostGeneration: cancellation.hostGeneration,
+    videoGeneration: cancellation.videoGeneration,
+    inputRevision: cancellation.inputRevision,
+    sessionId: cancellation.sessionId,
+    pointerdownId: cancellation.pointerdownId,
+    pointerdownAt: cancellation.pointerdownAt
+  });
+
+  assert.deepEqual(await pending, {
+    success: false,
+    accepted: false,
+    reason: 'stale-drawing-pointerdown-frame-response'
+  });
+});
+
+test('late pointerdown confirmation is rejected after input ownership changes', async () => {
+  const delayed = createDeferred();
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.confirmDrawingPointerdownFrame(')) return delayed.promise;
+      return undefined;
+    }
+  });
+  const tokens = await activateDrawingHost(harness, {
+    videoGeneration: 7,
+    sessionId: 'pointerdown-frame-session'
+  });
+  const confirmation = makeDrawingPointerdownFrameConfirmation(tokens.hostGeneration);
+  const pending = harness.host.confirmDrawingPointerdownFrame(confirmation);
+  await new Promise(resolve => setImmediate(resolve));
+  await harness.host.setDrawingInput(makeDrawingInput(tokens.hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 3,
+    enabled: false
+  }));
+  delayed.resolve({
+    accepted: true,
+    pointerdownId: confirmation.pointerdownId,
+    targetFrame: confirmation.targetFrame
+  });
+
+  assert.deepEqual(await pending, {
+    success: false,
+    accepted: false,
+    reason: 'stale-drawing-pointerdown-frame-response'
+  });
+});
+
+test('accepted passive frame presentation executes runtime, restacks, then invalidates', async () => {
+  const presented = [];
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.hydrateDrawingVideo(')) {
+        return { accepted: true, sceneCount: 0, objectCount: 0 };
+      }
+      if (script.includes('.presentDrawingFrame(')) {
+        const request = readFabricMethodPayload(script, 'presentDrawingFrame');
+        presented.push(request);
+        return { accepted: true };
+      }
+      return undefined;
+    }
+  });
+  const ensured = await harness.host.ensure({ x: 0, y: 0, width: 640, height: 360 });
+  const { hostGeneration } = ensured.drawingCapability;
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 1,
+    enabled: false
+  }));
+  await harness.host.hydrateDrawingVideo(makePersistenceHydration(hostGeneration));
+  harness.events.length = 0;
+
+  assert.deepEqual(
+    await harness.host.presentDrawingFrame(makeDrawingPresentation(hostGeneration)),
+    {
+      success: true,
+      accepted: true,
+      presentationRevision: 1,
+      targetFrame: 24,
+      sourceFrame: 12
+    }
+  );
+  assert.deepEqual(presented, [makeDrawingPresentation(hostGeneration)]);
+  assert.deepEqual(
+    harness.events
+      .filter(([name, script]) =>
+        (name === 'executeJavaScript' && script.includes?.('.presentDrawingFrame(')) ||
+        name === 'moveTop' ||
+        name === 'webContents.invalidate')
+      .map(([name]) => name === 'executeJavaScript' ? 'runtime.presentDrawingFrame' : name),
+    ['runtime.presentDrawingFrame', 'moveTop', 'webContents.invalidate']
+  );
+  assert.equal(harness.events.some(([name]) => name === 'overlay.focus'), false);
+  assert.equal(harness.events.some(([name]) => name === 'mainWindow.focus'), false);
+});
+
+test('rejected and failed passive frame presentations never restack or invalidate', async () => {
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.hydrateDrawingVideo(')) {
+        return { accepted: true, sceneCount: 0, objectCount: 0 };
+      }
+      if (!script.includes('.presentDrawingFrame(')) return undefined;
+      const request = readFabricMethodPayload(script, 'presentDrawingFrame');
+      if (request.presentationRevision === 1) return { accepted: false };
+      throw new Error('passive presentation failed');
+    }
+  });
+  const ensured = await harness.host.ensure({ x: 0, y: 0, width: 640, height: 360 });
+  const { hostGeneration } = ensured.drawingCapability;
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 1,
+    enabled: false
+  }));
+  await harness.host.hydrateDrawingVideo(makePersistenceHydration(hostGeneration));
+  harness.events.length = 0;
+
+  assert.deepEqual(
+    await harness.host.presentDrawingFrame(makeDrawingPresentation(hostGeneration)),
+    {
+      success: false,
+      accepted: false,
+      reason: 'drawing-presentation-rejected',
+      presentationRevision: 1,
+      targetFrame: 24,
+      sourceFrame: 12
+    }
+  );
+  assert.deepEqual(
+    await harness.host.presentDrawingFrame(makeDrawingPresentation(hostGeneration, {
+      presentationRevision: 2
+    })),
+    {
+      success: false,
+      accepted: false,
+      reason: 'drawing-presentation-failed',
+      presentationRevision: 2,
+      targetFrame: 24,
+      sourceFrame: 12
+    }
+  );
+  assert.equal(harness.events.some(([name]) => name === 'moveTop'), false);
+  assert.equal(harness.events.some(([name]) => name === 'webContents.invalidate'), false);
+});
+
+test('passive frame presentation strictly rejects missing, extra, and malformed viewport geometry', async () => {
+  let presentCalls = 0;
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.hydrateDrawingVideo(')) {
+        return { accepted: true, sceneCount: 0, objectCount: 0 };
+      }
+      if (script.includes('.presentDrawingFrame(')) presentCalls += 1;
+      return { accepted: true };
+    }
+  });
+  const ensured = await harness.host.ensure({ x: 0, y: 0, width: 640, height: 360 });
+  const { hostGeneration } = ensured.drawingCapability;
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 1,
+    enabled: false
+  }));
+  await harness.host.hydrateDrawingVideo(makePersistenceHydration(hostGeneration));
+
+  const missing = makeDrawingPresentation(hostGeneration);
+  delete missing.viewportTransform;
+  const invalidRequests = [
+    missing,
+    makeDrawingPresentation(hostGeneration, { extra: true }),
+    makeDrawingPresentation(hostGeneration, {
+      canvasRect: { left: 8, top: 12, width: 0, height: 540 }
+    }),
+    makeDrawingPresentation(hostGeneration, {
+      viewportTransform: { scale: 0, panX: 16, panY: -9 }
+    })
+  ];
+  for (const request of invalidRequests) {
+    assert.equal((await harness.host.presentDrawingFrame(request)).reason, 'invalid-presentation-request');
+  }
+  assert.equal(presentCalls, 0);
+});
+
+test('passive frame presentation rejects active input and a mismatched video identity before runtime execution', async () => {
+  let presentCalls = 0;
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.hydrateDrawingVideo(')) {
+        return { accepted: true, sceneCount: 0, objectCount: 0 };
+      }
+      if (script.includes('.presentDrawingFrame(')) {
+        presentCalls += 1;
+        return { accepted: true };
+      }
+      return undefined;
+    }
+  });
+  const ensured = await harness.host.ensure({ x: 0, y: 0, width: 640, height: 360 });
+  const { hostGeneration } = ensured.drawingCapability;
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 1,
+    enabled: false
+  }));
+  await harness.host.hydrateDrawingVideo(makePersistenceHydration(hostGeneration));
+
+  assert.deepEqual(
+    await harness.host.presentDrawingFrame(makeDrawingPresentation(hostGeneration, {
+      stableVideoIdentity: 'C:/shots/other-video.mov'
+    })),
+    {
+      success: false,
+      accepted: false,
+      reason: 'stale-presentation-fence',
+      presentationRevision: 1,
+      targetFrame: 24,
+      sourceFrame: 12
+    }
+  );
+
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 2,
+    enabled: true,
+    session: {
+      sessionId: 'active-presentation-session',
+      stableVideoIdentity: 'C:/shots/host-video.mov',
+      targetFrame: 24,
+      sourceFrame: 12,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      canvasRect: { x: 0, y: 0, width: 640, height: 360 },
+      viewportRevision: 0,
+      viewportTransform: { scale: 1, panX: 0, panY: 0 },
+      tool: 'brush'
+    }
+  }));
+  assert.deepEqual(
+    await harness.host.presentDrawingFrame(makeDrawingPresentation(hostGeneration, {
+      presentationRevision: 2
+    })),
+    {
+      success: false,
+      accepted: false,
+      reason: 'drawing-input-enabled',
+      presentationRevision: 2,
+      targetFrame: 24,
+      sourceFrame: 12
+    }
+  );
+  assert.equal(presentCalls, 0);
+});
+
+test('newer passive presentation supersedes an older in-flight response and owns the only invalidation', async () => {
+  const first = createDeferred();
+  const runtimeRevisions = [];
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.hydrateDrawingVideo(')) {
+        return { accepted: true, sceneCount: 0, objectCount: 0 };
+      }
+      if (script.includes('.presentDrawingFrame(')) {
+        const request = readFabricMethodPayload(script, 'presentDrawingFrame');
+        runtimeRevisions.push(request.presentationRevision);
+        if (request.presentationRevision === 1) return first.promise;
+        return { accepted: true };
+      }
+      return undefined;
+    }
+  });
+  const ensured = await harness.host.ensure({ x: 0, y: 0, width: 640, height: 360 });
+  const { hostGeneration } = ensured.drawingCapability;
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 1,
+    enabled: false
+  }));
+  await harness.host.hydrateDrawingVideo(makePersistenceHydration(hostGeneration));
+  harness.events.length = 0;
+
+  const older = harness.host.presentDrawingFrame(makeDrawingPresentation(hostGeneration));
+  await new Promise(resolve => setImmediate(resolve));
+  const newerRequest = makeDrawingPresentation(hostGeneration, {
+    presentationRevision: 2,
+    targetFrame: 30,
+    sourceFrame: 30
+  });
+  assert.deepEqual(await harness.host.presentDrawingFrame(newerRequest), {
+    success: true,
+    accepted: true,
+    presentationRevision: 2,
+    targetFrame: 30,
+    sourceFrame: 30
+  });
+
+  first.resolve({ accepted: true });
+  assert.deepEqual(await older, {
+    success: false,
+    accepted: false,
+    reason: 'stale-presentation-response',
+    presentationRevision: 1,
+    targetFrame: 24,
+    sourceFrame: 12
+  });
+  assert.deepEqual(runtimeRevisions, [1, 2]);
+  assert.equal(
+    harness.events.filter(([name]) => name === 'webContents.invalidate').length,
+    1
+  );
+  assert.equal(
+    harness.events.filter(([name]) => name === 'moveTop').length,
+    1
+  );
+});
+
+test('active frame updates accept only the current active session and strictly increasing revisions', async () => {
+  const updates = [];
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (!script.includes('.updateDrawingFrame(')) return undefined;
+      const request = readFabricMethodPayload(script, 'updateDrawingFrame');
+      updates.push(request);
+      return {
+        accepted: true,
+        sourceFrame: request.targetFrame === 20 ? 10 : 20,
+        repainted: request.targetFrame === 20
+      };
+    }
+  });
+  const ensured = await harness.host.ensure({ x: 0, y: 0, width: 640, height: 360 });
+  const { hostGeneration } = ensured.drawingCapability;
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 1,
+    enabled: false
+  }));
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 2,
+    enabled: true,
+    session: {
+      sessionId: 'active-frame-session',
+      stableVideoIdentity: 'C:/shots/host-video.mov',
+      targetFrame: 10,
+      sourceFrame: 10,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      canvasRect: { left: 0, top: 0, width: 640, height: 360 },
+      viewportRevision: 0,
+      viewportTransform: { scale: 1, panX: 0, panY: 0 },
+      tool: 'brush'
+    }
+  }));
+  harness.events.length = 0;
+
+  assert.deepEqual(await harness.host.updateDrawingFrame(
+    makeDrawingFrameUpdate(hostGeneration)
+  ), {
+    success: true,
+    accepted: true,
+    frameRevision: 1,
+    targetFrame: 20,
+    sourceFrame: 10
+  });
+  for (const invalid of [
+    makeDrawingFrameUpdate(hostGeneration, { frameRevision: 1, targetFrame: 21 }),
+    makeDrawingFrameUpdate(hostGeneration, { frameRevision: 2, inputRevision: 1 }),
+    makeDrawingFrameUpdate(hostGeneration, { frameRevision: 2, sessionId: 'other-session' }),
+    { ...makeDrawingFrameUpdate(hostGeneration, { frameRevision: 2 }), extra: true }
+  ]) {
+    assert.equal((await harness.host.updateDrawingFrame(invalid)).accepted, false);
+  }
+  assert.equal(updates.length, 1);
+  assert.equal(
+    harness.events.filter(([name]) => name === 'webContents.invalidate').length,
+    1
+  );
+
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 3,
+    enabled: false
+  }));
+  assert.equal((await harness.host.updateDrawingFrame(
+    makeDrawingFrameUpdate(hostGeneration, { inputRevision: 3, frameRevision: 1 })
+  )).accepted, false);
+});
+
+test('a late active frame response cannot supersede a newer accepted revision', async () => {
+  const first = createDeferred();
+  const runtimeRevisions = [];
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (!script.includes('.updateDrawingFrame(')) return undefined;
+      const request = readFabricMethodPayload(script, 'updateDrawingFrame');
+      runtimeRevisions.push(request.frameRevision);
+      if (request.frameRevision === 1) return first.promise;
+      return { accepted: true, sourceFrame: 20, repainted: true };
+    }
+  });
+  const ensured = await harness.host.ensure({ x: 0, y: 0, width: 640, height: 360 });
+  const { hostGeneration } = ensured.drawingCapability;
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 1,
+    enabled: false
+  }));
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 2,
+    enabled: true,
+    session: {
+      sessionId: 'active-frame-session',
+      stableVideoIdentity: 'C:/shots/host-video.mov',
+      targetFrame: 10,
+      sourceFrame: 10,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      canvasRect: { left: 0, top: 0, width: 640, height: 360 },
+      viewportRevision: 0,
+      viewportTransform: { scale: 1, panX: 0, panY: 0 },
+      tool: 'brush'
+    }
+  }));
+  harness.events.length = 0;
+
+  const older = harness.host.updateDrawingFrame(makeDrawingFrameUpdate(hostGeneration));
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(await harness.host.updateDrawingFrame(
+    makeDrawingFrameUpdate(hostGeneration, { frameRevision: 2, targetFrame: 21 })
+  ), {
+    success: true,
+    accepted: true,
+    frameRevision: 2,
+    targetFrame: 21,
+    sourceFrame: 20
+  });
+
+  first.resolve({ accepted: true, sourceFrame: 10, repainted: true });
+  assert.deepEqual(await older, {
+    success: false,
+    accepted: false,
+    reason: 'stale-active-frame-response'
+  });
+  assert.deepEqual(runtimeRevisions, [1, 2]);
+  assert.equal(
+    harness.events.filter(([name]) => name === 'webContents.invalidate').length,
+    1
+  );
+});
+
+test('active frame updates invalidate the host only when the runtime repaints', async () => {
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (!script.includes('.updateDrawingFrame(')) return undefined;
+      const request = readFabricMethodPayload(script, 'updateDrawingFrame');
+      return {
+        accepted: true,
+        sourceFrame: 10,
+        repainted: request.frameRevision === 2
+      };
+    }
+  });
+  const ensured = await harness.host.ensure({ x: 0, y: 0, width: 640, height: 360 });
+  const { hostGeneration } = ensured.drawingCapability;
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 1,
+    enabled: false
+  }));
+  await harness.host.setDrawingInput(makeDrawingInput(hostGeneration, {
+    videoGeneration: 7,
+    inputRevision: 2,
+    enabled: true,
+    session: {
+      sessionId: 'active-frame-session',
+      stableVideoIdentity: 'C:/shots/host-video.mov',
+      targetFrame: 10,
+      sourceFrame: 10,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      canvasRect: { left: 0, top: 0, width: 640, height: 360 },
+      viewportRevision: 0,
+      viewportTransform: { scale: 1, panX: 0, panY: 0 },
+      tool: 'brush'
+    }
+  }));
+  harness.events.length = 0;
+
+  assert.equal((await harness.host.updateDrawingFrame(
+    makeDrawingFrameUpdate(hostGeneration)
+  )).accepted, true);
+  assert.equal(
+    harness.events.filter(([name]) => name === 'webContents.invalidate').length,
+    0
+  );
+  assert.equal((await harness.host.updateDrawingFrame(
+    makeDrawingFrameUpdate(hostGeneration, { frameRevision: 2, targetFrame: 21 })
+  )).accepted, true);
+  assert.equal(
+    harness.events.filter(([name]) => name === 'webContents.invalidate').length,
+    1
   );
 });
 

--- a/scripts/tests/mpv-overlay-keyboard-relay.test.js
+++ b/scripts/tests/mpv-overlay-keyboard-relay.test.js
@@ -75,6 +75,18 @@ function validInput(overrides = {}) {
   };
 }
 
+function validPointerdownFrameRequest(overrides = {}) {
+  return {
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 11,
+    sessionId: 'main-preload-pointerdown-session',
+    pointerdownId: 'main-preload-pointerdown-1',
+    pointerdownAt: 1234,
+    ...overrides
+  };
+}
+
 test('main preload exposes a narrow validated overlay keyboard subscription', () => {
   const harness = loadMainPreload();
   const electronAPI = harness.exposed.get('electronAPI');
@@ -173,6 +185,52 @@ test('main preload exposes a narrow validated overlay pointer presence subscript
   unsubscribe();
   assert.equal(harness.listeners.has('mpv-overlay:pointer-presence'), false);
   assert.equal(harness.removed.length, 1);
+});
+
+test('main preload validates pointerdown frame subscriptions and exposes the confirm invoke', async () => {
+  const harness = loadMainPreload();
+  const electronAPI = harness.exposed.get('electronAPI');
+  assert.equal(typeof electronAPI.onMpvOverlayDrawingPointerdownFrame, 'function');
+  assert.equal(typeof electronAPI.mpvConfirmOverlayDrawingPointerdownFrame, 'function');
+
+  const received = [];
+  const unsubscribe = electronAPI.onMpvOverlayDrawingPointerdownFrame(request => {
+    received.push(request);
+  });
+  const listener = harness.listeners.get('mpv-overlay:drawing-pointerdown-frame-request');
+  assert.equal(typeof listener, 'function');
+
+  const request = validPointerdownFrameRequest();
+  listener({}, request);
+  assert.deepEqual(received, [request]);
+  assert.notEqual(received[0], request);
+  for (const malformed of [
+    null,
+    validPointerdownFrameRequest({ hostGeneration: 0 }),
+    validPointerdownFrameRequest({ sessionId: '' }),
+    validPointerdownFrameRequest({ pointerdownId: 'p'.repeat(257) }),
+    validPointerdownFrameRequest({ pointerdownAt: Number.POSITIVE_INFINITY }),
+    { ...validPointerdownFrameRequest(), injected: true }
+  ]) {
+    listener({}, malformed);
+  }
+  assert.equal(received.length, 1);
+
+  const confirmation = { ...request, targetFrame: 42 };
+  assert.deepEqual(
+    await electronAPI.mpvConfirmOverlayDrawingPointerdownFrame(confirmation),
+    { success: true }
+  );
+  assert.deepEqual(harness.invoked.at(-1), [
+    'mpv:confirm-overlay-drawing-pointerdown-frame',
+    confirmation
+  ]);
+
+  unsubscribe();
+  assert.equal(
+    harness.listeners.has('mpv-overlay:drawing-pointerdown-frame-request'),
+    false
+  );
 });
 
 test('main preload exposes the dedicated collaboration state invoke channel', async () => {

--- a/scripts/tests/mpv-overlay-preload.test.js
+++ b/scripts/tests/mpv-overlay-preload.test.js
@@ -36,6 +36,18 @@ function makeTransition(overrides = {}) {
   };
 }
 
+function makePointerdownFrameRequest(overrides = {}) {
+  return {
+    hostGeneration: 3,
+    videoGeneration: 7,
+    inputRevision: 11,
+    sessionId: 'overlay-pointerdown-session',
+    pointerdownId: 'pointerdown-frame-1',
+    pointerdownAt: 1234,
+    ...overrides
+  };
+}
+
 function loadOverlayPreload({
   sendError = null,
   overlayDocument = undefined,
@@ -147,13 +159,15 @@ function createPointerEnvironment(rect = { left: 20, top: 10, width: 200, height
   };
 }
 
-function loadPointerPresenceIpcHandlers() {
+function loadPointerPresenceIpcHandlers(setupOptions) {
   const eventHandlers = new Map();
   const invokeHandlers = new Map();
   const sent = [];
   const remoteCursorCalls = [];
   const collaborationCalls = [];
   const collaborationActionCalls = [];
+  const pointerdownFrameCalls = [];
+  const pointerdownFrameConfirmCalls = [];
   const allowedOverlaySender = {};
   const mainWebContents = {
     isDestroyed: () => false,
@@ -221,6 +235,19 @@ function loadPointerPresenceIpcHandlers() {
         forwardCollaborationAction(event, action) {
           collaborationActionCalls.push([event, action]);
           return { success: true, accepted: true, sequence: collaborationActionCalls.length };
+        },
+        forwardDrawingPointerdownFrameRequest(event, request) {
+          pointerdownFrameCalls.push([event, request]);
+          return { success: true, accepted: true };
+        },
+        confirmDrawingPointerdownFrame(request) {
+          pointerdownFrameConfirmCalls.push(request);
+          return {
+            success: true,
+            accepted: true,
+            pointerdownId: request.pointerdownId,
+            targetFrame: request.targetFrame
+          };
         }
       },
       normalizeMpvCollaborationState,
@@ -244,7 +271,7 @@ function loadPointerPresenceIpcHandlers() {
 
   try {
     const { setupIpcHandlers } = require(ipcHandlersPath);
-    setupIpcHandlers();
+    setupIpcHandlers(setupOptions);
   } finally {
     Module._load = originalLoad;
     delete require.cache[ipcHandlersPath];
@@ -257,6 +284,8 @@ function loadPointerPresenceIpcHandlers() {
     invokeHandlers,
     mainWebContents,
     mainWindow,
+    pointerdownFrameCalls,
+    pointerdownFrameConfirmCalls,
     remoteCursorCalls,
     sent
   };
@@ -266,7 +295,11 @@ test('overlay preload exposes one narrow committed-transition bridge and sends p
   const harness = loadOverlayPreload();
   assert.deepEqual(
     [...harness.exposed.keys()],
-    ['mpvOverlayPersistence', 'mpvOverlayCollaborationActions']
+    [
+      'mpvOverlayPersistence',
+      'mpvOverlayCollaborationActions',
+      'mpvOverlayDrawingFrame'
+    ]
   );
   const bridge = harness.exposed.get('mpvOverlayPersistence');
   assert.deepEqual(Object.keys(bridge), ['notifyCommittedTransition']);
@@ -278,6 +311,46 @@ test('overlay preload exposes one narrow committed-transition bridge and sends p
     { type: 'transition', transition }
   ]]);
   assert.notEqual(harness.sent[0][1].transition, transition);
+});
+
+test('overlay preload sends only exact bounded pointerdown frame requests', () => {
+  const harness = loadOverlayPreload();
+  const bridge = harness.exposed.get('mpvOverlayDrawingFrame');
+  assert.equal(Object.isFrozen(bridge), true);
+  assert.deepEqual(Object.keys(bridge), ['requestPointerdownFrame']);
+
+  const request = makePointerdownFrameRequest();
+  assert.equal(bridge.requestPointerdownFrame(request), true);
+  assert.deepEqual(harness.sent, [[
+    'mpv-overlay:drawing-pointerdown-frame-request',
+    request
+  ]]);
+  assert.notEqual(harness.sent[0][1], request);
+
+  const malformed = [
+    null,
+    [],
+    makePointerdownFrameRequest({ hostGeneration: 0 }),
+    makePointerdownFrameRequest({ videoGeneration: 1.5 }),
+    makePointerdownFrameRequest({ inputRevision: -1 }),
+    makePointerdownFrameRequest({ sessionId: '' }),
+    makePointerdownFrameRequest({ sessionId: 's'.repeat(257) }),
+    makePointerdownFrameRequest({ pointerdownId: '' }),
+    makePointerdownFrameRequest({ pointerdownId: 'p'.repeat(257) }),
+    makePointerdownFrameRequest({ pointerdownAt: -1 }),
+    makePointerdownFrameRequest({ pointerdownAt: 1.5 }),
+    { ...makePointerdownFrameRequest(), injected: true },
+    Object.defineProperty(makePointerdownFrameRequest(), 'hiddenInjected', {
+      value: true,
+      enumerable: false
+    }),
+    Object.assign(makePointerdownFrameRequest(), { [Symbol('injected')]: true }),
+    Object.assign(Object.create({ inherited: true }), makePointerdownFrameRequest())
+  ];
+  for (const value of malformed) {
+    assert.equal(bridge.requestPointerdownFrame(value), false);
+  }
+  assert.equal(harness.sent.length, 1);
 });
 
 test('overlay collaboration bridge accepts only exact allowlisted semantic actions', () => {
@@ -919,4 +992,66 @@ test('main IPC delegates raw collaboration actions to the overlay host sender fe
 
   relay(event, action);
   assert.deepEqual(harness.collaborationActionCalls, [[event, action]]);
+});
+
+test('main IPC relays pointerdown frame requests only for the enabled pilot and current overlay sender', () => {
+  const enabled = loadPointerPresenceIpcHandlers({
+    fabricDrawingPilot: { enabled: true }
+  });
+  const relay = enabled.eventHandlers.get('mpv-overlay:drawing-pointerdown-frame-request');
+  assert.equal(typeof relay, 'function');
+  const request = makePointerdownFrameRequest();
+  const currentEvent = { sender: enabled.allowedOverlaySender };
+
+  relay(currentEvent, request);
+  relay({ sender: {} }, request);
+  assert.deepEqual(enabled.pointerdownFrameCalls, [[currentEvent, request]]);
+
+  const disabled = loadPointerPresenceIpcHandlers({
+    fabricDrawingPilot: { enabled: false }
+  });
+  const disabledRelay = disabled.eventHandlers.get(
+    'mpv-overlay:drawing-pointerdown-frame-request'
+  );
+  disabledRelay({ sender: disabled.allowedOverlaySender }, request);
+  assert.equal(disabled.pointerdownFrameCalls.length, 0);
+});
+
+test('main IPC confirms pointerdown frames only for the enabled pilot and current main renderer', async () => {
+  const enabled = loadPointerPresenceIpcHandlers({
+    fabricDrawingPilot: { enabled: true }
+  });
+  const confirm = enabled.invokeHandlers.get(
+    'mpv:confirm-overlay-drawing-pointerdown-frame'
+  );
+  assert.equal(typeof confirm, 'function');
+  const confirmation = {
+    ...makePointerdownFrameRequest(),
+    targetFrame: 42
+  };
+
+  assert.deepEqual(await confirm({ sender: enabled.mainWebContents }, confirmation), {
+    success: true,
+    accepted: true,
+    pointerdownId: confirmation.pointerdownId,
+    targetFrame: 42
+  });
+  assert.deepEqual(enabled.pointerdownFrameConfirmCalls, [confirmation]);
+  assert.deepEqual(await confirm({ sender: {} }, confirmation), {
+    success: false,
+    error: 'Fabric drawing IPC sender is not allowed'
+  });
+  assert.equal(enabled.pointerdownFrameConfirmCalls.length, 1);
+
+  const disabled = loadPointerPresenceIpcHandlers({
+    fabricDrawingPilot: { enabled: false }
+  });
+  const disabledConfirm = disabled.invokeHandlers.get(
+    'mpv:confirm-overlay-drawing-pointerdown-frame'
+  );
+  assert.deepEqual(
+    await disabledConfirm({ sender: disabled.mainWebContents }, confirmation),
+    { success: false, error: 'Fabric drawing pilot is disabled' }
+  );
+  assert.equal(disabled.pointerdownFrameConfirmCalls.length, 0);
 });

--- a/scripts/tests/mpv-runtime-source.test.js
+++ b/scripts/tests/mpv-runtime-source.test.js
@@ -26,7 +26,9 @@ test('Fabric drawing pilot IPC channels and preload bridge names stay fixed', ()
     ['fabric-drawing:get-pilot-state', 'getFabricDrawingPilotState'],
     ['mpv:set-overlay-drawing-input', 'mpvSetOverlayDrawingInput'],
     ['mpv:update-overlay-drawing-tool', 'mpvUpdateOverlayDrawingTool'],
+    ['mpv:update-overlay-drawing-frame', 'mpvUpdateOverlayDrawingFrame'],
     ['mpv:apply-overlay-drawing-action', 'mpvApplyOverlayDrawingAction'],
+    ['mpv:present-overlay-drawing-frame', 'mpvPresentOverlayDrawingFrame'],
     ['mpv:get-overlay-drawing-diagnostics', 'mpvGetOverlayDrawingDiagnostics'],
     ['mpv:hydrate-overlay-drawing-video', 'mpvHydrateOverlayDrawingVideo'],
     ['mpv:export-overlay-drawing-video', 'mpvExportOverlayDrawingVideo']
@@ -84,7 +86,9 @@ test('Fabric drawing mutation IPC rejects pilot-off and non-main-renderer calls 
   const guardedCalls = [
     ['mpv:set-overlay-drawing-input', 'setDrawingInput'],
     ['mpv:update-overlay-drawing-tool', 'updateDrawingTool'],
+    ['mpv:update-overlay-drawing-frame', 'updateDrawingFrame'],
     ['mpv:apply-overlay-drawing-action', 'applyDrawingAction'],
+    ['mpv:present-overlay-drawing-frame', 'presentDrawingFrame'],
     ['mpv:get-overlay-drawing-diagnostics', 'getDrawingDiagnostics'],
     ['mpv:hydrate-overlay-drawing-video', 'hydrateDrawingVideo'],
     ['mpv:export-overlay-drawing-video', 'exportDrawingVideo']

--- a/scripts/tests/playlist-continuous-runtime.test.js
+++ b/scripts/tests/playlist-continuous-runtime.test.js
@@ -1937,7 +1937,13 @@ function createActualLoadRaceScenario({
   failFirstContinuousLoad = false,
   failFirstPreparedItem = false,
   holdSecondFileExists = false,
-  fabricFlushResults = null
+  fabricFlushResults = null,
+  hasExistingReviewData = false,
+  holdCollaborationStart = false,
+  afterVideoReadyResult = true,
+  fabricPilotOwnsDrawing = true,
+  fileIsAudio = false,
+  mpvLoadSucceeds = false
 } = {}) {
   const effects = {
     mediaLoads: [],
@@ -1954,7 +1960,9 @@ function createActualLoadRaceScenario({
     persistenceBypassStages: [],
     persistenceAbandons: 0,
     playlistStatusChanges: [],
-    toasts: []
+    toasts: [],
+    fabricAfterVideoReady: 0,
+    loadReadinessEvents: []
   };
   const queuedFabricFlushResults = Array.isArray(fabricFlushResults)
     ? [...fabricFlushResults]
@@ -1981,6 +1989,10 @@ function createActualLoadRaceScenario({
   let notifySecondMediaLoadStarted;
   const secondMediaLoadStarted = new Promise(resolve => { notifySecondMediaLoadStarted = resolve; });
   const heldSecondMediaLoad = new Promise(resolve => { releaseSecondMediaLoad = resolve; });
+  let releaseCollaborationStart;
+  let notifyCollaborationStarted;
+  const collaborationStarted = new Promise(resolve => { notifyCollaborationStarted = resolve; });
+  const heldCollaborationStart = new Promise(resolve => { releaseCollaborationStart = resolve; });
   let mediaLoadCalls = 0;
   let capturedDeadline = null;
   let preparedItemCalls = 0;
@@ -2053,6 +2065,14 @@ function createActualLoadRaceScenario({
       }
     }
   };
+  const audioWaveform = {
+    canvas: null,
+    _seekHandler: null,
+    mount: () => { audioWaveform.canvas = {}; },
+    show: () => {}, hide: () => {}, reset: () => {}, setPlaying: () => {},
+    loadAudio: async () => {},
+    addEventListener: () => {}, removeEventListener: () => {}
+  };
   const reviewDataManager = {
     currentBframePath: null,
     isModified: false,
@@ -2060,7 +2080,13 @@ function createActualLoadRaceScenario({
     hasUnsavedChanges: () => false,
     save: async () => true,
     pauseAutoSave: () => {}, resumeAutoSave: () => {}, setVersionInfo: () => {},
-    setVideoFile: async () => false, setFps: () => {}, getManualVersions: () => []
+    setVideoFile: async filePath => {
+      effects.loadReadinessEvents.push('local-review-installed');
+      reviewDataManager.currentBframePath = `${filePath}.bframe`;
+      return hasExistingReviewData;
+    },
+    setFps: () => { effects.loadReadinessEvents.push('local-review-fps-ready'); },
+    getManualVersions: () => []
   };
   const fabricDrawingPilotController = {
     flushPersistenceBeforeLeave: async () => {
@@ -2081,7 +2107,12 @@ function createActualLoadRaceScenario({
       effects.persistenceAbandons += 1;
       return true;
     },
-    afterVideoReady: async () => {}
+    afterVideoReady: async () => {
+      effects.fabricAfterVideoReady += 1;
+      effects.loadReadinessEvents.push('fabric-after-video-ready');
+      return afterVideoReadyResult;
+    },
+    shouldOwnDrawingShortcut: () => fabricPilotOwnsDrawing
   };
   const pendingReview = { token: null };
   const runtime = createActualLoadRaceHarness({
@@ -2121,9 +2152,10 @@ function createActualLoadRaceScenario({
       }
     },
     log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, trace: () => ({ end: () => {}, error: () => {} }) },
-    isAudioFile: () => false,
+    isAudioFile: () => fileIsAudio,
     isSameFilePath: (left, right) => left === right,
-    shouldUseMpvPilot: async () => useMpvPilot,
+    shouldUseMpvPilot: async (_filePath, options = {}) =>
+      useMpvPilot && options.fileIsAudio !== true,
     mpvPilotSeamlessTransitionGate: { begin: () => {}, clear: () => {} },
     isMpvPilotPlaybackActive: () => false,
     cancelPlaylistBackgroundTranscodesForMpvPilot: async () => {},
@@ -2144,12 +2176,16 @@ function createActualLoadRaceScenario({
       clearMarkers: () => {}, renderDrawingLayers: () => {}, setCurrentTime: () => {}, setPlayingState: () => {}
     },
     markerContainer: makeElement(), codecErrorOverlay: makeElement(),
-    getAudioWaveform: () => ({ hide: () => {}, reset: () => {}, setPlaying: () => {} }),
+    getAudioWaveform: () => audioWaveform,
     invalidateMpvHostVisibilityRequests: () => {}, resolveInitialFrameFromOptions: () => null,
     captureVideoTransitionFreezeFrame: () => false, releaseVideoTransitionFreezeFrame: () => {},
     resolveHtml5PlaybackFps: async () => 24, seekInitialVideoFrameBeforeReveal: async () => {},
     waitForVideoRenderable: async () => true, waitForNextVideoPaint: async () => {},
-    playVideoAfterMediaLoad: async () => { effects.playAfterLoad += 1; return true; },
+    playVideoAfterMediaLoad: async () => {
+      effects.playAfterLoad += 1;
+      effects.loadReadinessEvents.push('play-after-media-load');
+      return true;
+    },
     parseVersion: () => ({ version: 1 }),
     getVersionManager: () => ({
       setCurrentFile: async () => {
@@ -2164,7 +2200,16 @@ function createActualLoadRaceScenario({
     getVersionDropdown: () => ({ show: () => {}, onVersionSelect: () => {}, _render: () => {} }),
     toVersionInfo: () => ({}), generateThumbnails: async () => {},
     getThumbnailGenerator: () => ({ clear: () => {} }),
-    scheduleDeferredCollaborationStart: () => {}, startCollaborationForVideoLoad: async () => true,
+    scheduleDeferredCollaborationStart: () => {},
+    startCollaborationForVideoLoad: async () => {
+      effects.loadReadinessEvents.push('collaboration-started');
+      notifyCollaborationStarted();
+      if (holdCollaborationStart) {
+        await heldCollaborationStart;
+      }
+      effects.loadReadinessEvents.push('collaboration-resolved');
+      return true;
+    },
     startDeferredReviewFileDiscovery: () => {},
     showToast: (message, type) => { effects.toasts.push({ message, type }); },
     renderVideoMarkers: () => {}, renderActiveDrawingLayers: () => {},
@@ -2181,7 +2226,7 @@ function createActualLoadRaceScenario({
       return options.loaded === true;
     },
     retryDeferredMpvOverlayFallback: () => { effects.fallbacks += 1; }, resolveMpvThumbnailVideoPath: async filePath => filePath,
-    loadVideoWithMpvPilot: async () => false,
+    loadVideoWithMpvPilot: async () => mpvLoadSucceeds,
     beginMpvHtml5FallbackReviewTransition: () => null,
     beginExpectedMpvHtml5FallbackStop: () => 1,
     finishMpvHtml5FallbackReviewTransition: () => {},
@@ -2255,7 +2300,10 @@ function createActualLoadRaceScenario({
     getNextCutlistCut: () => null,
     advanceCutlistPlaybackFromCut: () => {},
     getContinuousPlaybackSnapshot: () => ({}),
-    userSettings: { getPlaylistAutoPlay: () => true }
+    userSettings: { getPlaylistAutoPlay: () => true },
+    requestAnimationFrame: callback => { callback(); return 1; },
+    isFabricDrawingPilotControllerEngaged: () => false,
+    exitDrawModeForSystemPath: () => {}
   }, { useActualPlayNext, useActualContinuousLoad });
 
   return {
@@ -2265,10 +2313,139 @@ function createActualLoadRaceScenario({
     secondFileExistsStarted, releaseSecondFileExists,
     firstMediaLoadStarted, releaseFirstMediaLoad,
     secondMediaLoadStarted, releaseSecondMediaLoad,
+    collaborationStarted, releaseCollaborationStart,
     setContinuousMediaEnded: ended => { mediaEnded = ended; },
     fireDeadline: () => { assert.equal(typeof capturedDeadline, 'function'); capturedDeadline(); }
   };
 }
+
+test('local Fabric review becomes ready before awaited collaboration startup resolves', async () => {
+  const scenario = createActualLoadRaceScenario({
+    hasExistingReviewData: true,
+    holdCollaborationStart: true
+  });
+  scenario.releaseOldTail();
+
+  const load = scenario.runtime.loadVideo(scenario.items[0].videoPath, {
+    allowMpvPilot: false
+  });
+  await scenario.collaborationStarted;
+
+  assert.deepEqual(scenario.effects.loadReadinessEvents, [
+    'local-review-installed',
+    'local-review-fps-ready',
+    'fabric-after-video-ready',
+    'collaboration-started'
+  ]);
+  assert.equal(scenario.effects.fabricAfterVideoReady, 1);
+
+  scenario.releaseCollaborationStart();
+  assert.equal(await load, true);
+  assert.equal(scenario.effects.fabricAfterVideoReady, 1, 'local Fabric readiness must run exactly once');
+});
+
+test('automatic playback waits for local Fabric readiness before collaboration startup', async () => {
+  const scenario = createActualLoadRaceScenario({
+    hasExistingReviewData: true,
+    holdCollaborationStart: true
+  });
+  scenario.releaseOldTail();
+
+  const load = scenario.runtime.loadVideo(scenario.items[0].videoPath, {
+    allowMpvPilot: false,
+    playWhenMediaReady: true
+  });
+  await scenario.collaborationStarted;
+
+  assert.deepEqual(scenario.effects.loadReadinessEvents, [
+    'local-review-installed',
+    'local-review-fps-ready',
+    'fabric-after-video-ready',
+    'play-after-media-load',
+    'collaboration-started'
+  ]);
+
+  scenario.releaseCollaborationStart();
+  assert.equal(await load, true);
+  assert.equal(scenario.effects.playAfterLoad, 1);
+  assert.equal(scenario.effects.fabricAfterVideoReady, 1);
+});
+
+test('mpv Fabric readiness rejection fails the load before autoplay and runs destructive cleanup', async () => {
+  const scenario = createActualLoadRaceScenario({
+    useMpvPilot: true,
+    mpvLoadSucceeds: true,
+    afterVideoReadyResult: false,
+    fabricPilotOwnsDrawing: true
+  });
+  scenario.releaseOldTail();
+
+  const loaded = await scenario.runtime.loadVideo(scenario.items[0].videoPath, {
+    allowMpvPilot: true,
+    playWhenMediaReady: true
+  });
+
+  assert.equal(scenario.effects.playAfterLoad, 0, 'autoplay must not outrun rejected Fabric readiness');
+  assert.equal(loaded, false, 'loadVideo must expose the readiness failure to its caller');
+  assert.deepEqual(scenario.effects.loadReadinessEvents, [
+    'local-review-installed',
+    'local-review-fps-ready',
+    'fabric-after-video-ready'
+  ]);
+  assert.equal(scenario.effects.fabricCancellations.length, 1);
+  assert.equal(scenario.effects.fabricCancellations[0].options?.restorePreviousVideo, false);
+  assert.equal(scenario.effects.settlements.at(-1)?.loaded, false);
+  assert.equal(scenario.effects.teardowns, 1);
+});
+
+test('non-applicable Fabric readiness rejection preserves existing autoplay routes', async (t) => {
+  const cases = [
+    {
+      name: 'HTML5 video',
+      scenario: { useMpvPilot: false },
+      loadOptions: {}
+    },
+    {
+      name: 'audio',
+      scenario: { useMpvPilot: true, fileIsAudio: true },
+      loadOptions: {}
+    },
+    {
+      name: 'engine swap',
+      scenario: { useMpvPilot: true, mpvLoadSucceeds: true },
+      loadOptions: { engineSwap: true }
+    },
+    {
+      name: 'mpv without Fabric ownership',
+      scenario: {
+        useMpvPilot: true,
+        mpvLoadSucceeds: true,
+        fabricPilotOwnsDrawing: false
+      },
+      loadOptions: {}
+    }
+  ];
+
+  for (const testCase of cases) {
+    await t.test(testCase.name, async () => {
+      const scenario = createActualLoadRaceScenario({
+        ...testCase.scenario,
+        afterVideoReadyResult: false
+      });
+      scenario.releaseOldTail();
+
+      const loaded = await scenario.runtime.loadVideo(scenario.items[0].videoPath, {
+        allowMpvPilot: true,
+        playWhenMediaReady: true,
+        ...testCase.loadOptions
+      });
+
+      assert.equal(loaded, true);
+      assert.equal(scenario.effects.playAfterLoad, 1);
+      assert.equal(scenario.effects.fabricAfterVideoReady, testCase.loadOptions.engineSwap ? 0 : 1);
+    });
+  }
+});
 
 test('드로잉 저장 게이트 실패는 이어붙이기를 한 번만 중단하고 현재 영상 선택을 복원한다', async (t) => {
   const cases = [

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -244,12 +244,12 @@ test('release build scripts pin stable while trial build scripts pin trial regar
   assert.match(packageJson.scripts['test:mpv'], /runtime-profile\.test\.js/);
 });
 
-test('stable engine promotion uses the 2.2.1 beta release version consistently', () => {
+test('stable engine promotion uses the 2.3.0 beta release version consistently', () => {
   const rootDir = path.resolve(__dirname, '..', '..');
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.2.1-beta');
-  assert.equal(packageLock.version, '2.2.1-beta');
-  assert.equal(packageLock.packages[''].version, '2.2.1-beta');
+  assert.equal(packageJson.version, '2.3.0-beta');
+  assert.equal(packageLock.version, '2.3.0-beta');
+  assert.equal(packageLock.packages[''].version, '2.3.0-beta');
 });


### PR DESCRIPTION
## 📋 업데이트 요약

- 🎬 **드로잉이 영상 재생을 따라갑니다.** B를 누르지 않아도 현재 프레임에 맞는 그림이 보이며, 다음 키프레임 전까지 유지되고 빈 키프레임에서 사라집니다.
- ✏️ **재생 중에도 정확한 프레임에 새 그림이 생깁니다.** 드로잉 모드를 켠 채 재생하다가 그리면 처음 그렸던 키프레임에 합쳐지지 않고 현재 프레임에 새 키프레임이 만들어집니다.
- ↔️ **타임라인 키프레임을 옮길 수 있습니다.** 다른 키프레임 위에 놓으면 Adobe Animate처럼 목적지를 덮어쓰며, 실행 취소와 다시 실행도 순서대로 동작합니다.
- 🚀 **첫 재생부터 그림을 준비합니다.** 협업 연결이 늦어도 로컬 드로잉을 먼저 준비하고, 준비에 실패한 경우 그림 없는 상태로 자동재생하지 않습니다.
- 🖼️ **B를 꺼도 화면이 유지됩니다.** 영상 위 드로잉 창의 표시 순서를 매번 복구해 재생 중 그림이 영상 뒤로 숨지 않습니다.

## 🔧 상세 기술 설명

- 버전을 `2.3.0-beta`로 올렸습니다.
- `renderer/scripts/modules/fabric-drawing-pilot-controller.js`, `preload/*.js`, `main/ipc-handlers.js`, `main/mpv-overlay-host.js`에 passive frame presentation과 active frame retarget 경로를 연결했습니다. host/video/input/session/revision fence와 exact DTO 검증으로 오래된 요청이 새 영상이나 새 세션을 덮지 못하게 했습니다.
- `renderer/scripts/modules/mpv-fabric-overlay-runtime.js`는 현재 프레임 이하의 마지막 non-empty 장면을 hold source로 표시하고 empty keyframe에서 끊습니다. active 재생 중에는 미리보기만 갱신하고, 실제 pointerdown/mutation 시점에 현재 프레임으로 copy-on-write하여 한 획을 한 프레임에 고정합니다.
- passive viewport에 원본 크기·캔버스 영역·zoom/pan을 함께 전달해 B-off 첫 표시와 크기 변경에서도 좌표를 보존합니다. 승인된 passive 표시만 `runtime render → BrowserWindow.moveTop() → invalidate()` 순서로 처리합니다.
- `renderer/scripts/modules/fabric-drawing-persistence-store.js`에 덮어쓰기 가능한 원자적 다중 키프레임 이동과 before/after edit token을 추가했습니다. `renderer/scripts/modules/timeline.js`는 synthetic Fabric 행만 잠금 상태에서 드래그를 허용하고, 소스 재렌더 중 오래된 drag는 폐기합니다.
- `renderer/scripts/app.js`는 Fabric 이동을 legacy drawing manager와 분리하고 global history 자리를 예약합니다. 이동 tail 동안 들어온 외부 action은 FIFO로 보존하며, 진행 중 Undo/Redo와 역방향 이동은 교차하지 않습니다.
- 영상 로드 순서를 `로컬 review → FPS → Fabric afterVideoReady → 선택적 자동재생 → collaboration`으로 바꿨습니다. 적용 대상 mpv Fabric에서 readiness가 `true`가 아니면 자동재생 전에 load를 실패로 닫고 정리합니다.
- runtime 소스와 재생성된 `renderer/scripts/lib/mpv-fabric-overlay.iife.js`를 같은 커밋에 포함했습니다.
- PR 1차 리뷰 반영으로 held source는 전체 장면을 복제하지 않고 frame 번호만 해석하며, passive 표시 IPC는 bounded deadline 뒤 최신 대기 프레임을 계속 처리합니다.
- PR 2차 리뷰 반영으로 B-on 승인이 늦어져도 승인 시점의 현재 재생 프레임을 다시 읽어 runtime 화면과 첫 pointerdown 저장 위치를 즉시 맞춥니다.
- PR 3차 리뷰 반영으로 pointerdown 승인 대기 중에도 브라우저가 묶어 보낸 펜 좌표와 압력을 순서대로 보존하고, 1,024개 상한을 넘으면 불완전한 stroke를 저장하지 않습니다.
- PR 4차 리뷰 반영으로 빠른 클릭의 pointerup 뒤 자동 capture 해제를 정상 완료로 보존하고, pointerup 전 실제 capture 손실은 계속 저장 없이 취소합니다.
- PR 5차 리뷰 반영으로 pointerdown 확인 응답이 사라져도 3초 뒤 입력 잠금을 풀고, 늦은 응답은 새 gesture나 저장 상태를 바꾸지 못하게 했습니다.

## 🚧 개발 난항

- 단위 IPC stub은 extra key를 허용해 통과했지만 실제 host의 exact DTO 검증은 요청을 거부했습니다. 실제 controller→host→runtime 통합 테스트를 추가해 이 차이를 잡았습니다.
- Fabric canvas에는 그림이 남아 있어도 Windows의 mpv sibling 창이 overlay 위로 올라오면 사용자에게는 그림이 사라진 것처럼 보였습니다. canvas 데이터와 Win32 창 순서를 따로 추적해 네이티브 restack 경계를 수정했습니다.
- B-on 재생 중 프레임 알림과 실제 pointerdown은 서로 다른 화면 프로세스에서 도착합니다. pointerdown 확인/취소 handshake와 owner fence를 추가해 오래된 프레임에 그려지는 경합을 막았습니다.
- 로컬 파일은 준비됐지만 협업 storage Promise가 pending이면 Fabric 준비까지 멈추는 콜드 스타트 순서 문제가 실기에서 발견됐습니다. 네트워크 협업과 로컬 표시 준비를 분리했습니다.
- 키프레임 이동 store commit과 화면 refresh 사이에 Undo 또는 댓글·하이라이트 기록이 들어오면 history 순서가 바뀔 수 있었습니다. 이동 전용 history reservation과 FIFO barrier로 시간 순서를 고정했습니다.

## ✅ 테스트 가이드

### 실사용자용

1. B를 누르지 않은 상태로 영상을 재생하고, 드로잉 키프레임 전은 비어 있고 키프레임부터 다음 키프레임 직전까지 그림이 유지되는지 확인합니다.
2. 빈 키프레임을 지나면 이전 그림이 사라지는지, 뒤로 탐색하면 다시 올바른 그림이 보이는지 확인합니다.
3. B를 켜고 10f에 그린 뒤 그대로 재생하여 20f 이후에 새로 그립니다. 10f 그림은 변하지 않고 현재 프레임에 새 키프레임이 생겨야 합니다.
4. 키프레임을 빈 프레임과 기존 키프레임 위로 각각 드래그합니다. 기존 키프레임 위에서는 목적지가 덮어써지고 Ctrl+Z/Ctrl+Y로 왕복되어야 합니다.
5. 앱을 새로 열고 B를 한 번도 누르지 않은 채 자동재생해 첫 드로잉부터 보이는지 확인합니다.

### 개발자용

- 25개 named test suite: **2,112 tests / 2,112 pass / 0 fail / 0 cancelled**, 모든 exit code 0 (기준선 1,925 대비 +187)
- 주요 게이트: `test:fabric-drawing-pilot` 441/441, `test:fabric-drawing-persistence` 156/156, `test:drawing` 291/291, `test:playlist` 326/326, `test:mpv` 321/321
- ESLint: exit 0, error 0, 기존 warning 59
- production JS 9개 `node --check`: 모두 exit 0
- runtime bundle 재생성 SHA-256: `AFFAE729EC2ECD63C3997C2B77A5B5B8839DF14E66C91FE8E13EAA717C9F8286` (재생성 전후 동일)
- Windows 실기: B 입력 0회인 passive 상태에서 15초 fixture를 정·역 재생하고 blank/hold/empty 장면, runtime passive 상태, canvas 픽셀을 확인
- preflight `electron-builder --dir`: 별도 출력 디렉터리에서 exit 0
- 비차단 보강점: 이동·autosave·직렬화 round-trip은 각각 검증했으나, 이동→autosave→fresh process reload를 한 흐름으로 묶은 통합 테스트는 후속 보강 가능
