### PR TITLE
Ctrl+Z를 애니메이트처럼 시각 순서 전역 실행취소로

### DIFF
--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -3447,6 +3447,8 @@ class MPVOverlayHost {
         mutationCount: Math.trunc(finiteDiagnosticNumber(result?.mutationCount)),
         undoDepth: Math.trunc(finiteDiagnosticNumber(result?.undoDepth)),
         redoDepth: Math.trunc(finiteDiagnosticNumber(result?.redoDepth)),
+        globalUndoDepth: Math.trunc(finiteDiagnosticNumber(result?.globalUndoDepth)),
+        globalRedoDepth: Math.trunc(finiteDiagnosticNumber(result?.globalRedoDepth)),
         historyBytes: Math.trunc(finiteDiagnosticNumber(result?.historyBytes)),
         dirty: result?.dirty === true,
         gestures: sanitizeFabricGestureDiagnostics(result?.gestures),

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -3254,7 +3254,12 @@
           knownIds.delete(entry.id);
         }
         function clearStack(stack) {
-          while (stack.length > 0) removeAt(stack, stack.length - 1);
+          const removedIds = [];
+          while (stack.length > 0) {
+            removedIds.push(stack[stack.length - 1].id);
+            removeAt(stack, stack.length - 1);
+          }
+          return removedIds;
         }
         function record(command) {
           if (!command || typeof command.id !== "string" || !command.id || typeof command.kind !== "string" || !command.kind || command.undoState === void 0 || command.redoState === void 0) {
@@ -3264,15 +3269,30 @@
           const stored = clonePlain(command);
           const estimatedBytes = Math.max(1, Math.trunc(Number(estimateEntryBytes(stored)) || 1));
           if (estimatedBytes > maxBytes) return { recorded: false, reason: "history-capacity-exceeded" };
-          clearStack(redoStack);
+          const clearedRedoIds = clearStack(redoStack);
+          const evictedUndoIds = [];
           while (undoStack.length >= maxEntries || historyBytes + estimatedBytes > maxBytes) {
-            if (undoStack.length === 0) return { recorded: false, reason: "history-capacity-exceeded" };
+            if (undoStack.length === 0) {
+              return {
+                recorded: false,
+                reason: "history-capacity-exceeded",
+                evictedUndoIds,
+                clearedRedoIds
+              };
+            }
+            evictedUndoIds.push(undoStack[0].id);
             removeAt(undoStack, 0);
           }
           undoStack.push({ ...stored, estimatedBytes });
           knownIds.add(stored.id);
           historyBytes += estimatedBytes;
-          return { recorded: true, undoDepth: undoStack.length, redoDepth: 0 };
+          return {
+            recorded: true,
+            undoDepth: undoStack.length,
+            redoDepth: 0,
+            evictedUndoIds,
+            clearedRedoIds
+          };
         }
         function moveTop(from, to, stateKey, applyState, direction) {
           const entry = from.at(-1);
@@ -3305,6 +3325,9 @@
           clearStack(undoStack);
           clearStack(redoStack);
         }
+        function clearRedo() {
+          return clearStack(redoStack);
+        }
         function getDiagnostics() {
           const undoBytes = undoStack.reduce((total, entry) => total + entry.estimatedBytes, 0);
           const redoBytes = redoStack.reduce((total, entry) => total + entry.estimatedBytes, 0);
@@ -3318,7 +3341,7 @@
             maxBytes
           };
         }
-        return { record, undo, redo, clear, getDiagnostics };
+        return { record, undo, redo, clear, clearRedo, getDiagnostics };
       }
       module.exports = { createDrawingCommandHistory };
     }
@@ -14037,6 +14060,75 @@ void main() {
             observerLifecycleFailureCount += 1;
           }
         }
+        const globalHistoryOrder = /* @__PURE__ */ new Map();
+        const MAX_GLOBAL_HISTORY_ATTEMPTS = 8;
+        function globalOrderFor(stableVideoIdentity, create = false) {
+          if (typeof stableVideoIdentity !== "string" || stableVideoIdentity.length === 0) return null;
+          let order = globalHistoryOrder.get(stableVideoIdentity);
+          if (!order && create) {
+            order = { undo: [], redo: [] };
+            globalHistoryOrder.set(stableVideoIdentity, order);
+          }
+          return order || null;
+        }
+        function reconcileGlobalOrder(scene, recorded) {
+          const order = globalOrderFor(scene?.stableVideoIdentity);
+          if (!order) return;
+          const dropped = /* @__PURE__ */ new Set();
+          for (const id of recorded?.evictedUndoIds || []) dropped.add(id);
+          for (const id of recorded?.clearedRedoIds || []) dropped.add(id);
+          if (dropped.size === 0) return;
+          order.undo = order.undo.filter((entry) => !dropped.has(entry.commandId));
+          order.redo = order.redo.filter((entry) => !dropped.has(entry.commandId));
+        }
+        function appendGlobalOrder(scene, commandId) {
+          const order = globalOrderFor(scene?.stableVideoIdentity, true);
+          if (!order || !scene) return;
+          const clearedSceneKeys = /* @__PURE__ */ new Set([scene.key]);
+          for (const entry of order.redo) {
+            if (clearedSceneKeys.has(entry.sceneKey)) continue;
+            clearedSceneKeys.add(entry.sceneKey);
+            const other = scenes.get(entry.sceneKey);
+            if (!other) continue;
+            other.history.clearRedo();
+            other.historyEntries = { undo: other.historyEntries.undo, redo: [] };
+          }
+          order.redo = [];
+          order.undo.push({ sceneKey: scene.key, commandId });
+        }
+        function* globalHistoryCandidates(direction) {
+          const order = globalOrderFor(activeSession?.stableVideoIdentity);
+          if (!order) return;
+          const list = direction === "undo" ? order.undo : order.redo;
+          let index = list.length - 1;
+          let attempts = 0;
+          while (index >= 0 && attempts < MAX_GLOBAL_HISTORY_ATTEMPTS) {
+            const scene = scenes.get(list[index].sceneKey);
+            if (!scene) {
+              list.splice(index, 1);
+              index -= 1;
+              continue;
+            }
+            attempts += 1;
+            yield { scene, order };
+            index -= 1;
+          }
+        }
+        function moveGlobalOrderEntry(order, direction, commandId) {
+          const from = direction === "undo" ? order.undo : order.redo;
+          const to = direction === "undo" ? order.redo : order.undo;
+          const index = from.findLastIndex((entry2) => entry2.commandId === commandId);
+          if (index < 0) return;
+          const [entry] = from.splice(index, 1);
+          to.push(entry);
+        }
+        function globalHistoryDepths() {
+          const order = globalOrderFor(activeSession?.stableVideoIdentity);
+          return {
+            globalUndoDepth: order ? order.undo.length : 0,
+            globalRedoDepth: order ? order.redo.length : 0
+          };
+        }
         function activeScene() {
           return activeSession ? scenes.get(activeSession.sceneKey) || null : null;
         }
@@ -14083,6 +14175,7 @@ void main() {
           }
           videoAccess.delete(stableVideoIdentity);
           persistenceByVideo.delete(stableVideoIdentity);
+          globalHistoryOrder.delete(stableVideoIdentity);
           if (latestPersistenceVideoIdentity === stableVideoIdentity) {
             latestPersistenceVideoIdentity = [...videoAccess.keys()].at(-1) || null;
           }
