### PR TITLE
키프레임 생성도 실행취소 대상으로 — 홀드 모델과 전역 실행취소의 모순 해소

### DIFF
--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -14442,6 +14442,10 @@ void main() {
             change.redoState,
             change.contentStableIds
           );
+          if (scene.provisional === true) {
+            command.materializesScene = true;
+            command.provisionalSourceFrame = scene.provisionalSourceFrame ?? null;
+          }
           const commandBytes = defaultEstimateObjectBytes(command);
           if (commandBytes > maxHistoryBytes) {
             return { applied: false, reason: "history-capacity-exceeded" };
@@ -14766,12 +14770,17 @@ void main() {
             sourceFrame: activeSession.sourceFrame
           };
         }
+        function provisionalSceneIsDisposable(scene) {
+          if (scene?.provisional !== true) return false;
+          const history = historyDiagnostics(scene);
+          return history.undoDepth === 0 && history.redoDepth === 0;
+        }
         function replaceActiveSession(session) {
           const previousScene = activeScene();
           const activation = activateSession(session);
           if (!activation.accepted) return activation;
           previousScene?.selectedObjectIds.clear();
-          if (previousScene?.provisional === true && previousScene.key !== activeSession.sceneKey) {
+          if (provisionalSceneIsDisposable(previousScene) && previousScene.key !== activeSession.sceneKey) {
             scenes.delete(previousScene.key);
             notifyScenesDropped([previousScene.sceneInstanceId]);
           }
@@ -14784,7 +14793,7 @@ void main() {
           }
           const scene = activeScene();
           scene?.selectedObjectIds.clear();
-          if (scene?.provisional === true) {
+          if (provisionalSceneIsDisposable(scene)) {
             scenes.delete(scene.key);
             notifyScenesDropped([scene.sceneInstanceId]);
           }
@@ -14792,7 +14801,7 @@ void main() {
           return { accepted: true, active: false };
         }
         function addStroke(stroke) {
-          const scene = activeScene();
+          const scene = syncProvisionalSceneForMutation(activeScene());
           if (!scene) return { applied: false, reason: "no-active-session" };
           if (!stroke || typeof stroke.id !== "string" || stroke.id.length === 0) {
             return { applied: false, reason: "invalid-stroke" };
@@ -14826,7 +14835,7 @@ void main() {
           return { changed, selection: [...next] };
         }
         function transformSelection(change = {}) {
-          const scene = activeScene();
+          const scene = syncProvisionalSceneForMutation(activeScene());
           if (!scene || scene.selectedObjectIds.size === 0) return { applied: false, objectIds: [] };
           const nextObjects = new Map(scene.objects);
           const changedIds = [];
@@ -14860,7 +14869,7 @@ void main() {
           return { applied: true, objectIds: changedIds };
         }
         function replaceObjects(change = {}) {
-          const scene = activeScene();
+          const scene = syncProvisionalSceneForMutation(activeScene());
           if (!scene) return { applied: false, reason: "no-active-session" };
           let replacements = Array.isArray(change.replacements) ? change.replacements.map((replacement) => ({
             removeId: replacement?.removeId,
@@ -15030,11 +15039,50 @@ void main() {
           touchVideo(scene.stableVideoIdentity);
           return { applied: true };
         }
+        function derivedProvisionalObjects(scene) {
+          const source = resolveCommittedSceneAtFrame(scene.stableVideoIdentity, scene.targetFrame);
+          return new Map(
+            [...(source?.objects || /* @__PURE__ */ new Map()).entries()].map(([id, object]) => [id, clonePlain(object)])
+          );
+        }
+        function sameObjectIds(left, right) {
+          if (left.size !== right.size) return false;
+          for (const id of left.keys()) {
+            if (!right.has(id)) return false;
+          }
+          return true;
+        }
+        function syncProvisionalSceneForMutation(scene) {
+          if (scene?.provisional !== true || provisionalSceneIsDisposable(scene)) return scene;
+          const derived = derivedProvisionalObjects(scene);
+          if (sameObjectIds(scene.objects, derived)) return scene;
+          let estimatedBytes;
+          try {
+            estimatedBytes = estimateObjectsBytes(derived);
+          } catch (_error) {
+            return scene;
+          }
+          const droppedIds = new Set(scene.history.clearRedo());
+          const order = globalOrderFor(scene.stableVideoIdentity);
+          if (order && droppedIds.size > 0) {
+            order.undo = order.undo.filter((entry) => !droppedIds.has(entry.commandId));
+            order.redo = order.redo.filter((entry) => !droppedIds.has(entry.commandId));
+          }
+          scene.historyEntries = { undo: [], redo: [] };
+          scene.objects = derived;
+          scene.selectedObjectIds = /* @__PURE__ */ new Set();
+          scene.estimatedBytes = estimatedBytes;
+          return scene;
+        }
         function applyHistoryEntry(scene, order, direction) {
           let transition = null;
           const result = scene.history[direction]((state, _historyDirection, entry) => {
             const applied = applyHistoryState(scene, state);
             if (applied.applied) {
+              if (entry.materializesScene === true) {
+                scene.provisional = direction === "undo";
+                scene.provisionalSourceFrame = direction === "undo" ? entry.provisionalSourceFrame ?? null : null;
+              }
               transition = {
                 origin: "history",
                 kind: entry.kind,
@@ -15063,8 +15111,9 @@ void main() {
             objectCount: scene.objects.size,
             selectedObjectIds: [],
             // 되돌린 씬이 지금 화면에 떠 있는 씬인지. 아니면 캔버스 재도색과 도구 모드
-            // 재설정을 건너뛴다.
-            affectedActiveScene: scene === activeScene(),
+            // 재설정을 건너뛴다. 다만 활성 씬이 임시 씬이면 그 화면은 커밋된 원본에서
+            // 파생되므로, 어느 씬이 바뀌었든 다시 그려야 한다.
+            affectedActiveScene: scene === activeScene() || activeScene()?.provisional === true,
             affectedTargetFrame: scene.targetFrame
           };
         }
@@ -15084,7 +15133,7 @@ void main() {
           return moveHistory("redo");
         }
         function deleteSelection() {
-          const scene = activeScene();
+          const scene = syncProvisionalSceneForMutation(activeScene());
           if (!scene || scene.selectedObjectIds.size === 0) {
             return { applied: false, deletedCount: 0, deletedIds: [] };
           }
@@ -15103,7 +15152,7 @@ void main() {
           return { applied: true, deletedCount: deletedIds.length, deletedIds };
         }
         function clearSession() {
-          const scene = activeScene();
+          const scene = syncProvisionalSceneForMutation(activeScene());
           const deletedCount = scene?.objects.size || 0;
           if (!scene || deletedCount === 0) return { applied: false, deletedCount: 0, deletedIds: [] };
           const deletedIds = [...scene.objects.keys()];
@@ -15227,7 +15276,11 @@ void main() {
           };
         }
         function getActiveSceneSnapshot() {
-          return snapshotScene(activeScene());
+          const scene = activeScene();
+          if (!scene || scene.provisional !== true || provisionalSceneIsDisposable(scene)) {
+            return snapshotScene(scene);
+          }
+          return snapshotScene({ ...scene, objects: derivedProvisionalObjects(scene) });
         }
         function hasScene(stableVideoIdentity, targetFrame) {
           return scenes.has(makeSceneKey(stableVideoIdentity, targetFrame));

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -1231,6 +1231,21 @@ function createSessionSceneStore(options = {}) {
       change.redoState,
       change.contentStableIds
     );
+    // 임시 씬을 정식 키프레임으로 승격시키는 커맨드인지 남겨 둔다.
+    //
+    // 키프레임은 직전 키프레임 내용을 복사해서 만들어진다(홀드 모델). 그 복사는
+    // 히스토리에 기록되지 않으므로, 이 커맨드를 되돌리면서 키프레임을 그대로 두면
+    // "원본 편집은 되돌렸는데 복사본은 남는" 모순이 생긴다 — 프레임 10의 획을
+    // 되돌려도 프레임 20이 들고 있는 복사본은 그대로라 화면이 바뀌지 않는다.
+    //
+    // 애니메이트처럼 키프레임 생성 자체를 되돌림 대상에 포함시킨다. 씬을 삭제하지
+    // 않고 provisional 로 되돌리는 이유는 redo 가 그 씬을 다시 찾아야 하기 때문이며,
+    // provisional 씬은 exportVideo 와 resolveCommittedSceneAtFrame 이 모두 건너뛰므로
+    // 파일과 이후 프레임 해석에서는 키프레임이 사라진 것과 같다.
+    if (scene.provisional === true) {
+      command.materializesScene = true;
+      command.provisionalSourceFrame = scene.provisionalSourceFrame ?? null;
+    }
     const commandBytes = defaultEstimateObjectBytes(command);
     if (commandBytes > maxHistoryBytes) {
       return { applied: false, reason: 'history-capacity-exceeded' };
@@ -1619,12 +1634,24 @@ function createSessionSceneStore(options = {}) {
     };
   }
 
+  // 임시 씬은 원래 "한 번도 편집되지 않은 스크래치"라 자리를 뜨면 버려도 됐다.
+  // 그런데 키프레임 생성을 되돌리면 정식 씬이 다시 임시가 되고, 그 씬은 redo 를
+  // 위한 히스토리를 들고 있다. 그것까지 버리면 되돌린 뒤 프레임을 옮기는 순간
+  // 다시 실행이 영영 불가능해진다. 히스토리가 있는 임시 씬은 남긴다
+  // (export 는 여전히 임시 씬을 걸러 내므로 파일에는 키프레임이 없다).
+  function provisionalSceneIsDisposable(scene) {
+    if (scene?.provisional !== true) return false;
+    const history = historyDiagnostics(scene);
+    return history.undoDepth === 0 && history.redoDepth === 0;
+  }
+
   function replaceActiveSession(session) {
     const previousScene = activeScene();
     const activation = activateSession(session);
     if (!activation.accepted) return activation;
     previousScene?.selectedObjectIds.clear();
-    if (previousScene?.provisional === true && previousScene.key !== activeSession.sceneKey) {
+    if (provisionalSceneIsDisposable(previousScene) &&
+        previousScene.key !== activeSession.sceneKey) {
       scenes.delete(previousScene.key);
       notifyScenesDropped([previousScene.sceneInstanceId]);
     }
@@ -1638,7 +1665,7 @@ function createSessionSceneStore(options = {}) {
     }
     const scene = activeScene();
     scene?.selectedObjectIds.clear();
-    if (scene?.provisional === true) {
+    if (provisionalSceneIsDisposable(scene)) {
       scenes.delete(scene.key);
       notifyScenesDropped([scene.sceneInstanceId]);
     }
@@ -1647,7 +1674,8 @@ function createSessionSceneStore(options = {}) {
   }
 
   function addStroke(stroke) {
-    const scene = activeScene();
+    // 낡은 사본 위에 커밋하면 이미 지워진 내용이 되살아난다.
+    const scene = syncProvisionalSceneForMutation(activeScene());
     if (!scene) return { applied: false, reason: 'no-active-session' };
     if (!stroke || typeof stroke.id !== 'string' || stroke.id.length === 0) {
       return { applied: false, reason: 'invalid-stroke' };
@@ -1685,7 +1713,8 @@ function createSessionSceneStore(options = {}) {
   }
 
   function transformSelection(change = {}) {
-    const scene = activeScene();
+    // 낡은 사본 위에 커밋하면 이미 지워진 내용이 되살아난다.
+    const scene = syncProvisionalSceneForMutation(activeScene());
     if (!scene || scene.selectedObjectIds.size === 0) return { applied: false, objectIds: [] };
     const nextObjects = new Map(scene.objects);
     const changedIds = [];
@@ -1722,7 +1751,8 @@ function createSessionSceneStore(options = {}) {
   }
 
   function replaceObjects(change = {}) {
-    const scene = activeScene();
+    // 낡은 사본 위에 커밋하면 이미 지워진 내용이 되살아난다.
+    const scene = syncProvisionalSceneForMutation(activeScene());
     if (!scene) return { applied: false, reason: 'no-active-session' };
     let replacements = Array.isArray(change.replacements)
       ? change.replacements.map(replacement => ({
@@ -1907,11 +1937,69 @@ function createSessionSceneStore(options = {}) {
     return { applied: true };
   }
 
+  // 임시 씬은 저장되지 않는 **파생 뷰**다 — exportVideo 도 resolveCommittedSceneAtFrame 도
+  // 임시 씬을 건너뛴다. 그런데 씬 객체 안에는 만들어질 당시의 사본이 그대로 들어 있어,
+  // 되돌림으로 원본이 바뀌면 그 사본이 낡는다. 사본을 그 자리에서 갈아끼우면 그 씬의
+  // 히스토리(절대 스냅샷)와 어긋나 redo 가 invalid-history-state 로 죽으므로,
+  // **저장된 사본은 건드리지 않고 화면에 보여 줄 때만 원본에서 다시 파생**한다.
+  function derivedProvisionalObjects(scene) {
+    const source = resolveCommittedSceneAtFrame(scene.stableVideoIdentity, scene.targetFrame);
+    return new Map(
+      [...(source?.objects || new Map()).entries()]
+        .map(([id, object]) => [id, clonePlain(object)])
+    );
+  }
+
+  function sameObjectIds(left, right) {
+    if (left.size !== right.size) return false;
+    for (const id of left.keys()) {
+      if (!right.has(id)) return false;
+    }
+    return true;
+  }
+
+  // 낡은 사본 위에 새로 그리면 이미 지워진 내용이 되살아난다. 새 편집은 어차피 이 씬의
+  // redo 를 무효화하므로(되돌린 뒤 새 동작을 하면 다시실행이 사라지는 일반 규칙),
+  // 여기서 히스토리를 비우고 원본에서 다시 파생해 둔다.
+  function syncProvisionalSceneForMutation(scene) {
+    // 히스토리가 없는 임시 씬은 "한 번도 편집되지 않은 스크래치"다. 그 내용은
+    // activateSession 이 정한 것이며 낡음 문제가 없다. 되돌려서 임시가 된 씬만 맞춘다.
+    if (scene?.provisional !== true || provisionalSceneIsDisposable(scene)) return scene;
+    const derived = derivedProvisionalObjects(scene);
+    if (sameObjectIds(scene.objects, derived)) return scene;
+    let estimatedBytes;
+    try {
+      estimatedBytes = estimateObjectsBytes(derived);
+    } catch (_error) {
+      return scene;
+    }
+    // 임시가 된 정식 씬은 자기 materialize 커맨드 하나만 redo 로 들고 있다.
+    const droppedIds = new Set(scene.history.clearRedo());
+    const order = globalOrderFor(scene.stableVideoIdentity);
+    if (order && droppedIds.size > 0) {
+      order.undo = order.undo.filter(entry => !droppedIds.has(entry.commandId));
+      order.redo = order.redo.filter(entry => !droppedIds.has(entry.commandId));
+    }
+    scene.historyEntries = { undo: [], redo: [] };
+    scene.objects = derived;
+    scene.selectedObjectIds = new Set();
+    scene.estimatedBytes = estimatedBytes;
+    return scene;
+  }
+
   function applyHistoryEntry(scene, order, direction) {
     let transition = null;
     const result = scene.history[direction]((state, _historyDirection, entry) => {
       const applied = applyHistoryState(scene, state);
       if (applied.applied) {
+        // 키프레임 생성(임시 씬 정식화)까지 함께 되돌린다. 되돌리면 그 프레임은
+        // 다시 "키프레임 아님"이 되어 이후 프레임이 앞 키프레임을 따라간다.
+        if (entry.materializesScene === true) {
+          scene.provisional = direction === 'undo';
+          scene.provisionalSourceFrame = direction === 'undo'
+            ? (entry.provisionalSourceFrame ?? null)
+            : null;
+        }
         transition = {
           origin: 'history',
           kind: entry.kind,
@@ -1940,8 +2028,9 @@ function createSessionSceneStore(options = {}) {
       objectCount: scene.objects.size,
       selectedObjectIds: [],
       // 되돌린 씬이 지금 화면에 떠 있는 씬인지. 아니면 캔버스 재도색과 도구 모드
-      // 재설정을 건너뛴다.
-      affectedActiveScene: scene === activeScene(),
+      // 재설정을 건너뛴다. 다만 활성 씬이 임시 씬이면 그 화면은 커밋된 원본에서
+      // 파생되므로, 어느 씬이 바뀌었든 다시 그려야 한다.
+      affectedActiveScene: scene === activeScene() || activeScene()?.provisional === true,
       affectedTargetFrame: scene.targetFrame
     };
   }
@@ -1969,7 +2058,8 @@ function createSessionSceneStore(options = {}) {
   }
 
   function deleteSelection() {
-    const scene = activeScene();
+    // 낡은 사본 위에 커밋하면 이미 지워진 내용이 되살아난다.
+    const scene = syncProvisionalSceneForMutation(activeScene());
     if (!scene || scene.selectedObjectIds.size === 0) {
       return { applied: false, deletedCount: 0, deletedIds: [] };
     }
@@ -1989,7 +2079,8 @@ function createSessionSceneStore(options = {}) {
   }
 
   function clearSession() {
-    const scene = activeScene();
+    // 낡은 사본 위에 커밋하면 이미 지워진 내용이 되살아난다.
+    const scene = syncProvisionalSceneForMutation(activeScene());
     const deletedCount = scene?.objects.size || 0;
     if (!scene || deletedCount === 0) return { applied: false, deletedCount: 0, deletedIds: [] };
     const deletedIds = [...scene.objects.keys()];
@@ -2133,7 +2224,14 @@ function createSessionSceneStore(options = {}) {
   }
 
   function getActiveSceneSnapshot() {
-    return snapshotScene(activeScene());
+    const scene = activeScene();
+    // 되돌려서 임시가 된 씬만 파생한다. 스크래치 임시 씬의 내용은 activateSession 이
+    // 정한 것이므로 그대로 보여 준다(원본이 없으면 빈 화면인 것이 기존 계약이다).
+    if (!scene || scene.provisional !== true || provisionalSceneIsDisposable(scene)) {
+      return snapshotScene(scene);
+    }
+    // 저장된 사본은 건드리지 않는다 — 그래야 그 씬의 redo 가 살아 있다.
+    return snapshotScene({ ...scene, objects: derivedProvisionalObjects(scene) });
   }
 
   function hasScene(stableVideoIdentity, targetFrame) {

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -9449,23 +9449,25 @@ test('undo and redo follow visual order within a video while videos stay indepen
   // 되돌린 순서가 frame(25) → base(24) 였으므로 redo 는 base(24) 부터다.
   // 재생헤드를 25 에 둔 채 redo 해도 24 가 복원되며, 그때 화면(25)에는 변화가 없다.
   assert.equal(activate('frame-session-3', 'runtime-video', 25).restored, true);
+  // redo 는 되돌린 순서의 역순이다 — base(24) 가 먼저, frame(25) 가 나중.
+  // (affectedActiveScene 플래그 자체는 전용 테스트에서 검증한다. 여기서는 순서와
+  //  영상 격리가 관심사다.)
   const redoBase = sceneStore.redo();
   assert.equal(redoBase.applied, true);
-  assert.equal(redoBase.affectedActiveScene, false, '활성 씬이 아닌 키프레임을 복원했다');
-  assert.equal(redoBase.affectedTargetFrame, 24);
-  assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects.map(object => object.id), [],
-    '재생헤드가 있는 25 는 아직 비어 있다');
+  assert.equal(redoBase.affectedTargetFrame, 24, '활성 씬이 아닌 키프레임을 먼저 복원한다');
 
   const redoFrame = sceneStore.redo();
   assert.equal(redoFrame.applied, true);
-  assert.equal(redoFrame.affectedActiveScene, true);
-  assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects.map(object => object.id), ['scene-frame']);
-  assertHistoryDiagnostics(harness, { mutationCount: 3, undoDepth: 1, redoDepth: 0 });
+  assert.equal(redoFrame.affectedTargetFrame, 25);
 
-  assert.equal(activate('base-session-3', 'runtime-video', 24).restored, true);
-  assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects.map(object => object.id), ['scene-base'],
-    '24 는 앞선 redo 에서 이미 복원됐다');
-  assertHistoryDiagnostics(harness, { mutationCount: 3, undoDepth: 1, redoDepth: 0 });
+  assert.deepEqual(
+    sceneStore.getSceneSnapshot('runtime-video', 24)?.objects.map(object => object.id) || [],
+    ['scene-base']
+  );
+  assert.deepEqual(
+    sceneStore.getSceneSnapshot('runtime-video', 25)?.objects.map(object => object.id) || [],
+    ['scene-frame']
+  );
 });
 
 test('전역 실행취소는 재생헤드와 무관하게 가장 최근 편집부터 되돌린다', () => {
@@ -9498,8 +9500,12 @@ test('전역 실행취소는 재생헤드와 무관하게 가장 최근 편집�
   // 예전(씬별 히스토리)에는 여기서 아무 일도 일어나지 않았다.
   const second = sceneStore.undo();
   assert.equal(second.applied, true);
-  assert.equal(second.affectedActiveScene, false, '다른 키프레임을 되돌렸다');
-  assert.equal(second.affectedTargetFrame, 10);
+  assert.equal(second.affectedTargetFrame, 10, '다른 키프레임을 되돌렸다');
+  // 20 은 앞선 undo 로 임시 씬이 됐다. 임시 씬의 화면은 커밋된 원본에서 파생하므로
+  // 10 이 바뀌면 다시 그려야 한다.
+  assert.equal(second.affectedActiveScene, true);
+  assert.deepEqual(sceneStore.getActiveSceneSnapshot().objects.map(object => object.id), [],
+    '되돌린 획이 화면에 남지 않는다');
   assert.deepEqual(objectIdsAt(10), []);
   assert.equal(runtime.getDiagnostics().globalUndoDepth, 0);
   assert.equal(runtime.getDiagnostics().globalRedoDepth, 2);
@@ -9532,8 +9538,9 @@ test('재생헤드가 키프레임에 없어도 전역 실행취소가 동작한
 
   const result = sceneStore.undo();
   assert.equal(result.applied, true, '§6 요구의 핵심 — 여기서 반드시 되돌아와야 한다');
-  assert.equal(result.affectedActiveScene, false);
   assert.equal(result.affectedTargetFrame, 10);
+  // 15 는 임시 씬이라 10 의 사본을 들고 있다. 되돌리면 사본도 갱신된다.
+  assert.equal(result.affectedActiveScene, true);
   assert.deepEqual(
     sceneStore.getSceneSnapshot('runtime-video', 10)?.objects.map(object => object.id),
     []
@@ -9690,8 +9697,8 @@ test('활성 씬이 아닌 곳을 되돌려도 지속화 관찰자에게 전파�
   // 활성 씬(20)에는 히스토리가 없다. 전역 실행취소가 10 을 되돌린다.
   const result = sceneStore.undo();
   assert.equal(result.applied, true);
-  assert.equal(result.affectedActiveScene, false);
-  assert.ok(transitions.length > 0, '화면에 안 보여도 저장 계층에는 전파돼야 한다');
+  assert.equal(result.affectedTargetFrame, 10);
+  assert.ok(transitions.length > 0, '되돌린 씬 기준으로 저장 계층에 전파돼야 한다');
   assert.equal(transitions.at(-1).scene.targetFrame, 10, '되돌린 씬 기준으로 발화한다');
 });
 
@@ -9738,6 +9745,132 @@ test('적용에 실패한 항목이 전역 스택을 막지 않는다', () => {
   const retried = sceneStore.undo();
   assert.equal(retried.applied, true, '원인이 사라지면 그 항목이 다시 적용된다');
   assert.equal(retried.affectedTargetFrame, 20);
+});
+
+test('프레임을 옮겨 그린 뒤 되돌리면 그때 만들어진 키프레임도 함께 사라진다', () => {
+  // 실기의 프레임 이동은 retargetActiveSession 경로다(활성 세션 유지). 이 경로에서만
+  // 임시 씬이 앞 키프레임 내용을 복사하므로, activateSession 으로 쓴 테스트는 이
+  // 회귀를 잡지 못했다.
+  const harness = createHistoryHarness();
+  const { sceneStore, runtime } = harness;
+  const exportRequest = {
+    hostGeneration: 1, videoGeneration: 1, persistenceSessionId: 'ps-hold',
+    stableVideoIdentity: 'hold-video', fps: 24, totalFrames: 240
+  };
+  assert.equal(sceneStore.hydrateVideo({ ...exportRequest, keyframes: [] }).accepted, true);
+  assert.equal(sceneStore.activateSession({
+    sessionId: 'hold-session', stableVideoIdentity: 'hold-video', targetFrame: 10,
+    hostGeneration: 1, videoGeneration: 1, tool: 'brush'
+  }).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('hold-A')).applied, true);
+
+  assert.equal(sceneStore.retargetActiveSession({
+    sessionId: 'hold-session', stableVideoIdentity: 'hold-video', targetFrame: 20,
+    hostGeneration: 1, videoGeneration: 1, tool: 'brush'
+  }).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('hold-B')).applied, true);
+
+  const framesOf = () => (sceneStore.exportVideo(exportRequest).snapshot?.scenes || [])
+    .map(scene => ({ frame: scene.targetFrame, ids: scene.objects.map(object => object.id) }));
+  assert.deepEqual(framesOf(), [
+    { frame: 10, ids: ['hold-A'] },
+    { frame: 20, ids: ['hold-A', 'hold-B'] }
+  ], '20 은 10 의 사본 위에 만들어진다');
+
+  // 획 B 를 되돌리면 그 획이 만들어 낸 키프레임 20 도 사라져야 한다. 그러지 않으면
+  // 다음 되돌리기로 10 의 획을 지워도 20 이 사본을 들고 남아 화면이 바뀌지 않는다.
+  assert.equal(sceneStore.undo().applied, true);
+  assert.deepEqual(framesOf(), [{ frame: 10, ids: ['hold-A'] }], '키프레임 20 이 사라진다');
+
+  assert.equal(sceneStore.undo().applied, true);
+  assert.deepEqual(framesOf(), [], '10 의 획과 키프레임도 사라진다');
+  assert.equal(runtime.getDiagnostics().globalRedoDepth, 2);
+
+  assert.equal(sceneStore.redo().applied, true);
+  assert.equal(sceneStore.redo().applied, true);
+  assert.deepEqual(framesOf(), [
+    { frame: 10, ids: ['hold-A'] },
+    { frame: 20, ids: ['hold-A', 'hold-B'] }
+  ], 'redo 로 키프레임까지 완전 복원된다');
+});
+
+test('되돌려서 임시가 된 키프레임은 화면도 원본을 따라가고 새 편집이 지워진 내용을 되살리지 않는다', () => {
+  const harness = createHistoryHarness();
+  const { sceneStore } = harness;
+  const exportRequest = {
+    hostGeneration: 1, videoGeneration: 1, persistenceSessionId: 'ps-derive',
+    stableVideoIdentity: 'derive-video', fps: 24, totalFrames: 240
+  };
+  const setup = () => {
+    assert.equal(sceneStore.hydrateVideo({ ...exportRequest, keyframes: [] }).accepted, true);
+    assert.equal(sceneStore.activateSession({
+      sessionId: 'derive-session', stableVideoIdentity: 'derive-video', targetFrame: 10,
+      hostGeneration: 1, videoGeneration: 1, tool: 'brush'
+    }).accepted, true);
+    assert.equal(sceneStore.addStroke(makeHistoryStroke('derive-A')).applied, true);
+    assert.equal(sceneStore.retargetActiveSession({
+      sessionId: 'derive-session', stableVideoIdentity: 'derive-video', targetFrame: 20,
+      hostGeneration: 1, videoGeneration: 1, tool: 'brush'
+    }).accepted, true);
+    assert.equal(sceneStore.addStroke(makeHistoryStroke('derive-B')).applied, true);
+  };
+  const shown = () => (sceneStore.getActiveSceneSnapshot()?.objects || []).map(object => object.id);
+  const inFile = () => (sceneStore.exportVideo(exportRequest).snapshot?.scenes || [])
+    .map(scene => `${scene.targetFrame}:${scene.objects.map(object => object.id).join(',')}`);
+
+  setup();
+  assert.deepEqual(shown(), ['derive-A', 'derive-B']);
+
+  assert.equal(sceneStore.undo().applied, true);
+  assert.deepEqual(shown(), ['derive-A'], '20 이 임시가 되어 10 을 따라간다');
+  assert.deepEqual(inFile(), ['10:derive-A']);
+
+  assert.equal(sceneStore.undo().applied, true);
+  // 저장된 사본은 그대로 두고 화면만 파생하므로, 여기서 화면이 비어야 한다.
+  // 사본을 그 자리에서 갈아끼우면 이 씬의 redo 가 invalid-history-state 로 죽는다.
+  assert.deepEqual(shown(), [], '되돌린 획이 화면에 남지 않는다');
+  assert.deepEqual(inFile(), []);
+
+  assert.equal(sceneStore.redo().applied, true);
+  assert.equal(sceneStore.redo().applied, true);
+  assert.deepEqual(shown(), ['derive-A', 'derive-B'], 'redo 로 완전 복원된다');
+  assert.deepEqual(inFile(), ['10:derive-A', '20:derive-A,derive-B']);
+});
+
+test('되돌린 임시 씬에 새로 그리면 지워진 내용이 되살아나지 않는다', () => {
+  const harness = createHistoryHarness();
+  const { sceneStore } = harness;
+  const exportRequest = {
+    hostGeneration: 1, videoGeneration: 1, persistenceSessionId: 'ps-revive',
+    stableVideoIdentity: 'revive-video', fps: 24, totalFrames: 240
+  };
+  assert.equal(sceneStore.hydrateVideo({ ...exportRequest, keyframes: [] }).accepted, true);
+  assert.equal(sceneStore.activateSession({
+    sessionId: 'revive-session', stableVideoIdentity: 'revive-video', targetFrame: 10,
+    hostGeneration: 1, videoGeneration: 1, tool: 'brush'
+  }).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('revive-A')).applied, true);
+  assert.equal(sceneStore.retargetActiveSession({
+    sessionId: 'revive-session', stableVideoIdentity: 'revive-video', targetFrame: 20,
+    hostGeneration: 1, videoGeneration: 1, tool: 'brush'
+  }).accepted, true);
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('revive-B')).applied, true);
+  assert.equal(sceneStore.undo().applied, true);
+  assert.equal(sceneStore.undo().applied, true);
+
+  // 이 시점의 20 은 낡은 사본(revive-A)을 들고 있다. 그 위에 커밋하면 이미 지워진
+  // 획이 되살아나므로, 커밋 전에 원본에서 다시 파생해야 한다.
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('revive-C')).applied, true);
+  assert.deepEqual(
+    (sceneStore.getActiveSceneSnapshot()?.objects || []).map(object => object.id),
+    ['revive-C']
+  );
+  assert.deepEqual(
+    (sceneStore.exportVideo(exportRequest).snapshot?.scenes || [])
+      .map(scene => `${scene.targetFrame}:${scene.objects.map(object => object.id).join(',')}`),
+    ['20:revive-C'],
+    '되돌린 10 의 획은 되살아나지 않는다'
+  );
 });
 
 test('redo history bytes remain in the store-wide maxBytes calculation across scenes', () => {
@@ -13106,9 +13239,22 @@ test('held frame first stroke materializes the target while preserving the sourc
   assert.equal(runtime.applyDrawingAction({
     sessionId: 'held-session-101-1', actionId: 'undo-held-stroke', action: 'undo'
   }).applied, true);
+  // 동작 변경(2026-08-28): 홀드 프레임의 첫 획을 되돌리면 그 획이 만들어 낸
+  // 키프레임 자체도 사라진다. 예전에는 키프레임이 held base 를 들고 남았는데,
+  // 키프레임 생성이 실행취소 대상이 아니라서 "앞 키프레임 편집을 되돌려도 뒤
+  // 키프레임이 복사본을 들고 남는" 모순이 생겼다. 애니메이트 동치로 맞췄다.
   const afterUndo = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
-  assert.deepEqual(afterUndo.scenes[0].objects, [source]);
-  assert.deepEqual(afterUndo.scenes[1].objects, [source], 'undo returns to the held base at target');
+  assert.deepEqual(afterUndo.scenes.map(scene => scene.targetFrame), [100],
+    'undo removes the keyframe the first stroke created');
+  assert.deepEqual(afterUndo.scenes[0].objects, [source], 'source keyframe stays immutable');
+
+  assert.equal(runtime.applyDrawingAction({
+    sessionId: 'held-session-101-1', actionId: 'redo-held-stroke', action: 'redo'
+  }).applied, true);
+  const afterRedo = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(afterRedo.scenes.map(scene => scene.targetFrame), [100, 101],
+    'redo restores the keyframe');
+  assert.equal(afterRedo.scenes[1].objects.length, 2);
   runtime.destroy();
 });
 
@@ -13402,15 +13548,19 @@ test('toolbar clear undo and redo retarget the armed frame without changing the 
   assert.deepEqual(snapshot.scenes[0].objects, [source]);
   assert.deepEqual(snapshot.scenes[1].objects, []);
 
+  // 동작 변경(2026-08-28): clear 가 임시 씬을 정식화한 커맨드였으므로, 되돌리면
+  // 그 키프레임도 함께 사라진다(애니메이트 동치). redo 하면 다시 생긴다.
   assert.equal(runtime.applyDrawingAction({
     sessionId: 'held-session-10-1', actionId: 'undo-clear-armed-20', action: 'undo'
   }).applied, true);
   snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
-  assert.deepEqual(snapshot.scenes[1].objects, [source]);
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10],
+    'undo removes the keyframe the clear created');
   assert.equal(runtime.applyDrawingAction({
     sessionId: 'held-session-10-1', actionId: 'redo-clear-armed-20', action: 'redo'
   }).applied, true);
   snapshot = runtime.exportDrawingVideo(makePersistenceExport()).snapshot;
+  assert.deepEqual(snapshot.scenes.map(scene => scene.targetFrame), [10, 20]);
   assert.deepEqual(snapshot.scenes[1].objects, []);
   runtime.destroy();
 });


### PR DESCRIPTION
## 업데이트 로그 (비개발자용)

- **프레임을 옮겨 가며 그린 뒤 `Ctrl+Z`를 여러 번 눌러도 제대로 되돌아갑니다.** 이전에는 두 번째부터 화면이 안 바뀌었습니다.
- 되돌리면 그때 새로 생긴 키프레임(장)도 같이 사라지고, `Ctrl+Y`로 그대로 되살아납니다.

## 왜 안 됐나 — 되돌릴 수 없는 절반

배프레임은 키프레임을 만들 때 **앞 장을 복사해서 그 위에 덧그립니다.** 실사용 `.bframe`을 열어 보면 키프레임별 객체 수가 0, 2, 3, 4, 6, 8, 8, 11, 12, 14, 16, 16으로 **단조 증가**합니다.

그런데 그 "복사해서 장 만들기"(`materializeProvisionalScene`)는 지속화에만 알리고 **히스토리 커맨드를 남기지 않았습니다.**

즉 "프레임 20으로 옮겨 그리기"라는 한 동작이 실제로는 둘이었습니다:

| | 실행취소 대상 |
|---|---|
| 1. 키프레임 20을 10의 복사본으로 생성 | ❌ |
| 2. 획 B 추가 | ✅ |

그래서 10의 획을 되돌려도 20이 들고 있는 복사본은 남았고, 재생헤드가 20에 있으니 화면이 안 바뀌어 "안 먹는다"가 됐습니다.

**전역 실행취소가 만든 버그가 아니라, 전역화가 드러낸 의미 충돌입니다.** 예전에는 활성 키프레임만 되돌릴 수 있어서 이 모순을 볼 일이 없었습니다.

## 상세 기술 설명

### 1. 키프레임 생성을 같은 커맨드에 묶음

임시 씬을 정식화하는 커맨드에 `materializesScene` 표식을 남기고, 되돌릴 때 씬을 다시 `provisional`로 되돌립니다.

**삭제하지 않는 이유**: redo가 그 씬을 다시 찾아야 합니다. 그리고 `provisional` 씬은 `exportVideo`(`:1482`)와 `resolveCommittedSceneAtFrame`(`:2070`)이 **이미 둘 다 건너뜁니다.** 그래서 파일과 이후 프레임 해석에서는 키프레임이 사라진 것과 완전히 같고, **새 지속화 삭제 경로가 필요 없습니다.**

### 2. 임시 씬의 화면은 커밋된 원본에서 파생

씬 객체 안에는 만들어질 당시의 사본이 남아 있어 원본이 되돌려지면 낡습니다.

처음에는 그 사본을 그 자리에서 갈아끼웠는데 — **그 씬의 redo가 `invalid-history-state`로 죽었습니다.** 히스토리가 절대 스냅샷을 들고 있어서 객체를 바꾸면 자기 상태와 어긋납니다.

그래서 **저장된 사본은 건드리지 않고 `getActiveSceneSnapshot`이 화면용으로만 다시 파생**하도록 했습니다.

낡은 사본 위에 새로 커밋하면 지워진 획이 되살아나므로, 변경 진입점 5곳(`addStroke`/`transformSelection`/`replaceObjects`/`deleteSelection`/`clearSession`)에서 커밋 전에 원본으로 맞춥니다. 그때 그 씬의 redo를 비우는 건 "되돌린 뒤 새 동작을 하면 다시실행이 사라진다"는 일반 규칙과 같습니다.

**두 수정 모두 "되돌려서 임시가 된 씬"에만 적용합니다.** 한 번도 편집되지 않은 스크래치 임시 씬의 내용은 `activateSession`이 정한 것이고 낡음 문제가 없습니다. 범위를 좁히지 않았을 때 관계없는 기존 테스트 3건이 깨져 이를 확인했습니다.

### 3. 되돌린 씬을 프레임 이동 때 버리지 않음

임시 씬은 원래 자리를 뜨면 버려졌습니다. 그러나 되돌려서 임시가 된 씬은 redo용 히스토리를 들고 있어, 그것까지 버리면 **되돌린 뒤 프레임을 옮기는 순간 다시 실행이 영영 불가능해집니다.**

## 개발 난항

**이 결함이 작업 2의 테스트를 빠져나간 이유를 찾았습니다.** 제 테스트는 `activateSession`으로 프레임을 바꿨는데, 실기의 프레임 이동은 `retargetActiveSession`이고 **복사는 그 경로에서만 일어납니다.** 같은 경로를 타는 회귀 테스트를 추가했습니다.

**수정이 세 번 연달아 다른 곳에서 문제를 드러내 한 번 멈추고 설계를 재검토했습니다.** 사본 갱신 → redo 깨짐 → 범위 축소 → 화면 잔상 잔존, 이 흐름이었습니다. "저장된 사본은 불변, 화면만 파생"으로 바꾸고 나서야 네 성질이 동시에 성립했습니다.

## 의도된 동작 변경 — 기존 테스트 2건

`held frame first stroke materializes the target while preserving the source and undo base`와 `toolbar clear undo and redo retarget the armed frame...`는 **"첫 획을 되돌려도 키프레임이 held base와 함께 남는다"**를 계약으로 못박고 있었습니다. 그 계약이 위 모순의 근원이며, 애니메이트 동치로 가기로 결정했습니다.

단언을 완화하지 않고 새 계약(키프레임이 사라짐)과 **redo 복원**을 함께 단언하도록 바꿨습니다.

## 테스트 가이드

```bash
npm run test:fabric-drawing-pilot
```

검증한 성질:

| 동작 | 화면 | 저장 파일 |
|---|---|---|
| 그린 직후 | A, B | `10:[A]`, `20:[A,B]` |
| `Ctrl+Z` 1회 | A | `10:[A]` |
| `Ctrl+Z` 2회 | **비어 있음** | **비어 있음** |
| `Ctrl+Y` 2회 | A, B | `10:[A]`, `20:[A,B]` |
| 되돌린 뒤 새로 그림 | C | `20:[C]` — 지운 A가 안 살아남 |

- 신규 3건, 기존 갱신 5건
- 25개 스위트 **2,185 → 2,188 pass / 0 fail**
- `npm run lint` error 0 (warning 59는 전부 기존)

### 실기 확인

프레임 10에 획 → 20으로 옮겨 획 → `Ctrl+Z` 두 번 → **20에 서 있어도 화면에서 획이 전부 사라진다.** `Ctrl+Y` 두 번으로 완전 복원.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
