### PR TITLE
실행취소·삭제 후 화면이 늦게 갱신되던 문제 — 동기 렌더 + 합성 강제

### DIFF
--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -3319,6 +3319,12 @@ class MPVOverlayHost {
       if (!this._drawingActionExecutionIsCurrent(request, executionContext)) {
         return { success: false, applied: false, error: 'stale drawing action response' };
       }
+      // 투명 오버레이는 다시 그린 내용을 다음 입력까지 늦게 합성할 수 있다. 실행취소·
+      // 삭제로 화면이 바뀌었으면 프레임 변경 경로와 같이 합성을 강제한다. 이게 없으면
+      // 되돌린 획이 잠깐 남아 보인다.
+      if (result?.repainted === true) {
+        executionContext.hostWindow.webContents?.invalidate?.();
+      }
       return {
         success: result?.applied === true || result?.duplicate === true,
         applied: result?.applied === true,

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -19771,15 +19771,17 @@ void main() {
           const result = action === "delete-selection" ? sceneStore.deleteSelection() : action === "clear-session" ? sceneStore.clearSession() : action === "undo" ? sceneStore.undo() : sceneStore.redo();
           if (result.applied) {
             if (action === "undo" || action === "redo") {
+              let repainted = false;
               if (result.affectedActiveScene !== false) {
-                renderActiveScene();
+                renderActiveScene({ immediate: true });
                 fabricCanvas.discardActiveObject();
                 sceneStore.selectObjects([]);
                 setToolMode(currentSession?.tool || "brush");
+                repainted = true;
               }
               updateObjectMetric();
               settleArmedFramePreview();
-              return result;
+              return { ...result, repainted };
             }
             const deletedIds = new Set(result.deletedIds);
             for (const object of fabricCanvas.getObjects()) {
@@ -19787,8 +19789,14 @@ void main() {
             }
             fabricCanvas.discardActiveObject();
             refreshSelectionInteractionPolicy();
-            fabricCanvas.requestRenderAll();
+            if (typeof fabricCanvas.renderAll === "function") {
+              fabricCanvas.renderAll();
+            } else {
+              fabricCanvas.requestRenderAll();
+            }
             updateObjectMetric();
+            settleArmedFramePreview();
+            return { ...result, repainted: true };
           }
           settleArmedFramePreview();
           return result;

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -7344,15 +7344,20 @@ function createFabricOverlayRuntime(options = {}) {
         // 그때까지 캔버스를 다시 그리고 도구 모드를 재설정하면 헛일이고, 사용자의
         // 활성 선택만 사라진다. 활성 씬이 실제로 바뀐 경우에만 손댄다.
         // !== false 로 쓰는 이유: 이 필드 없이 도달하는 경로는 안전한 쪽(재도색)이 기본이어야 한다.
+        let repainted = false;
         if (result.affectedActiveScene !== false) {
-          renderActiveScene();
+          // 오버레이는 투명 BrowserWindow 라 requestRenderAll 의 다음 프레임을 기다리면
+          // 지워진 획이 잠깐 남아 보인다. 여기서 동기로 그려 두고, 호스트가 응답을 받아
+          // invalidate() 로 합성을 강제한다(updateDrawingFrame 의 repainted 규약과 동일).
+          renderActiveScene({ immediate: true });
           fabricCanvas.discardActiveObject();
           sceneStore.selectObjects([]);
           setToolMode(currentSession?.tool || 'brush');
+          repainted = true;
         }
         updateObjectMetric();
         settleArmedFramePreview();
-        return result;
+        return { ...result, repainted };
       }
       const deletedIds = new Set(result.deletedIds);
       for (const object of fabricCanvas.getObjects()) {
@@ -7360,8 +7365,15 @@ function createFabricOverlayRuntime(options = {}) {
       }
       fabricCanvas.discardActiveObject();
       refreshSelectionInteractionPolicy();
-      fabricCanvas.requestRenderAll();
+      // 삭제·전체 지우기도 같은 이유로 동기 렌더 후 합성을 강제한다.
+      if (typeof fabricCanvas.renderAll === 'function') {
+        fabricCanvas.renderAll();
+      } else {
+        fabricCanvas.requestRenderAll();
+      }
       updateObjectMetric();
+      settleArmedFramePreview();
+      return { ...result, repainted: true };
     }
     settleArmedFramePreview();
     return result;

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -1862,6 +1862,63 @@ test('drawing persistence IPC normalization resyncs malformed nested deltas with
   );
 });
 
+test('drawing actions that repaint force the transparent overlay to composite', async () => {
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.applyDrawingAction(')) {
+        return { applied: true, repainted: true, deletedCount: 0 };
+      }
+      return undefined;
+    }
+  });
+  await activateDrawingHost(harness, { sessionId: 'session-repaint-invalidate' });
+  harness.events.length = 0;
+
+  const result = await harness.host.applyDrawingAction({
+    hostGeneration: harness.host.hostGeneration,
+    videoGeneration: 1,
+    inputRevision: 2,
+    sessionId: 'session-repaint-invalidate',
+    actionId: 'undo-repaint-1',
+    action: 'undo'
+  });
+  assert.equal(result.success, true);
+  // 투명 BrowserWindow 는 다시 그린 내용을 다음 입력까지 늦게 합성할 수 있다.
+  // 프레임 변경 경로와 같이 여기서도 합성을 강제해야 되돌린 획이 남아 보이지 않는다.
+  assert.ok(
+    harness.events.some(([name]) => name === 'webContents.invalidate'),
+    'a repainting drawing action must invalidate the overlay'
+  );
+});
+
+test('drawing actions that do not repaint leave the overlay alone', async () => {
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.applyDrawingAction(')) {
+        return { applied: true, repainted: false, deletedCount: 0 };
+      }
+      return undefined;
+    }
+  });
+  await activateDrawingHost(harness, { sessionId: 'session-no-repaint' });
+  harness.events.length = 0;
+
+  const result = await harness.host.applyDrawingAction({
+    hostGeneration: harness.host.hostGeneration,
+    videoGeneration: 1,
+    inputRevision: 2,
+    sessionId: 'session-no-repaint',
+    actionId: 'undo-no-repaint-1',
+    action: 'undo'
+  });
+  assert.equal(result.success, true);
+  assert.equal(
+    harness.events.some(([name]) => name === 'webContents.invalidate'),
+    false,
+    '다른 키프레임만 바뀌었으면 합성을 강제할 이유가 없다'
+  );
+});
+
 test('drawing diagnostics relay global history depths', async () => {
   const harness = createDrawingHostHarness({
     executeDrawing(script) {


### PR DESCRIPTION
## 업데이트 로그 (비개발자용)

- **`Ctrl+Z`나 삭제 후 화면이 곧바로 깔끔하게 갱신됩니다.** 이전에는 지워진 획이 잠깐 남아 보였습니다.

## 원인 — 두 가지가 겹쳤습니다

그리기 화면은 영상 위에 얹힌 **투명한 창**입니다. 투명 창은 다시 그린 내용을 **다음 입력이 있을 때까지 미뤄서** 합성하는 성질이 있습니다.

이 저장소는 그 성질을 **이미 알고 있었습니다** — `updateDrawingFrame`(프레임 이동)은 런타임이 `repainted: true`를 보고하면 `hostWindow.webContents.invalidate()`로 합성을 강제합니다(`main/mpv-overlay-host.js:3143`).

**그런데 `applyDrawingAction`(실행취소·다시실행·선택삭제·전체지우기) 경로에는 그 규약이 아예 없었습니다.**

거기에 하나 더 겹쳤습니다. 실행취소 분기는 `renderActiveScene()`을 옵션 없이 불러 `requestRenderAll`(다음 프레임)로 그리고 있었습니다 — 세션 진입 경로는 같은 함수를 `immediate: true`로 부릅니다.

즉 **"다음 프레임에 그리기" + "합성은 다음 입력까지 지연"** 이 겹쳐 지워진 획이 잠깐 남아 보였습니다.

## 상세 기술 설명

### 1. 런타임 — 동기 렌더 + `repainted` 보고

실행취소·다시실행은 `renderActiveScene({ immediate: true })`로 동기 렌더하고, **실제로 다시 그렸을 때만** 결과에 `repainted: true`를 실어 보냅니다. 삭제·전체지우기도 `renderAll`로 동기화하고 같은 표식을 붙입니다.

### 2. 호스트 — 합성 강제

`_performDrawingAction`이 `repainted: true`를 받으면 `updateDrawingFrame`과 **동일한 규약으로** `invalidate()`를 호출합니다.

### 낭비 없음

다른 키프레임만 되돌려 화면에 변화가 없는 경우(`affectedActiveScene: false`)에는 `repainted`가 `false`라 합성을 강제하지 않습니다. 두 경우를 각각 테스트로 고정했습니다.

## 테스트 가이드

```bash
npm run test:mpv
npm run test:fabric-drawing-pilot
```

- 신규 2건: `drawing actions that repaint force the transparent overlay to composite` / `drawing actions that do not repaint leave the overlay alone`
- 25개 스위트 **2,188 → 2,190 pass / 0 fail**
- `npm run lint` error 0 (warning 59는 전부 기존)

### 실기 확인

프레임 10에 획 → 20으로 옮겨 획 → `Ctrl+Z` 두 번 → **획이 즉시 사라진다** (잔상 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