@@ -14369,9 +14462,11 @@ void main() {
             return { applied: false, reason: "scene-capacity-exceeded" };
           }
           const recorded = scene.history.record(command);
+          reconcileGlobalOrder(scene, recorded);
           if (!recorded.recorded) {
             return { applied: false, reason: recorded.reason || "history-record-failed" };
           }
+          appendGlobalOrder(scene, command.id);
           for (const stableVideoIdentity of plannedEvictions) evictVideo(stableVideoIdentity);
           materializeProvisionalScene(scene);
           scene.historyEntries = { undo: projectedHistory.undo, redo: projectedHistory.redo };
@@ -14507,6 +14602,7 @@ void main() {
             droppedSceneInstanceIds.push(scene.sceneInstanceId);
             scenes.delete(key);
           }
+          globalHistoryOrder.delete(request.stableVideoIdentity);
           for (const scene of hydratedScenes) scenes.set(scene.key, scene);
           persistenceByVideo.set(request.stableVideoIdentity, {
             hostGeneration: request.hostGeneration,
@@ -14934,9 +15030,7 @@ void main() {
           touchVideo(scene.stableVideoIdentity);
           return { applied: true };
         }
-        function moveHistory(direction) {
-          const scene = activeScene();
-          if (!scene) return { applied: false, reason: "history-empty" };
+        function applyHistoryEntry(scene, order, direction) {
           let transition = null;
           const result = scene.history[direction]((state, _historyDirection, entry) => {
             const applied = applyHistoryState(scene, state);
@@ -14953,6 +15047,7 @@ void main() {
             return applied;
           });
           if (!result.applied) return result;
+          moveGlobalOrderEntry(order, direction, result.commandId);
           const from = direction === "undo" ? scene.historyEntries.undo : scene.historyEntries.redo;
           const to = direction === "undo" ? scene.historyEntries.redo : scene.historyEntries.undo;
           const entryIndex = from.findLastIndex((entry) => entry.id === result.commandId);
@@ -14966,8 +15061,21 @@ void main() {
           return {
             ...result,
             objectCount: scene.objects.size,
-            selectedObjectIds: []
+            selectedObjectIds: [],
+            // 되돌린 씬이 지금 화면에 떠 있는 씬인지. 아니면 캔버스 재도색과 도구 모드
+            // 재설정을 건너뛴다.
+            affectedActiveScene: scene === activeScene(),
+            affectedTargetFrame: scene.targetFrame
           };
+        }
+        function moveHistory(direction) {
+          let lastFailure = null;
+          for (const { scene, order } of globalHistoryCandidates(direction)) {
+            const attempt = applyHistoryEntry(scene, order, direction);
+            if (attempt.applied) return attempt;
+            lastFailure = attempt;
+          }
+          return lastFailure || { applied: false, reason: "history-empty" };
         }
         function undo() {
           return moveHistory("undo");
@@ -15157,6 +15265,9 @@ void main() {
             provisionalSourceFrame: scene?.provisionalSourceFrame ?? null,
             undoDepth: history.undoDepth,
             redoDepth: history.redoDepth,
+            // 활성 씬 기준 깊이(위)와 전역 순서 인덱스 깊이(아래)는 의미가 다르다.
+            // 기존 진단의 의미를 바꾸지 않으려고 새 필드로 낸다.
+            ...globalHistoryDepths(),
             undoBytes: history.undoBytes,
             historyBytes: history.historyBytes,
             sceneKeys: [...scenes.keys()]
@@ -15167,6 +15278,7 @@ void main() {
           destroyed = true;
           const droppedSceneInstanceIds = [...scenes.values()].map((scene) => scene.sceneInstanceId);
           scenes.clear();
+          globalHistoryOrder.clear();
           videoAccess.clear();
           persistenceByVideo.clear();
           latestPersistenceVideoIdentity = null;
@@ -19606,10 +19718,12 @@ void main() {
           const result = action === "delete-selection" ? sceneStore.deleteSelection() : action === "clear-session" ? sceneStore.clearSession() : action === "undo" ? sceneStore.undo() : sceneStore.redo();
           if (result.applied) {
             if (action === "undo" || action === "redo") {
-              renderActiveScene();
-              fabricCanvas.discardActiveObject();
-              sceneStore.selectObjects([]);
-              setToolMode(currentSession?.tool || "brush");
+              if (result.affectedActiveScene !== false) {
+                renderActiveScene();
+                fabricCanvas.discardActiveObject();
+                sceneStore.selectObjects([]);
+                setToolMode(currentSession?.tool || "brush");
+              }
               updateObjectMetric();
               settleArmedFramePreview();
               return result;
@@ -19689,6 +19803,8 @@ void main() {
             dirty: scene.dirty,
             undoDepth: scene.undoDepth,
             redoDepth: scene.redoDepth,
+            globalUndoDepth: scene.globalUndoDepth,
+            globalRedoDepth: scene.globalRedoDepth,
             undoBytes: scene.undoBytes,
             historyBytes: scene.historyBytes,
             cache: {

--- a/renderer/scripts/modules/drawing-v3/drawing-command-history.js
+++ b/renderer/scripts/modules/drawing-v3/drawing-command-history.js
@@ -29,8 +29,14 @@ function createDrawingCommandHistory(options = {}) {
     knownIds.delete(entry.id);
   }
 
+  // 전역 실행취소 순서 인덱스가 같은 항목을 지울 수 있도록 버린 id를 돌려준다.
   function clearStack(stack) {
-    while (stack.length > 0) removeAt(stack, stack.length - 1);
+    const removedIds = [];
+    while (stack.length > 0) {
+      removedIds.push(stack[stack.length - 1].id);
+      removeAt(stack, stack.length - 1);
+    }
+    return removedIds;
   }
 
   function record(command) {
@@ -44,15 +50,32 @@ function createDrawingCommandHistory(options = {}) {
     const estimatedBytes = Math.max(1, Math.trunc(Number(estimateEntryBytes(stored)) || 1));
     if (estimatedBytes > maxBytes) return { recorded: false, reason: 'history-capacity-exceeded' };
 
-    clearStack(redoStack);
+    // redo 폐기는 기록 성공 여부와 무관하게 이미 일어난다. 따라서 실패 반환에도
+    // clearedRedoIds를 실어야 전역 인덱스가 없는 항목을 가리킨 채 남지 않는다.
+    const clearedRedoIds = clearStack(redoStack);
+    const evictedUndoIds = [];
     while (undoStack.length >= maxEntries || historyBytes + estimatedBytes > maxBytes) {
-      if (undoStack.length === 0) return { recorded: false, reason: 'history-capacity-exceeded' };
+      if (undoStack.length === 0) {
+        return {
+          recorded: false,
+          reason: 'history-capacity-exceeded',
+          evictedUndoIds,
+          clearedRedoIds
+        };
+      }
+      evictedUndoIds.push(undoStack[0].id);
       removeAt(undoStack, 0);
     }
     undoStack.push({ ...stored, estimatedBytes });
     knownIds.add(stored.id);
     historyBytes += estimatedBytes;
-    return { recorded: true, undoDepth: undoStack.length, redoDepth: 0 };
+    return {
+      recorded: true,
+      undoDepth: undoStack.length,
+      redoDepth: 0,
+      evictedUndoIds,
+      clearedRedoIds
+    };
   }
 
   function moveTop(from, to, stateKey, applyState, direction) {
@@ -90,6 +113,12 @@ function createDrawingCommandHistory(options = {}) {
     clearStack(redoStack);
   }
 
+  // 다른 씬에서 새 편집이 일어나면 이 씬의 redo도 전역적으로 무효가 된다.
+  // undo 스택은 건드리지 않고 redo만 비우고, 버린 id를 돌려준다.
+  function clearRedo() {
+    return clearStack(redoStack);
+  }
+
   function getDiagnostics() {
     const undoBytes = undoStack.reduce((total, entry) => total + entry.estimatedBytes, 0);
     const redoBytes = redoStack.reduce((total, entry) => total + entry.estimatedBytes, 0);
@@ -104,7 +133,7 @@ function createDrawingCommandHistory(options = {}) {
     };
   }
 
-  return { record, undo, redo, clear, getDiagnostics };
+  return { record, undo, redo, clear, clearRedo, getDiagnostics };
 }
 
 module.exports = { createDrawingCommandHistory };

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -767,6 +767,112 @@ function createSessionSceneStore(options = {}) {
     }
   }
 
+  // ── 전역 실행취소 순서 인덱스 ────────────────────────────────────────────────
+  // 씬별 히스토리·씬별 예산 회계·undoDepth 진단의 의미는 그대로 두고, "어느 씬의
+  // 어떤 커맨드가 시각 순서 몇 번째였는가"만 따로 쌓는다. Ctrl+Z는 재생헤드 위치와
+  // 무관하게 이 스택의 마지막 항목을 되돌린다(애니메이트 동치).
+  //
+  // 영상별로 나누는 이유: 실행취소는 문서 단위여야 하고, 씬 축출(evictVideo)이
+  // 영상 단위라 인덱스 회수 경계가 자연히 일치해 유령 항목이 생기지 않는다.
+  //
+  // 정합성: 한 씬 안에서 커맨드는 scene.history의 undoStack과 order.undo에 같은
+  // 순서로 쌓이므로, order.undo의 마지막 항목은 언제나 그 씬 히스토리의 최상단이다.
+  const globalHistoryOrder = new Map();
+  // 적용에 실패한 항목을 건너뛰며 시도할 최대 횟수. 한 번의 Ctrl+Z가 스택 전체를
+  // 훑으며 시간을 쓰지 않도록 상한을 둔다.
+  const MAX_GLOBAL_HISTORY_ATTEMPTS = 8;
+
+  function globalOrderFor(stableVideoIdentity, create = false) {
+    if (typeof stableVideoIdentity !== 'string' || stableVideoIdentity.length === 0) return null;
+    let order = globalHistoryOrder.get(stableVideoIdentity);
+    if (!order && create) {
+      order = { undo: [], redo: [] };
+      globalHistoryOrder.set(stableVideoIdentity, order);
+    }
+    return order || null;
+  }
+
+  // 씬 히스토리가 버린 항목(용량 축출 + redo 폐기)을 전역 인덱스에서도 지운다.
+  function reconcileGlobalOrder(scene, recorded) {
+    const order = globalOrderFor(scene?.stableVideoIdentity);
+    if (!order) return;
+    const dropped = new Set();
+    for (const id of recorded?.evictedUndoIds || []) dropped.add(id);
+    for (const id of recorded?.clearedRedoIds || []) dropped.add(id);
+    if (dropped.size === 0) return;
+    order.undo = order.undo.filter(entry => !dropped.has(entry.commandId));
+    order.redo = order.redo.filter(entry => !dropped.has(entry.commandId));
+  }
+
+  // 새 편집이 들어오면 전역 redo는 전부 무효다(애니메이트 동일). 커맨드를 기록한
+  // 씬의 redo는 history.record()가 이미 비웠으므로 나머지 씬만 비운다. 이걸 빼면
+  // 전역 인덱스에서 사라진 항목이 씬 히스토리에 남아 redoDepth 진단이 어긋난다.
+  function appendGlobalOrder(scene, commandId) {
+    const order = globalOrderFor(scene?.stableVideoIdentity, true);
+    if (!order || !scene) return;
+    const clearedSceneKeys = new Set([scene.key]);
+    for (const entry of order.redo) {
+      if (clearedSceneKeys.has(entry.sceneKey)) continue;
+      clearedSceneKeys.add(entry.sceneKey);
+      const other = scenes.get(entry.sceneKey);
+      if (!other) continue;
+      other.history.clearRedo();
+      // 바이트 거울도 함께 비운다. 남겨 두면 estimateSceneBytes가 이미 사라진
+      // redo 상태를 계속 예약해 용량을 과대 계상한다.
+      other.historyEntries = { undo: other.historyEntries.undo, redo: [] };
+    }
+    order.redo = [];
+    order.undo.push({ sceneKey: scene.key, commandId });
+  }
+
+  // 전역 스택을 위에서부터 훑으며 적용 가능한 후보를 순서대로 내놓는다.
+  //
+  // 최상단 하나만 보면 안 되는 이유: applyHistoryState는 실패할 수 있고
+  // (scene-capacity-exceeded / mutation-sequence-overflow / invalid-history-state),
+  // 실패 시 씬 히스토리의 moveTop은 스택을 pop하지 않는다. 최상단에서 멈추면 그
+  // 항목이 영구히 남아 이후 모든 Ctrl+Z가 같은 실패를 반복한다. 씬별 히스토리에는
+  // 없던 고착이다 — 예전에는 다른 키프레임으로 옮기면 그 씬의 undo가 동작했다.
+  //
+  // 실패한 항목은 **버리지 않고 건너뛴다**. 일시적 실패(용량 압박)라면 다음에 다시
+  // 시도할 수 있어야 하기 때문이다. 건너뛰어도 불변식은 유지된다 — 각 항목은 여전히
+  // 자기 씬 히스토리의 최상단이고, 중간에서 하나가 빠져도 상대 순서는 그대로다.
+  function* globalHistoryCandidates(direction) {
+    const order = globalOrderFor(activeSession?.stableVideoIdentity);
+    if (!order) return;
+    const list = direction === 'undo' ? order.undo : order.redo;
+    let index = list.length - 1;
+    let attempts = 0;
+    while (index >= 0 && attempts < MAX_GLOBAL_HISTORY_ATTEMPTS) {
+      const scene = scenes.get(list[index].sceneKey);
+      if (!scene) {
+        // 정리 누락으로 남은 유령 항목만 실제로 걷어낸다.
+        list.splice(index, 1);
+        index -= 1;
+        continue;
+      }
+      attempts += 1;
+      yield { scene, order };
+      index -= 1;
+    }
+  }
+
+  function moveGlobalOrderEntry(order, direction, commandId) {
+    const from = direction === 'undo' ? order.undo : order.redo;
+    const to = direction === 'undo' ? order.redo : order.undo;
+    const index = from.findLastIndex(entry => entry.commandId === commandId);
+    if (index < 0) return;
+    const [entry] = from.splice(index, 1);
+    to.push(entry);
+  }
+
+  function globalHistoryDepths() {
+    const order = globalOrderFor(activeSession?.stableVideoIdentity);
+    return {
+      globalUndoDepth: order ? order.undo.length : 0,
+      globalRedoDepth: order ? order.redo.length : 0
+    };
+  }
+
   function activeScene() {
     return activeSession ? scenes.get(activeSession.sceneKey) || null : null;
   }
@@ -820,6 +926,8 @@ function createSessionSceneStore(options = {}) {
     }
     videoAccess.delete(stableVideoIdentity);
     persistenceByVideo.delete(stableVideoIdentity);
+    // 씬이 사라지면 그 영상의 전역 실행취소 순서도 함께 사라진다.
+    globalHistoryOrder.delete(stableVideoIdentity);
     if (latestPersistenceVideoIdentity === stableVideoIdentity) {
       latestPersistenceVideoIdentity = [...videoAccess.keys()].at(-1) || null;
     }
@@ -1143,9 +1251,14 @@ function createSessionSceneStore(options = {}) {
       return { applied: false, reason: 'scene-capacity-exceeded' };
     }
     const recorded = scene.history.record(command);
+    // 씬 히스토리가 버린 항목을 전역 인덱스에서도 지운다. 기록 실패 경로에서도
+    // redo는 이미 폐기됐으므로 성공 여부와 무관하게 먼저 맞춘다.
+    reconcileGlobalOrder(scene, recorded);
     if (!recorded.recorded) {
       return { applied: false, reason: recorded.reason || 'history-record-failed' };
     }
+    // evictVideo가 globalHistoryOrder를 지우므로 방금 넣은 항목보다 먼저 둔다.
+    appendGlobalOrder(scene, command.id);
     for (const stableVideoIdentity of plannedEvictions) evictVideo(stableVideoIdentity);
 
     materializeProvisionalScene(scene);
@@ -1316,6 +1429,8 @@ function createSessionSceneStore(options = {}) {
       droppedSceneInstanceIds.push(scene.sceneInstanceId);
       scenes.delete(key);
     }
+    // 씬이 통째로 교체되므로 이 영상의 전역 실행취소 순서는 전부 무효다.
+    globalHistoryOrder.delete(request.stableVideoIdentity);
     for (const scene of hydratedScenes) scenes.set(scene.key, scene);
     persistenceByVideo.set(request.stableVideoIdentity, {
       hostGeneration: request.hostGeneration,
@@ -1792,9 +1907,7 @@ function createSessionSceneStore(options = {}) {
     return { applied: true };
   }
 
-  function moveHistory(direction) {
-    const scene = activeScene();
-    if (!scene) return { applied: false, reason: 'history-empty' };
+  function applyHistoryEntry(scene, order, direction) {
     let transition = null;
     const result = scene.history[direction]((state, _historyDirection, entry) => {
       const applied = applyHistoryState(scene, state);
@@ -1811,6 +1924,7 @@ function createSessionSceneStore(options = {}) {
       return applied;
     });
     if (!result.applied) return result;
+    moveGlobalOrderEntry(order, direction, result.commandId);
     const from = direction === 'undo' ? scene.historyEntries.undo : scene.historyEntries.redo;
     const to = direction === 'undo' ? scene.historyEntries.redo : scene.historyEntries.undo;
     const entryIndex = from.findLastIndex(entry => entry.id === result.commandId);
@@ -1824,8 +1938,26 @@ function createSessionSceneStore(options = {}) {
     return {
       ...result,
       objectCount: scene.objects.size,
-      selectedObjectIds: []
+      selectedObjectIds: [],
+      // 되돌린 씬이 지금 화면에 떠 있는 씬인지. 아니면 캔버스 재도색과 도구 모드
+      // 재설정을 건너뛴다.
+      affectedActiveScene: scene === activeScene(),
+      affectedTargetFrame: scene.targetFrame
     };
+  }
+
+  function moveHistory(direction) {
+    // 대상은 활성 씬이 아니라 전역 순서 인덱스의 최상단이다. 재생헤드가 키프레임에
+    // 정확히 있지 않아도, 다른 키프레임의 편집이어도 시각 순서의 역순으로 되돌린다.
+    // 되돌린 곳이 현재 보고 있는 키프레임이 아니면 화면에는 변화가 없다 — 의도된
+    // 동작이며, 사용자 결정에 따라 재생헤드를 옮기지 않는다.
+    let lastFailure = null;
+    for (const { scene, order } of globalHistoryCandidates(direction)) {
+      const attempt = applyHistoryEntry(scene, order, direction);
+      if (attempt.applied) return attempt;
+      lastFailure = attempt;
+    }
+    return lastFailure || { applied: false, reason: 'history-empty' };
   }
 
   function undo() {
@@ -2041,6 +2173,9 @@ function createSessionSceneStore(options = {}) {
       provisionalSourceFrame: scene?.provisionalSourceFrame ?? null,
       undoDepth: history.undoDepth,
       redoDepth: history.redoDepth,
+      // 활성 씬 기준 깊이(위)와 전역 순서 인덱스 깊이(아래)는 의미가 다르다.
+      // 기존 진단의 의미를 바꾸지 않으려고 새 필드로 낸다.
+      ...globalHistoryDepths(),
       undoBytes: history.undoBytes,
       historyBytes: history.historyBytes,
       sceneKeys: [...scenes.keys()]
@@ -2052,6 +2187,7 @@ function createSessionSceneStore(options = {}) {
     destroyed = true;
     const droppedSceneInstanceIds = [...scenes.values()].map(scene => scene.sceneInstanceId);
     scenes.clear();
+    globalHistoryOrder.clear();
     videoAccess.clear();
     persistenceByVideo.clear();
     latestPersistenceVideoIdentity = null;
@@ -7106,10 +7242,16 @@ function createFabricOverlayRuntime(options = {}) {
           : sceneStore.redo();
     if (result.applied) {
       if (action === 'undo' || action === 'redo') {
-        renderActiveScene();
-        fabricCanvas.discardActiveObject();
-        sceneStore.selectObjects([]);
-        setToolMode(currentSession?.tool || 'brush');
+        // 전역 실행취소가 다른 키프레임을 되돌린 경우 화면에는 아무 변화가 없다.
+        // 그때까지 캔버스를 다시 그리고 도구 모드를 재설정하면 헛일이고, 사용자의
+        // 활성 선택만 사라진다. 활성 씬이 실제로 바뀐 경우에만 손댄다.
+        // !== false 로 쓰는 이유: 이 필드 없이 도달하는 경로는 안전한 쪽(재도색)이 기본이어야 한다.
+        if (result.affectedActiveScene !== false) {
+          renderActiveScene();
+          fabricCanvas.discardActiveObject();
+          sceneStore.selectObjects([]);
+          setToolMode(currentSession?.tool || 'brush');
+        }
         updateObjectMetric();
         settleArmedFramePreview();
         return result;
@@ -7201,6 +7343,8 @@ function createFabricOverlayRuntime(options = {}) {
       dirty: scene.dirty,
       undoDepth: scene.undoDepth,
       redoDepth: scene.redoDepth,
+      globalUndoDepth: scene.globalUndoDepth,
+      globalRedoDepth: scene.globalRedoDepth,
       undoBytes: scene.undoBytes,
       historyBytes: scene.historyBytes,
       cache: {

--- a/scripts/tests/drawing-v3-command-history.test.js
+++ b/scripts/tests/drawing-v3-command-history.test.js
@@ -193,3 +193,49 @@ test('clear removes both stacks and bytes', () => {
     maxBytes: 4096
   });
 });
+
+test('record는 용량 초과로 축출한 undo id를 보고한다', () => {
+  const history = createDrawingCommandHistory({ maxEntries: 2, maxBytes: 65536 });
+  assert.deepEqual(history.record(command('evict-1', 0, 1)).evictedUndoIds, []);
+  assert.deepEqual(history.record(command('evict-2', 1, 2)).evictedUndoIds, []);
+  // 세 번째부터 가장 오래된 항목이 밀린다 — 전역 순서 인덱스가 같은 id를 지울 수 있어야 한다.
+  assert.deepEqual(history.record(command('evict-3', 2, 3)).evictedUndoIds, ['evict-1']);
+  assert.equal(history.getDiagnostics().undoDepth, 2);
+});
+
+test('record는 성공·실패 양쪽에서 폐기한 redo id를 보고한다', () => {
+  const history = createDrawingCommandHistory({ maxEntries: 2, maxBytes: 65536 });
+  assert.equal(history.record(command('redo-src-1', 0, 1)).recorded, true);
+  assert.equal(history.undo(() => ({ applied: true })).applied, true);
+  assert.equal(history.getDiagnostics().redoDepth, 1);
+
+  // 성공 경로 — 새 커맨드가 redo를 폐기하고 그 id를 돌려준다.
+  const success = history.record(command('redo-killer', 1, 2));
+  assert.equal(success.recorded, true);
+  assert.deepEqual(success.clearedRedoIds, ['redo-src-1']);
+
+  // 커맨드 하나가 통째로 용량을 넘는 경우는 clearStack 이전에 조기 반환한다.
+  // 즉 아무것도 폐기하지 않았으므로 redo가 살아 있어야 하고, 전역 인덱스도 그대로여야 한다.
+  const tiny = createDrawingCommandHistory({ maxEntries: 4, maxBytes: 400 });
+  assert.equal(tiny.record(command('tiny-1', 0, 1)).recorded, true);
+  assert.equal(tiny.undo(() => ({ applied: true })).applied, true);
+  assert.equal(tiny.getDiagnostics().redoDepth, 1);
+  const oversized = tiny.record(command('tiny-oversized', 'x'.repeat(4000), 2));
+  assert.equal(oversized.recorded, false);
+  assert.equal(oversized.reason, 'history-capacity-exceeded');
+  assert.equal(tiny.getDiagnostics().redoDepth, 1, '조기 반환은 redo를 폐기하지 않는다');
+});
+
+test('clearRedo는 redo 스택만 비우고 버린 id를 돌려준다', () => {
+  const history = createDrawingCommandHistory({ maxEntries: 4, maxBytes: 65536 });
+  assert.equal(history.record(command('keep-1', 0, 1)).recorded, true);
+  assert.equal(history.record(command('keep-2', 1, 2)).recorded, true);
+  assert.equal(history.undo(() => ({ applied: true })).applied, true);
+  assert.equal(history.getDiagnostics().undoDepth, 1);
+  assert.equal(history.getDiagnostics().redoDepth, 1);
+
+  assert.deepEqual(history.clearRedo(), ['keep-2']);
+  assert.equal(history.getDiagnostics().undoDepth, 1, 'undo 스택은 건드리지 않는다');
+  assert.equal(history.getDiagnostics().redoDepth, 0);
+  assert.deepEqual(history.clearRedo(), [], '이미 비었으면 빈 배열이다');
+});

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -9410,7 +9410,7 @@ test('two consecutive moves create two distinct undo redo commands', () => {
   assertHistoryDiagnostics(harness, { mutationCount: 7, undoDepth: 3, redoDepth: 0 });
 });
 
-test('video and frame scene histories remain independent across undo and redo', () => {
+test('undo and redo follow visual order within a video while videos stay independent', () => {
   const harness = createHistoryHarness();
   const { sceneStore } = harness;
   const activate = (sessionId, stableVideoIdentity, targetFrame) => sceneStore.activateSession({
@@ -9439,20 +9439,305 @@ test('video and frame scene histories remain independent across undo and redo', 
   assert.equal(sceneStore.undo().applied, true);
   assertHistoryDiagnostics(harness, { mutationCount: 2, undoDepth: 0, redoDepth: 1 });
 
+  // 영상 경계는 그대로다 — other-video 의 redo 는 runtime-video 와 섞이지 않는다.
   assert.equal(activate('video-session-2', 'other-video', 24).restored, true);
   assert.equal(sceneStore.redo().applied, true);
   assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects.map(object => object.id), ['scene-video']);
   assertHistoryDiagnostics(harness, { mutationCount: 3, undoDepth: 1, redoDepth: 0 });
 
+  // 한 영상 안에서는 프레임과 무관하게 시각 순서의 역순으로 되돌아온다.
+  // 되돌린 순서가 frame(25) → base(24) 였으므로 redo 는 base(24) 부터다.
+  // 재생헤드를 25 에 둔 채 redo 해도 24 가 복원되며, 그때 화면(25)에는 변화가 없다.
   assert.equal(activate('frame-session-3', 'runtime-video', 25).restored, true);
-  assert.equal(sceneStore.redo().applied, true);
+  const redoBase = sceneStore.redo();
+  assert.equal(redoBase.applied, true);
+  assert.equal(redoBase.affectedActiveScene, false, '활성 씬이 아닌 키프레임을 복원했다');
+  assert.equal(redoBase.affectedTargetFrame, 24);
+  assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects.map(object => object.id), [],
+    '재생헤드가 있는 25 는 아직 비어 있다');
+
+  const redoFrame = sceneStore.redo();
+  assert.equal(redoFrame.applied, true);
+  assert.equal(redoFrame.affectedActiveScene, true);
   assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects.map(object => object.id), ['scene-frame']);
   assertHistoryDiagnostics(harness, { mutationCount: 3, undoDepth: 1, redoDepth: 0 });
 
   assert.equal(activate('base-session-3', 'runtime-video', 24).restored, true);
-  assert.equal(sceneStore.redo().applied, true);
-  assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects.map(object => object.id), ['scene-base']);
+  assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects.map(object => object.id), ['scene-base'],
+    '24 는 앞선 redo 에서 이미 복원됐다');
   assertHistoryDiagnostics(harness, { mutationCount: 3, undoDepth: 1, redoDepth: 0 });
+});
+
+test('전역 실행취소는 재생헤드와 무관하게 가장 최근 편집부터 되돌린다', () => {
+  const harness = createHistoryHarness();
+  const { sceneStore, runtime } = harness;
+  const activate = targetFrame => sceneStore.activateSession({
+    sessionId: `global-undo-${targetFrame}`,
+    stableVideoIdentity: 'runtime-video',
+    targetFrame,
+    videoGeneration: 1,
+    tool: 'brush'
+  });
+  const objectIdsAt = targetFrame =>
+    sceneStore.getSceneSnapshot('runtime-video', targetFrame)?.objects.map(object => object.id) || [];
+
+  assert.equal(activate(10).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('stroke-f10')).applied, true);
+  assert.equal(activate(20).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('stroke-f20')).applied, true);
+  assert.equal(runtime.getDiagnostics().globalUndoDepth, 2);
+
+  // 재생헤드는 20 에 있다 — 가장 최근 편집(20)이 먼저 되돌아온다.
+  const first = sceneStore.undo();
+  assert.equal(first.applied, true);
+  assert.equal(first.affectedActiveScene, true);
+  assert.deepEqual(objectIdsAt(20), []);
+  assert.deepEqual(objectIdsAt(10), ['stroke-f10']);
+
+  // 한 번 더 — 재생헤드는 그대로 20 인데 10 의 획이 사라진다.
+  // 예전(씬별 히스토리)에는 여기서 아무 일도 일어나지 않았다.
+  const second = sceneStore.undo();
+  assert.equal(second.applied, true);
+  assert.equal(second.affectedActiveScene, false, '다른 키프레임을 되돌렸다');
+  assert.equal(second.affectedTargetFrame, 10);
+  assert.deepEqual(objectIdsAt(10), []);
+  assert.equal(runtime.getDiagnostics().globalUndoDepth, 0);
+  assert.equal(runtime.getDiagnostics().globalRedoDepth, 2);
+});
+
+test('재생헤드가 키프레임에 없어도 전역 실행취소가 동작한다', () => {
+  const harness = createHistoryHarness();
+  const { sceneStore, runtime } = harness;
+
+  assert.equal(sceneStore.activateSession({
+    sessionId: 'off-keyframe-draw',
+    stableVideoIdentity: 'runtime-video',
+    targetFrame: 10,
+    videoGeneration: 1,
+    tool: 'brush'
+  }).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('stroke-off-keyframe')).applied, true);
+
+  // 키프레임이 아닌 15 로 이동한다. 임시(provisional) 씬이 서므로 활성 씬에는
+  // 히스토리가 없다 — 예전에는 여기서 Ctrl+Z 가 history-empty 로 끝났다.
+  assert.equal(sceneStore.activateSession({
+    sessionId: 'off-keyframe-idle',
+    stableVideoIdentity: 'runtime-video',
+    targetFrame: 15,
+    videoGeneration: 1,
+    tool: 'brush'
+  }).accepted, true);
+  assert.equal(runtime.getDiagnostics().undoDepth, 0, '활성 씬에는 히스토리가 없다');
+  assert.equal(runtime.getDiagnostics().globalUndoDepth, 1);
+
+  const result = sceneStore.undo();
+  assert.equal(result.applied, true, '§6 요구의 핵심 — 여기서 반드시 되돌아와야 한다');
+  assert.equal(result.affectedActiveScene, false);
+  assert.equal(result.affectedTargetFrame, 10);
+  assert.deepEqual(
+    sceneStore.getSceneSnapshot('runtime-video', 10)?.objects.map(object => object.id),
+    []
+  );
+});
+
+test('새 편집은 전역 redo 를 전부 무효화하고 다른 씬의 redo 도 함께 비운다', () => {
+  const harness = createHistoryHarness();
+  const { sceneStore, runtime } = harness;
+  const activate = targetFrame => sceneStore.activateSession({
+    sessionId: `redo-invalidate-${targetFrame}`,
+    stableVideoIdentity: 'runtime-video',
+    targetFrame,
+    videoGeneration: 1,
+    tool: 'brush'
+  });
+
+  assert.equal(activate(10).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('invalidate-f10')).applied, true);
+  assert.equal(activate(20).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('invalidate-f20')).applied, true);
+  assert.equal(sceneStore.undo().applied, true);
+  assert.equal(sceneStore.undo().applied, true);
+  assert.equal(runtime.getDiagnostics().globalRedoDepth, 2);
+
+  assert.equal(activate(30).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('invalidate-f30')).applied, true);
+
+  assert.equal(runtime.getDiagnostics().globalRedoDepth, 0, '전역 redo 가 무효화된다');
+  const redo = sceneStore.redo();
+  assert.equal(redo.applied, false);
+  assert.equal(redo.reason, 'history-empty');
+  // 다른 씬의 씬별 redo 도 함께 비워야 진단이 어긋나지 않는다.
+  for (const targetFrame of [10, 20]) {
+    assert.equal(activate(targetFrame).restored, true);
+    assert.equal(runtime.getDiagnostics().redoDepth, 0, `프레임 ${targetFrame} 의 redo 가 남아 있다`);
+  }
+});
+
+test('용량 초과로 축출된 항목은 전역 순서에서도 사라진다', () => {
+  const harness = createHistoryHarness({ maxHistory: 2 });
+  const { sceneStore, runtime } = harness;
+
+  for (let index = 0; index < 5; index += 1) {
+    assert.equal(sceneStore.addStroke(makeHistoryStroke(`evicted-${index}`)).applied, true);
+  }
+  // 씬 히스토리가 2건만 남기므로 전역 순서도 2건이어야 한다.
+  assert.equal(runtime.getDiagnostics().undoDepth, 2);
+  assert.equal(runtime.getDiagnostics().globalUndoDepth, 2);
+
+  assert.equal(sceneStore.undo().applied, true);
+  assert.equal(sceneStore.undo().applied, true);
+  const exhausted = sceneStore.undo();
+  assert.equal(exhausted.applied, false);
+  assert.equal(exhausted.reason, 'history-empty', '축출된 항목을 가리키는 유령이 남지 않는다');
+});
+
+test('영상을 축출하면 그 영상의 전역 순서도 사라진다', () => {
+  const harness = createHistoryHarness({ maxVideos: 1 });
+  const { sceneStore, runtime } = harness;
+
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('evict-video-first')).applied, true);
+  assert.equal(runtime.getDiagnostics().globalUndoDepth, 1);
+
+  // maxVideos 1 이므로 다른 영상을 열면 앞 영상이 축출된다.
+  assert.equal(sceneStore.activateSession({
+    sessionId: 'evict-video-second',
+    stableVideoIdentity: 'other-video',
+    targetFrame: 24,
+    videoGeneration: 1,
+    tool: 'brush'
+  }).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('evict-video-second-stroke')).applied, true);
+
+  // 전역 깊이는 활성 영상 기준이다 — 앞 영상의 항목이 새 영상으로 새지 않는다.
+  assert.equal(runtime.getDiagnostics().globalUndoDepth, 1);
+  assert.equal(sceneStore.undo().applied, true);
+  assert.equal(sceneStore.undo().applied, false, '축출된 영상의 항목은 되돌릴 수 없다');
+});
+
+test('영상을 재수화하면 그 영상의 전역 순서가 초기화된다', () => {
+  const harness = createHistoryHarness();
+  const { sceneStore, runtime } = harness;
+
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('hydrate-reset-stroke')).applied, true);
+  assert.equal(runtime.getDiagnostics().globalUndoDepth, 1);
+
+  // hydrateVideo 는 활성 영상을 거부한다(video-active). 다른 영상으로 옮겨 둔다.
+  assert.equal(sceneStore.activateSession({
+    sessionId: 'hydrate-reset-other',
+    stableVideoIdentity: 'other-video',
+    targetFrame: 1,
+    videoGeneration: 1,
+    tool: 'brush'
+  }).accepted, true);
+
+  assert.equal(sceneStore.hydrateVideo({
+    hostGeneration: 3,
+    videoGeneration: 7,
+    persistenceSessionId: 'hydrate-reset-session',
+    stableVideoIdentity: 'runtime-video',
+    fps: 24,
+    totalFrames: 240,
+    keyframes: [{
+      id: 'keyframe-24',
+      frame: 24,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      mutationSequence: 1,
+      objects: [makeHistoryStroke('hydrated-stroke')]
+    }]
+  }).accepted, true);
+
+  // 재수화가 영상을 지속화 세대에 묶으므로 재활성도 같은 세대여야 한다
+  // (hostGeneration 3 / videoGeneration 7 — hydrate 요청과 동일).
+  assert.equal(sceneStore.activateSession({
+    sessionId: 'hydrate-reset-back',
+    stableVideoIdentity: 'runtime-video',
+    targetFrame: 24,
+    hostGeneration: 3,
+    videoGeneration: 7,
+    tool: 'brush'
+  }).accepted, true);
+  assert.deepEqual(
+    sceneStore.getActiveSceneSnapshot().objects.map(object => object.id),
+    ['hydrated-stroke'],
+    '재수화된 내용으로 교체됐다'
+  );
+  assert.equal(runtime.getDiagnostics().globalUndoDepth, 0, '교체된 씬의 항목은 무효다');
+  assert.equal(sceneStore.undo().applied, false);
+});
+
+test('활성 씬이 아닌 곳을 되돌려도 지속화 관찰자에게 전파된다', () => {
+  const transitions = [];
+  const harness = createHistoryHarness({
+    drawingEngineObserver: {
+      enqueueTransition(event) { transitions.push(event); }
+    }
+  });
+  const { sceneStore } = harness;
+  const activate = targetFrame => sceneStore.activateSession({
+    sessionId: `notify-${targetFrame}`,
+    stableVideoIdentity: 'runtime-video',
+    targetFrame,
+    videoGeneration: 1,
+    tool: 'brush'
+  });
+
+  assert.equal(activate(10).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('notify-f10')).applied, true);
+  assert.equal(activate(20).accepted, true);
+  transitions.length = 0;
+
+  // 활성 씬(20)에는 히스토리가 없다. 전역 실행취소가 10 을 되돌린다.
+  const result = sceneStore.undo();
+  assert.equal(result.applied, true);
+  assert.equal(result.affectedActiveScene, false);
+  assert.ok(transitions.length > 0, '화면에 안 보여도 저장 계층에는 전파돼야 한다');
+  assert.equal(transitions.at(-1).scene.targetFrame, 10, '되돌린 씬 기준으로 발화한다');
+});
+
+test('적용에 실패한 항목이 전역 스택을 막지 않는다', () => {
+  const blocked = new Set();
+  const harness = createHistoryHarness({
+    estimateObjectBytes(object) {
+      if (blocked.has(object.id)) throw new Error('validation-injected');
+      return JSON.stringify(object).length * 2;
+    }
+  });
+  const { sceneStore, runtime } = harness;
+  const activate = targetFrame => sceneStore.activateSession({
+    sessionId: `stall-${targetFrame}`,
+    stableVideoIdentity: 'runtime-video',
+    targetFrame,
+    videoGeneration: 1,
+    tool: 'brush'
+  });
+
+  assert.equal(activate(10).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('stall-f10')).applied, true);
+  assert.equal(activate(20).accepted, true);
+  const doomed = makeHistoryStroke('stall-f20');
+  assert.equal(sceneStore.addStroke(doomed).applied, true);
+  sceneStore.selectObjects([doomed.id]);
+  assert.equal(sceneStore.deleteSelection().applied, true);
+  const depthBefore = runtime.getDiagnostics().globalUndoDepth;
+
+  // 프레임 20 의 삭제를 되돌리려면 stall-f20 을 되살려야 하는데 그 추정이 던진다.
+  // 최상단에서 멈추면 그 항목이 영구히 남아 이후 모든 Ctrl+Z 가 같은 실패를 반복한다.
+  blocked.add('stall-f20');
+  const result = sceneStore.undo();
+  assert.equal(result.applied, true, '실패 항목을 건너뛰고 다음 후보를 적용해야 한다');
+  assert.equal(result.affectedTargetFrame, 10);
+  assert.deepEqual(
+    sceneStore.getSceneSnapshot('runtime-video', 10)?.objects.map(object => object.id),
+    []
+  );
+  // 실패 항목은 버리지 않는다 — 일시적 실패라면 다음에 다시 시도할 수 있어야 한다.
+  assert.equal(runtime.getDiagnostics().globalUndoDepth, depthBefore - 1);
+
+  blocked.clear();
+  const retried = sceneStore.undo();
+  assert.equal(retried.applied, true, '원인이 사라지면 그 항목이 다시 적용된다');
+  assert.equal(retried.affectedTargetFrame, 20);
 });
 
 test('redo history bytes remain in the store-wide maxBytes calculation across scenes', () => {
@@ -9549,7 +9834,14 @@ test('later commands on sibling frames cannot consume the capacity reserved for 
   assert.ok(sceneStore.getDiagnostics().estimatedBytes <= 30000);
 
   assert.equal(activate(0, 'return-frame-0').restored, true);
-  assert.equal(sceneStore.undo().applied, true);
+  // 전역 실행취소는 시각 순서의 역순이므로 형제 프레임의 최신 항목부터 걷힌다.
+  // 프레임 0 의 삭제에 닿을 때까지 되돌린다 — 형제들이 예약 용량을 먹지 않았다면
+  // 그 항목은 여기서 여전히 적용 가능해야 한다(이 테스트의 본래 의도).
+  let undoAttempts = 0;
+  while (sceneStore.getActiveSceneSnapshot().objects.length === 0 && undoAttempts < 16) {
+    assert.equal(sceneStore.undo().applied, true);
+    undoAttempts += 1;
+  }
   assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects, [restorable]);
   assert.equal(sceneStore.redo().applied, true);
   assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects, []);

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -1862,6 +1862,32 @@ test('drawing persistence IPC normalization resyncs malformed nested deltas with
   );
 });
 
+test('drawing diagnostics relay global history depths', async () => {
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (!script.includes('.getDiagnostics(')) return undefined;
+      return {
+        state: 'active',
+        prepared: true,
+        inputEnabled: true,
+        undoDepth: 2,
+        redoDepth: 1,
+        globalUndoDepth: 7.9,
+        globalRedoDepth: -3
+      };
+    }
+  });
+  await activateDrawingHost(harness, { sessionId: 'session-global-history' });
+
+  const diagnostics = await harness.host.getDrawingDiagnostics();
+  assert.equal(diagnostics.success, true);
+  // 활성 씬 기준 깊이와 전역 순서 깊이는 의미가 다르다 — 둘 다 중계돼야 한다.
+  assert.equal(diagnostics.undoDepth, 2);
+  assert.equal(diagnostics.redoDepth, 1);
+  assert.equal(diagnostics.globalUndoDepth, 7);
+  assert.equal(diagnostics.globalRedoDepth, 0, '음수는 0으로 잘린다');
+});
+
 test('drawing diagnostics relay the bounded gesture probe', async () => {
   const harness = createDrawingHostHarness({
     executeDrawing(script) {


### PR DESCRIPTION
## 업데이트 로그 (비개발자용)

- **`Ctrl+Z`가 이제 애니메이트처럼 동작합니다.** 재생헤드가 어디 있든, 방금 한 편집부터 순서대로 되돌립니다.
- 예전에는 재생헤드가 키프레임에 정확히 있어야만 반응했고, 그렇지 않으면 눌러도 아무 일도 일어나지 않았습니다.
- 되돌린 편집이 지금 보고 있는 프레임이 아니면 **화면에는 변화가 없습니다.** 정상입니다 — 다른 프레임이 바뀐 것이고, 저장도 정상적으로 됩니다.
- 프레임 이동·재생·도구 전환은 실행취소 대상이 아닙니다(요구사항대로).

## 설계 — 기존 구조를 갈아엎지 않았습니다

계획 문서는 "씬 단위 예산 회계 재설계 + `undoDepth` 단언 116줄 흔들림"을 우려했지만, **그 재설계는 필요 없었습니다.**

그대로 둔 것:
- `scene.history` 인스턴스와 `scene.historyEntries` 바이트 거울 (씬별)
- `estimateSceneBytes` / `reachableObjectBytes` / `planProjectedEvictions` (씬 단위 예산 회계)
- `undoDepth` / `redoDepth` 진단의 의미 = **활성 씬의 깊이**

새로 만든 것은 `Map<stableVideoIdentity, { undo, redo }>` 하나뿐이고, 항목은 `{ sceneKey, commandId }`입니다. 전역 깊이는 `globalUndoDepth` / `globalRedoDepth`라는 **새 필드**로 냅니다.

### 왜 영상별인가

실행취소는 문서 단위여야 합니다. 게다가 씬 축출(`evictVideo`)이 영상 단위라 **인덱스 회수 경계가 자연히 일치**해 유령 항목이 생기지 않습니다.

### 정합성이 성립하는 이유

한 씬 안에서 커맨드는 `scene.history`의 `undoStack`과 `order.undo`에 **같은 순서로** 쌓입니다. 따라서 `order.undo`의 마지막 항목은 언제나 그 씬 히스토리의 최상단입니다. 전역 undo는 "최상단 항목의 씬을 골라 그 씬의 `history.undo()`를 호출"하면 끝나고, **씬 히스토리 자료구조를 건드릴 필요가 없습니다.**

## 상세 기술 설명

### 1. 적용 실패가 스택을 영구히 막지 않게

`applyHistoryState`는 실패할 수 있고(`scene-capacity-exceeded` 등), 그때 `moveTop`은 스택을 pop하지 않습니다. **최상단에서 멈추면 그 항목이 영구히 남아 이후 모든 `Ctrl+Z`가 같은 실패를 반복합니다** — 씬별 히스토리에는 없던 고착입니다(예전에는 다른 키프레임으로 옮기면 그 씬의 undo가 동작했습니다).

후보를 순회하며 실패 항목은 **버리지 않고 건너뜁니다.** 일시적 실패라면 다음에 다시 시도할 수 있어야 하기 때문입니다. 건너뛰어도 불변식은 유지됩니다 — 각 항목은 여전히 자기 씬 히스토리의 최상단이고, 중간에서 하나가 빠져도 상대 순서는 그대로입니다.

### 2. 새 편집은 전역 redo를 전부 무효화

커맨드를 기록한 씬의 redo는 `history.record()`가 이미 비우므로, **나머지 씬의 redo만** `clearRedo()`로 비웁니다. 이걸 빼면 전역 인덱스에서 사라진 항목이 씬 히스토리에 남아 `redoDepth` 진단이 어긋납니다. 바이트 거울(`historyEntries.redo`)도 함께 비워야 `estimateSceneBytes`가 이미 사라진 상태를 계속 예약하지 않습니다.

### 3. 재생헤드는 옮기지 않습니다 (사용자 결정)

다른 키프레임을 되돌리면 화면에 변화가 없습니다. 이때 캔버스를 다시 그리고 도구 모드를 재설정하면 헛일이고 **사용자의 활성 선택만 사라집니다.** `affectedActiveScene`으로 활성 씬이 실제로 바뀐 경우에만 손댑니다.

`notifyCommittedTransition`은 되돌린 씬 기준으로 그대로 발화하므로 **화면에 안 보여도 저장은 됩니다.** 테스트가 이 계약을 고정합니다.

### 4. 정리 경로

`evictVideo` / `hydrateVideo` / `destroy` 세 곳에서 인덱스를 지웁니다. `scenes.delete()` 호출은 4곳이지만 나머지 두 곳은 **provisional(임시) 씬만** 지우고, 임시 씬은 `commitStagedMutation` 안에서 즉시 정식화되므로 커맨드를 가진 채 삭제될 수 없습니다.

## 개발 난항

**기존 테스트 2건이 걸렸는데 둘 다 계획서가 미리 짚은 유형이었습니다.** 단언을 완화하지 않고 의도를 분리했습니다.

- `video and frame scene histories remain independent across undo and redo` — **영상 간 독립성**은 여전히 유효하므로 지키고, **프레임 간 독립성**은 전역화가 의도적으로 바꾸는 성질이라 시각 순서 의미를 명시하도록 다시 썼습니다. 이제 "재생헤드를 25에 둔 채 redo하면 24가 복원되고 화면(25)엔 변화가 없다"까지 단언합니다. 테스트가 오히려 강해졌습니다.
- `later commands on sibling frames cannot consume the capacity reserved for an admitted undo redo` — 본래 의도는 **용량 예약**이므로 그대로 두고, 전역 순서상 형제 프레임 항목을 먼저 걷어낸 뒤 프레임 0의 항목에 닿도록 바꿨습니다.

**계획서의 단언 하나가 도달 불가능했습니다.** "`record()` 실패 경로에도 `clearedRedoIds`를 실어야 한다"고 썼는데, 커맨드가 통째로 용량을 넘는 경우는 `clearStack(redoStack)` **이전**에 조기 반환합니다. 방어 코드 자체는 옳으므로 두되, 테스트는 실제로 성립하는 불변식(`조기 반환은 redo를 폐기하지 않는다`)으로 바꿨습니다.

**작업 중 Python 파일 쓰기가 소스를 CRLF로 바꿔 `test:mpv`의 소스 정규식 테스트가 깨졌습니다.** 저장소 규약은 `* text=auto`(LF)이고 커밋본은 정상이었으니 작업 사본만 오염된 것이었습니다. LF로 되돌렸고 커밋본 CR=0을 확인했습니다.

## 테스트 가이드

```bash
npm run test:fabric-drawing-pilot
npm run test:drawing
npm run test:mpv
```

신규 12건:

| 대상 | 내용 |
|---|---|
| 런타임 | 재생헤드와 무관한 최근 편집 되돌리기 / **키프레임이 아닌 프레임에서도 동작**(§6 요구의 핵심) / 새 편집의 전역 redo 무효화 + 다른 씬 redo 전파 / 축출 항목의 인덱스 정리 / 영상 축출 / 영상 재수화 / **비활성 씬 되돌림의 저장 전파** / **적용 실패 시 고착 방지** |
| 명령 히스토리 | `evictedUndoIds` / `clearedRedoIds` / `clearRedo` |
| 호스트 | 전역 깊이 중계 |

- 25개 스위트 **2,173 → 2,185 pass / 0 fail**
- 기존 `undoDepth` 참조 116줄 **무영향**
- `npm run lint` error 0 (warning 59는 전부 기존)
- `npm run bundle:mpv-fabric-overlay` 재생성본 포함

### 실기 확인 (배포 후)

1. 프레임 10에 획 → 프레임 20에 획 → 20에서 `Ctrl+Z` → 20의 획만 사라짐
2. 이어서 `Ctrl+Z` → **10의 획이 사라짐.** 재생헤드는 20 그대로, 화면 변화 없음 (정상)
3. 프레임 15(키프레임 아님)로 이동 후 `Ctrl+Z` → **가장 최근 편집이 되돌려짐.** 무반응이 아님
4. 2번 뒤 `Ctrl+Y` 2회 → 10·20이 순서대로 복원
5. 2번 뒤 프레임 30에 새 획 → `Ctrl+Y` → 아무 일도 일어나지 않음
6. 2번 뒤 저장하고 파일 재오픈 → **되돌려진 상태가 저장돼 있음**
7. 다른 영상을 열고 `Ctrl+Z` → 앞 영상의 편집이 되돌려지지 않음

## 배경

`C:\BAEframe\BAEFRAME_수정계획_드로잉-실행취소-UI정식화.md`(독립 검증 2패스)의 **작업 2 / PR ②**입니다. 이어질 PR ③: 도구 6종·지우개 모드·`[`/`]` 단축키·팔레트 재구성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
