### PR TITLE
키프레임 이동 단축키(A/D)를 파일럿 투영에 배선 (v2.4.3-beta)

### DIFF
--- a/docs/drawing-keyframe-features.md
+++ b/docs/drawing-keyframe-features.md
@@ -33,8 +33,8 @@
 | `keyframeDelete` | `Delete` | 키프레임 삭제 | 레거시 | **A. 차단** (+ `deleteSelectedOrCurrentKeyframes`가 투영 존재 시 조기 반환) |
 | `keyframeConvertToFrame` | `Shift+2` | 키프레임 → 일반 프레임 | 레거시 | **A. 차단** |
 | `keyframeConvertToKeyframe` | `Shift+3` | 프레임 → 키프레임 | 레거시 | **A. 차단** |
-| `prevKeyframe` | `A` | 이전 키프레임 | 레거시 | **B. 빈 데이터** — 차단 목록에 없다 |
-| `nextKeyframe` | `D` | 다음 키프레임 | 레거시 | **B. 빈 데이터** — 차단 목록에 없다 |
+| `prevKeyframe` | `A` | 이전 키프레임 | **소유자에 따라 분기** | ✅ 동작 (v2.4.3-beta) |
+| `nextKeyframe` | `D` | 다음 키프레임 | **소유자에 따라 분기** | ✅ 동작 (v2.4.3-beta) |
 
 ### 2.2 프레임 조작
 
@@ -117,7 +117,7 @@
 
 | 항목 | 상태 |
 |---|---|
-| `prevKeyframe` / `nextKeyframe` (A/D) | ⬜ 대기 — 출처만 파일럿 투영으로 바꾸면 됨 (데이터 미변경) |
+| `prevKeyframe` / `nextKeyframe` (A/D) | ✅ 완료 (v2.4.3-beta) — `getAdjacentDrawingKeyframeFrame()`이 소유자에 맞는 출처를 고른다. 파일럿 소유 중엔 투영 행 전부의 키프레임 합집합, html5 폴백은 기존 `drawingManager` |
 | `keyframeDelete` (Delete) | ⬜ 대기 |
 | `keyframeAddWithCopy` / `keyframeAddBlank` (F6/F7) | ⬜ 대기 |
 | 키프레임↔프레임 변환 (Shift+2/3) | ⬜ 대기 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.4.2-beta",
+  "version": "2.4.3-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.4.2-beta",
+      "version": "2.4.3-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.4.2-beta",
+  "version": "2.4.3-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/scripts/app.js
+++ b/renderer/scripts/app.js
@@ -6454,6 +6454,36 @@ async function initApp() {
     };
   }
 
+  // 키프레임 이동(A/D)의 데이터 출처를 소유자에 맞춘다.
+  // 파일럿이 소유 중이면 화면에 떠 있는 것은 drawingsV3 투영 행이고 레거시
+  // drawingManager는 비어 있다. 출처를 고르지 않으면 키는 통과하는데 조용히
+  // 아무 일도 일어나지 않는다(docs/drawing-keyframe-features.md 실패 유형 B).
+  // 조회 전용이라 어떤 데이터도 변경하지 않는다.
+  function getAdjacentDrawingKeyframeFrame(direction) {
+    const currentFrame = Math.max(0, Math.trunc(Number(videoPlayer.currentFrame) || 0));
+    const pilotLayers = getFabricPilotTimelineLayers();
+    if (!pilotLayers) {
+      return direction === 'prev'
+        ? drawingManager.getPrevKeyframeFrame()
+        : drawingManager.getNextKeyframeFrame();
+    }
+    // 파일럿 행과 읽기 전용으로 투영된 레거시 행을 함께 본다 — 타임라인에 보이는
+    // 모든 키프레임이 이동 대상이어야 사용자가 놓치는 지점이 없다.
+    const frames = new Set();
+    for (const layer of pilotLayers) {
+      for (const keyframe of layer.keyframes || []) {
+        const frame = Math.trunc(Number(keyframe?.frame));
+        if (Number.isInteger(frame) && frame >= 0) frames.add(frame);
+      }
+    }
+    if (frames.size === 0) return null;
+    const ordered = [...frames].sort((a, b) => a - b);
+    const target = direction === 'prev'
+      ? ordered.filter(frame => frame < currentFrame).pop()
+      : ordered.find(frame => frame > currentFrame);
+    return target === undefined ? null : target;
+  }
+
   function shouldSuppressLegacyDrawingForFabricPilot() {
     return fabricDrawingPilotController.shouldOwnDrawingShortcut() &&
       isMpvPilotPlaybackActive();
@@ -14357,13 +14387,13 @@ async function initApp() {
     }
     if (userSettings.matchShortcut('prevKeyframe', e)) {
       e.preventDefault();
-      const prevKf = drawingManager.getPrevKeyframeFrame();
+      const prevKf = getAdjacentDrawingKeyframeFrame('prev');
       if (prevKf !== null) videoPlayer.seekToFrame(prevKf);
       return;
     }
     if (userSettings.matchShortcut('nextKeyframe', e)) {
       e.preventDefault();
-      const nextKf = drawingManager.getNextKeyframeFrame();
+      const nextKf = getAdjacentDrawingKeyframeFrame('next');
       if (nextKf !== null) videoPlayer.seekToFrame(nextKf);
       return;
     }

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -1594,3 +1594,49 @@ test('팔레트 모듈은 레거시 헤더·접기·경계 클램프·안전한 
     /module\.exports = \{\n\s+createFabricDrawingPalette,\n\s+clampPalettePosition,\n\s+normalizePaletteState,\n\s+PALETTE_STORAGE_KEY,\n\s+PALETTE_MARGIN\n\};/
   );
 });
