### PR TITLE
[v2.3.0] 드로잉 키프레임 릴리스 기록 완성

### DIFF
--- a/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
+++ b/DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md
@@ -15,7 +15,7 @@
 | 2. 재생 표시 | B를 누르지 않아도 현재 프레임의 드로잉이 재생·탐색 중 표시됨 | app, controller, preload/IPC, host, runtime/IIFE | ✅ 완료 |
 | 3. 편집·이동 | B-on 재생 중 새 획은 현재 프레임에 생기고, 타임라인 이동은 기존 목적지를 덮어씀 | persistence store, timeline, app | ✅ 완료 |
 | 4. 콜드 스타트·검증 | 협업 연결을 기다리지 않고 로컬 드로잉을 먼저 준비하며 자동재생도 그 뒤 시작 | app, playlist runtime test, 전체 게이트, Windows 실기 | ✅ 완료 |
-| 5. 릴리스 | PR 리뷰·merge commit 빌드·공유드라이브 교체·해시 parity | GitHub, release worktree, 공유드라이브 | 🔄 진행중 |
+| 5. 릴리스 | PR 리뷰·merge commit 빌드·공유드라이브 교체·해시 parity | GitHub, release worktree, 공유드라이브 | ✅ 완료 |
 
 ## 배경과 사용자에게 보이는 결과
 
@@ -163,7 +163,7 @@
 
 - 사용자 지정 기준선 `1,925` 대비 `+187`개이며 25개 named suite가 모두 통과했다.
 - ESLint: exit 0, error 0, 기존 warning 59.
-- 변경 생산 JavaScript 9개 `node --check`: exit 0.
+- 변경 생산 JavaScript 10개 `node --check`: exit 0.
 - `git diff --check`: exit 0.
 - runtime bundle 2회 재생성 SHA-256 일치: `AFFAE729EC2ECD63C3997C2B77A5B5B8839DF14E66C91FE8E13EAA717C9F8286`.
 - Windows x64 unpacked preflight build: exit 0.
@@ -216,10 +216,25 @@
 
 ## 릴리스 기록
 
