### PR TITLE
DEVLOG: 작업 1-b HUD 원형 복원·v2.4.5-beta 배포 기록

### DIFF
--- a/DEVLOG/2026-08-28-드로잉-실행취소-UI정식화-구현.md
+++ b/DEVLOG/2026-08-28-드로잉-실행취소-UI정식화-구현.md
@@ -10,6 +10,7 @@
 |------|------|----------|------|-----|------|
 | 1 | §7.1 | mpv-overlay-host.js, mpv-fabric-overlay-runtime.js, iife 번들, 테스트 2 | 오버레이 창이 키보드 포커스를 가진 적이 없어 Alt 드래그가 `altKey:false`로 도착 | [#188](https://github.com/baehandoridori/BAEFRAME/pull/188) | ✅ 완료 |
 | — | — | package.json, package-lock.json, runtime-profile.test.js | 실기 확인용 패치 버전 상향 | [#189](https://github.com/baehandoridori/BAEFRAME/pull/189) | ✅ 완료 |
+| 1-b | §7.1 후속 | mpv-fabric-overlay-runtime.js, iife 번들, 테스트 1 | 실기 보고 — HUD가 굵기를 보여주지 않아 알아채지 못함 | [#191](https://github.com/baehandoridori/BAEFRAME/pull/191) | ✅ 완료 |
 | 2 | §6 | (예정) | Ctrl+Z 전역 실행취소 | ② | ⬜ 대기 |
 | 3 | §7.2 | (예정) | 도구 6종 신설 | ③ | ⬜ 대기 |
 | 4 | §7.3 | (예정) | 지우개 도구·모드 섹션 | ③ | ⬜ 대기 |
@@ -136,3 +137,93 @@ enable 경로가 포커스를 되돌리게 되면 2가 된다. **단언을 완�
 
 PR ② Ctrl+Z 전역 실행취소 → PR ③ 도구 6종·지우개 모드·`[`/`]`·팔레트 재구성.
 라운드 종료 후 `docs/drawing-keyframe-features.md` 갱신(계획서 부록 C-6).
+
+---
+
+# 작업 1-b — Alt 크기조절 HUD 원형 복원 (PR ①b, v2.4.5-beta)
+
+## 사용자 보고
+
+v2.4.4-beta 실기 확인 결과: **"크기는 변하는데, 화면 중앙에 오버레이는 나오지 않네."**
+
+→ **작업 1의 근본 원인(오버레이 창의 키보드 포커스 부재)이 확정됐다.** Alt 크기 조절이 실제로 동작한다.
+남은 것은 표시 문제였다.
+
+## 이건 렌더링 버그가 아니었다 — 실측으로 배제
+
+추측하지 않고 실제 Electron 렌더러에 오버레이를 띄워 측정했다(일회성 프로브, 커밋하지 않음).
+
+| 측정 | 결과 |
+|---|---|
+| DOM 존재 | ✅ |
+| `display` / `visibility` / `opacity` | `block` / `visible` / `1` |
+| 좌표·크기 | (316, 222) 43.7×20 — 뷰포트 안 |
+| 조상 사슬 | `transform`/`filter`/`contain`/`will-change` 없음 → `position: fixed` 정상 해석 |
+| 페인트 순서 | `hudIsTopmost: true` — fabric 캔버스 **위** |
+| 캡처 픽셀 | HUD 중심 RGB(82,82,84) α240, 좌측 끝 RGB(22,22,25) α235 = `rgba(24,24,28,0.92)` |
+
+게다가 HUD는 팔레트(`z-index 2`)보다 위(`z-index 3`)다. **팔레트가 보이는 이상 HUD도 그려진다.**
+
+### 프로브가 두 번 오진할 뻔했다
+
+1. `document.elementFromPoint`가 fabric 캔버스를 돌려줘 "HUD가 캔버스 밑"이라는 결론이 가능했다.
+   실제로는 HUD가 `pointer-events: none`이라 **히트테스트에서 건너뛰어진 것**이었다.
+   잠시 `pointer-events: auto`로 되돌려 재측정해 `hudIsTopmost: true`를 확인했다.
+2. 픽셀 샘플링이 캡처 배율을 무시했다. 창은 800×600인데 캡처는 1200×900(디바이스 배율 1.5×) —
+   CSS 좌표로 읽어 α4의 빈 픽셀이 나왔다. 배율을 곱한 뒤에야 α240의 칩 픽셀이 나왔다.
+
+## 진짜 원인 — 생김새
+
+레거시 `.brush-size-hud`(`renderer/styles/main.css:2314`)와 비교하면 명확하다.
+
+| | 레거시 | 파일럿(수정 전) |
+|---|---|---|
+| 형태 | **실제 브러시 굵기만 한 원** — 브러시 색 50% 알파 채움 + 브러시 색 테두리 | 44×20 검은 텍스트 칩 |
+| 라벨 | 원 위에 `NNpx` (`::after`) | 칩 안 텍스트 |
+| 앵커 | 드래그 시작점, `translate(-50%,-50%)` 중심 정렬 | 시작점 + (16, −28) |
+
+이 제스처의 목적은 **굵기를 눈으로 보는 것**인데 파일럿엔 그게 통째로 빠져 있었다. 숫자만으로는 알아채지 못한다.
+
+## 수정
+
+- 원 지름 = **브러시 크기 × 화면 표시 배율**. 브러시 크기는 소스 픽셀 단위이므로(획 표본이
+  `mapClientPointToSource`로 소스 좌표에 매핑된다) 배율 보정이 필수다. 레거시의
+  `rect.width / canvas.width`에 대응하되, 확대·이동이 반영된 `resolveEffectiveCanvasRect`를 재사용한다.
+- 채움 `#RRGGBB80`, 테두리는 브러시 색. `style.color`는 스키마상 항상 6자리 hex라 8자리 알파 표기가 안전하다.
+- 앵커 좌표가 원의 **중심**이 되므로 `SIZE_ADJUST_HUD_OFFSET_X/Y` 상수는 필요 없어져 제거했다.
+- 라벨을 원의 자식 `span`으로 분리했다. 원의 `width`/`height`가 매 프레임 바뀌는데 글자는 그대로여야 한다.
+
+## "화면 중앙"의 정체
+
+레거시 `updateBrushSizeHud`가 좌표 없는 호출에서 화면 중앙으로 폴백한다.
+
+```js
+const x = Number.isFinite(detail.clientX) ? detail.clientX : window.innerWidth / 2;
+```
+
+그런데 Alt 드래그는 `_emit('sizeadjust', { clientX: this._sizeAdjustStartX, ... })`로 **드래그 시작 좌표를 보낸다.**
+즉 레거시에서도 Alt 드래그 HUD는 시작점에 뜬다. **화면 중앙은 `[` / `]` 단축키·슬라이더 경로의 폴백이다.**
+
+`[` / `]`는 아직 IPC 채널조차 없어 작업 5에서 신설하므로, 그때 중앙 HUD를 함께 띄우도록
+계획서 §5.7 (d-5)에 설계를 남겼다(자동 숨김 타이머 + Alt 제스처 시 타이머 취소 포함).
+
+## 결과
+
+- 신규 테스트 1건(배율 0.5 세션에서 크기 3 → 최소 2px, 13 → 7px, 채움 `#ff475780`, 테두리 `#ff4757`)
+- 기존 Alt HUD 단언 갱신 — 앵커 오프셋 제거(`116px` → `100px`), 라벨 자식 분리
+- 25스위트 **2,172 → 2,173 pass / 0 fail**
+
+## 배포 기록 (v2.4.5-beta)
+
+| 항목 | 값 |
+|------|-----|
+| 배포 시각 | **2026-08-28 18:43** |
+| 소스 커밋 | `c17c0e3` (main, PR #191 머지) |
+| 배포 방식 | `robocopy /MIR` — exit 1(정상), FAILED 0 |
+| 검증 | 전체 트리 SHA-256 **82/82, MismatchCount=0 / MissingCount=0 / ExtraFiles=0** |
+| exe SHA-256 | `2C723C5FA5A53DF50C5EB46D531840B9BED1766AA8BF033A4628DDE74DE44AED` |
+| app.asar SHA-256 | `1C96E7D16B75C548C10039175F6CFB04D9C8CDA536FB3FD60E71BA7FECC47E3A` |
+| `FileVersion` | `2.4.5-beta` |
+| 직전 배포본 | v2.4.4-beta, 2026-08-28 18:27 (교체됨) |
+
+**실기 확인**: `B` → Alt 드래그 → 브러시 색 원이 드래그 시작점에 뜨고 크기에 따라 커졌다 작아진다. 위에 `NNpx` 라벨.


### PR DESCRIPTION
실측으로 렌더링 버그를 배제한 과정, 진짜 원인(레거시 대비 생김새 차이), '화면 중앙'의 정체, v2.4.5-beta 배포 기록입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)