+
+test('키프레임 이동 단축키는 소유자에 맞는 데이터 출처를 고른다', () => {
+  const source = appSource.match(
+    /function getAdjacentDrawingKeyframeFrame\(direction\) \{[\s\S]*?\n  \}\n\n  function shouldSuppressLegacyDrawingForFabricPilot/
+  )?.[0]?.replace(/\n\n  function shouldSuppressLegacyDrawingForFabricPilot$/, '');
+  assert.ok(source, '키프레임 이동 헬퍼를 추출할 수 있어야 한다');
+
+  const build = (currentFrame, pilotLayers, legacy) => new Function(
+    'videoPlayer',
+    'getFabricPilotTimelineLayers',
+    'drawingManager',
+    `${source}\nreturn getAdjacentDrawingKeyframeFrame;`
+  )({ currentFrame }, () => pilotLayers, legacy);
+
+  // 파일럿 소유 중에는 투영된 키프레임을 본다 (파일럿 행 + 읽기 전용 레거시 행 합집합)
+  const pilotLayers = [
+    { keyframes: [{ frame: 10 }, { frame: 40 }, { frame: 90 }] },
+    { keyframes: [{ frame: 25 }, { frame: 40 }] }
+  ];
+  const legacyStub = {
+    getPrevKeyframeFrame: () => 999,
+    getNextKeyframeFrame: () => 999
+  };
+  assert.equal(build(40, pilotLayers, legacyStub)('prev'), 25);
+  assert.equal(build(40, pilotLayers, legacyStub)('next'), 90);
+  assert.equal(build(0, pilotLayers, legacyStub)('prev'), null, '앞이 없으면 null');
+  assert.equal(build(90, pilotLayers, legacyStub)('next'), null, '뒤가 없으면 null');
+  assert.equal(build(26, pilotLayers, legacyStub)('prev'), 25, '키프레임 사이에서도 동작한다');
+
+  // 집계 타임라인 등으로 투영이 비면 이동 대상이 없다
+  assert.equal(build(40, [], legacyStub)('prev'), null);
+
+  // 파일럿이 소유하지 않으면(html5 폴백) 레거시 매니저를 그대로 쓴다
+  assert.equal(build(40, null, legacyStub)('prev'), 999);
+  assert.equal(build(40, null, legacyStub)('next'), 999);
+
+  // 단축키 핸들러가 이 헬퍼를 쓰는지 — 레거시 직접 조회로 되돌아가지 않았는지 고정
+  assert.match(
+    appSource,
+    /matchShortcut\('prevKeyframe', e\)\) \{\n\s+e\.preventDefault\(\);\n\s+const prevKf = getAdjacentDrawingKeyframeFrame\('prev'\);/
+  );
+  assert.match(
+    appSource,
+    /matchShortcut\('nextKeyframe', e\)\) \{\n\s+e\.preventDefault\(\);\n\s+const nextKf = getAdjacentDrawingKeyframeFrame\('next'\);/
+  );
+});

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -249,7 +249,7 @@ test('stable engine promotion uses the 2.3.0 beta release version consistently',
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.4.2-beta');
-  assert.equal(packageLock.version, '2.4.2-beta');
-  assert.equal(packageLock.packages[''].version, '2.4.2-beta');
+  assert.equal(packageJson.version, '2.4.3-beta');
+  assert.equal(packageLock.version, '2.4.3-beta');
+  assert.equal(packageLock.packages[''].version, '2.4.3-beta');
 });


