### PR TITLE
fix: 오버레이 스크롤바를 배프레임 테마에 맞춘다

### DIFF
--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -383,6 +383,27 @@ const OVERLAY_HTML = String.raw`
       overflow: hidden;
       pointer-events: none;
     }
+    /* 오버레이는 별도 BrowserWindow 라 renderer/styles/main.css 를 불러오지 않는다.
+       그대로 두면 윈도우 기본 스크롤바(밝은 회색 화살표 막대)가 그려져 어두운
+       팔레트 위에 홀로 튄다. 본체와 **같은 값**으로 다시 적어 테마를 맞춘다
+       (main.css 의 Scrollbar 절과 대조). */
+    ::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
+    }
+    ::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    ::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 4px;
+    }
+    ::-webkit-scrollbar-thumb:hover {
+      background: rgba(255, 255, 255, 0.18);
+    }
+    ::-webkit-scrollbar-corner {
+      background: transparent;
+    }
     .mpv-fabric-pilot-toolbar {
       display: block;
       --fabric-palette-gap: 6px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.6.1-beta",
+  "version": "2.6.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.6.1-beta",
+      "version": "2.6.2-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.6.1-beta",
+  "version": "2.6.2-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -1580,6 +1580,34 @@ test('오버레이 드로잉 UI는 상단 탭이 아니라 드래그형 팔레�
   assert.doesNotMatch(fabricRuntimeSource, /maxHeight: '210px'/);
 });
 
+test('오버레이 스크롤바는 본체 테마와 같은 값을 쓴다', () => {
+  // 오버레이는 별도 BrowserWindow 라 renderer/styles/main.css 를 불러오지 않는다.
+  // 스크롤바를 안 적으면 윈도우 기본 막대(밝은 회색 + 화살표 버튼)가 그려져
+  // 어두운 팔레트 위에 홀로 튄다.
+  //
+  // 값을 손으로 베껴 둔 것이므로 본체 테마가 바뀌면 소리 없이 어긋난다.
+  // 그래서 main.css 에서 **실제 값을 뽑아** 대조한다.
+  // 선택자를 **줄 처음**에 앵커한다. 그러지 않으면 `.playback-controls-scroll::`
+  // 같은 한정 규칙이 먼저 잡혀 엉뚱한 값과 대조하게 된다.
+  const thumb = /^[ \t]*::-webkit-scrollbar-thumb \{\s*background: (rgba\([^)]+\));\s*border-radius: (\d+px);/m;
+  const mainThumb = mainCss.match(thumb);
+  assert.ok(mainThumb, 'main.css 에서 스크롤바 thumb 규칙을 찾지 못했다');
+  const overlayThumb = overlayHostSource.match(thumb);
+  assert.ok(overlayThumb, '오버레이에 스크롤바 thumb 규칙이 없다 — 윈도우 기본 막대가 나온다');
+  assert.equal(overlayThumb[1], mainThumb[1], '스크롤바 thumb 색이 본체와 다르다');
+  assert.equal(overlayThumb[2], mainThumb[2], '스크롤바 thumb 모서리가 본체와 다르다');
+
+  const width = /^[ \t]*::-webkit-scrollbar \{\s*width: (\d+px);\s*height: (\d+px);/m;
+  const mainWidth = mainCss.match(width);
+  const overlayWidth = overlayHostSource.match(width);
+  assert.ok(overlayWidth, '오버레이에 스크롤바 폭 규칙이 없다');
+  assert.equal(overlayWidth[1], mainWidth[1], '스크롤바 폭이 본체와 다르다');
+  assert.equal(overlayWidth[2], mainWidth[2], '스크롤바 높이가 본체와 다르다');
+
+  // 트랙은 비워 둬야 팔레트 배경이 그대로 비친다.
+  assert.match(overlayHostSource, /^[ \t]*::-webkit-scrollbar-track \{\s*background: transparent;/m);
+});
+
 test('팔레트가 붙이는 모든 클래스는 스타일 출처를 갖는다', () => {
   // 이 라운드에서 UI 가 깨진 근본 원인이다. `mpv-fabric-pilot-brush-status` 와
   // `-eraser-mode` 는 JS 가 클래스를 붙이지만 **어디에도 CSS 규칙이 없었다.**

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -249,7 +249,7 @@ test('stable engine promotion uses the 2.3.0 beta release version consistently',
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.6.1-beta');
-  assert.equal(packageLock.version, '2.6.1-beta');
-  assert.equal(packageLock.packages[''].version, '2.6.1-beta');
+  assert.equal(packageJson.version, '2.6.2-beta');
+  assert.equal(packageLock.version, '2.6.2-beta');
+  assert.equal(packageLock.packages[''].version, '2.6.2-beta');
 });


### PR DESCRIPTION
사용자 보고: 브러시 설정을 열면 팔레트에 **윈도우 기본 스크롤바**(밝은 회색 막대 +
위아래 화살표 버튼)가 그려져 어두운 팔레트 위에 홀로 튑니다.

## 원인

오버레이는 **별도 BrowserWindow** 라 `renderer/styles/main.css` 를 불러오지 않습니다.
본체에는 테마 스크롤바가 있지만(main.css 의 `Scrollbar` 절) 오버레이 스타일시트에는
아무 규칙도 없어 크로뮴이 OS 기본 막대를 그렸습니다.

## 조치

본체와 **같은 값**을 오버레이 스타일시트에 적었습니다 — 폭 8px, 트랙 투명,
thumb `rgba(255,255,255,0.1)` 반경 4px, hover 0.18, corner 투명.
규칙을 하나라도 적으면 크로뮴이 커스텀 렌더로 넘어가 화살표 버튼도 함께 사라집니다.

## 회귀 테스트

값을 손으로 베낀 것이라 본체 테마가 바뀌면 소리 없이 어긋납니다. 그래서
**main.css 에서 실제 값을 뽑아 대조**합니다(폭·thumb 색·모서리 반경).

선택자는 **줄 처음에 앵커**했습니다 — 안 그러면 `.playback-controls-scroll::` 같은
한정 규칙이 먼저 잡혀 엉뚱한 값(0.18/999px)과 대조하게 됩니다. 실제로 처음 쓴
정규식이 그렇게 잡혀서 고쳤습니다.

되돌려 실패 확인: 규칙을 지우면 `오버레이에 스크롤바 thumb 규칙이 없다 — 윈도우
기본 막대가 나온다` 로 실패합니다.

25개 스위트 **2,284 pass / 0 fail**(버전 올린 뒤 재실행), Electron 레이아웃 2 pass.
버전 2.6.2-beta — `package.json`·`package-lock.json`·`runtime-profile.test.js` 동시 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)