### PR TITLE
버전 2.4.7-beta — 키프레임 생성 되돌리기 실기 확인용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.4.6-beta",
+  "version": "2.4.7-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.4.6-beta",
+      "version": "2.4.7-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.4.6-beta",
+  "version": "2.4.7-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -249,7 +249,7 @@ test('stable engine promotion uses the 2.3.0 beta release version consistently',
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.4.6-beta');
-  assert.equal(packageLock.version, '2.4.6-beta');
-  assert.equal(packageLock.packages[''].version, '2.4.6-beta');
+  assert.equal(packageJson.version, '2.4.7-beta');
+  assert.equal(packageLock.version, '2.4.7-beta');
+  assert.equal(packageLock.packages[''].version, '2.4.7-beta');
 });


### PR DESCRIPTION
PR #196 의 실기 확인을 위한 패치 버전 상향입니다. `package.json` / `package-lock.json` 2곳 / `runtime-profile.test.js` 단언 3개.

`npm run test:mpv` 338 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)