### PR TITLE
버전 2.4.4-beta — Alt 복구 실기 확인용 배포

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.4.3-beta",
+  "version": "2.4.4-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.4.3-beta",
+      "version": "2.4.4-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.4.3-beta",
+  "version": "2.4.4-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -249,7 +249,7 @@ test('stable engine promotion uses the 2.3.0 beta release version consistently',
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.4.3-beta');
-  assert.equal(packageLock.version, '2.4.3-beta');
-  assert.equal(packageLock.packages[''].version, '2.4.3-beta');
+  assert.equal(packageJson.version, '2.4.4-beta');
+  assert.equal(packageLock.version, '2.4.4-beta');
+  assert.equal(packageLock.packages[''].version, '2.4.4-beta');
 });


### PR DESCRIPTION
PR #188(Alt 브러시 크기 조절 복구)의 실기 확인을 위한 패치 버전 상향입니다.

## 변경
- `package.json` 2.4.3-beta → 2.4.4-beta
- `package-lock.json` 2곳 (최상위 `version`, `packages[""].version`)
- `scripts/tests/runtime-profile.test.js` 버전 단언 3개

## 왜 지금 올리나

Alt 수정은 **근본 원인이 아직 확정되지 않은 상태**입니다. 계획서가 (a)포커스 획득 수정과 (b)진단 계측을 함께 넣은 이유가 "배포 → 재현 1회 → 진단값으로 원인 특정"을 전제로 설계됐기 때문입니다. PR ②③(Ctrl+Z 전역 실행취소, 도구 6종·팔레트 재구성)를 먼저 하면 Alt가 여전히 안 될 때 싸게 반복할 기회를 잃습니다.

## 검증
`npm run test:mpv` 337 pass / 0 fail (버전 단언 3개 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)