### PR TITLE
DEVLOG: 작업 2-c 구현·v2.4.8-beta 배포 기록

### DIFF
--- a/DEVLOG/2026-08-28-드로잉-실행취소-UI정식화-구현.md
+++ b/DEVLOG/2026-08-28-드로잉-실행취소-UI정식화-구현.md
@@ -13,6 +13,7 @@
 | 1-b | §7.1 후속 | mpv-fabric-overlay-runtime.js, iife 번들, 테스트 1 | 실기 보고 — HUD가 굵기를 보여주지 않아 알아채지 못함 | [#191](https://github.com/baehandoridori/BAEFRAME/pull/191) | ✅ 완료 |
 | 2 | §6 | mpv-fabric-overlay-runtime.js, drawing-command-history.js, mpv-overlay-host.js, iife 번들, 테스트 12 | 히스토리가 씬별이라 재생헤드가 키프레임에 있어야만 반응 | [#193](https://github.com/baehandoridori/BAEFRAME/pull/193) | ✅ 완료 |
 | 2-b | §6 후속 | mpv-fabric-overlay-runtime.js, iife 번들, 테스트 3+5 | 실기 보고 — 키프레임 생성이 실행취소 대상이 아니라 앞 획을 되돌려도 복사본이 남음 | [#196](https://github.com/baehandoridori/BAEFRAME/pull/196) | ✅ 완료 |
+| 2-c | §6 후속 | mpv-fabric-overlay-runtime.js, mpv-overlay-host.js, iife 번들, 테스트 2 | 실기 보고 — 되돌린 획이 잠깐 남아 보임(투명 오버레이 합성 지연) | [#199](https://github.com/baehandoridori/BAEFRAME/pull/199) | ✅ 완료 |
 | 3 | §7.2 | (예정) | 도구 6종 신설 | ③ | ⬜ 대기 |
 | 4 | §7.3 | (예정) | 지우개 도구·모드 섹션 | ③ | ⬜ 대기 |
 | 5 | §7.4 | (예정) | `[` / `]` 브러시 크기 단축키 | ③ | ⬜ 대기 |
@@ -449,3 +450,66 @@ held base와 함께 남는다"**를 계약으로 못박고 있었다. 그 계약
 
 **실기 확인**: 프레임 10에 획 → 20으로 옮겨 획 → `Ctrl+Z` 두 번 →
 20에 서 있어도 화면에서 획이 전부 사라진다. `Ctrl+Y` 두 번으로 완전 복원.
+
+---
+
+# 작업 2-c — 실행취소 후 화면 즉시 반영 (PR ②c, v2.4.8-beta)
+
+## 사용자 보고
+
+v2.4.7-beta 실기: **"키프레임이 사라지긴 하는데 화면에서 깔끔하게 없어지지 않는다, 조금 렉이 있다."**
+
+기능은 맞고 표시만 늦는 증상이다.
+
+## 원인 — 두 가지가 겹쳤다
+
+오버레이는 mpv 위에 얹힌 **투명 BrowserWindow**다. 투명 창은 다시 그린 내용을 **다음 입력까지 늦게 합성**할 수 있다.
+
+**이 저장소는 그 성질을 이미 알고 있었다.** `updateDrawingFrame`(프레임 이동)은 런타임이
+`repainted: true`를 보고하면 `hostWindow.webContents.invalidate()`로 합성을 강제한다
+(`main/mpv-overlay-host.js:3143`). `_setNativeDrawingInput`에도 같은 취지의 주석과 호출이 있다.
+
+**그런데 `applyDrawingAction`(실행취소·다시실행·선택삭제·전체지우기) 경로에는 그 규약이 아예 없었다.**
+
+거기에 하나 더 겹쳤다 — 실행취소 분기는 `renderActiveScene()`을 옵션 없이 불러
+`requestRenderAll`(다음 프레임)로 그렸다. 세션 진입 경로(`:7023`)는 같은 함수를
+`immediate: true`로 부른다.
+
+즉 **"다음 프레임에 그리기" + "합성은 다음 입력까지 지연"** 이 겹쳐 지워진 획이 잠깐 남아 보였다.
+
+## 수정
+
+1. **런타임** — 실행취소·다시실행은 `renderActiveScene({ immediate: true })`로 동기 렌더하고,
+   실제로 다시 그렸을 때만 결과에 `repainted: true`를 실어 보낸다. 삭제·전체지우기도
+   `renderAll`로 동기화하고 같은 표식을 붙인다.
+2. **호스트** — `_performDrawingAction`이 `repainted: true`를 받으면 `updateDrawingFrame`과
+   **동일한 규약으로** `invalidate()`를 호출한다.
+
+다른 키프레임만 되돌려 화면에 변화가 없는 경우(`affectedActiveScene: false`)에는 `repainted`가
+`false`라 합성을 강제하지 않는다 — 불필요한 갱신을 만들지 않는다.
+
+## 배운 것
+
+**같은 계층에 이미 있던 규약을 새 경로가 물려받지 않았다.** 프레임 이동 경로에는 있고
+드로잉 액션 경로에는 없던 `repainted → invalidate` 규약이 그것이다. 앞으로 오버레이 화면을
+바꾸는 경로를 새로 만들 때는 이 규약을 함께 배선해야 한다.
+
+## 결과
+
+- 신규 2건(다시 그린 액션은 합성을 강제한다 / 그렇지 않은 액션은 건드리지 않는다)
+- 25스위트 **2,188 → 2,190 pass / 0 fail**
+
+## 배포 기록 (v2.4.8-beta)
+
+| 항목 | 값 |
+|------|-----|
+| 배포 시각 | **2026-08-28 22:53** |
+| 소스 커밋 | `2cfcf62` (main, PR #200 머지) |
+| 배포 방식 | `robocopy /MIR` — exit 1(정상), FAILED 0 |
+| 검증 | 전체 트리 SHA-256 **82/82, MismatchCount=0 / MissingCount=0 / ExtraFiles=0** |
+| exe SHA-256 | `C49DE7001F584D1210B69A5C484B9B428943936DF3CB164EF90AB8C6A8E0C491` |
+| app.asar SHA-256 | `214951B520A438DD7C991A8A459F36ED14B76ABE1F7C77F33F0B538290344497` |
+| `FileVersion` | `2.4.8-beta` |
+| 직전 배포본 | v2.4.7-beta, 2026-08-28 22:43 (교체됨) |
+
+**실기 확인**: 프레임 10에 획 → 20으로 옮겨 획 → `Ctrl+Z` 두 번 → 잔상 없이 즉시 사라진다.


### PR DESCRIPTION
투명 오버레이 합성 지연과 repainted→invalidate 규약 누락, v2.4.8-beta 배포 기록입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)