### PR TITLE
DEVLOG: 작업 2 구현·v2.4.6-beta 배포 기록

### DIFF
--- a/DEVLOG/2026-08-28-드로잉-실행취소-UI정식화-구현.md
+++ b/DEVLOG/2026-08-28-드로잉-실행취소-UI정식화-구현.md
@@ -11,7 +11,7 @@
 | 1 | §7.1 | mpv-overlay-host.js, mpv-fabric-overlay-runtime.js, iife 번들, 테스트 2 | 오버레이 창이 키보드 포커스를 가진 적이 없어 Alt 드래그가 `altKey:false`로 도착 | [#188](https://github.com/baehandoridori/BAEFRAME/pull/188) | ✅ 완료 |
 | — | — | package.json, package-lock.json, runtime-profile.test.js | 실기 확인용 패치 버전 상향 | [#189](https://github.com/baehandoridori/BAEFRAME/pull/189) | ✅ 완료 |
 | 1-b | §7.1 후속 | mpv-fabric-overlay-runtime.js, iife 번들, 테스트 1 | 실기 보고 — HUD가 굵기를 보여주지 않아 알아채지 못함 | [#191](https://github.com/baehandoridori/BAEFRAME/pull/191) | ✅ 완료 |
-| 2 | §6 | (예정) | Ctrl+Z 전역 실행취소 | ② | ⬜ 대기 |
+| 2 | §6 | mpv-fabric-overlay-runtime.js, drawing-command-history.js, mpv-overlay-host.js, iife 번들, 테스트 12 | 히스토리가 씬별이라 재생헤드가 키프레임에 있어야만 반응 | [#193](https://github.com/baehandoridori/BAEFRAME/pull/193) | ✅ 완료 |
 | 3 | §7.2 | (예정) | 도구 6종 신설 | ③ | ⬜ 대기 |
 | 4 | §7.3 | (예정) | 지우개 도구·모드 섹션 | ③ | ⬜ 대기 |
 | 5 | §7.4 | (예정) | `[` / `]` 브러시 크기 단축키 | ③ | ⬜ 대기 |
@@ -227,3 +227,108 @@ const x = Number.isFinite(detail.clientX) ? detail.clientX : window.innerWidth /
 | 직전 배포본 | v2.4.4-beta, 2026-08-28 18:27 (교체됨) |
 
 **실기 확인**: `B` → Alt 드래그 → 브러시 색 원이 드래그 시작점에 뜨고 크기에 따라 커졌다 작아진다. 위에 `NNpx` 라벨.
+
+---
+
+# 작업 2 — Ctrl+Z 전역 실행취소 (PR ②, v2.4.6-beta)
+
+## 문제
+
+히스토리가 키프레임(씬)별로 분리되어 `moveHistory()`가 `activeScene()` 하나만 봤다.
+재생헤드가 키프레임에 정확히 있지 않으면 되돌릴 대상이 없어 **아무 반응이 없었다.**
+
+## 설계 — 기존 구조를 갈아엎지 않았다
+
+계획 문서 §6.4는 "씬 단위 예산 회계 재설계 + `undoDepth` 단언 116줄 흔들림"을 우려했지만
+**그 재설계는 필요 없었다.** 아래를 전부 그대로 뒀다.
+
+- `scene.history` 인스턴스와 `scene.historyEntries` 바이트 거울 (씬별)
+- `estimateSceneBytes` / `reachableObjectBytes` / `planProjectedEvictions` (씬 단위 예산 회계)
+- `undoDepth` / `redoDepth` 진단의 의미 = **활성 씬의 깊이**
+
+새로 만든 것은 `Map<stableVideoIdentity, { undo, redo }>` 하나뿐이고 항목은 `{ sceneKey, commandId }`다.
+전역 깊이는 `globalUndoDepth` / `globalRedoDepth`라는 **새 필드**로 낸다.
+
+### 정합성이 성립하는 이유
+
+한 씬 안에서 커맨드는 `scene.history`의 `undoStack`과 `order.undo`에 **같은 순서로** 쌓인다.
+따라서 `order.undo`의 마지막 항목은 언제나 그 씬 히스토리의 최상단이다. 전역 undo는
+"최상단 항목의 씬을 골라 그 씬의 `history.undo()`를 호출"하면 끝이고, **씬 히스토리
+자료구조를 건드릴 필요가 없다.**
+
+영상별로 나눈 이유: 실행취소는 문서 단위여야 하고, 씬 축출(`evictVideo`)이 영상 단위라
+인덱스 회수 경계가 자연히 일치해 유령 항목이 생기지 않는다.
+
+## 구현하며 새로 막은 결함 — 전역화가 만드는 고착
+
+`applyHistoryState`는 실패할 수 있고(`scene-capacity-exceeded`·`mutation-sequence-overflow` 등)
+그때 `moveTop`은 스택을 pop하지 않는다. **최상단에서 멈추면 그 항목이 영구히 남아
+그 시점부터 모든 Ctrl+Z가 같은 실패를 반복한다.** 씬별 히스토리에는 없던 문제다 —
+예전에는 다른 키프레임으로 옮기면 그 씬의 undo가 동작했다.
+
+후보를 순회하며 실패 항목은 **버리지 않고 건너뛴다**(`globalHistoryCandidates`, 최대 8회).
+일시적 실패라면 다음에 다시 시도할 수 있어야 하기 때문이다. 건너뛰어도 불변식은 유지된다 —
+각 항목은 여전히 자기 씬 히스토리의 최상단이고 상대 순서도 그대로다.
+
+## 재생헤드는 옮기지 않는다 (결정 5)
+
+다른 키프레임을 되돌리면 화면에 변화가 없다. 이때 캔버스를 다시 그리고 도구 모드를
+재설정하면 헛일이고 사용자의 활성 선택만 사라지므로, `affectedActiveScene`으로 활성 씬이
+실제로 바뀐 경우에만 손댄다.
+
+`notifyCommittedTransition`은 되돌린 씬 기준으로 그대로 발화하므로 **화면에 안 보여도
+저장은 된다.** 테스트가 이 계약을 고정한다.
+
+## 기존 테스트 2건 — 단언을 완화하지 않고 의도를 분리했다
+
+| 테스트 | 조치 |
+|---|---|
+| `video and frame scene histories remain independent across undo and redo` | **영상 간 독립성**은 여전히 유효하므로 지키고, **프레임 간 독립성**은 전역화가 의도적으로 바꾸는 성질이라 시각 순서 의미를 명시하도록 재작성. "재생헤드를 25에 둔 채 redo하면 24가 복원되고 화면(25)엔 변화가 없다"까지 단언해 오히려 강해졌다 |
+| `later commands on sibling frames cannot consume the capacity reserved for an admitted undo redo` | 본래 의도는 **용량 예약**이므로 그대로 두고, 전역 순서상 형제 프레임 항목을 먼저 걷어낸 뒤 프레임 0의 항목에 닿도록 변경 |
+
+## 계획서와 달랐던 지점
+
+계획서는 `record()` **실패 경로에도** `clearedRedoIds`를 실으라고 했다. 방어로서는 옳지만,
+커맨드가 통째로 용량을 넘는 경우는 `clearStack(redoStack)` **이전**에 조기 반환하므로
+그 경로는 실제로 도달할 수 없다. 방어 코드는 두되 테스트는 성립하는 불변식
+("조기 반환은 redo를 폐기하지 않는다")으로 바꿨다.
+
+## 작업 중 걸린 것 — Python 쓰기의 CRLF 변환
+
+`io.open(p, 'w')`가 Windows에서 개행을 CRLF로 바꿔 `test:mpv`의 소스 정규식 테스트가 깨졌다
+(`
+    };
+
+    let collabRippleAnimationId` 패턴이 매칭되지 않음).
+저장소 규약은 `.gitattributes`의 `* text=auto`(LF)이고 커밋본은 정상이었으니 작업 사본만
+오염된 것이었다. LF로 되돌리고 이후 쓰기는 `newline=''`로 고정했다.
+**교훈: 이 저장소에서 Python으로 파일을 쓸 때는 반드시 `newline=''`를 준다.**
+
+## 결과
+
+- 신규 12건 — 런타임 8(재생헤드가 키프레임에 없을 때 동작·비활성 씬의 저장 전파·적용 실패 시 고착 방지 포함), 명령 히스토리 3, 호스트 1
+- 25스위트 **2,173 → 2,185 pass / 0 fail**
+- 기존 `undoDepth` 참조 116줄 **무영향**
+
+## 배포 기록 (v2.4.6-beta)
+
+| 항목 | 값 |
+|------|-----|
+| 배포 시각 | **2026-08-28 19:28** |
+| 소스 커밋 | `afa2663` (main, PR #194 머지) |
+| 배포 방식 | `robocopy /MIR` — exit 1(정상), FAILED 0 |
+| 검증 | 전체 트리 SHA-256 **82/82, MismatchCount=0 / MissingCount=0 / ExtraFiles=0** |
+| exe SHA-256 | `A1AD796F722860C48FA1441922650F4E77F09A9E6B18D73CDD1121B2390F0422` |
+| app.asar SHA-256 | `2484FB7767F0702041E8B4CA761D89D668268BE0335BEDE730D2C20D408BD039` |
+| `FileVersion` | `2.4.6-beta` |
+| 직전 배포본 | v2.4.5-beta, 2026-08-28 18:43 (교체됨) |
+
+### 실기 확인 필요 (부록 A의 A-6 ~ A-12)
+
+1. 프레임 10에 획 → 20에 획 → 20에서 `Ctrl+Z` → 20의 획만 사라진다
+2. 이어서 `Ctrl+Z` → **10의 획이 사라진다.** 재생헤드는 20 그대로, 화면 변화 없음 (정상)
+3. 프레임 15(키프레임 아님)로 이동 후 `Ctrl+Z` → **가장 최근 편집이 되돌려진다.** 무반응이 아니다
+4. 2번 뒤 `Ctrl+Y` 2회 → 10·20이 순서대로 복원
+5. 2번 뒤 프레임 30에 새 획 → `Ctrl+Y` → 아무 일도 일어나지 않는다
+6. 2번 뒤 저장하고 파일 재오픈 → **되돌려진 상태가 저장돼 있다**
+7. 다른 영상을 열고 `Ctrl+Z` → 앞 영상의 편집이 되돌려지지 않는다


### PR DESCRIPTION
Ctrl+Z 전역 실행취소의 설계 근거, 전역화가 만드는 고착을 막은 과정, 기존 테스트 2건의 의도 분리, Python CRLF 함정, v2.4.6-beta 배포 기록입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)