### PR TITLE
G:드라이브 저장 견고화와 동시 세션 표시 복구 (작업 7·8)

### DIFF
--- a/main/review-file-store.js
+++ b/main/review-file-store.js
@@ -49,6 +49,15 @@ const TRANSIENT_READ_ERROR_CODES = new Set([
 ]);
 const RECOVERY_SCHEMA_VERSION = 1;
 const MAX_AUTO_RECOVERY_JSON_BYTES = 64 * 1024 * 1024;
+// main→renderer로는 error.code가 전달되지 않고 결과 객체 필드와 메시지
+// 문자열만 남는다. 치명 실패는 원인을 알려주는 고정 문구를 error 필드에
+// 실어 보내, renderer가 '.bframe 저장 실패' 폴백을 타지 않게 한다.
+const ATOMIC_REPLACE_UNSUPPORTED_MESSAGE =
+  '공유 드라이브가 파일 교체를 허용하지 않았습니다. ' +
+  '파일이 다른 프로그램에서 열려 있는지 확인해 주세요.';
+const RECOVERY_REQUIRED_MESSAGE =
+  '저장을 끝내지 못해 복구가 필요합니다. ' +
+  '파일을 다른 프로그램에서 닫은 뒤 다시 시도해 주세요.';
 const GENERATED_TEMP_REMAINDER_PATTERN =
   /^([1-9]\d*)-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(\.(?:commit|prepare|restore))?$/;
 
