### PR TITLE
Alt 크기조절 HUD를 브러시 굵기만 한 원으로 복원

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.4.4-beta",
+  "version": "2.4.5-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.4.4-beta",
+      "version": "2.4.5-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.4.4-beta",
+  "version": "2.4.5-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -13468,8 +13468,6 @@ void main() {
       var MIN_BRUSH_OPACITY_PERCENT = 10;
       var MAX_BRUSH_OPACITY_PERCENT = 100;
       var SIZE_ADJUST_PIXELS_PER_STEP = 4;
-      var SIZE_ADJUST_HUD_OFFSET_X = 16;
-      var SIZE_ADJUST_HUD_OFFSET_Y = 28;
       var FABRIC_PERSISTENCE_BADGE_PREFIX = "\uC0C8 \uB4DC\uB85C\uC789 \xB7 \uB9AC\uBDF0 \uC790\uB3D9 \uC800\uC7A5";
       var SELECTION_HIT_MARGIN_CSS_PX = 6;
       var MIN_SELECTION_HIT_TOLERANCE = 2;
@@ -15442,6 +15440,7 @@ void main() {
         let sizeAdjustGesture = null;
         let strokeEraseGesture = null;
         let sizeAdjustHud = null;
+        let sizeAdjustHudLabel = null;
         const overlayModifierState = { alt: false, ctrl: false };
         const gestureProbe = {
           overlayAltKeyDownCount: 0,
@@ -17994,22 +17993,55 @@ void main() {
             top: "0px",
             zIndex: "3",
             pointerEvents: "none",
-            padding: "4px 8px",
-            borderRadius: "6px",
-            font: "600 12px/1 sans-serif",
-            whiteSpace: "nowrap",
-            background: "rgba(24, 24, 28, 0.92)",
-            color: "#fff"
+            boxSizing: "border-box",
+            borderRadius: "50%",
+            borderStyle: "solid",
+            borderWidth: "2px",
+            borderColor: "rgba(255, 255, 255, 0.9)",
+            // 앵커 좌표를 원의 중심으로 삼는다. 레거시와 같다.
+            transform: "translate(-50%, -50%)",
+            boxShadow: "0 4px 16px rgba(0, 0, 0, 0.35)"
           });
+          const label = documentRef.createElement("span");
+          label.className = "mpv-fabric-pilot-size-hud-label";
+          label.dataset.fabricPilotOutput = "size-adjust-label";
+          setStyles(label, {
+            position: "absolute",
+            left: "50%",
+            top: "-22px",
+            transform: "translateX(-50%)",
+            padding: "3px 6px",
+            borderRadius: "6px",
+            background: "rgba(9, 12, 18, 0.84)",
+            color: "#fff",
+            font: "700 11px/1 sans-serif",
+            whiteSpace: "nowrap",
+            pointerEvents: "none"
+          });
+          hud.appendChild(label);
+          sizeAdjustHudLabel = label;
           return hud;
+        }
+        function sourceToClientScale(session) {
+          const sourceWidth = Math.max(0, finiteNumber(session?.sourceWidth, 0));
+          if (sourceWidth <= 0) return 1;
+          const rect = resolveEffectiveCanvasRect(session.canvasRect, session.viewportTransform);
+          if (!(rect.width > 0)) return 1;
+          return rect.width / sourceWidth;
         }
         function showSizeAdjustHud(clientX, clientY, size) {
           if (!sizeAdjustHud) return;
-          sizeAdjustHud.textContent = `${size}px`;
+          const diameter = Math.max(2, Math.round(size * sourceToClientScale(currentSession)));
+          if (sizeAdjustHudLabel) sizeAdjustHudLabel.textContent = `${size}px`;
           setStyles(sizeAdjustHud, {
             display: "block",
-            left: `${Math.round(finiteNumber(clientX) + SIZE_ADJUST_HUD_OFFSET_X)}px`,
-            top: `${Math.round(finiteNumber(clientY) - SIZE_ADJUST_HUD_OFFSET_Y)}px`
+            left: `${Math.round(finiteNumber(clientX))}px`,
+            top: `${Math.round(finiteNumber(clientY))}px`,
+            width: `${diameter}px`,
+            height: `${diameter}px`,
+            // 색은 8자리 hex 로 알파를 붙인다(스키마상 style.color 는 항상 #RRGGBB).
+            background: `${brushStyle.color}80`,
+            borderColor: brushStyle.color
           });
         }
         function hideSizeAdjustHud() {
@@ -19105,6 +19137,7 @@ void main() {
           selectionControls = null;
           badge = null;
           sizeAdjustHud = null;
+          sizeAdjustHudLabel = null;
           container = null;
           root = null;
           prepared = false;

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -93,8 +93,6 @@ const MIN_BRUSH_OPACITY_PERCENT = 10;
 const MAX_BRUSH_OPACITY_PERCENT = 100;
 // 레거시 Canvas2D 엔진(drawing-canvas.js `_updateSizeAdjust`)의 delta/4 감도를 그대로 계승한다.
 const SIZE_ADJUST_PIXELS_PER_STEP = 4;
-const SIZE_ADJUST_HUD_OFFSET_X = 16;
-const SIZE_ADJUST_HUD_OFFSET_Y = 28;
 const FABRIC_PERSISTENCE_BADGE_PREFIX = '새 드로잉 · 리뷰 자동 저장';
 const SELECTION_HIT_MARGIN_CSS_PX = 6;
 const MIN_SELECTION_HIT_TOLERANCE = 2;
@@ -2402,6 +2400,7 @@ function createFabricOverlayRuntime(options = {}) {
   let sizeAdjustGesture = null;
   let strokeEraseGesture = null;
   let sizeAdjustHud = null;
+  let sizeAdjustHudLabel = null;
   const overlayModifierState = { alt: false, ctrl: false };
   // Alt 제스처 실기 미동작(v2.4.3-beta) 원인 확정용 관측값.
   // "오버레이 문서가 Alt keydown을 받기는 하는가"와 "마우스 pointerdown이 altKey를
@@ -5295,6 +5294,8 @@ function createFabricOverlayRuntime(options = {}) {
     event.preventDefault?.();
   }
 
+  // 레거시 .brush-size-hud 계승 — 숫자만 띄우면 제스처의 목적(굵기를 눈으로 보는 것)이
+  // 사라진다. 실제 브러시 굵기만 한 원을 브러시 색으로 그리고 라벨을 위에 붙인다.
   function createSizeAdjustHud() {
     const hud = documentRef.createElement('div');
     hud.className = 'mpv-fabric-pilot-size-hud';
@@ -5309,23 +5310,60 @@ function createFabricOverlayRuntime(options = {}) {
       top: '0px',
       zIndex: '3',
       pointerEvents: 'none',
-      padding: '4px 8px',
-      borderRadius: '6px',
-      font: '600 12px/1 sans-serif',
-      whiteSpace: 'nowrap',
-      background: 'rgba(24, 24, 28, 0.92)',
-      color: '#fff'
+      boxSizing: 'border-box',
+      borderRadius: '50%',
+      borderStyle: 'solid',
+      borderWidth: '2px',
+      borderColor: 'rgba(255, 255, 255, 0.9)',
+      // 앵커 좌표를 원의 중심으로 삼는다. 레거시와 같다.
+      transform: 'translate(-50%, -50%)',
+      boxShadow: '0 4px 16px rgba(0, 0, 0, 0.35)'
     });
+    const label = documentRef.createElement('span');
+    label.className = 'mpv-fabric-pilot-size-hud-label';
+    label.dataset.fabricPilotOutput = 'size-adjust-label';
+    setStyles(label, {
+      position: 'absolute',
+      left: '50%',
+      top: '-22px',
+      transform: 'translateX(-50%)',
+      padding: '3px 6px',
+      borderRadius: '6px',
+      background: 'rgba(9, 12, 18, 0.84)',
+      color: '#fff',
+      font: '700 11px/1 sans-serif',
+      whiteSpace: 'nowrap',
+      pointerEvents: 'none'
+    });
+    hud.appendChild(label);
+    sizeAdjustHudLabel = label;
     return hud;
+  }
+
+  // 브러시 크기는 소스 픽셀 단위다. 화면에 보이는 굵기와 맞추려면 표시 배율을 곱해야
+  // 한다(레거시 updateBrushSizeHud 의 rect.width / canvas.width 와 같은 계산이며,
+  // 여기서는 확대·이동이 반영된 유효 rect 를 쓴다).
+  function sourceToClientScale(session) {
+    const sourceWidth = Math.max(0, finiteNumber(session?.sourceWidth, 0));
+    if (sourceWidth <= 0) return 1;
+    const rect = resolveEffectiveCanvasRect(session.canvasRect, session.viewportTransform);
+    if (!(rect.width > 0)) return 1;
+    return rect.width / sourceWidth;
   }
 
   function showSizeAdjustHud(clientX, clientY, size) {
     if (!sizeAdjustHud) return;
-    sizeAdjustHud.textContent = `${size}px`;
+    const diameter = Math.max(2, Math.round(size * sourceToClientScale(currentSession)));
+    if (sizeAdjustHudLabel) sizeAdjustHudLabel.textContent = `${size}px`;
     setStyles(sizeAdjustHud, {
       display: 'block',
-      left: `${Math.round(finiteNumber(clientX) + SIZE_ADJUST_HUD_OFFSET_X)}px`,
-      top: `${Math.round(finiteNumber(clientY) - SIZE_ADJUST_HUD_OFFSET_Y)}px`
+      left: `${Math.round(finiteNumber(clientX))}px`,
+      top: `${Math.round(finiteNumber(clientY))}px`,
+      width: `${diameter}px`,
+      height: `${diameter}px`,
+      // 색은 8자리 hex 로 알파를 붙인다(스키마상 style.color 는 항상 #RRGGBB).
+      background: `${brushStyle.color}80`,
+      borderColor: brushStyle.color
     });
   }
 
@@ -6540,6 +6578,7 @@ function createFabricOverlayRuntime(options = {}) {
     selectionControls = null;
     badge = null;
     sizeAdjustHud = null;
+    sizeAdjustHudLabel = null;
     container = null;
     root = null;
     prepared = false;

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -386,6 +386,8 @@ function getBrushControls(root) {
     toolbar,
     sizeHud: findOne(root.querySelectorAllByClass('mpv-fabric-overlay-surface')[0],
       node => node.dataset.fabricPilotOutput === 'size-adjust'),
+    sizeHudLabel: findOne(root.querySelectorAllByClass('mpv-fabric-overlay-surface')[0],
+      node => node.dataset.fabricPilotOutput === 'size-adjust-label'),
     undoButton: findOne(toolbar, node => node.dataset.fabricPilotAction === 'undo'),
     redoButton: findOne(toolbar, node => node.dataset.fabricPilotAction === 'redo'),
     settingsButton: findOne(toolbar, node => node.dataset.fabricPilotAction === 'brush-settings'),
@@ -13733,16 +13735,18 @@ test('Alt 드래그는 브러시 크기를 1~50으로 조절하고 팔레트·HU
   element.dispatch('pointerdown', { pointerId: 900, button: 0, altKey: true, clientX: 100, clientY: 100 });
   assert.equal(runtime.getDiagnostics().gestures.altSizeAdjustActive, true);
   assert.equal(controls.sizeHud.style.display, 'block');
-  assert.equal(controls.sizeHud.style.left, '116px');
-  assert.equal(controls.sizeHud.style.top, '72px');
-  assert.equal(controls.sizeHud.textContent, '3px');
+  // 앵커 좌표가 원의 중심이다(transform: translate(-50%, -50%)) — 오프셋을 더하지 않는다.
+  assert.equal(controls.sizeHud.style.left, '100px');
+  assert.equal(controls.sizeHud.style.top, '100px');
+  assert.equal(controls.sizeHudLabel.textContent, '3px');
+  assert.equal(controls.sizeHud.style.borderRadius, '50%');
   element.dispatch('pointermove', { pointerId: 900, altKey: true, clientX: 140, clientY: 130 });
   // delta 40 / 4 = 10 → 3 + 10 = 13
   assert.equal(controls.sizeInput.value, '13');
   assert.equal(controls.sizeOutput.textContent, '13px');
   assert.equal(controls.summary.textContent, '13px · 100%');
-  assert.equal(controls.sizeHud.textContent, '13px');
-  assert.equal(controls.sizeHud.style.left, '116px', 'HUD는 드래그 시작점에 고정된다');
+  assert.equal(controls.sizeHudLabel.textContent, '13px');
+  assert.equal(controls.sizeHud.style.left, '100px', 'HUD는 드래그 시작점에 고정된다');
   element.dispatch('pointermove', { pointerId: 900, altKey: true, clientX: 1000, clientY: 130 });
   assert.equal(controls.sizeInput.value, '50');
   element.dispatch('pointermove', { pointerId: 900, altKey: true, clientX: -1000, clientY: 130 });
@@ -13753,6 +13757,38 @@ test('Alt 드래그는 브러시 크기를 1~50으로 조절하고 팔레트·HU
   assert.equal(controls.sizeInput.value, '1', '종료 시 크기를 되돌리지 않는다');
   assert.equal(runtime.getDiagnostics().objectCount, 0);
   assert.equal(runtime.getDiagnostics().mutationCount, 0, '크기 조절은 씬을 변경하지 않는다');
+});
+
+test('Alt 크기조절 HUD는 실제 브러시 굵기만 한 원을 브러시 색으로 그린다', () => {
+  FakeCanvas.instances = [];
+  const document = new FakeDocument();
+  const root = document.createElement('div');
+  const runtime = createFabricOverlayRuntime({
+    fabric: { Canvas: FakeCanvas, Path: FakePath },
+    document
+  });
+  runtime.prepare(root);
+  // sourceWidth 1920 / canvasRect.width 960 → 표시 배율 0.5.
+  // 브러시 크기는 소스 픽셀이므로 화면 굵기는 그 절반이어야 한다.
+  runtime.setDrawingInput(makeInput());
+  const controls = getBrushControls(root);
+  const element = FakeCanvas.instances[0].upperCanvasEl;
+
+  element.dispatch('pointerdown', { pointerId: 940, button: 0, altKey: true, clientX: 200, clientY: 150 });
+  assert.equal(controls.sizeHud.style.width, '2px', '크기 3 × 0.5 = 1.5 → 최소 2px');
+  assert.equal(controls.sizeHud.style.height, '2px');
+  assert.equal(controls.sizeHud.style.background, '#ff475780', '브러시 색 + 50% 알파');
+  assert.equal(controls.sizeHud.style.borderColor, '#ff4757');
+  assert.equal(controls.sizeHudLabel.textContent, '3px');
+
+  // delta 40 / 4 = 10 → 3 + 10 = 13 → 13 × 0.5 = 6.5 → 7px
+  element.dispatch('pointermove', { pointerId: 940, altKey: true, clientX: 240, clientY: 150 });
+  assert.equal(controls.sizeHud.style.width, '7px');
+  assert.equal(controls.sizeHud.style.height, '7px');
+  assert.equal(controls.sizeHudLabel.textContent, '13px');
+
+  element.dispatch('pointerup', { pointerId: 940, altKey: true, clientX: 240, clientY: 150 });
+  assert.equal(controls.sizeHud.style.display, 'none');
 });
 
 test('Alt 드래그는 획을 만들지 않고 우클릭 시작과 컨텍스트 메뉴 차단을 지원한다', () => {

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -249,7 +249,7 @@ test('stable engine promotion uses the 2.3.0 beta release version consistently',
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.4.4-beta');
-  assert.equal(packageLock.version, '2.4.4-beta');
-  assert.equal(packageLock.packages[''].version, '2.4.4-beta');
+  assert.equal(packageJson.version, '2.4.5-beta');
+  assert.equal(packageLock.version, '2.4.5-beta');
+  assert.equal(packageLock.packages[''].version, '2.4.5-beta');
 });


### PR DESCRIPTION
## 업데이트 로그 (비개발자용)

- **Alt를 누른 채 끌 때, 브러시가 실제로 얼마나 굵어지는지 보이는 원형 미리보기가 다시 나옵니다.** 브러시 색 그대로 칠해지고 위에 `12px` 같은 숫자가 붙습니다.
- 이전에는 작은 검은 글자 상자만 떠서 알아보기 어려웠습니다.

## 이건 렌더링 버그가 아니었습니다

v2.4.4-beta 실기 확인에서 "크기는 변하는데 오버레이가 안 나온다"는 보고를 받고, 추측 대신 **실제 Electron에서 측정**했습니다.

| 측정 항목 | 결과 |
|---|---|
| DOM 존재 | ✅ 있음 |
| `display` / `visibility` / `opacity` | `block` / `visible` / `1` |
| 좌표 | (316, 222) — 드래그 시작점 + 오프셋, 뷰포트 안 |
| 페인트 순서 | `hudIsTopmost: true` (fabric 캔버스 **위**) |
| 캡처한 실제 픽셀 | HUD 중심 RGB(82,82,84) α240 — 칩이 실제로 칠해짐 |

게다가 HUD는 팔레트(`z-index 2`)보다 위(`z-index 3`)라, **팔레트가 보이는 이상 HUD도 그려집니다.**

## 진짜 원인 — 생김새

레거시 `.brush-size-hud`(`renderer/styles/main.css:2314`)와 비교하면 명확합니다.

| | 레거시 | 파일럿(수정 전) |
|---|---|---|
| 형태 | **실제 브러시 굵기만 한 원** — 브러시 색 50% 알파 채움 + 브러시 색 테두리 | 44×20 검은 텍스트 칩 |
| 라벨 | 원 위에 `NNpx` (`::after`) | 칩 안 텍스트 |
| 앵커 | 드래그 시작점, `translate(-50%,-50%)`로 중심 정렬 | 시작점 + (16, −28) |

이 제스처의 목적은 **굵기를 눈으로 보는 것**인데 파일럿엔 그게 통째로 빠져 있었습니다. 숫자만으로는 알아채지 못하는 게 당연합니다.

## 상세 기술 설명

### 배율 보정이 핵심입니다

브러시 크기는 **소스 픽셀 단위**입니다(획 표본이 `mapClientPointToSource`로 소스 좌표에 매핑되므로). 1920 폭 영상을 800px로 보고 있으면 23px 브러시는 화면에서 약 10px입니다. 그래서 원 지름을 그대로 쓰면 안 되고 표시 배율을 곱해야 합니다.

레거시는 `rect.width / canvas.width`로 계산했고, 파일럿은 **확대·이동이 반영된 유효 rect**를 써야 하므로 기존 `resolveEffectiveCanvasRect(canvasRect, viewportTransform)`를 재사용합니다.

```js
function sourceToClientScale(session) {
  const sourceWidth = Math.max(0, finiteNumber(session?.sourceWidth, 0));
  if (sourceWidth <= 0) return 1;
  const rect = resolveEffectiveCanvasRect(session.canvasRect, session.viewportTransform);
  if (!(rect.width > 0)) return 1;
  return rect.width / sourceWidth;
}
```

### 그 외

- 채움은 `#RRGGBB80`. `style.color`는 스키마상 항상 6자리 hex(`/^#[0-9a-f]{6}$/i`)라 8자리 알파 표기가 안전합니다 — 레거시도 같은 방식입니다.
- 앵커 좌표가 원의 **중심**이 되므로(`translate(-50%,-50%)`) 기존 `SIZE_ADJUST_HUD_OFFSET_X/Y` 상수는 필요 없어져 제거했습니다.
- 라벨을 원의 자식 `span`으로 분리했습니다. 원의 `width`/`height`가 매 프레임 바뀌는데 글자는 그대로여야 하므로 같은 요소일 수 없습니다.

## 개발 난항

**첫 프로브가 잘못된 결론을 낼 뻔했습니다.** `document.elementFromPoint`로 최상위 요소를 확인했더니 fabric 캔버스가 나와 "HUD가 캔버스 밑에 깔린다"는 오진이 가능했습니다. 실제로는 HUD가 `pointer-events: none`이라 히트테스트에서 건너뛰어진 것뿐이었습니다. 잠시 `pointer-events: auto`로 되돌리고 재측정해 `hudIsTopmost: true`를 확인했습니다.

**픽셀 샘플링도 한 번 틀렸습니다.** 캡처가 1200×900인데 창은 800×600 — 디바이스 배율 1.5×를 반영하지 않아 엉뚱한 좌표를 읽었습니다. 배율을 곱한 뒤에야 α240의 칩 픽셀이 나왔습니다.

## 테스트 가이드

```bash
npm run test:fabric-drawing-pilot
```

- 신규 1건: `Alt 크기조절 HUD는 실제 브러시 굵기만 한 원을 브러시 색으로 그린다`
  (배율 0.5 세션에서 크기 3 → 최소 2px, 크기 13 → 7px, 채움 `#ff475780`, 테두리 `#ff4757`)
- 기존 Alt HUD 단언 갱신: 앵커 오프셋 제거(`116px` → `100px`), 라벨이 자식으로 분리됨
- 25개 스위트 **2,172 → 2,173 pass / 0 fail**
- `npm run bundle:mpv-fabric-overlay` 재생성본 포함

### 실기 확인

`B` → Alt 누른 채 드래그 → **브러시 색 원이 드래그 시작점에 뜨고 크기에 따라 커졌다 작아진다.** 위에 `NNpx` 라벨.

## 남은 것

레거시의 **화면 중앙** HUD는 좌표가 없는 호출(`[`/`]` 단축키·슬라이더)의 폴백입니다. `[`/`]`는 아직 IPC 채널조차 없어 작업 5에서 신설하므로, 그때 중앙 HUD를 함께 띄우도록 계획서 §5.7 (d-5)에 남겼습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
