### PR TITLE
실행취소로 키프레임이 바뀌면 타임라인도 즉시 따라오게

### DIFF
--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -3258,7 +3258,11 @@ class MPVOverlayHost {
       return { success: false, applied: false, error: 'stale or invalid drawing action request' };
     }
     if (this.completedActionIds.has(request.actionId)) {
-      return { success: true, applied: false, duplicate: true, deletedCount: 0 };
+      // 중복 액션은 아무것도 바꾸지 않으므로 keyframeSetChanged 는 항상 false 다.
+      // 성공 응답의 형태를 _performDrawingAction 과 같게 유지한다.
+      return {
+        success: true, applied: false, duplicate: true, deletedCount: 0, keyframeSetChanged: false
+      };
     }
     const inFlight = this.inFlightDrawingActions.get(request.actionId);
     if (inFlight) return inFlight;
@@ -3330,7 +3334,8 @@ class MPVOverlayHost {
         applied: result?.applied === true,
         duplicate: result?.duplicate === true,
         ...(typeof result?.reason === 'string' ? { reason: result.reason } : {}),
-        deletedCount: Math.max(0, Math.trunc(finiteDiagnosticNumber(result?.deletedCount)))
+        deletedCount: Math.max(0, Math.trunc(finiteDiagnosticNumber(result?.deletedCount))),
+        keyframeSetChanged: result?.keyframeSetChanged === true
       };
     } catch (error) {
       return { success: false, applied: false, error: error.message };

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -15076,10 +15076,12 @@ void main() {
         }
         function applyHistoryEntry(scene, order, direction) {
           let transition = null;
+          let entryMaterializesScene = false;
           const result = scene.history[direction]((state, _historyDirection, entry) => {
             const applied = applyHistoryState(scene, state);
             if (applied.applied) {
               if (entry.materializesScene === true) {
+                entryMaterializesScene = true;
                 scene.provisional = direction === "undo";
                 scene.provisionalSourceFrame = direction === "undo" ? entry.provisionalSourceFrame ?? null : null;
               }
@@ -15114,7 +15116,11 @@ void main() {
             // 재설정을 건너뛴다. 다만 활성 씬이 임시 씬이면 그 화면은 커밋된 원본에서
             // 파생되므로, 어느 씬이 바뀌었든 다시 그려야 한다.
             affectedActiveScene: scene === activeScene() || activeScene()?.provisional === true,
-            affectedTargetFrame: scene.targetFrame
+            affectedTargetFrame: scene.targetFrame,
+            // 키프레임이 생기거나 사라졌으면 지속화 스토어의 키프레임 목록과 어긋난다.
+            // 전이(transition)는 객체 단위라 "이 키프레임이 사라졌다"를 표현할 수 없어,
+            // 타임라인이 다음 저장 주기까지 옛 마커를 들고 있게 된다. 재동기를 요청하도록 알린다.
+            keyframeSetChanged: entryMaterializesScene
           };
         }
         function moveHistory(direction) {
@@ -19781,7 +19787,7 @@ void main() {
               }
               updateObjectMetric();
               settleArmedFramePreview();
-              return { ...result, repainted };
+              return { ...result, repainted, keyframeSetChanged: result.keyframeSetChanged === true };
             }
             const deletedIds = new Set(result.deletedIds);
             for (const object of fabricCanvas.getObjects()) {

--- a/renderer/scripts/modules/fabric-drawing-pilot-controller.js
+++ b/renderer/scripts/modules/fabric-drawing-pilot-controller.js
@@ -1294,9 +1294,14 @@ export function createFabricDrawingPilotController(options = {}) {
   async function sendDrawingActionRequest(request) {
     try {
       const response = await electronAPI.mpvApplyOverlayDrawingAction(request);
-      return response && typeof response === 'object'
-        ? response
-        : { success: false, applied: false };
+      if (!response || typeof response !== 'object') {
+        return { success: false, applied: false };
+      }
+      // 실행취소가 키프레임을 없애거나 되살리면 전이만으로는 스토어의 키프레임 목록을
+      // 맞출 수 없다(전이는 객체 단위다). 그대로 두면 타임라인이 다음 저장 주기까지
+      // 사라진 키프레임 마커를 들고 있으므로 즉시 재동기한다.
+      if (response.keyframeSetChanged === true) runDetached(requestPersistenceResync());
+      return response;
     } catch {
       return { success: false, applied: false };
     }

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -1989,12 +1989,14 @@ function createSessionSceneStore(options = {}) {
 
   function applyHistoryEntry(scene, order, direction) {
     let transition = null;
+    let entryMaterializesScene = false;
     const result = scene.history[direction]((state, _historyDirection, entry) => {
       const applied = applyHistoryState(scene, state);
       if (applied.applied) {
         // 키프레임 생성(임시 씬 정식화)까지 함께 되돌린다. 되돌리면 그 프레임은
         // 다시 "키프레임 아님"이 되어 이후 프레임이 앞 키프레임을 따라간다.
         if (entry.materializesScene === true) {
+          entryMaterializesScene = true;
           scene.provisional = direction === 'undo';
           scene.provisionalSourceFrame = direction === 'undo'
             ? (entry.provisionalSourceFrame ?? null)
@@ -2031,7 +2033,11 @@ function createSessionSceneStore(options = {}) {
       // 재설정을 건너뛴다. 다만 활성 씬이 임시 씬이면 그 화면은 커밋된 원본에서
       // 파생되므로, 어느 씬이 바뀌었든 다시 그려야 한다.
       affectedActiveScene: scene === activeScene() || activeScene()?.provisional === true,
-      affectedTargetFrame: scene.targetFrame
+      affectedTargetFrame: scene.targetFrame,
+      // 키프레임이 생기거나 사라졌으면 지속화 스토어의 키프레임 목록과 어긋난다.
+      // 전이(transition)는 객체 단위라 "이 키프레임이 사라졌다"를 표현할 수 없어,
+      // 타임라인이 다음 저장 주기까지 옛 마커를 들고 있게 된다. 재동기를 요청하도록 알린다.
+      keyframeSetChanged: entryMaterializesScene
     };
   }
 
@@ -7357,7 +7363,7 @@ function createFabricOverlayRuntime(options = {}) {
         }
         updateObjectMetric();
         settleArmedFramePreview();
-        return { ...result, repainted };
+        return { ...result, repainted, keyframeSetChanged: result.keyframeSetChanged === true };
       }
       const deletedIds = new Set(result.deletedIds);
       for (const object of fabricCanvas.getObjects()) {

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -9873,6 +9873,36 @@ test('되돌린 임시 씬에 새로 그리면 지워진 내용이 되살아나�
   );
 });
 
+test('키프레임이 생기거나 사라지는 되돌리기만 재동기를 요청한다', () => {
+  const harness = createHistoryHarness();
+  const { sceneStore } = harness;
+  const base = {
+    hostGeneration: 1, videoGeneration: 1, persistenceSessionId: 'ps-kfset',
+    stableVideoIdentity: 'kfset-video', fps: 24, totalFrames: 240
+  };
+  assert.equal(sceneStore.hydrateVideo({ ...base, keyframes: [] }).accepted, true);
+  assert.equal(sceneStore.activateSession({
+    sessionId: 'kfset-session', stableVideoIdentity: 'kfset-video', targetFrame: 10,
+    hostGeneration: 1, videoGeneration: 1, tool: 'brush'
+  }).accepted, true);
+  // 첫 획이 임시 씬을 정식화한다 = 키프레임을 만든다.
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('kfset-A')).applied, true);
+  // 두 번째 획은 이미 정식인 씬에 얹힌다 = 키프레임 집합이 그대로다.
+  assert.equal(sceneStore.addStroke(makeHistoryStroke('kfset-B')).applied, true);
+
+  const plain = sceneStore.undo();
+  assert.equal(plain.applied, true);
+  assert.equal(plain.keyframeSetChanged, false, '키프레임 집합이 그대로면 재동기가 필요 없다');
+
+  const removesKeyframe = sceneStore.undo();
+  assert.equal(removesKeyframe.applied, true);
+  assert.equal(removesKeyframe.keyframeSetChanged, true, '키프레임이 사라지면 재동기해야 한다');
+
+  const restoresKeyframe = sceneStore.redo();
+  assert.equal(restoresKeyframe.applied, true);
+  assert.equal(restoresKeyframe.keyframeSetChanged, true, '되살아날 때도 마찬가지다');
+});
+
 test('redo history bytes remain in the store-wide maxBytes calculation across scenes', () => {
   const harness = createHistoryHarness({
     maxBytes: 700,

--- a/scripts/tests/mpv-overlay-host.test.js
+++ b/scripts/tests/mpv-overlay-host.test.js
@@ -1862,6 +1862,30 @@ test('drawing persistence IPC normalization resyncs malformed nested deltas with
   );
 });
 
+test('drawing actions relay the keyframe set change flag', async () => {
+  const harness = createDrawingHostHarness({
+    executeDrawing(script) {
+      if (script.includes('.applyDrawingAction(')) {
+        return { applied: true, repainted: true, deletedCount: 0, keyframeSetChanged: true };
+      }
+      return undefined;
+    }
+  });
+  await activateDrawingHost(harness, { sessionId: 'session-keyframe-set' });
+
+  const result = await harness.host.applyDrawingAction({
+    hostGeneration: harness.host.hostGeneration,
+    videoGeneration: 1,
+    inputRevision: 2,
+    sessionId: 'session-keyframe-set',
+    actionId: 'undo-keyframe-set-1',
+    action: 'undo'
+  });
+  // 전이는 객체 단위라 "이 키프레임이 사라졌다"를 표현할 수 없다. 이 신호가 없으면
+  // 타임라인이 다음 저장 주기까지 옛 마커를 들고 있는다.
+  assert.equal(result.keyframeSetChanged, true);
+});
+
 test('drawing actions that repaint force the transparent overlay to composite', async () => {
   const harness = createDrawingHostHarness({
     executeDrawing(script) {
@@ -3121,8 +3145,12 @@ test('deduplicates drawing actions and allowlists lightweight host responses', a
   };
   const first = await host.applyDrawingAction(action);
   const duplicate = await host.applyDrawingAction(action);
-  assert.deepEqual(first, { success: true, applied: true, duplicate: false, deletedCount: 1 });
-  assert.deepEqual(duplicate, { success: true, applied: false, duplicate: true, deletedCount: 0 });
+  assert.deepEqual(first, {
+    success: true, applied: true, duplicate: false, deletedCount: 1, keyframeSetChanged: false
+  });
+  assert.deepEqual(duplicate, {
+    success: true, applied: false, duplicate: true, deletedCount: 0, keyframeSetChanged: false
+  });
   assert.equal(
     events.filter(([name, value]) => name === 'executeJavaScript' && value.includes?.('.applyDrawingAction(')).length,
     1
@@ -3262,13 +3290,15 @@ test('allowlists undo and redo while rejecting unknown drawing actions', async (
     success: true,
     applied: true,
     duplicate: false,
-    deletedCount: 1
+    deletedCount: 1,
+    keyframeSetChanged: false
   });
   assert.deepEqual(await harness.host.applyDrawingAction(makeAction('redo', 'history-redo-1')), {
     success: true,
     applied: true,
     duplicate: false,
-    deletedCount: 1
+    deletedCount: 1,
+    keyframeSetChanged: false
   });
   assert.deepEqual(await harness.host.applyDrawingAction(makeAction('export-scene', 'unknown-1')), {
     success: false,
@@ -3320,7 +3350,8 @@ test('serializes different actions and continues after the first action fails', 
     success: true,
     applied: true,
     duplicate: false,
-    deletedCount: 0
+    deletedCount: 0,
+    keyframeSetChanged: false
   });
   assert.deepEqual(actionOrder, ['undo', 'redo']);
 });
@@ -3581,12 +3612,15 @@ test('shares an in-flight action failure and keeps the action ID retryable until
   await waitForAsyncReposition();
   assert.equal(actionCallCount, 2);
   retryAttempt.resolve({ applied: true, deletedCount: 2 });
-  assert.deepEqual(await retry, { success: true, applied: true, duplicate: false, deletedCount: 2 });
+  assert.deepEqual(await retry, {
+    success: true, applied: true, duplicate: false, deletedCount: 2, keyframeSetChanged: false
+  });
   assert.deepEqual(await host.applyDrawingAction(action), {
     success: true,
     applied: false,
     duplicate: true,
-    deletedCount: 0
+    deletedCount: 0,
+    keyframeSetChanged: false
   });
   assert.equal(actionCallCount, 2);
 });


### PR DESCRIPTION
## 업데이트 로그 (비개발자용)

- **`Ctrl+Z`로 키프레임이 사라지거나 되살아나면 타임라인 패널도 곧바로 따라옵니다.** 이전에는 캔버스만 바뀌고 타임라인의 키프레임 표시가 잠시 남아 있었습니다.

## 원인 — 전이(transition)는 키프레임 제거를 전달할 수 없다

캔버스는 오버레이 런타임에서 바로 그리지만, **타임라인은 다른 출처를 봅니다** — `getFabricPilotTimelineLayers()`가 `fabricDrawingPersistenceStore.getHydrationDocument()`를 읽습니다.

경로 자체는 이미 빠릅니다. 스토어는 전이 이벤트로 증분 갱신되고, 그 구독이 `requestAnimationFrame`으로 `renderActiveDrawingLayers()`를 부릅니다.

**문제는 전이가 객체 단위라는 것입니다.** `applyTransition`은 `targetFrame`으로 키프레임을 찾아 `removals`/`insertions`를 적용할 뿐, **"이 키프레임이 사라졌다"를 표현할 방법이 없습니다.**

[#196](https://github.com/baehandoridori/BAEFRAME/pull/196)이 키프레임 생성을 되돌림 대상에 넣으면서 런타임은 키프레임을 없앨 수 있게 됐는데, 그 사실이 스토어로 전달되지 않았습니다. 그래서 타임라인이 다음 전체 저장 주기(`export` → `replaceFromOverlay`)까지 이미 사라진 마커를 들고 있었습니다.

## 상세 기술 설명

전이 이벤트 계약을 늘리는 대신 **기존 재동기 장치**를 씁니다.

| 계층 | 변경 |
|---|---|
| 런타임 | `materializesScene` 커맨드를 되돌리거나 다시 실행하면 결과에 `keyframeSetChanged: true` |
| 호스트 | `_performDrawingAction` 응답 화이트리스트에 필드 추가. 중복 액션 조기 반환도 같은 형태를 갖도록 `false` 명시 |
| 컨트롤러 | 응답에 표식이 있으면 `requestPersistenceResync()` |

### 그리기 중에도 안전합니다

소스 에포크가 그대로면 `ensurePersistenceBindingCurrent`가 즉시 통과하고 **재수화 없이 `export` → `replaceFromOverlay`만** 돕니다. 호스트가 `desiredInputEnabled`일 때 거부하는 것은 **재수화 경로**이지 회수 경로가 아닙니다.

### 낭비 없음

일반 획 되돌리기는 `keyframeSetChanged`가 `false`라 재동기를 태우지 않습니다. 키프레임이 실제로 생기거나 사라진 경우에만 돕니다.

## 개발 난항

응답 형태를 `deepEqual`로 고정한 **화이트리스트 단언 4건**이 새 필드 때문에 깨졌습니다. 이 테스트들은 "호스트가 무엇을 렌더러로 내보내는가"를 의도적으로 못박는 계약이므로, **단언을 지우지 않고** 기대값에 새 필드를 더했습니다. 중복 액션의 조기 반환도 같은 형태를 갖도록 맞춰 응답 shape이 경로마다 갈리지 않게 했습니다.

## 테스트 가이드

```bash
npm run test:fabric-drawing-pilot
npm run test:mpv
```

- 신규 2건: `키프레임이 생기거나 사라지는 되돌리기만 재동기를 요청한다` / `drawing actions relay the keyframe set change flag`
- 25개 스위트 **2,190 → 2,192 pass / 0 fail**
- `npm run lint` error 0 (warning 59는 전부 기존)

### 실기 확인

프레임 10에 획 → 20으로 옮겨 획 → `Ctrl+Z` 두 번 → **타임라인의 키프레임 마커도 캔버스와 동시에 사라진다.** `Ctrl+Y`로 함께 되살아난다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