-- 구현 커밋: 배포 완료 후 기록
-- PR: 배포 완료 후 기록
-- Codex GitHub 리뷰: 배포 완료 후 기록
-- merge commit: 배포 완료 후 기록
-- exact-merge build: 배포 완료 후 기록
+- 구현 커밋:
+  - `08d47db`: 설계 기록
+  - `6754541`: hold 표시·active retarget·키프레임 이동·콜드 스타트 구현
+  - `01bf627`: held source 경량 해석·passive IPC deadline
+  - `e593a4a`: 지연된 B-on 승인 프레임 재동기화
+  - `e3965be`: pending coalesced 펜 샘플 보존
+  - `b3bf1bf`: buffered pointerup 뒤 implicit capture loss 보존
+  - `9baa045`: pointerdown confirm 무응답 3초 복구
+- PR: [#181](https://github.com/baehandoridori/BAEFRAME/pull/181), 2026-08-25 merge.
+- Codex GitHub 리뷰:
+  - 1차 P2 2건, 2차 P1 1건, 3차 P2 1건, 4차 P1 1건, 5차 P2 1건을 각각 RED → GREEN으로 반영했다.
+  - 6차에서 `Didn't find any major issues` 명시 완료 신호를 받았으며 검토 HEAD는 `9baa045`다.
+- merge commit: `51be01ff69c09bf12b3f8d578931677d1f7c2864`.
+- exact-merge build: `C:\Users\user\.codex\worktrees\baeframe-release-2.3.0-beta-51be01f\BAEFRAME\dist\win-unpacked`, `npm run build` exit 0.
+- exact-merge 검증: 25개 named suite **2,112/2,112**, fail 0, cancelled 0, 모든 exit 0. ESLint error 0 / 기존 warning 59, 변경 JavaScript 10개 `node --check` 통과.
 - 공유드라이브 배포 경로: `G:\공유 드라이브\JBBJ 자료실\한솔이의 두근두근 실험실\BAEFRAME\테스트버전 빌드`
-- source → staging → live 전체 파일 path/size/SHA-256 parity: 배포 완료 후 실제 파일 수·zero-byte·mismatch·핵심 해시 기록
+- source → staging → live 전체 파일 path/size/SHA-256 parity: **82/82파일**, **750,899,804바이트**, zero-byte 0, missing 0, extra 0, `MismatchCount=0`.
+- 배포본 핵심 SHA-256:
+  - `BFRAME_alpha_v2.exe`: `EA77587C21E3D48348D84F7CA0AA2CDBBDF04703DAF0473EBE44F2099D7143F1`
+  - `resources\app.asar`: `4ECA939408B7BB3040715E1F67826A8F104AE4185D378025F7B3E04D1A4A878E`
+- 필수 mpv 4종·FFmpeg 2종·`ReviewFileCasHelper.exe`·`fabric-v3-stable` runtime marker는 모두 non-zero이며 exact source와 일치했다.
+- rollback 백업: `G:\공유 드라이브\JBBJ 자료실\한솔이의 두근두근 실험실\BAEFRAME\테스트버전 빌드.__backup_20260825-230143` (배포 검증 후 보존).


### PR DESCRIPTION
## 📋 업데이트 요약

- 📝 **2.3.0-beta 배포 결과를 프로젝트 기록에 남겼습니다.** 어떤 수정이 들어갔고, 어떤 검증을 거쳐 어디에 배포됐는지 한 문서에서 확인할 수 있습니다.
- ✅ 앱 기능과 배포 파일은 바뀌지 않습니다. 이미 배포된 드로잉 키프레임 표시·이동 개선의 최종 기록만 보완합니다.

## 🔧 상세 기술 설명

- `DEVLOG/2026-08-25-드로잉-키프레임-표시-이동-구현.md`의 Phase 5를 완료 상태로 갱신했습니다.
- PR #181의 7개 구현 커밋, Codex 리뷰 6회와 최종 no-major 신호, merge commit `51be01ff69c09bf12b3f8d578931677d1f7c2864`를 기록했습니다.
- exact-merge 25-suite 2,112/2,112, ESLint 0 errors/59 existing warnings, 변경 JavaScript 10개 문법 검증 결과를 반영했습니다.
- source → staging → live 82파일 전체 경로·크기·SHA-256 parity와 `MismatchCount=0`, exe/app.asar 해시, 필수 mpv·FFmpeg·native helper·stable profile 검증을 기록했습니다.
- 공유드라이브 라이브 경로와 rollback 백업 경로를 함께 남겼습니다.

## 🚧 개발 난항

- 기능 PR은 단위 테스트만으로 보이지 않던 Windows 창 순서, 비동기 프레임 경합, 고주파 펜 입력과 무응답 IPC를 Codex 리뷰 5차까지 반복 보강했습니다.
- 배포 기록은 PR·GitHub 리뷰·exact-merge 테스트·로컬 산출물·공유드라이브 라이브를 서로 대조해야 했습니다. 별도 release artifact audit로 테스트 합계, 커밋, 해시, 파일 수를 다시 확인했습니다.
- staging 폴더는 라이브 교체 뒤 이름이 바뀌므로, 교체 전 source→staging 전체 해시 검증과 교체 후 source→live 전체 해시 검증을 각각 수행했습니다.

## ✅ 테스트 가이드

### 실사용자용

- 앱 변경이 없는 문서 전용 PR입니다. 기능 재검증이나 재설치는 필요하지 않습니다.
- 공유드라이브 `테스트버전 빌드`가 `2.3.0-beta`인지 확인하면 됩니다.

### 개발자용

- DEVLOG의 25개 suite 행 합계: 2,112/2,112
- `git diff --check`: exit 0
- 변경 생산 JavaScript base→merge 산정: 10개, `node --check` 10/10
- 배포 full-tree parity: 82/82파일, 750,899,804바이트, zero-byte 0, `MismatchCount=0`
- 핵심 SHA-256: exe `EA77587C21E3D48348D84F7CA0AA2CDBBDF04703DAF0473EBE44F2099D7143F1`, app.asar `4ECA939408B7BB3040715E1F67826A8F104AE4185D378025F7B3E04D1A4A878E`