### PR TITLE
fix: 그리기 팔레트 UI 깨짐 5건 — CSS 규칙 누락이 근본 원인

### DIFF
--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -507,6 +507,15 @@ const OVERLAY_HTML = String.raw`
       min-height: 32px;
       padding: 0;
     }
+    /* 색 견본은 한 줄에 넷이 들어가야 8개가 두 줄로 끝난다.
+       팔레트 220px → 패널 안쪽 166px, 4*36 + 3*6 = 162 <= 166. */
+    .mpv-fabric-pilot-toolbar [data-fabric-pilot-panel="brush-settings"] button[data-fabric-pilot-color] {
+      width: 36px;
+      height: 36px;
+      min-width: 36px;
+      min-height: 36px;
+      padding: 0;
+    }
     .mpv-fabric-pilot-brush-status {
       display: flex;
       align-items: center;
@@ -565,6 +574,15 @@ const OVERLAY_HTML = String.raw`
       }
       .mpv-fabric-pilot-toolbar [data-fabric-pilot-output="selection-summary"] {
         display: none;
+      }
+      /* 팔레트가 190px 로 좁아지면 패널 안쪽은 약 156px 이다.
+         36px 그대로면 4*36 + 3*4 = 156 을 넘겨 3/3/2 로 흘러 세 줄이 된다.
+         32px 이면 4*32 + 3*4 = 140 이라 넉넉히 넷이 앉는다. */
+      .mpv-fabric-pilot-toolbar [data-fabric-pilot-panel="brush-settings"] button[data-fabric-pilot-color] {
+        width: 32px;
+        height: 32px;
+        min-width: 32px;
+        min-height: 32px;
       }
     }
     .mirror-canvas {

--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -507,6 +507,30 @@ const OVERLAY_HTML = String.raw`
       min-height: 32px;
       padding: 0;
     }
+    .mpv-fabric-pilot-brush-status {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+      color: var(--text-tertiary);
+      font-size: 11px;
+      font-variant-numeric: tabular-nums;
+    }
+    .mpv-fabric-pilot-brush-status [data-fabric-pilot-output="brush-status-swatch"] {
+      flex: 0 0 auto;
+    }
+    .mpv-fabric-pilot-brush-status [data-fabric-pilot-output="brush-status-text"] {
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    .mpv-fabric-pilot-eraser-mode,
+    .mpv-fabric-pilot-recent-colors {
+      display: flex;
+      flex-flow: row wrap;
+      gap: var(--fabric-palette-gap);
+    }
     .mpv-fabric-pilot-badge {
       display: block;
       width: 100%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.6.0-beta",
+  "version": "2.6.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.6.0-beta",
+      "version": "2.6.1-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.6.0-beta",
+  "version": "2.6.1-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -16499,7 +16499,8 @@ void main() {
           setStyles(palette, {
             display: "flex",
             flexWrap: "wrap",
-            gap: "6px"
+            // 좁은 화면에서 미디어 쿼리가 4px 로 줄이는 변수를 그대로 쓴다.
+            gap: "var(--fabric-palette-gap)"
           });
           const colorButtons = BRUSH_COLORS.map((color) => {
             const button = createButton("", "brush-color");
@@ -16509,12 +16510,7 @@ void main() {
             setStyles(button, {
               display: "inline-flex",
               alignItems: "center",
-              justifyContent: "center",
-              width: "36px",
-              height: "36px",
-              minWidth: "36px",
-              minHeight: "36px",
-              padding: "0"
+              justifyContent: "center"
             });
             const dot = documentRef.createElement("span");
             setStyles(dot, {

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -16010,7 +16010,7 @@ void main() {
         }
         function syncBrushStatusRow(tool = sceneStore.getDiagnostics().tool) {
           if (!brushStatusRow) return;
-          const diameter = Math.min(22, Math.max(2, brushStyle.size));
+          const diameter = Math.min(22, Math.max(4, brushStyle.size));
           setStyles(brushStatusRow.swatch, {
             display: "inline-block",
             width: `${diameter}px`,
@@ -16076,8 +16076,8 @@ void main() {
           caret.innerHTML = SHAPE_MENU_CARET_SVG;
           setStyles(caret, {
             position: "absolute",
-            right: "2px",
-            bottom: "2px",
+            right: "4px",
+            bottom: "4px",
             lineHeight: "0",
             pointerEvents: "none"
           });
@@ -16472,9 +16472,6 @@ void main() {
             display: "none",
             position: "static",
             width: "100%",
-            maxHeight: "210px",
-            overflowY: "auto",
-            overscrollBehavior: "contain",
             flexDirection: "column",
             gap: "10px",
             marginTop: "6px",
@@ -16513,13 +16510,16 @@ void main() {
               display: "inline-flex",
               alignItems: "center",
               justifyContent: "center",
-              minWidth: "40px",
-              minHeight: "40px"
+              width: "36px",
+              height: "36px",
+              minWidth: "36px",
+              minHeight: "36px",
+              padding: "0"
             });
             const dot = documentRef.createElement("span");
             setStyles(dot, {
-              width: "22px",
-              height: "22px",
+              width: "20px",
+              height: "20px",
               borderRadius: "50%",
               background: color,
               border: color === "#ffffff" ? "1px solid rgba(0, 0, 0, 0.7)" : "none"
@@ -16559,7 +16559,7 @@ void main() {
             input.step = "1";
             input.dataset.fabricPilotSetting = setting;
             input.setAttribute?.("aria-label", label);
-            setStyles(input, { flex: "1 1 auto", minWidth: "0" });
+            setStyles(input, { flex: "1 1 0", minWidth: "0" });
             const increase = createButton("+", increaseAction);
             increase.setAttribute?.("aria-label", increaseLabel);
             const outputElement = documentRef.createElement("span");

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -3613,25 +3613,22 @@ function createFabricOverlayRuntime(options = {}) {
     setStyles(palette, {
       display: 'flex',
       flexWrap: 'wrap',
-      gap: '6px'
+      // 좁은 화면에서 미디어 쿼리가 4px 로 줄이는 변수를 그대로 쓴다.
+      gap: 'var(--fabric-palette-gap)'
     });
     const colorButtons = BRUSH_COLORS.map(color => {
       const button = createButton('', 'brush-color');
       button.dataset.fabricPilotColor = color;
       button.setAttribute?.('aria-label', `브러시 색상 ${BRUSH_COLOR_LABELS[color]}`);
       button.setAttribute?.('aria-pressed', 'false');
-      // 기본 버튼 CSS 의 `padding: 0 12px` 가 22px 점에 더해져 46px 이 되면
-      // 폭 166px 짜리 패널에 한 줄 둘밖에 못 들어가 색 8개가 네 줄을 잡아먹는다.
-      // 패딩을 지우고 36px 정사각으로 고정하면 네 개씩 두 줄에 들어간다.
+      // 치수는 **인라인으로 주지 않는다.** 기본 버튼 CSS 의 `padding: 0 12px` 가
+      // 22px 점에 더해져 46px 이 되면 한 줄에 둘밖에 못 들어가지만, 인라인으로
+      // 36px 을 박으면 이번엔 좁은 화면(≤800px, 팔레트 190px)에서 미디어 쿼리가
+      // 이길 수 없어 3/3/2 로 흘러넘친다. 호스트 CSS 가 두 폭 모두 책임진다.
       setStyles(button, {
         display: 'inline-flex',
         alignItems: 'center',
-        justifyContent: 'center',
-        width: '36px',
-        height: '36px',
-        minWidth: '36px',
-        minHeight: '36px',
-        padding: '0'
+        justifyContent: 'center'
       });
       const dot = documentRef.createElement('span');
       setStyles(dot, {

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -3053,7 +3053,9 @@ function createFabricOverlayRuntime(options = {}) {
 
   function syncBrushStatusRow(tool = sceneStore.getDiagnostics().tool) {
     if (!brushStatusRow) return;
-    const diameter = Math.min(22, Math.max(2, brushStyle.size));
+    // 하한이 2px 이면 문장 앞의 마침표로 읽힌다. 정확한 굵기는 옆의 숫자가 말하므로
+    // 견본은 색을 알아볼 수 있는 최소 크기(4px)를 지킨다.
+    const diameter = Math.min(22, Math.max(4, brushStyle.size));
     setStyles(brushStatusRow.swatch, {
       display: 'inline-block',
       width: `${diameter}px`,
@@ -3123,10 +3125,13 @@ function createFabricOverlayRuntime(options = {}) {
     const caret = documentRef.createElement('span');
     caret.dataset.fabricPilotOutput = 'shape-menu-caret';
     caret.innerHTML = SHAPE_MENU_CARET_SVG;
+    // 버튼 모서리 반경은 8px 이다. 2px 만 들이면 캐럿의 바깥 꼭짓점이 그 호(弧)
+    // **밖**으로 나가(중심에서 √(6²+6²)=8.49 > 8) 버튼에 매달린 티끌처럼 보인다.
+    // 4px 이면 √(4²+4²)=5.66 < 8 이라 확실히 버튼 면 안에 앉는다.
     setStyles(caret, {
       position: 'absolute',
-      right: '2px',
-      bottom: '2px',
+      right: '4px',
+      bottom: '4px',
       lineHeight: '0',
       pointerEvents: 'none'
     });
@@ -3570,13 +3575,15 @@ function createFabricOverlayRuntime(options = {}) {
     panel.setAttribute?.('role', 'group');
     panel.setAttribute?.('aria-label', '브러시 설정');
     // 팔레트 안에 인라인으로 펼쳐진다(더 이상 툴바 아래로 떨어지는 드롭다운이 아니다)
+    // 높이를 210px 로 자르면 안 된다 — 내용이 500px 을 넘어(색·굵기·불투명도·
+    // 외곽선·최근 색) **팔레트 스크롤 안에 또 스크롤**이 생기고, 맨 아래 외곽선
+    // 설정은 안쪽 스크롤을 따로 내려야만 닿는다. 바깥
+    // `.mpv-fabric-pilot-toolbar-content` 가 이미 70vh 에서 스크롤하므로
+    // 여기서는 자르지 않는다 — 스크롤 막대는 하나여야 한다.
     setStyles(panel, {
       display: 'none',
       position: 'static',
       width: '100%',
-      maxHeight: '210px',
-      overflowY: 'auto',
-      overscrollBehavior: 'contain',
       flexDirection: 'column',
       gap: '10px',
       marginTop: '6px',
@@ -3613,17 +3620,23 @@ function createFabricOverlayRuntime(options = {}) {
       button.dataset.fabricPilotColor = color;
       button.setAttribute?.('aria-label', `브러시 색상 ${BRUSH_COLOR_LABELS[color]}`);
       button.setAttribute?.('aria-pressed', 'false');
+      // 기본 버튼 CSS 의 `padding: 0 12px` 가 22px 점에 더해져 46px 이 되면
+      // 폭 166px 짜리 패널에 한 줄 둘밖에 못 들어가 색 8개가 네 줄을 잡아먹는다.
+      // 패딩을 지우고 36px 정사각으로 고정하면 네 개씩 두 줄에 들어간다.
       setStyles(button, {
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
-        minWidth: '40px',
-        minHeight: '40px'
+        width: '36px',
+        height: '36px',
+        minWidth: '36px',
+        minHeight: '36px',
+        padding: '0'
       });
       const dot = documentRef.createElement('span');
       setStyles(dot, {
-        width: '22px',
-        height: '22px',
+        width: '20px',
+        height: '20px',
         borderRadius: '50%',
         background: color,
         border: color === '#ffffff' ? '1px solid rgba(0, 0, 0, 0.7)' : 'none'
@@ -3664,7 +3677,10 @@ function createFabricOverlayRuntime(options = {}) {
       input.step = '1';
       input.dataset.fabricPilotSetting = setting;
       input.setAttribute?.('aria-label', label);
-      setStyles(input, { flex: '1 1 auto', minWidth: '0' });
+      // basis 를 auto 로 두면 range 입력의 기본 폭(크로뮴 기준 129px)이 그대로
+      // 예약돼 폭 166px 짜리 패널에서 줄이 넘치고, −·슬라이더·+ 가 **세 줄로**
+      // 쪼개진다. basis 0 이면 남는 자리만큼만 늘어나 한 줄에 앉는다.
+      setStyles(input, { flex: '1 1 0', minWidth: '0' });
       const increase = createButton('+', increaseAction);
       increase.setAttribute?.('aria-label', increaseLabel);
       const outputElement = documentRef.createElement('span');

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -1573,7 +1573,51 @@ test('오버레이 드로잉 UI는 상단 탭이 아니라 드래그형 팔레�
   assert.doesNotMatch(fabricRuntimeSource, /top: 'calc\(100% \+ 6px\)'/);
   assert.match(
     fabricRuntimeSource,
-    /panel\.dataset\.fabricPilotPanel = 'brush-settings';[\s\S]+position: 'static',\n\s+width: '100%',\n\s+maxHeight: '210px',\n\s+overflowY: 'auto',\n\s+overscrollBehavior: 'contain',/
+    /panel\.dataset\.fabricPilotPanel = 'brush-settings';[\s\S]+position: 'static',\n\s+width: '100%',\n\s+flexDirection: 'column',/
+  );
+  // 패널은 스스로 스크롤하지 않는다 — 잘라 두면 팔레트 스크롤 안에 스크롤이
+  // 또 생겨 맨 아래 외곽선 설정에 닿으려면 안쪽 막대를 따로 내려야 한다.
+  assert.doesNotMatch(fabricRuntimeSource, /maxHeight: '210px'/);
+});
+
+test('팔레트가 붙이는 모든 클래스는 스타일 출처를 갖는다', () => {
+  // 이 라운드에서 UI 가 깨진 근본 원인이다. `mpv-fabric-pilot-brush-status` 와
+  // `-eraser-mode` 는 JS 가 클래스를 붙이지만 **어디에도 CSS 규칙이 없었다.**
+  // 그래서 상태 줄은 display:block·16px 로 떨어져 팔레트에서 가장 큰 글자가 됐고,
+  // 지우개 방식 버튼은 간격 없이 서로 맞붙었다. 런타임 테스트는 클래스 이름만
+  // 확인하므로 이걸 잡지 못한다 — 이름은 제대로 붙어 있었기 때문이다.
+  //
+  // 규칙: 클래스를 붙였으면 호스트 CSS 에 규칙이 있거나, 인라인 setStyles 로
+  // 스스로 배치를 지정해야 한다. 둘 다 아니면 브라우저 기본값에 맡긴 것이고
+  // 그건 의도가 아니라 누락이다.
+  const inlineStyled = new Set([
+    // 아래는 생성 직후 setStyles 로 배치를 직접 지정한다. 새 클래스를 이 목록에
+    // 넣기 전에 정말 인라인으로 배치하는지 코드에서 확인할 것.
+    'mpv-fabric-pilot-outline',
+    'mpv-fabric-pilot-shape-menu',
+    'mpv-fabric-pilot-size-hud',
+    'mpv-fabric-pilot-size-hud-label',
+    'mpv-fabric-pilot-viewport',
+    // 라벨·행 자식이 각자 CSS 를 갖는 단순 세로 래퍼다.
+    'mpv-fabric-pilot-section'
+  ]);
+  const used = new Set();
+  for (const source of [fabricRuntimeSource, fabricPaletteSource]) {
+    for (const match of source.matchAll(/className = '(mpv-fabric-pilot-[a-z-]+)'/g)) {
+      used.add(match[1]);
+    }
+  }
+  assert.ok(used.size >= 8, `팔레트 클래스를 ${used.size}개만 찾았다 — 추출 정규식을 확인할 것`);
+  const unstyled = [...used].filter(name =>
+    !inlineStyled.has(name) &&
+    !overlayHostSource.includes(`.${name} `) &&
+    !overlayHostSource.includes(`.${name},`) &&
+    !overlayHostSource.includes(`.${name} {`)
+  );
+  assert.deepEqual(
+    unstyled,
+    [],
+    `CSS 규칙도 인라인 배치도 없는 클래스: ${unstyled.join(', ')}`
   );
 });
 

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -8388,9 +8388,11 @@ test('responsive toolbar keeps one accessible DOM and a compact persistence badg
   assert.equal(toolbar.dataset.collapsed, 'false');
   assert.equal(panel.style.position, 'static');
   assert.equal(panel.style.width, '100%');
-  assert.equal(panel.style.maxHeight, '210px');
-  assert.equal(panel.style.overflowY, 'auto');
-  assert.equal(panel.style.overscrollBehavior, 'contain');
+  // 브러시 설정 패널은 스스로 스크롤하지 않는다. 바깥 팔레트 본문이 70vh 에서
+  // 스크롤하므로, 여기서 또 자르면 스크롤 막대가 둘이 되고 맨 아래 외곽선
+  // 설정이 안쪽 막대를 내리기 전에는 보이지 않는다.
+  assert.equal(panel.style.maxHeight, undefined);
+  assert.equal(panel.style.overflowY, undefined);
   for (const [action, label] of expectedLabels) {
     const button = findOne(toolbar, node => node.dataset.fabricPilotAction === action);
     assert.ok(button, `expected ${action} toolbar button`);

--- a/scripts/tests/mpv-fabric-overlay-toolbar-layout.test.js
+++ b/scripts/tests/mpv-fabric-overlay-toolbar-layout.test.js
@@ -285,9 +285,50 @@ async function runElectronProbe() {
       })();
     `, true);
 
+    // 브러시 설정 패널은 팔레트 스크롤 **안에 또** 스크롤을 만들면 안 되고,
+    // 슬라이더 줄은 한 줄에 앉아야 한다. 둘 다 눈으로만 보이던 결함이라
+    // 실제 렌더에서 재어야 잡힌다.
+    const panel = await host.window.webContents.executeJavaScript(`
+      (async () => {
+        const settle = () => new Promise(resolve =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        document.querySelector('[data-fabric-pilot-action="brush"]').click();
+        await settle();
+        document.querySelector('[data-fabric-pilot-action="brush-settings"]').click();
+        await settle();
+        const node = document.querySelector('[data-fabric-pilot-panel="brush-settings"]');
+        const style = getComputedStyle(node);
+        const colors = [...document.querySelectorAll('[data-fabric-pilot-color]')];
+        const firstTop = colors[0].getBoundingClientRect().top;
+        const sizeInput = document.querySelector('[data-fabric-pilot-setting="size"]');
+        const sizeRow = sizeInput.parentElement;
+        const controls = [...sizeRow.children].filter(child =>
+          child.tagName === 'BUTTON' || child.tagName === 'INPUT' ||
+          child.dataset.fabricPilotOutput);
+        const inputTop = sizeInput.getBoundingClientRect().top;
+        const status = document.querySelector('.mpv-fabric-pilot-brush-status');
+        const statusStyle = getComputedStyle(status);
+        return {
+          display: style.display,
+          maxHeight: style.maxHeight,
+          overflowY: style.overflowY,
+          scrollHeight: node.scrollHeight,
+          clientHeight: node.clientHeight,
+          colorsPerRow: colors.filter(color =>
+            Math.abs(color.getBoundingClientRect().top - firstTop) < 2).length,
+          controlCount: controls.length,
+          controlsOnInputLine: controls.filter(child =>
+            Math.abs(child.getBoundingClientRect().top - inputTop) < 12).length,
+          statusDisplay: statusStyle.display,
+          statusFontSize: statusStyle.fontSize
+        };
+      })();
+    `, true);
+
     process.stdout.write(`${PROBE_PREFIX}${JSON.stringify({
       measurements,
-      interaction
+      interaction,
+      panel
     })}\n`);
   } finally {
     try {
@@ -435,6 +476,35 @@ if (process.versions.electron) {
       probe.interaction.rootClientWidth,
       'dragging never creates overlay scroll'
     );
+
+    // 브러시 설정 패널 — 눈으로만 보이던 깨짐을 실제 렌더 치수로 못박는다.
+    const panel = probe.panel;
+    assert.equal(panel.display, 'flex', '브러시 설정 패널이 열린다');
+    // 패널이 스스로 잘리면 팔레트 스크롤 안에 스크롤이 또 생기고, 맨 아래
+    // 외곽선 설정은 안쪽 막대를 따로 내려야만 닿는다.
+    assert.equal(panel.maxHeight, 'none', '패널은 높이를 자르지 않는다');
+    assert.ok(
+      panel.overflowY !== 'auto' && panel.overflowY !== 'scroll',
+      `패널이 스스로 스크롤한다: overflowY=${panel.overflowY}`
+    );
+    assert.ok(
+      panel.scrollHeight <= panel.clientHeight + 1,
+      `패널 안에 스크롤이 생겼다: ${panel.scrollHeight} > ${panel.clientHeight}`
+    );
+    // 색 버튼이 패딩 때문에 46px 이 되면 한 줄에 둘밖에 못 들어가 네 줄을 잡아먹는다.
+    assert.ok(
+      panel.colorsPerRow >= 4,
+      `색 견본이 한 줄에 ${panel.colorsPerRow}개뿐이다`
+    );
+    // −·슬라이더·+·수치는 한 줄이다. range 입력의 기본 폭을 basis 로 두면 세 줄로 쪼개진다.
+    assert.equal(
+      panel.controlsOnInputLine,
+      panel.controlCount,
+      `크기 조절 줄이 ${panel.controlCount}개 중 ${panel.controlsOnInputLine}개만 같은 줄에 있다`
+    );
+    // 상태 줄에 CSS 규칙이 없으면 display:block·16px 로 떨어져 팔레트에서 가장 큰 글자가 된다.
+    assert.equal(panel.statusDisplay, 'flex', '상태 줄은 가로 배치다');
+    assert.equal(panel.statusFontSize, '11px', '상태 줄은 보조 글자 크기다');
   });
 
   test('hidden Chromium layout probe exits non-zero when its setup fails', {

--- a/scripts/tests/mpv-fabric-overlay-toolbar-layout.test.js
+++ b/scripts/tests/mpv-fabric-overlay-toolbar-layout.test.js
@@ -288,14 +288,30 @@ async function runElectronProbe() {
     // 브러시 설정 패널은 팔레트 스크롤 **안에 또** 스크롤을 만들면 안 되고,
     // 슬라이더 줄은 한 줄에 앉아야 한다. 둘 다 눈으로만 보이던 결함이라
     // 실제 렌더에서 재어야 잡힌다.
-    const panel = await host.window.webContents.executeJavaScript(`
+    // 좁은 폭(≤800px, 팔레트 190px)과 넓은 폭(팔레트 220px)을 **둘 다** 잰다.
+    // 801px 에서만 재면 미디어 쿼리가 바꾸는 치수를 통째로 놓친다.
+    const panels = {};
+    for (const [key, width] of [['narrow', 800], ['wide', 801]]) {
+      host.updateBounds({ x: 0, y: 0, width, height: 720 });
+      await host.window.webContents.executeJavaScript(`
+        new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      `, true);
+      panels[key] = await measurePanel();
+    }
+
+    async function measurePanel() {
+      return host.window.webContents.executeJavaScript(`
       (async () => {
         const settle = () => new Promise(resolve =>
           requestAnimationFrame(() => requestAnimationFrame(resolve)));
         document.querySelector('[data-fabric-pilot-action="brush"]').click();
         await settle();
-        document.querySelector('[data-fabric-pilot-action="brush-settings"]').click();
-        await settle();
+        const settingsButton = document.querySelector('[data-fabric-pilot-action="brush-settings"]');
+        // 두 폭을 연달아 재므로 이미 열려 있으면 다시 누르지 않는다.
+        if (settingsButton.getAttribute('aria-expanded') !== 'true') {
+          settingsButton.click();
+          await settle();
+        }
         const node = document.querySelector('[data-fabric-pilot-panel="brush-settings"]');
         const style = getComputedStyle(node);
         const colors = [...document.querySelectorAll('[data-fabric-pilot-color]')];
@@ -324,11 +340,12 @@ async function runElectronProbe() {
         };
       })();
     `, true);
+    }
 
     process.stdout.write(`${PROBE_PREFIX}${JSON.stringify({
       measurements,
       interaction,
-      panel
+      panels
     })}\n`);
   } finally {
     try {
@@ -478,33 +495,36 @@ if (process.versions.electron) {
     );
 
     // 브러시 설정 패널 — 눈으로만 보이던 깨짐을 실제 렌더 치수로 못박는다.
-    const panel = probe.panel;
-    assert.equal(panel.display, 'flex', '브러시 설정 패널이 열린다');
-    // 패널이 스스로 잘리면 팔레트 스크롤 안에 스크롤이 또 생기고, 맨 아래
-    // 외곽선 설정은 안쪽 막대를 따로 내려야만 닿는다.
-    assert.equal(panel.maxHeight, 'none', '패널은 높이를 자르지 않는다');
-    assert.ok(
-      panel.overflowY !== 'auto' && panel.overflowY !== 'scroll',
-      `패널이 스스로 스크롤한다: overflowY=${panel.overflowY}`
-    );
-    assert.ok(
-      panel.scrollHeight <= panel.clientHeight + 1,
-      `패널 안에 스크롤이 생겼다: ${panel.scrollHeight} > ${panel.clientHeight}`
-    );
-    // 색 버튼이 패딩 때문에 46px 이 되면 한 줄에 둘밖에 못 들어가 네 줄을 잡아먹는다.
-    assert.ok(
-      panel.colorsPerRow >= 4,
-      `색 견본이 한 줄에 ${panel.colorsPerRow}개뿐이다`
-    );
-    // −·슬라이더·+·수치는 한 줄이다. range 입력의 기본 폭을 basis 로 두면 세 줄로 쪼개진다.
-    assert.equal(
-      panel.controlsOnInputLine,
-      panel.controlCount,
-      `크기 조절 줄이 ${panel.controlCount}개 중 ${panel.controlsOnInputLine}개만 같은 줄에 있다`
-    );
-    // 상태 줄에 CSS 규칙이 없으면 display:block·16px 로 떨어져 팔레트에서 가장 큰 글자가 된다.
-    assert.equal(panel.statusDisplay, 'flex', '상태 줄은 가로 배치다');
-    assert.equal(panel.statusFontSize, '11px', '상태 줄은 보조 글자 크기다');
+    // 좁은 폭(≤800px)과 넓은 폭을 둘 다 본다. 미디어 쿼리가 팔레트를 190px 로
+    // 줄이면 패널 안쪽도 함께 좁아져, 한쪽만 재면 다른 쪽 깨짐을 놓친다.
+    for (const [key, panel] of Object.entries(probe.panels)) {
+      assert.equal(panel.display, 'flex', `${key}: 브러시 설정 패널이 열린다`);
+      // 패널이 스스로 잘리면 팔레트 스크롤 안에 스크롤이 또 생기고, 맨 아래
+      // 외곽선 설정은 안쪽 막대를 따로 내려야만 닿는다.
+      assert.equal(panel.maxHeight, 'none', `${key}: 패널은 높이를 자르지 않는다`);
+      assert.ok(
+        panel.overflowY !== 'auto' && panel.overflowY !== 'scroll',
+        `${key}: 패널이 스스로 스크롤한다 overflowY=${panel.overflowY}`
+      );
+      assert.ok(
+        panel.scrollHeight <= panel.clientHeight + 1,
+        `${key}: 패널 안에 스크롤이 생겼다 ${panel.scrollHeight} > ${panel.clientHeight}`
+      );
+      // 색 버튼이 패딩 때문에 46px 이 되면 한 줄에 둘밖에 못 들어가 네 줄을 잡아먹는다.
+      assert.ok(
+        panel.colorsPerRow >= 4,
+        `${key}: 색 견본이 한 줄에 ${panel.colorsPerRow}개뿐이다`
+      );
+      // −·슬라이더·+·수치는 한 줄이다. range 입력의 기본 폭을 basis 로 두면 세 줄로 쪼개진다.
+      assert.equal(
+        panel.controlsOnInputLine,
+        panel.controlCount,
+        `${key}: 크기 조절 줄이 ${panel.controlCount}개 중 ${panel.controlsOnInputLine}개만 같은 줄에 있다`
+      );
+      // 상태 줄에 CSS 규칙이 없으면 display:block·16px 로 떨어져 팔레트에서 가장 큰 글자가 된다.
+      assert.equal(panel.statusDisplay, 'flex', `${key}: 상태 줄은 가로 배치다`);
+      assert.equal(panel.statusFontSize, '11px', `${key}: 상태 줄은 보조 글자 크기다`);
+    }
   });
 
   test('hidden Chromium layout probe exits non-zero when its setup fails', {

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -249,7 +249,7 @@ test('stable engine promotion uses the 2.3.0 beta release version consistently',
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.6.0-beta');
-  assert.equal(packageLock.version, '2.6.0-beta');
-  assert.equal(packageLock.packages[''].version, '2.6.0-beta');
+  assert.equal(packageJson.version, '2.6.1-beta');
+  assert.equal(packageLock.version, '2.6.1-beta');
+  assert.equal(packageLock.packages[''].version, '2.6.1-beta');
 });


### PR DESCRIPTION
사용자 보고: "유아이가 좀 깨져". Electron 실기 프로브로 재현해 원인 5건을 확정했습니다.

## 근본 원인은 하나

**JS 가 클래스를 붙이는데 CSS 규칙이 어디에도 없어 브라우저 기본값으로 떨어졌습니다.**
클래스 이름은 제대로 붙어 있으므로 기존 런타임 테스트는 이걸 잡을 수 없었습니다.

## 고친 것

| # | 증상 | 원인 |
|---|---|---|
| 1 | 상태 줄이 팔레트에서 가장 큰 글자, 3px 견본이 마침표로 읽힘 | `.mpv-fabric-pilot-brush-status` CSS 규칙 없음 → `display:block` · `16px` |
| 2 | 픽셀·획 버튼이 간격 없이 맞붙음 | `.mpv-fabric-pilot-eraser-mode` CSS 규칙 없음 |
| 3 | 팔레트 스크롤 **안에 또** 스크롤, 외곽선 설정에 닿을 수 없음 | 패널을 210px 로 자르는데 내용은 531px |
| 4 | 색 견본 8개가 네 줄을 먹음 | 기본 버튼 패딩 `0 12px` 이 더해져 버튼이 46px |
| 5 | 크기·불투명도 슬라이더 줄이 **세 줄로 쪼개짐** | range 입력의 `flex-basis: auto` 가 크로뮴 기본 폭 129px 을 예약 |

3·5 는 210px 컷 아래 가려져 있던 기존 결함이고, 컷을 걷어 내며 드러났습니다.
패널 높이 **531px → 303px**.

캐럿: 도형 버튼 드롭다운 캐럿이 2px 만 들여 있어 바깥 꼭짓점이 모서리 반경 8px 호
**밖**으로 나갔습니다(중심에서 √72≈8.49 > 8). 4px 로 들이면 √32≈5.66 < 8 이라
버튼 면 안에 앉습니다.

## 회귀 테스트 — 전부 되돌려 실패하는 것을 확인

- **Electron 레이아웃 프로브에 패널 실측 단언 추가**: 높이 컷 없음 · 안쪽 스크롤 없음 ·
  색 4개/줄 · 슬라이더 줄 한 줄 · 상태 줄 flex 11px. 네 건 각각 개별 되돌림으로 검증.
- **소스 가드 신설**: 팔레트가 붙이는 모든 클래스는 호스트 CSS 규칙이 있거나 인라인
  `setStyles` 로 배치를 지정해야 한다. 되돌리면 깨졌던 클래스 3개를 정확히 지목합니다.

25개 스위트 **2,283 pass / 0 fail**, Electron 레이아웃 2 pass. 버전 2.6.1-beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