### PR DESCRIPTION
## 요약

mpv 모드에서 `A`/`D`(이전/다음 키프레임)가 **조용히 아무 일도 하지 않던** 문제를 고친다. 키프레임 기능을 fabric 파일럿으로 이식하는 작업의 첫 조각이며, 데이터를 변경하지 않는 조회 전용 수정이다.

## 업데이트 로그 (비개발자용)

- **`A` / `D`로 이전·다음 키프레임으로 이동할 수 있습니다.** 예전엔 눌러도 아무 반응이 없었습니다.
- 타임라인에 보이는 키프레임은 전부 이동 대상입니다 — 새로 그린 드로잉과, 예전 버전으로 그려 읽기 전용으로 표시되는 것까지 함께 훑습니다.

## 상세 기술 설명

방화벽 차단이 아니었다. `A`/`D`는 `FABRIC_DRAWING_LEGACY_SHORTCUTS`에 **없어서 키는 정상 통과**하는데, 핸들러가 이렇게 되어 있었다:

```js
const prevKf = drawingManager.getPrevKeyframeFrame();   // ← 레거시
if (prevKf !== null) videoPlayer.seekToFrame(prevKf);
```

mpv 모드에서 화면에 떠 있는 건 `drawingsV3` 투영인데 레거시 `drawingManager`는 비어 있다. `null`이 돌아오고 `seekToFrame`이 호출되지 않아 **조용한 no-op**이 된다. 새로 만든 대조표의 **실패 유형 B**(빈 데이터 조회)에 해당한다.

`getAdjacentDrawingKeyframeFrame(direction)`을 두어 소유자에 맞는 출처를 고르게 했다:

- **파일럿 소유 중** → `getFabricPilotTimelineLayers()`가 돌려주는 **투영 행 전부**(파일럿 행 + 읽기 전용 레거시 행)의 키프레임 **합집합**. 타임라인에 보이는 모든 키프레임이 이동 대상이어야 사용자가 놓치는 지점이 없다.
- **html5 폴백** → 기존 `drawingManager` 경로 그대로.

집계 타임라인(플레이리스트 연속·컷리스트)에서는 투영이 `[]`라 이동 대상이 없어 `null`을 돌려준다 — 기존 동작과 일치한다.

조회 전용이라 `drawingsV3`·`drawings` 어느 쪽도 변경하지 않는다.

## 함께 추가한 문서

[`docs/drawing-keyframe-features.md`](docs/drawing-keyframe-features.md) — 키프레임 단축키·표시를 다룰 때 매번 코드를 다시 뒤지지 않기 위한 단일 참조. 실패 유형 두 가지, 단축키 25종 전건 대조표(액션 id·기본 키·보는 데이터·현재 상태), 타임라인 표시 대조, 이식 시 함정 6가지, 진행 상황 체크리스트.

문서에 근거와 함께 명시해 둔 사실: **이 기능들이 안 되는 건 회귀가 아니라 `1615fba`(파일럿 연결)부터의 미구현 영역이다.** 나중에 "언제부터 깨졌지"로 시간을 쓰지 않기 위함이다.

`CLAUDE.md` 주요 파일 표와 `docs/architecture.md` §11에서 이 문서를 가리킨다.

## 테스트

- 25개 `test:*` 스위트: **2,165 → 2,166 pass / 0 fail** (+1)
- 신규 1건 — 투영 합집합, 경계(앞/뒤 없음), 키프레임 사이 위치, 빈 투영, html5 폴백, 핸들러 배선 고정
- `npm run lint` 0 error

## 테스트 가이드

1. mpv로 드로잉이 있는 영상을 연다.
2. `A` / `D` → **이전·다음 키프레임으로 재생헤드가 이동**한다.
3. 첫 키프레임에서 `A`, 마지막에서 `D` → 아무 일도 안 일어난다(정상).
4. 레거시 드로잉이 있는 과거 `.bframe` → 읽기 전용 행의 키프레임도 이동 대상에 포함된다.
5. 플레이리스트 연속 재생 모드 → 기존대로 이동 안 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)