@@ -1071,6 +1080,10 @@ function createReviewFileStore(configuration = {}) {
     const delays = renameRetryDelaysMs.length > 0
       ? renameRetryDelaysMs
       : [0];
+    // unsupported(exit 5)는 ReplaceFileW/MoveFileExW가 false를 돌려준
+    // 직후에만 나오므로 target은 그대로다. 공유 드라이브 리다이렉터의
+    // 일시적 거부를 위해 딱 1회만 다시 시도한다.
+    let unsupportedRetried = false;
 
     for (let attempt = 0; attempt < delays.length; attempt += 1) {
       await delay(Math.max(0, Number(delays[attempt]) || 0));
@@ -1143,10 +1156,15 @@ function createReviewFileStore(configuration = {}) {
         };
       }
       if (casResult?.status === 'unsupported') {
+        if (!unsupportedRetried && attempt < delays.length - 1) {
+          unsupportedRetried = true;
+          continue;
+        }
         return {
           success: false,
           fatal: true,
           reason: 'atomic-replace-unsupported',
+          error: ATOMIC_REPLACE_UNSUPPORTED_MESSAGE,
           casResult
         };
       }
@@ -1849,7 +1867,8 @@ function createReviewFileStore(configuration = {}) {
           return {
             success: false,
             fatal: true,
-            reason: 'recovery-required'
+            reason: 'recovery-required',
+            error: RECOVERY_REQUIRED_MESSAGE
           };
         }
         await cleanupCasBackups(
@@ -1869,7 +1888,8 @@ function createReviewFileStore(configuration = {}) {
       return {
         success: false,
         fatal: true,
-        reason: 'recovery-required'
+        reason: 'recovery-required',
+        error: RECOVERY_REQUIRED_MESSAGE
       };
     } catch (error) {
       if (!prepared) {
@@ -1962,7 +1982,20 @@ function createReviewFileStore(configuration = {}) {
       await cleanupOrphanTemps(filePath);
 
       const currentContent = await readTextOrNull(fsPromises, filePath);
-      if (currentContent !== null) JSON.parse(currentContent);
+      if (currentContent !== null && !failIfExists) {
+        try {
+          JSON.parse(currentContent);
+        } catch {
+          // 저장 경로는 손상 복구를 직접 하지 않는다. 다음 저장 시도가
+          // 먼저 부르는 readReviewSnapshot이 .bak 복구를 수행하므로,
+          // 여기서는 원본을 건드리지 않고 재시도 신호만 돌려준다.
+          return {
+            success: false,
+            retryable: true,
+            reason: 'malformed-target'
+          };
+        }
+      }
       const initialStateResult = currentStateResult(
         currentContent,
         versionToken,
@@ -2060,7 +2093,11 @@ function createReviewFileStore(configuration = {}) {
       while (await pathExists(fsPromises, sidecarPath)) {
         const release = await acquireLock(filePath);
         if (!release) {
-          const error = new Error('Review recovery lock timed out');
+          // renderer로는 code가 아니라 message만 전달되므로 코드 문자열을
+          // 메시지 앞에 각인해 재시도 가능 실패로 식별되게 한다.
+          const error = new Error(
+            'ERR_REVIEW_LOCK_TIMEOUT: Review recovery lock timed out'
+          );
           error.code = 'ERR_REVIEW_LOCK_TIMEOUT';
           throw error;
         }
@@ -2075,7 +2112,9 @@ function createReviewFileStore(configuration = {}) {
         }
         if (!active) break;
         if (Date.now() - startedAt >= lockAcquireTimeoutMs) {
-          const error = new Error('Review transaction wait timed out');
+          const error = new Error(
+            'ERR_REVIEW_LOCK_TIMEOUT: Review transaction wait timed out'
+          );
           error.code = 'ERR_REVIEW_LOCK_TIMEOUT';
           throw error;
         }

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -7215,6 +7215,14 @@ async function initApp() {
       if (isStaleVideoLoadToken(loadToken) || !isCurrentReviewPath(bframePath)) return false;
       const existingRoomId = bframeData?.liveblocksRoomId || null;
 
+      // 참여자 카운트 기준값만 Room 접속 이전에 잡는다 — LiveblocksManager.stop()은
+      // collaboratorsChanged([])를 발생시키지 않아 이전 방의 참여자 수가 남으면 새 방의
+      // 0→N 에지를 놓친다. 구독이 Storage 대기보다 먼저 설치되어 start() 실행 중에도
+      // collaboratorsChanged가 도착하므로 반드시 여기서 0으로 되돌린다.
+      // 억제 창 시각(_collaborationSessionStartedAt)은 여기서 찍지 않는다 — sync 모듈이
+      // 전부 기동한 playbackSync.start() 직후에 찍는다(아래 c-2).
+      _previousOthersCount = 0;
+
       const { roomId, isNewRoom } = await liveblocksManager.start(
         bframePath,
         userName,
@@ -7246,9 +7254,10 @@ async function initApp() {
       drawingSync.start();
       fabricDrawingSync.start();
       playbackSync.start();
-      // 새 협업 세션 기준값 초기화 — LiveblocksManager.stop()은 collaboratorsChanged([])를
-      // 발생시키지 않아 이전 방의 참여자 수가 남으면 새 방의 late seed 조건을 놓친다
-      _previousOthersCount = 0;
+      // late seed 억제 창은 sync 모듈이 전부 기동한 이 시점부터 센다. 접속 소요시간이
+      // 10초를 넘어도(G: 드라이브 저장 재시도 등) broadcastCurrentState가
+      // fabricDrawingSync.start() 이전에 나가지 않도록 여기서 다시 찍는다.
+      // 참여자 카운트 기준값(_previousOthersCount)은 (c-1)이 접속 직전에 잡는다.
       _collaborationSessionStartedAt = Date.now();
       if (seedCurrentState) {
         // 댓글·레거시 drawing seed는 삭제 경합을 수렴시킬 causal 정보가 없어 제외한다.
@@ -17567,14 +17576,25 @@ async function initApp() {
 
   liveblocksManager.addEventListener('collaborationStarted', (e) => {
     log.info('협업 시작됨 (Liveblocks)', e.detail);
-    // 다른 협업자가 있을 때만 알림 표시 (단일 세션에서는 무시)
-    if (liveblocksManager.hasOtherCollaborators()) {
-      if (!e.detail.isNewRoom) {
-        showToast('실시간 협업 세션에 참여했습니다', 'info');
-      }
-      // AirDrop 스타일 리플 효과
-      _triggerCollabRipple();
-    }
+    // 초기 참여자 스냅샷 1회 반영 — room.subscribe('others')는 변화가 있을 때만
+    // 발화하므로 구독 설치 이전에 확정된 기존 참여자는 이벤트로 오지 않는다.
+    // LiveblocksManager의 자체 보상 발행과 겹쳐도 같은 스냅샷이라 UI는 멱등하다.
+    const isSyncing = playbackSync.syncEnabled;
+    const me = {
+      name: userSettings.getUserName(),
+      color: userSettings.getColorForName(userSettings.getUserName()) || '#4a9eff',
+      isMe: true,
+      syncActive: isSyncing
+    };
+    const others = liveblocksManager.getOthers().map(u => ({
+      name: u.presence?.userName || '알 수 없음',
+      color: u.presence?.userColor || '#888',
+      isMe: false,
+      syncActive: isSyncing
+    }));
+    updateCollaboratorsUI([me, ...others]);
+    // 참여 알림(안내 배너·리플)은 collaboratorsChanged의 0→N 에지가 단독으로 담당한다.
+    // 여기서 다시 알리면 초기 스냅샷 보상 발행과 겹쳐 두 번 재생된다.
   });
 
   liveblocksManager.addEventListener('connectionStatusChanged', (e) => {

--- a/renderer/scripts/modules/liveblocks-manager.js
+++ b/renderer/scripts/modules/liveblocks-manager.js
@@ -143,6 +143,12 @@ export class LiveblocksManager extends EventTarget {
       this._room = result.room;
       this._leave = result.leave;
 
+      // 이벤트 구독 설정 — Storage 로드를 기다리기 전에 설치해야 접속 직후 도착하는
+      // 초기 참여자 상태(ROOM_STATE)를 놓치지 않는다. room.subscribe('others')는
+      // 구독 시점의 현재 값을 초기 발화하지 않는 순수 이벤트 소스이기 때문이다.
+      // _setupSubscriptions()는 this._room만 사용하므로 Storage 없이 안전하다.
+      this._setupSubscriptions();
+
       // Storage 로드 대기
       this._storage = await new Promise((resolve, reject) => {
         const timeout = setTimeout(() => {
@@ -166,9 +172,6 @@ export class LiveblocksManager extends EventTarget {
         }
       });
 
-      // 이벤트 구독 설정
-      this._setupSubscriptions();
-
       this._isConnected = true;
       this._connectionStatus = 'connected';
 
@@ -186,9 +189,26 @@ export class LiveblocksManager extends EventTarget {
 
       this._emit('connectionStatusChanged', { status: 'connected' });
 
+      // 구독 설치 이전에 이미 확정된 초기 참여자 목록을 1회 보상 발행한다.
+      // 구독을 앞당겨도 접속 직전에 확정된 상태는 변화 이벤트로 오지 않으므로,
+      // 이 자체 발행이 없으면 먼저 접속해 있던 참여자가 UI에 나타나지 않는다.
+      this._emitCollaboratorsChanged();
+
       return { roomId: this._roomId, isNewRoom };
     } catch (error) {
       log.error('Room 접속 실패', error);
+      // 구독을 Storage 대기보다 먼저 설치하므로, 접속이 실패하면 죽은 방의 구독이
+      // collaboratorsChanged를 계속 발행하지 않도록 여기서 반드시 정리한다.
+      this._unsubscribers.forEach(unsub => {
+        try { unsub(); } catch (e) { /* 무시 */ }
+      });
+      this._unsubscribers = [];
+      if (this._leave) {
+        try { this._leave(); } catch (e) { /* 무시 */ }
+      }
+      this._room = null;
+      this._leave = null;
+      this._storage = null;
       this._isConnected = false;
       this._connectionStatus = 'disconnected';
       this._emit('connectionStatusChanged', { status: 'disconnected', error });
@@ -371,21 +391,31 @@ export class LiveblocksManager extends EventTarget {
   /**
    * 이벤트 구독 설정
    */
+  /**
+   * 현재 others 스냅샷으로 collaboratorsChanged를 발행
+   * room.subscribe('others')는 변화가 있을 때만 발화하므로, 구독 설치 이전에
+   * 확정된 목록이나 재연결 직후 목록을 보상 푸시할 때도 이 경로를 재사용한다.
+   */
+  _emitCollaboratorsChanged() {
+    if (!this._room) return;
+    const others = this.getOthers();
+    this._emit('collaboratorsChanged', {
+      collaborators: others.map(u => ({
+        userName: u.presence?.userName || '알 수 없음',
+        userColor: u.presence?.userColor || '#888',
+        cursor: u.presence?.cursor,
+        currentFrame: u.presence?.currentFrame,
+        isDrawing: u.presence?.isDrawing,
+        activeComment: u.presence?.activeComment,
+        connectionId: u.connectionId
+      }))
+    });
+  }
+
   _setupSubscriptions() {
     // Others 변경 (접속/퇴장/presence 변경)
     const unsubOthers = this._room.subscribe('others', () => {
-      const others = this.getOthers();
-      this._emit('collaboratorsChanged', {
-        collaborators: others.map(u => ({
-          userName: u.presence?.userName || '알 수 없음',
-          userColor: u.presence?.userColor || '#888',
-          cursor: u.presence?.cursor,
-          currentFrame: u.presence?.currentFrame,
-          isDrawing: u.presence?.isDrawing,
-          activeComment: u.presence?.activeComment,
-          connectionId: u.connectionId
-        }))
-      });
+      this._emitCollaboratorsChanged();
     });
     this._unsubscribers.push(unsubOthers);
 
@@ -400,6 +430,9 @@ export class LiveblocksManager extends EventTarget {
         this._connectionStatus = 'connected';
         this._isConnected = true;
         this._emit('connectionStatusChanged', { status: 'connected' });
+        // 'lost' 동안 others가 비워져 UI가 1명으로 줄어든 뒤, 복구 시 others 변화가
+        // 발생하지 않으면 목록이 그대로 고착된다 — 복구 시점 스냅샷을 1회 재푸시한다.
+        this._emitCollaboratorsChanged();
         log.info('연결 복구됨');
       } else if (event === 'failed') {
         this._connectionStatus = 'disconnected';

--- a/renderer/scripts/modules/review-data-manager.js
+++ b/renderer/scripts/modules/review-data-manager.js
@@ -54,6 +54,16 @@ const BLOCKING_SAVE_FAILURE_REASONS = new Set([
   'fabric-drawing-source-refresh-failed'
 ]);
 
+// main→renderer IPC는 error.code를 보존하지 않으므로 메시지에 각인된
+// 코드 리터럴로도 함께 식별한다 (main/review-file-store.js readReviewSnapshot).
+const REVIEW_LOCK_TIMEOUT_CODE = 'ERR_REVIEW_LOCK_TIMEOUT';
+
+function isReviewLockTimeoutError(error) {
+  if (!error) return false;
+  if (error.code === REVIEW_LOCK_TIMEOUT_CODE) return true;
+  return String(error.message || '').includes(REVIEW_LOCK_TIMEOUT_CODE);
+}
+
 function toTime(value) {
   if (!value) return 0;
   const time = new Date(value).getTime();
@@ -1348,7 +1358,35 @@ export class ReviewDataManager extends EventTarget {
         }
 
         this._assertSaveOwner(saveOwner);
-        const latestRoot = await this._refreshRootEnvelopeBeforeSave(saveOwner);
+        let latestRoot;
+        try {
+          latestRoot = await this._refreshRootEnvelopeBeforeSave(saveOwner);
+        } catch (error) {
+          if (!error?.reviewSaveRetryReason ||
+              !this._ownsSave(saveOwner)) {
+            throw error;
+          }
+          this.isDirty = true;
+          log.warn('.bframe 저장이 잠시 지연됨', {
+            path: saveOwner.bframePath,
+            reason: error.reviewSaveRetryReason
+          });
+          this._emit('saveDeferred', {
+            path: saveOwner.bframePath,
+            reason: error.reviewSaveRetryReason
+          });
+          if (this.autoSaveEnabled) {
+            this._scheduleAutoSave();
+          }
+          // §7 C-9 — 작업 6 (j-2)와 동일한 종결. 지연은 예외 경로가 아니라
+          // _classifySaveFailure를 거치지 않으므로 실제 사유를 직접 실어 보낸다.
+          this._saveStateSettled = true;
+          this._emitSaveState(
+            this.autoSaveEnabled ? 'retrying' : 'save-failed',
+            error.reviewSaveRetryReason
+          );
+          return false;
+        }
         this._assertSaveOwner(saveOwner);
         this._assertRootEnvelopeWritable();
         this._ensureReviewDocumentId();
@@ -2561,7 +2599,17 @@ export class ReviewDataManager extends EventTarget {
     if (!this._hasPersistedFile) return null;
 
     const reviewPath = saveOwner?.bframePath || this.currentBframePath;
-    const snapshot = await this._readReviewSnapshot(reviewPath);
+    let snapshot;
+    try {
+      snapshot = await this._readReviewSnapshot(reviewPath);
+    } catch (error) {
+      // 다른 프로세스가 커밋 중이라 락을 못 잡은 것뿐이다. 저장 실패가
+      // 아니라 재시도 가능한 지연으로 표시해 _doSave가 saveDeferred로
+      // 흘려보내게 한다.
+      if (!isReviewLockTimeoutError(error)) throw error;
+      error.reviewSaveRetryReason = 'review-snapshot-lock-timeout';
+      throw error;
+    }
     if (saveOwner) this._assertSaveOwner(saveOwner);
     const latestRoot = snapshot.data;
     if (!latestRoot || typeof latestRoot !== 'object' || Array.isArray(latestRoot)) {

--- a/scripts/tests/collaboration-cursors-source.test.js
+++ b/scripts/tests/collaboration-cursors-source.test.js
@@ -8,6 +8,9 @@ const normalizeNewlines = value => value.replace(/\r\n/g, '\n');
 const appSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/app.js'), 'utf8'));
 const userSettingsSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/user-settings.js'), 'utf8'));
 const indexSource = normalizeNewlines(fs.readFileSync(path.join(rootDir, 'renderer/index.html'), 'utf8'));
+const liveblocksManagerSource = normalizeNewlines(
+  fs.readFileSync(path.join(rootDir, 'renderer/scripts/modules/liveblocks-manager.js'), 'utf8')
+);
 
 test('remote cursor visibility is a local user setting', () => {
   assert.match(userSettingsSource, /showRemoteCursors:\s*true/);
@@ -47,4 +50,65 @@ test('collaborator avatars are built with text-only DOM operations', () => {
   assert.match(updateMatch[1], /avatar\.textContent = initials/);
   assert.match(updateMatch[1], /collaboratorsAvatars\.replaceChildren/);
   assert.doesNotMatch(updateMatch[1], /innerHTML/);
+});
+
+test('others 구독은 Storage 로드 대기보다 먼저 설치되고 접속 후 초기 스냅샷을 보상 발행한다', () => {
+  const startBody = liveblocksManagerSource.match(
+    /this\._room = result\.room;([\s\S]*?)return \{ roomId: this\._roomId, isNewRoom \};/
+  );
+  assert.ok(startBody, 'start()의 Room 확보 이후 구간을 찾을 수 있어야 한다');
+
+  const setupIndex = startBody[1].indexOf('this._setupSubscriptions();');
+  const storageIndex = startBody[1].indexOf('// Storage 로드 대기');
+  const backfillIndex = startBody[1].indexOf('this._emitCollaboratorsChanged();');
+
+  assert.ok(setupIndex > -1, '구독 설치 호출이 start() 안에 있어야 한다');
+  assert.ok(storageIndex > -1, 'Storage 로드 대기 구간이 남아 있어야 한다');
+  assert.ok(backfillIndex > -1, '초기 참여자 보상 발행이 start() 안에 있어야 한다');
+  assert.ok(setupIndex < storageIndex, '구독 설치가 Storage 대기보다 앞서야 한다');
+  assert.ok(backfillIndex > storageIndex, '보상 발행은 접속 완료 이후여야 한다');
+});
+
+test('collaboratorsChanged 발행 경로는 하나이며 연결 복구 시에도 재푸시된다', () => {
+  assert.match(
+    liveblocksManagerSource,
+    /_emitCollaboratorsChanged\(\) \{\s*\n\s*if \(!this\._room\) return;\s*\n\s*const others = this\.getOthers\(\);\s*\n\s*this\._emit\('collaboratorsChanged'/
+  );
+  assert.match(
+    liveblocksManagerSource,
+    /this\._room\.subscribe\('others', \(\) => \{\s*\n\s*this\._emitCollaboratorsChanged\(\);\s*\n\s*\}\);/
+  );
+  assert.match(
+    liveblocksManagerSource,
+    /else if \(event === 'restored'\) \{[\s\S]*?this\._emitCollaboratorsChanged\(\);/
+  );
+  assert.equal(
+    (liveblocksManagerSource.match(/this\._emit\('collaboratorsChanged'/g) || []).length,
+    1,
+    'collaboratorsChanged 발행은 _emitCollaboratorsChanged 한 곳으로 모여야 한다'
+  );
+  assert.match(
+    liveblocksManagerSource,
+    /log\.error\('Room 접속 실패', error\);[\s\S]*?this\._unsubscribers = \[\];[\s\S]*?this\._room = null;/
+  );
+});
+
+test('협업 세션 기준값은 Room 접속 전에 초기화되고 초기 스냅샷이 UI에 반영된다', () => {
+  const startFn = appSource.match(
+    /async function startCollaborationForVideoLoad\(loadToken, bframePath, options = \{\}\) \{([\s\S]*?)\n  \}\n/
+  );
+  assert.ok(startFn, 'startCollaborationForVideoLoad 본문을 찾을 수 있어야 한다');
+  const resetIndex = startFn[1].indexOf('_previousOthersCount = 0;');
+  const enterIndex = startFn[1].indexOf('await liveblocksManager.start(');
+  assert.ok(resetIndex > -1 && enterIndex > -1);
+  assert.ok(resetIndex < enterIndex, '세션 기준값은 Room 접속 이전에 초기화되어야 한다');
+
+  const startedHandler = appSource.match(
+    /liveblocksManager\.addEventListener\('collaborationStarted', \(e\) => \{([\s\S]*?)\n  \}\);/
+  );
+  assert.ok(startedHandler, 'collaborationStarted 핸들러를 찾을 수 있어야 한다');
+  assert.match(startedHandler[1], /liveblocksManager\.getOthers\(\)\.map\(u => \(\{/);
+  assert.match(startedHandler[1], /updateCollaboratorsUI\(\[me, \.\.\.others\]\);/);
+  assert.doesNotMatch(startedHandler[1], /_triggerCollabRipple\(\);/);
+  assert.doesNotMatch(startedHandler[1], /showToast\(/);
 });

--- a/scripts/tests/lazy-bframe-creation-source.test.js
+++ b/scripts/tests/lazy-bframe-creation-source.test.js
@@ -246,7 +246,18 @@ test('Fabric 드로잉(drawingsV3) 동기화가 배선되어 있다', () => {
   assert.match(appSource, /new FabricDrawingSync\(\{/);
   assert.match(appSource, /fabricDrawingSync\.broadcastCurrentState\?\.\(\);/);
   assert.match(appSource, /reloadDrawingsV3FromDisk/);
-  assert.match(appSource, /_previousOthersCount = 0;\s*\n\s*_collaborationSessionStartedAt = Date\.now\(\);/);
+  // 기준값 이중 스탬프: 참여자 카운트는 Room 접속 직전, 억제 창 시각은 playbackSync.start() 직후.
+  assert.equal((appSource.match(/^\s+_previousOthersCount = 0;$/gm) || []).length, 1);
+  assert.equal((appSource.match(/_collaborationSessionStartedAt = Date\.now\(\);/g) || []).length, 1);
+  assert.ok(
+    appSource.indexOf('\n      _previousOthersCount = 0;') <
+      appSource.indexOf('await liveblocksManager.start('),
+    '참여자 카운트 기준값은 Room 접속 이전에 초기화되어야 한다'
+  );
+  assert.match(
+    appSource,
+    /playbackSync\.start\(\);[\s\S]{0,400}?_collaborationSessionStartedAt = Date\.now\(\);/
+  );
   assert.match(appSource, /currentOthersCount > _previousOthersCount &&\s*\n\s*Date\.now\(\) - _collaborationSessionStartedAt > 10000/);
   const syncSource = fs.readFileSync(
     path.join(rootDir, 'renderer/scripts/modules/fabric-drawing-sync.js'), 'utf8'

--- a/scripts/tests/review-data-manager-save.test.js
+++ b/scripts/tests/review-data-manager-save.test.js
@@ -1115,6 +1115,52 @@ test('retryable review lock contention keeps changes dirty without a save error 
   manager.disconnect();
 });
 
+test('a review snapshot lock timeout defers the save without a save error alert', async () => {
+  const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
+  const commentManager = createCommentManager();
+  const diskRoot = createReviewRoot({
+    reviewDocumentId: REVIEW_ID_EXISTING
+  });
+  const saveCalls = [];
+  window.electronAPI = {
+    loadReview: async () => structuredClone(diskRoot),
+    loadReviewSnapshot: async () => {
+      throw new Error(
+        "Error invoking remote method 'file:load-review-snapshot': " +
+        'Error: ERR_REVIEW_LOCK_TIMEOUT: Review recovery lock timed out'
+      );
+    },
+    saveReview: async (path, data, options) => {
+      saveCalls.push({ path, data, options });
+      return { success: true, versionToken: 'b'.repeat(64) };
+    }
+  };
+  const manager = new ReviewDataManager({
+    autoSave: false,
+    commentManager
+  });
+  manager.connect();
+  await manager.setVideoFile('C:/reviews/snapshot-lock-timeout.mp4');
+  addSubstantiveComment(manager, commentManager, 'snapshot-lock-comment');
+  let deferredReason = null;
+  let saveErrorEvents = 0;
+  manager.addEventListener('saveDeferred', event => {
+    deferredReason = event.detail?.reason || null;
+  });
+  manager.addEventListener('saveError', () => {
+    saveErrorEvents += 1;
+  });
+
+  assert.equal(await manager.save(), false);
+  assert.equal(deferredReason, 'review-snapshot-lock-timeout');
+  assert.equal(saveErrorEvents, 0);
+  assert.equal(saveCalls.length, 0);
+  assert.equal(manager.isDirty, true);
+  assert.equal(manager.hasUnsavedChanges(), true);
+  assert.equal(manager._writeBlockedReason, null);
+  manager.disconnect();
+});
+
 test('remote drawing layer order event marks a persisted review as unsaved', async () => {
   const { ReviewDataManager } = await import('../../renderer/scripts/modules/review-data-manager.js');
   const drawingManager = new EventTarget();

--- a/scripts/tests/review-file-store-recovery.test.js
+++ b/scripts/tests/review-file-store-recovery.test.js
@@ -800,3 +800,50 @@ test('a malformed main is restored from valid .bak through the store transaction
     assert.notEqual(sidecar.state, 'prepared');
   }
 });
+
+test('a malformed target defers the save instead of throwing out of the lock', async t => {
+  const {
+    createReviewFileStore,
+    createReviewVersionToken
+  } = require(reviewFileStorePath);
+  const { filePath } = await createReviewFixture(t, {
+    reviewDocumentId: 'malformed-save-defer',
+    revision: 1
+  });
+  const malformedContent = '{"reviewDocumentId":"malformed-save-defer"';
+  await fsp.writeFile(filePath, malformedContent, 'utf8');
+  const store = createReviewFileStore({ renameRetryDelaysMs: [0] });
+
+  const result = await saveResultWithoutThrow(store.saveReviewFile(
+    filePath,
+    { reviewDocumentId: 'malformed-save-defer', revision: 2 },
+    { expectedVersionToken: createReviewVersionToken(malformedContent) }
+  ));
+
+  assert.equal(result?.thrownError, undefined);
+  assert.equal(result?.success, false);
+  assert.equal(result?.retryable, true);
+  assert.equal(result?.reason, 'malformed-target');
+  assert.equal(await fsp.readFile(filePath, 'utf8'), malformedContent);
+});
+
+test('a malformed target with failIfExists reports exists without parsing', async t => {
+  const { createReviewFileStore } = require(reviewFileStorePath);
+  const { filePath } = await createReviewFixture(t, {
+    reviewDocumentId: 'malformed-first-create',
+    revision: 1
+  });
+  const malformedContent = '{"reviewDocumentId":"malformed-first-create"';
+  await fsp.writeFile(filePath, malformedContent, 'utf8');
+  const store = createReviewFileStore({ renameRetryDelaysMs: [0] });
+
+  const result = await saveResultWithoutThrow(store.saveReviewFile(
+    filePath,
+    { reviewDocumentId: 'malformed-first-create', revision: 2 },
+    { failIfExists: true }
+  ));
+
+  assert.equal(result?.thrownError, undefined);
+  assert.deepEqual(result, { success: false, exists: true });
+  assert.equal(await fsp.readFile(filePath, 'utf8'), malformedContent);
+});

--- a/scripts/tests/review-save-version-token-source.test.js
+++ b/scripts/tests/review-save-version-token-source.test.js
@@ -96,3 +96,45 @@ test('review file store checks the token before preparing and uses guarded CAS a
     /atomicCompareAndReplace\(\{[\s\S]*expectedVersionToken,[\s\S]*replacementVersionToken/
   );
 });
+
+test('review file store labels lock timeouts, malformed targets and unsupported CAS for the renderer', () => {
+  assert.match(
+    reviewFileStoreSource,
+    /'ERR_REVIEW_LOCK_TIMEOUT: Review recovery lock timed out'/
+  );
+  assert.match(
+    reviewFileStoreSource,
+    /'ERR_REVIEW_LOCK_TIMEOUT: Review transaction wait timed out'/
+  );
+  assert.match(reviewFileStoreSource, /reason: 'malformed-target'/);
+  assert.match(
+    reviewFileStoreSource,
+    /공유 드라이브가 파일 교체를 허용하지 않았습니다/
+  );
+  assert.match(
+    reviewFileStoreSource,
+    /error: ATOMIC_REPLACE_UNSUPPORTED_MESSAGE/
+  );
+
+  const commitRetryStart = reviewFileStoreSource.indexOf(
+    'async function commitWithRetry'
+  );
+  const commitRetryEnd = reviewFileStoreSource.indexOf(
+    'async function createCorruptedCopy',
+    commitRetryStart
+  );
+  assert.ok(commitRetryStart >= 0 && commitRetryEnd > commitRetryStart);
+  const commitRetry = reviewFileStoreSource.slice(
+    commitRetryStart,
+    commitRetryEnd
+  );
+  assert.match(commitRetry, /let unsupportedRetried = false;/);
+  assert.match(
+    commitRetry,
+    /if \(!unsupportedRetried && attempt < delays\.length - 1\) \{\s*unsupportedRetried = true;\s*continue;/
+  );
+  assert.doesNotMatch(
+    commitRetry,
+    /status === 'indeterminate'\)[\s\S]{0,60}continue;/
+  );
+});


### PR DESCRIPTION
## 요약

PR ①에 이어 §5의 PR ② 구성(작업 7 → 8)을 구현한다. 성격이 다른 두 계층 — main 프로세스의 파일 저장과 렌더러의 협업 연결 — 을 묶어 독립 검증 가능하게 했다.

| 증상 | 근본 원인 | 작업 |
|---|---|---|
| G: 드라이브에서 "이유 없는 저장 실패" 토스트 | `review-file-store`의 4등급 분류 체계(retryable/conflict/exists/fatal) 바깥으로 새는 실패 3종 | 작업 7 |
| 같은 링크로 같은 영상을 켰는데 동시 세션 표기가 안 됨 | `others` 구독이 Storage 로드 이후에 설치되어 입장 시점 참여자 스냅샷을 통째로 유실 | 작업 8 |

## 업데이트 로그 (비개발자용)

- **G: 드라이브 저장 실패가 훨씬 줄어듭니다.** 다른 사람이 같은 파일을 저장하는 중이라 잠깐 밀린 경우, 파일이 깨져 있어 복구가 필요한 경우 모두 조용히 다시 시도합니다.
- **저장이 정말 실패할 때는 이유를 알려 줍니다.** "저장 실패" 대신 "공유 드라이브가 파일 교체를 허용하지 않았습니다. 파일이 다른 프로그램에서 열려 있는지 확인해 주세요." 처럼 무엇을 하면 되는지 나옵니다.
- **같은 링크로 같은 영상을 열면 이미 보고 있던 사람이 바로 보입니다.** 예전에는 상대가 마우스를 움직여야만 나타났습니다. 네트워크가 끊겼다 돌아와도 인원이 1명으로 줄어든 채 멈추지 않습니다.

## 상세 기술 설명

### 작업 7 — G:드라이브 저장 실패 원인 보강

`review-file-store`는 이미 저장 실패를 4등급으로 분류해 반환하고 renderer `_doSave`도 그 등급을 정확히 다루도록 짜여 있는데, 세 경로만 그 체계 밖으로 샜다.

1. **락 대기 초과**가 결과 객체가 아니라 예외로 나갔다. `ipcRenderer.invoke`는 `error.code`를 renderer로 전달하지 않으므로, 메시지 앞에 `ERR_REVIEW_LOCK_TIMEOUT:` 리터럴을 각인해 renderer가 식별할 수 있게 했다. `error.code` 대입은 main 내부·단위 테스트용으로 유지한다.
2. **저장 락 안의 무방비 `JSON.parse`** — 읽기 경로는 같은 상황에서 `.bak` 복구를 하는데 저장 경로만 그대로 throw했다. `.bak` 복구를 저장 경로에 복제하지 않고 `malformed-target` 재시도 신호만 돌려준다. renderer의 저장 1회차는 반드시 `_refreshRootEnvelopeBeforeSave` → `readReviewSnapshot`로 시작하므로 다음 시도에서 읽기 경로가 대칭 복구를 대신 수행한다. 복구 로직 중복 0, 신규 쓰기 경로 0. `failIfExists === true`일 때는 파싱을 건너뛴다 — 여기서 재시도를 돌려주면 `_hasPersistedFile === false` 때문에 사전 읽기가 생략되어 무한 지연 루프가 된다.
3. **CAS `unsupported`** — helper의 exit 5는 `ReplaceFileW`/`MoveFileExW`가 `false`를 돌려준 직후에만 나오므로 target은 손대지 않은 상태다. 1회만 재시도하고, 실패 시 원인 안내 문구를 `error` 필드로 실어 보낸다. `indeterminate`는 재시도하지 않는다 — `commitSerializedUnderLock`이 이미 `verifyMainState`로 실제 디스크 상태를 판정하도록 설계돼 있고, 교체 여부가 불확실한 상태에서 CAS를 한 번 더 돌리면 이중 커밋 위험이 있다.

### 작업 8 — 동시 세션 초기 참여자 표시 복구

번들된 Liveblocks 클라이언트의 `subscribe('others')`는 **구독 시점의 현재 값을 초기 발화하지 않는 순수 이벤트 소스**다(`liveblocks-client.js:7831`). `LiveblocksManager.start()`가 이 구독을 Storage 동기화 `await` 이후에 설치하므로, 접속 직후 도착해 그 await 구간 동안 이미 소비된 초기 참여자 상태(ROOM_STATE)가 콜백으로 전달되지 않는다.

- `_setupSubscriptions()`를 Storage 대기 이전으로 통째로 이동했다. 함수 본문 3개 구독(`others`/`lost-connection`/`event`)이 전부 `this._room`만 참조하고 `this._storage`를 쓰지 않음을 전수 확인했다.
- 구독을 앞당겨도 접속 **직전에** 확정된 상태는 변화 이벤트로 오지 않으므로, 접속 완료 후 `_emitCollaboratorsChanged()`로 1회 보상 발행한다.
- 발행 경로를 `_emitCollaboratorsChanged` 하나로 단일화하고 연결 `restored`에서도 재푸시한다 — `lost` 동안 others가 비워진 뒤 복구 시 변화가 없으면 목록이 1명으로 고착된다.
- 구독을 앞당긴 대가로 생기는 유령 구독을 막기 위해 접속 실패 catch에서 구독·leave·room 참조를 정리한다.
- app.js의 세션 기준값은 **이중 스탬프**다: 참여자 카운트는 Room 접속 직전, 억제 창 시각은 `playbackSync.start()` 직후. 둘을 함께 앞당기면 접속 소요시간이 10초를 넘을 때(G: 드라이브 저장 재시도 등) `collaboratorsChanged` 핸들러가 `broadcastCurrentState`를 `fabricDrawingSync.start()` 이전에 호출한다.
- `collaborationStarted`에서 초기 스냅샷을 UI에 1회 반영하고, 참여 알림·리플은 `collaboratorsChanged`의 0→N 에지가 단독으로 담당하게 해 중복 재생을 없앴다.

## 개발 난항

**신호를 어디에 실을 것인가.** main→renderer IPC는 `error.code`를 보존하지 않고 메시지 문자열과 결과 객체 필드만 보존한다. 따라서 분류 신호는 결과 객체 필드 또는 메시지에 박힌 고정 리터럴로만 전달할 수 있고, 이 제약이 작업 7의 설계 전체를 규정했다.

**기준값 이중 스탬프의 필요성.** 처음에는 두 대입을 함께 접속 이전으로 옮기려 했으나, `startCollaborationForVideoLoad`에는 `start()` 이후에도 `await reviewDataManager.save({ skipMerge: true })`와 `await commentSync.start()`가 있고 그 저장이 바로 이 라운드가 다루는 G: 드라이브 대상이라 접속~sync 기동 사이 지연이 10초를 넘는 일이 흔하다. 억제 창까지 앞당기면 `broadcastCurrentState`가 `fabricDrawingSync.start()` 이전에 나간다 — 기존 코드가 리셋을 `start()` 뒤에 둔 이유가 정확히 이것이었다.

## 테스트

- 25개 `test:*` 스위트: **2,136 → 2,144 pass / 0 fail** (+8)
- 작업별 증분: 작업 7 +5 / 작업 8 +3 — 계획서 부록 B 델타 표와 일치
- `npm run lint` 0 error
- `main/ipc-handlers.js`, `preload/preload.js`, `main/mpv-overlay-host.js`, `native/review-file-cas-helper/*` 변경 0 (PR ② 분기점 대비)

## 테스트 가이드

**A. 손상 main 자동 복구**
1. G: 드라이브 `.bframe`을 열어 댓글 1개 추가·저장(`.bak` 생성).
2. 앱을 켠 채 탐색기에서 그 `.bframe`의 마지막 `}`를 지워 저장.
3. 앱에서 댓글을 하나 더 추가·저장 → **저장 실패 토스트가 뜨지 않고 잠시 후 정상 저장**. 로그에 `reason: malformed-target` 1줄 → 다음 시도에서 `.bframe 파일 저장됨`.

**B. 락 대기 초과**
1. 같은 `.bframe`을 두 인스턴스에서 동시에 연다.
2. 양쪽에서 거의 동시에 드로잉해 저장을 겹친다(10회 이상) → **`.bframe 저장 실패` 토스트가 한 번도 뜨지 않고** 키프레임이 사라지지 않는다.

**C. CAS unsupported 안내**
1. 대상 `.bframe`을 다른 프로그램으로 열어 핸들을 잡은 상태에서 저장 시도.
2. **즉시**(재시도를 거치지 않고) "공유 드라이브가 파일 교체를 허용하지 않았습니다…" 토스트. 원본 `.bframe`은 변경되지 않는다.

**D. 동시 세션**
1. 두 PC(또는 두 창)에서 같은 링크로 같은 영상을 연다 — 먼저 연 쪽 A, 나중에 연 쪽 B.
2. **B 쪽에서도** A의 아바타/인원 표기와 진입 효과가 즉시 보인다.
3. 네트워크를 잠깐 끊었다 복구 → 인원 표기가 1명으로 줄어든 채 고착되지 않고 복구된다.
4. 참여 토스트·리플이 **한 번만** 재생된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)