### PR TITLE
fix: 크기·불투명도 줄을 목업의 필드 구성으로

### DIFF
--- a/main/mpv-overlay-host.js
+++ b/main/mpv-overlay-host.js
@@ -361,6 +361,8 @@ const OVERLAY_HTML = String.raw`
       --border-subtle: rgba(255, 255, 255, 0.16);
       --text-primary: #f5f5f5;
       --text-tertiary: rgba(255, 255, 255, 0.55);
+      --text-faint: rgba(255, 255, 255, 0.34);
+      --track-idle: rgba(255, 255, 255, 0.14);
       --success: #2ed573;
       --error: #ff5555;
       --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.38);
@@ -536,6 +538,71 @@ const OVERLAY_HTML = String.raw`
       min-width: 36px;
       min-height: 36px;
       padding: 0;
+    }
+    /* 목업(§0.3 시안)의 field 구성 — 라벨과 수치를 한 줄에, 그 아래 3px 트랙.
+       버튼이 없으므로 트랙이 이 줄에서 가장 큰 요소가 된다. */
+    .mpv-fabric-pilot-field {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+    }
+    .mpv-fabric-pilot-field-top {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 8px;
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: 0.11em;
+      text-transform: uppercase;
+      color: var(--text-faint);
+    }
+    .mpv-fabric-pilot-field-top b {
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0;
+      text-transform: none;
+      font-variant-numeric: tabular-nums;
+      color: var(--text-primary);
+    }
+    /* range 입력을 목업의 트랙 모양으로 다시 그린다. 기본 렌더는 OS 위젯이라
+       팔레트와 따로 논다(스크롤바와 같은 이유). */
+    .mpv-fabric-pilot-toolbar input[type="range"] {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 100%;
+      /* 9px 손잡이가 잘리지 않을 만큼만. 더 키우면 필드 사이가 벌어진다. */
+      height: 9px;
+      margin: 0;
+      padding: 0;
+      background: transparent;
+      cursor: pointer;
+    }
+    .mpv-fabric-pilot-toolbar input[type="range"]::-webkit-slider-runnable-track {
+      height: 3px;
+      border-radius: 2px;
+      /* 채운 부분과 남은 부분의 경계는 런타임이 --fabric-range-fill 로 넘긴다.
+         range 입력은 기본으로 채움을 그리지 않는다. */
+      background: linear-gradient(
+        to right,
+        var(--text-tertiary) 0 var(--fabric-range-fill, 0%),
+        var(--track-idle) var(--fabric-range-fill, 0%) 100%
+      );
+    }
+    .mpv-fabric-pilot-toolbar input[type="range"]::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: var(--text-primary);
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+      /* 트랙 3px 한가운데에 9px 손잡이를 앉힌다: (3 - 9) / 2 */
+      margin-top: -3px;
+    }
+    .mpv-fabric-pilot-toolbar input[type="range"]:focus-visible {
+      outline: 2px solid var(--accent-secondary);
+      outline-offset: 2px;
     }
     .mpv-fabric-pilot-brush-status {
       display: flex;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baeframe",
-  "version": "2.6.2-beta",
+  "version": "2.6.3-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baeframe",
-      "version": "2.6.2-beta",
+      "version": "2.6.3-beta",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baeframe",
-  "version": "2.6.2-beta",
+  "version": "2.6.3-beta",
   "description": "애니메이션 스튜디오를 위한 비디오 리뷰/피드백 도구",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/scripts/lib/mpv-fabric-overlay.iife.js
+++ b/renderer/scripts/lib/mpv-fabric-overlay.iife.js
@@ -16411,6 +16411,7 @@ void main() {
           brushControls.opacityInput.value = String(opacityPercent);
           brushControls.sizeOutput.textContent = `${brushStyle.size}px`;
           brushControls.opacityOutput.textContent = `${opacityPercent}%`;
+          brushControls.syncFill();
           brushControls.summary.textContent = `${brushStyle.size}px \xB7 ${opacityPercent}%`;
           brushControls.colorPreview.style.background = brushStyle.color;
           brushControls.sizePreview.style.width = `${Math.min(22, Math.max(2, brushStyle.size))}px`;
@@ -16425,6 +16426,7 @@ void main() {
             setStyles(outlineControls.widthRow.row, { display: detailDisplay });
             outlineControls.widthRow.input.value = String(outlineStyle.width);
             outlineControls.widthRow.output.textContent = `${outlineStyle.width}px`;
+            outlineControls.syncFill();
             for (const button of outlineControls.colorButtons) {
               const active = button.dataset.fabricPilotOutlineColor === outlineStyle.color;
               button.setAttribute?.("aria-pressed", String(active));
@@ -16524,29 +16526,20 @@ void main() {
             palette.appendChild(button);
             return button;
           });
-          const createRangeRow = ({
-            label,
-            setting,
-            min,
-            max,
-            decreaseAction,
-            decreaseLabel,
-            increaseAction,
-            increaseLabel,
-            output
-          }) => {
+          const createRangeRow = ({ label, setting, min, max, output }) => {
             const row = documentRef.createElement("div");
-            setStyles(row, {
-              display: "flex",
-              flexFlow: "row wrap",
-              alignItems: "center",
-              gap: "6px"
-            });
+            row.className = "mpv-fabric-pilot-field";
+            const top = documentRef.createElement("div");
+            top.className = "mpv-fabric-pilot-field-top";
             const labelElement = documentRef.createElement("span");
             labelElement.textContent = label;
-            setStyles(labelElement, { flex: "1 1 100%", fontSize: "11px" });
-            const decrease = createButton("\u2212", decreaseAction);
-            decrease.setAttribute?.("aria-label", decreaseLabel);
+            const outputElement = documentRef.createElement("b");
+            outputElement.dataset.fabricPilotOutput = output;
+            outputElement.setAttribute?.("role", "status");
+            outputElement.setAttribute?.("aria-live", "polite");
+            outputElement.setAttribute?.("aria-atomic", "true");
+            top.appendChild(labelElement);
+            top.appendChild(outputElement);
             const input = documentRef.createElement("input");
             input.type = "range";
             input.tabIndex = -1;
@@ -16555,42 +16548,28 @@ void main() {
             input.step = "1";
             input.dataset.fabricPilotSetting = setting;
             input.setAttribute?.("aria-label", label);
-            setStyles(input, { flex: "1 1 0", minWidth: "0" });
-            const increase = createButton("+", increaseAction);
-            increase.setAttribute?.("aria-label", increaseLabel);
-            const outputElement = documentRef.createElement("span");
-            outputElement.dataset.fabricPilotOutput = output;
-            outputElement.setAttribute?.("role", "status");
-            outputElement.setAttribute?.("aria-live", "polite");
-            outputElement.setAttribute?.("aria-atomic", "true");
-            setStyles(outputElement, { minWidth: "42px", textAlign: "right" });
-            row.appendChild(labelElement);
-            row.appendChild(decrease);
+            row.appendChild(top);
             row.appendChild(input);
-            row.appendChild(increase);
-            row.appendChild(outputElement);
-            return { row, decrease, input, increase, output: outputElement };
+            return { row, input, output: outputElement };
+          };
+          const syncRangeFill = (input, min, max) => {
+            const span = Number(max) - Number(min);
+            const ratio = span > 0 ? (Number(input.value) - Number(min)) / span : 0;
+            const percent = Math.max(0, Math.min(1, ratio)) * 100;
+            input.style.setProperty("--fabric-range-fill", `${percent}%`);
           };
           const sizeRow = createRangeRow({
-            label: "\uBE0C\uB7EC\uC2DC \uD06C\uAE30",
+            label: "\uD06C\uAE30",
             setting: "size",
             min: MIN_BRUSH_SIZE,
             max: MAX_BRUSH_SIZE,
-            decreaseAction: "size-decrease",
-            decreaseLabel: "\uBE0C\uB7EC\uC2DC \uD06C\uAE30 1px \uC904\uC774\uAE30",
-            increaseAction: "size-increase",
-            increaseLabel: "\uBE0C\uB7EC\uC2DC \uD06C\uAE30 1px \uB298\uB9AC\uAE30",
             output: "size"
           });
           const opacityRow = createRangeRow({
-            label: "\uBE0C\uB7EC\uC2DC \uBD88\uD22C\uBA85\uB3C4",
+            label: "\uBD88\uD22C\uBA85\uB3C4",
             setting: "opacity",
             min: MIN_BRUSH_OPACITY_PERCENT,
             max: MAX_BRUSH_OPACITY_PERCENT,
-            decreaseAction: "opacity-decrease",
-            decreaseLabel: "\uBE0C\uB7EC\uC2DC \uBD88\uD22C\uBA85\uB3C4 1% \uC904\uC774\uAE30",
-            increaseAction: "opacity-increase",
-            increaseLabel: "\uBE0C\uB7EC\uC2DC \uBD88\uD22C\uBA85\uB3C4 1% \uB298\uB9AC\uAE30",
             output: "opacity"
           });
           const outlineGroup = documentRef.createElement("div");
@@ -16625,14 +16604,10 @@ void main() {
           });
           outlineGroup.appendChild(outlinePalette);
           const outlineWidthRow = createRangeRow({
-            label: "\uC678\uACFD\uC120 \uAD75\uAE30",
+            label: "\uAD75\uAE30",
             setting: "outline-width",
             min: MIN_OUTLINE_WIDTH,
             max: MAX_OUTLINE_WIDTH,
-            decreaseAction: "outline-width-decrease",
-            decreaseLabel: "\uC678\uACFD\uC120 \uAD75\uAE30 1px \uC904\uC774\uAE30",
-            increaseAction: "outline-width-increase",
-            increaseLabel: "\uC678\uACFD\uC120 \uAD75\uAE30 1px \uB298\uB9AC\uAE30",
             output: "outline-width"
           });
           setStyles(outlineWidthRow.row, { flex: "1 1 100%" });
@@ -16650,14 +16625,6 @@ void main() {
           });
           addDomListener(sizeRow.input, "input", () => setBrushSize(sizeRow.input.value));
           addDomListener(opacityRow.input, "input", () => setBrushOpacityPercent(opacityRow.input.value));
-          addDomListener(sizeRow.decrease, "click", () => setBrushSize(brushStyle.size - 1));
-          addDomListener(sizeRow.increase, "click", () => setBrushSize(brushStyle.size + 1));
-          addDomListener(opacityRow.decrease, "click", () => {
-            setBrushOpacityPercent(Math.round(brushStyle.opacity * 100) - 1);
-          });
-          addDomListener(opacityRow.increase, "click", () => {
-            setBrushOpacityPercent(Math.round(brushStyle.opacity * 100) + 1);
-          });
           for (const button of colorButtons) {
             addDomListener(button, "click", () => setBrushColor(button.dataset.fabricPilotColor));
           }
@@ -16666,8 +16633,6 @@ void main() {
             addDomListener(button, "click", () => setOutlineColor(button.dataset.fabricPilotOutlineColor));
           }
           addDomListener(outlineWidthRow.input, "input", () => setOutlineWidth(outlineWidthRow.input.value));
-          addDomListener(outlineWidthRow.decrease, "click", () => setOutlineWidth(outlineStyle.width - 1));
-          addDomListener(outlineWidthRow.increase, "click", () => setOutlineWidth(outlineStyle.width + 1));
           return {
             settingsButton,
             panel,
@@ -16676,6 +16641,14 @@ void main() {
             opacityInput: opacityRow.input,
             sizeOutput: sizeRow.output,
             opacityOutput: opacityRow.output,
+            syncFill: () => {
+              syncRangeFill(sizeRow.input, MIN_BRUSH_SIZE, MAX_BRUSH_SIZE);
+              syncRangeFill(
+                opacityRow.input,
+                MIN_BRUSH_OPACITY_PERCENT,
+                MAX_BRUSH_OPACITY_PERCENT
+              );
+            },
             summary,
             colorPreview,
             sizePreview,
@@ -16685,7 +16658,12 @@ void main() {
               toggle: outlineToggle,
               palette: outlinePalette,
               colorButtons: outlineColorButtons,
-              widthRow: outlineWidthRow
+              widthRow: outlineWidthRow,
+              syncFill: () => syncRangeFill(
+                outlineWidthRow.input,
+                MIN_OUTLINE_WIDTH,
+                MAX_OUTLINE_WIDTH
+              )
             }
           };
         }

--- a/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
+++ b/renderer/scripts/modules/mpv-fabric-overlay-runtime.js
@@ -3509,6 +3509,7 @@ function createFabricOverlayRuntime(options = {}) {
     brushControls.opacityInput.value = String(opacityPercent);
     brushControls.sizeOutput.textContent = `${brushStyle.size}px`;
     brushControls.opacityOutput.textContent = `${opacityPercent}%`;
+    brushControls.syncFill();
     brushControls.summary.textContent = `${brushStyle.size}px · ${opacityPercent}%`;
     brushControls.colorPreview.style.background = brushStyle.color;
     brushControls.sizePreview.style.width = `${Math.min(22, Math.max(2, brushStyle.size))}px`;
@@ -3524,6 +3525,7 @@ function createFabricOverlayRuntime(options = {}) {
       setStyles(outlineControls.widthRow.row, { display: detailDisplay });
       outlineControls.widthRow.input.value = String(outlineStyle.width);
       outlineControls.widthRow.output.textContent = `${outlineStyle.width}px`;
+      outlineControls.syncFill();
       for (const button of outlineControls.colorButtons) {
         const active = button.dataset.fabricPilotOutlineColor === outlineStyle.color;
         button.setAttribute?.('aria-pressed', String(active));
@@ -3643,29 +3645,26 @@ function createFabricOverlayRuntime(options = {}) {
       return button;
     });
 
-    const createRangeRow = ({
-      label,
-      setting,
-      min,
-      max,
-      decreaseAction,
-      decreaseLabel,
-      increaseAction,
-      increaseLabel,
-      output
-    }) => {
+    // 목업(§0.3 시안)의 `.field` 구성이다 — **라벨과 수치를 한 줄에 두고 그 아래
+    // 3px 트랙**. 목업에는 −/+ 버튼이 없다. 40px 짜리 버튼 두 개가 트랙 양옆에
+    // 붙어 있으면 정작 조절하는 트랙보다 버튼이 커 보인다.
+    //
+    // ±1 정밀 조절은 `[` / `]` 단축키와 Alt 드래그가 맡는다. range 입력 자체도
+    // step=1 이라 클릭하면 정수 값으로 바로 간다.
+    const createRangeRow = ({ label, setting, min, max, output }) => {
       const row = documentRef.createElement('div');
-      setStyles(row, {
-        display: 'flex',
-        flexFlow: 'row wrap',
-        alignItems: 'center',
-        gap: '6px'
-      });
+      row.className = 'mpv-fabric-pilot-field';
+      const top = documentRef.createElement('div');
+      top.className = 'mpv-fabric-pilot-field-top';
       const labelElement = documentRef.createElement('span');
       labelElement.textContent = label;
-      setStyles(labelElement, { flex: '1 1 100%', fontSize: '11px' });
-      const decrease = createButton('−', decreaseAction);
-      decrease.setAttribute?.('aria-label', decreaseLabel);
+      const outputElement = documentRef.createElement('b');
+      outputElement.dataset.fabricPilotOutput = output;
+      outputElement.setAttribute?.('role', 'status');
+      outputElement.setAttribute?.('aria-live', 'polite');
+      outputElement.setAttribute?.('aria-atomic', 'true');
+      top.appendChild(labelElement);
+      top.appendChild(outputElement);
       const input = documentRef.createElement('input');
       input.type = 'range';
       input.tabIndex = -1;
@@ -3674,46 +3673,32 @@ function createFabricOverlayRuntime(options = {}) {
       input.step = '1';
       input.dataset.fabricPilotSetting = setting;
       input.setAttribute?.('aria-label', label);
-      // basis 를 auto 로 두면 range 입력의 기본 폭(크로뮴 기준 129px)이 그대로
-      // 예약돼 폭 166px 짜리 패널에서 줄이 넘치고, −·슬라이더·+ 가 **세 줄로**
-      // 쪼개진다. basis 0 이면 남는 자리만큼만 늘어나 한 줄에 앉는다.
-      setStyles(input, { flex: '1 1 0', minWidth: '0' });
-      const increase = createButton('+', increaseAction);
-      increase.setAttribute?.('aria-label', increaseLabel);
-      const outputElement = documentRef.createElement('span');
-      outputElement.dataset.fabricPilotOutput = output;
-      outputElement.setAttribute?.('role', 'status');
-      outputElement.setAttribute?.('aria-live', 'polite');
-      outputElement.setAttribute?.('aria-atomic', 'true');
-      setStyles(outputElement, { minWidth: '42px', textAlign: 'right' });
-      row.appendChild(labelElement);
-      row.appendChild(decrease);
+      row.appendChild(top);
       row.appendChild(input);
-      row.appendChild(increase);
-      row.appendChild(outputElement);
-      return { row, decrease, input, increase, output: outputElement };
+      return { row, input, output: outputElement };
+    };
+
+    // 트랙의 채워진 부분. range 입력은 기본으로 채움을 그리지 않으므로 값에 맞춘
+    // 그러데이션 경계를 사용자 정의 속성으로 넘긴다(호스트 CSS 가 읽는다).
+    const syncRangeFill = (input, min, max) => {
+      const span = Number(max) - Number(min);
+      const ratio = span > 0 ? (Number(input.value) - Number(min)) / span : 0;
+      const percent = Math.max(0, Math.min(1, ratio)) * 100;
+      input.style.setProperty('--fabric-range-fill', `${percent}%`);
     };
 
     const sizeRow = createRangeRow({
-      label: '브러시 크기',
+      label: '크기',
       setting: 'size',
       min: MIN_BRUSH_SIZE,
       max: MAX_BRUSH_SIZE,
-      decreaseAction: 'size-decrease',
-      decreaseLabel: '브러시 크기 1px 줄이기',
-      increaseAction: 'size-increase',
-      increaseLabel: '브러시 크기 1px 늘리기',
       output: 'size'
     });
     const opacityRow = createRangeRow({
-      label: '브러시 불투명도',
+      label: '불투명도',
       setting: 'opacity',
       min: MIN_BRUSH_OPACITY_PERCENT,
       max: MAX_BRUSH_OPACITY_PERCENT,
-      decreaseAction: 'opacity-decrease',
-      decreaseLabel: '브러시 불투명도 1% 줄이기',
-      increaseAction: 'opacity-increase',
-      increaseLabel: '브러시 불투명도 1% 늘리기',
       output: 'opacity'
     });
 
@@ -3752,14 +3737,10 @@ function createFabricOverlayRuntime(options = {}) {
     outlineGroup.appendChild(outlinePalette);
 
     const outlineWidthRow = createRangeRow({
-      label: '외곽선 굵기',
+      label: '굵기',
       setting: 'outline-width',
       min: MIN_OUTLINE_WIDTH,
       max: MAX_OUTLINE_WIDTH,
-      decreaseAction: 'outline-width-decrease',
-      decreaseLabel: '외곽선 굵기 1px 줄이기',
-      increaseAction: 'outline-width-increase',
-      increaseLabel: '외곽선 굵기 1px 늘리기',
       output: 'outline-width'
     });
     setStyles(outlineWidthRow.row, { flex: '1 1 100%' });
@@ -3779,14 +3760,6 @@ function createFabricOverlayRuntime(options = {}) {
     });
     addDomListener(sizeRow.input, 'input', () => setBrushSize(sizeRow.input.value));
     addDomListener(opacityRow.input, 'input', () => setBrushOpacityPercent(opacityRow.input.value));
-    addDomListener(sizeRow.decrease, 'click', () => setBrushSize(brushStyle.size - 1));
-    addDomListener(sizeRow.increase, 'click', () => setBrushSize(brushStyle.size + 1));
-    addDomListener(opacityRow.decrease, 'click', () => {
-      setBrushOpacityPercent(Math.round(brushStyle.opacity * 100) - 1);
-    });
-    addDomListener(opacityRow.increase, 'click', () => {
-      setBrushOpacityPercent(Math.round(brushStyle.opacity * 100) + 1);
-    });
     for (const button of colorButtons) {
       addDomListener(button, 'click', () => setBrushColor(button.dataset.fabricPilotColor));
     }
@@ -3795,8 +3768,6 @@ function createFabricOverlayRuntime(options = {}) {
       addDomListener(button, 'click', () => setOutlineColor(button.dataset.fabricPilotOutlineColor));
     }
     addDomListener(outlineWidthRow.input, 'input', () => setOutlineWidth(outlineWidthRow.input.value));
-    addDomListener(outlineWidthRow.decrease, 'click', () => setOutlineWidth(outlineStyle.width - 1));
-    addDomListener(outlineWidthRow.increase, 'click', () => setOutlineWidth(outlineStyle.width + 1));
 
     return {
       settingsButton,
@@ -3806,6 +3777,14 @@ function createFabricOverlayRuntime(options = {}) {
       opacityInput: opacityRow.input,
       sizeOutput: sizeRow.output,
       opacityOutput: opacityRow.output,
+      syncFill: () => {
+        syncRangeFill(sizeRow.input, MIN_BRUSH_SIZE, MAX_BRUSH_SIZE);
+        syncRangeFill(
+          opacityRow.input,
+          MIN_BRUSH_OPACITY_PERCENT,
+          MAX_BRUSH_OPACITY_PERCENT
+        );
+      },
       summary,
       colorPreview,
       sizePreview,
@@ -3815,7 +3794,12 @@ function createFabricOverlayRuntime(options = {}) {
         toggle: outlineToggle,
         palette: outlinePalette,
         colorButtons: outlineColorButtons,
-        widthRow: outlineWidthRow
+        widthRow: outlineWidthRow,
+        syncFill: () => syncRangeFill(
+          outlineWidthRow.input,
+          MIN_OUTLINE_WIDTH,
+          MAX_OUTLINE_WIDTH
+        )
       }
     };
   }

--- a/scripts/tests/drawing-sync-remote-overlay.test.js
+++ b/scripts/tests/drawing-sync-remote-overlay.test.js
@@ -36,7 +36,18 @@ class FakeCanvas extends EventTarget {
     super();
     this.width = 1920;
     this.height = 1080;
-    this.style = {};
+    this.style = {
+      setProperty(name, value) { this[name] = String(value); },
+      getPropertyValue(name) {
+        const value = this[name];
+        return typeof value === 'string' ? value : '';
+      },
+      removeProperty(name) {
+        const value = this.getPropertyValue(name);
+        delete this[name];
+        return value;
+      }
+    };
     this.context = new FakeCanvasContext();
     this.parentElement = {
       appendChild: element => {

--- a/scripts/tests/fabric-drawing-pilot-integration.test.js
+++ b/scripts/tests/fabric-drawing-pilot-integration.test.js
@@ -44,7 +44,18 @@ class FakeElement {
     this.children = [];
     this.parentNode = null;
     this.dataset = {};
-    this.style = {};
+    this.style = {
+      setProperty(name, value) { this[name] = String(value); },
+      getPropertyValue(name) {
+        const value = this[name];
+        return typeof value === 'string' ? value : '';
+      },
+      removeProperty(name) {
+        const value = this.getPropertyValue(name);
+        delete this[name];
+        return value;
+      }
+    };
     this.className = '';
     this.textContent = '';
     this.listeners = new Map();

--- a/scripts/tests/fabric-drawing-pilot-source.test.js
+++ b/scripts/tests/fabric-drawing-pilot-source.test.js
@@ -1580,6 +1580,45 @@ test('오버레이 드로잉 UI는 상단 탭이 아니라 드래그형 팔레�
   assert.doesNotMatch(fabricRuntimeSource, /maxHeight: '210px'/);
 });
 
+test('오버레이 슬라이더를 탭 순서에 넣지 않는다 — 키가 도달하지 못한다', () => {
+  // 코덱스가 "-/+ 버튼을 지웠으니 슬라이더를 탭 순서에 넣으라"고 지적했다.
+  // 그 전제가 이 창에서는 성립하지 않는다.
+  //
+  // 그리기 입력이 켜져 있는 동안 호스트의 before-input-event 가 Tab·Enter·Space·
+  // 방향키를 **메인 창으로 릴레이하고 preventDefault() 한다.** 오버레이 문서는
+  // 그 키를 아예 받지 못한다. 그래서
+  //   - Tab 으로는 오버레이 안 어떤 컨트롤에도 갈 수 없고(지운 -/+ 버튼도 마찬가지였다),
+  //   - 설령 슬라이더가 포커스를 얻어도 방향키가 소모돼 값이 바뀌지 않는다.
+  // tabindex 를 달면 조작할 수 있다는 **거짓 표시**만 남는다.
+  //
+  // 실제로 열어 주려면 오버레이→호스트 포커스 상태 채널이 먼저 필요하다.
+  // 그 전에는 tabIndex = -1 이 정직한 표시다.
+  const relayStart = overlayHostSource.indexOf('FORWARDED_NAMED_KEY_CODES = new Set([');
+  assert.ok(relayStart > 0, '릴레이 키 목록을 찾지 못했다');
+  const relayList = overlayHostSource.slice(relayStart, overlayHostSource.indexOf(']);', relayStart));
+  for (const code of ['Tab', 'Enter', 'Space', 'ArrowLeft', 'ArrowRight']) {
+    assert.ok(
+      relayList.includes("'" + code + "'"),
+      code + ' 가 릴레이 대상이 아니면 이 판단을 다시 해야 한다'
+    );
+  }
+  // 릴레이한 키는 오버레이 문서에 남기지 않는다.
+  assert.ok(overlayHostSource.includes('this.keyboardRelayCount += 1;'));
+  assert.ok(overlayHostSource.includes('createForwardedKeyboardInput(input, drawModeShortcut)'));
+
+  // 슬라이더는 모두 탭 순서 밖이다.
+  const marker = "input.type = 'range';";
+  let at = fabricRuntimeSource.indexOf(marker);
+  let seen = 0;
+  while (at !== -1) {
+    const near = fabricRuntimeSource.slice(at, at + 200);
+    assert.ok(near.includes('input.tabIndex = -1;'), '슬라이더는 탭 순서 밖이어야 한다');
+    seen += 1;
+    at = fabricRuntimeSource.indexOf(marker, at + marker.length);
+  }
+  assert.ok(seen >= 1, 'range 입력 생성부를 찾지 못했다');
+});
+
 test('오버레이 스크롤바는 본체 테마와 같은 값을 쓴다', () => {
   // 오버레이는 별도 BrowserWindow 라 renderer/styles/main.css 를 불러오지 않는다.
   // 스크롤바를 안 적으면 윈도우 기본 막대(밝은 회색 + 화살표 버튼)가 그려져

--- a/scripts/tests/mpv-fabric-overlay-runtime.test.js
+++ b/scripts/tests/mpv-fabric-overlay-runtime.test.js
@@ -81,7 +81,21 @@ class FakeElement {
     this.children = [];
     this.parentNode = null;
     this.dataset = {};
-    this.style = {};
+    // 런타임이 사용자 정의 속성(--fabric-range-fill)을 표준 API 로 넘기므로
+    // 가짜 style 도 setProperty/getPropertyValue 를 가져야 한다. 순수 객체로 두면
+    // 팔레트 구성 도중 TypeError 가 나 prepare() 자체가 실패한다.
+    this.style = {
+      setProperty(name, value) { this[name] = String(value); },
+      getPropertyValue(name) {
+        const value = this[name];
+        return typeof value === 'string' ? value : '';
+      },
+      removeProperty(name) {
+        const value = this.getPropertyValue(name);
+        delete this[name];
+        return value;
+      }
+    };
     this.attributes = new Map();
     this.className = '';
     this.textContent = '';
@@ -406,10 +420,9 @@ function getBrushControls(root) {
     summary: findOne(toolbar, node => node.dataset.fabricPilotOutput === 'summary'),
     colorPreview: findOne(toolbar, node => node.dataset.fabricPilotOutput === 'color-preview'),
     sizePreview: findOne(toolbar, node => node.dataset.fabricPilotOutput === 'size-preview'),
-    sizeDecrease: findOne(toolbar, node => node.dataset.fabricPilotAction === 'size-decrease'),
-    sizeIncrease: findOne(toolbar, node => node.dataset.fabricPilotAction === 'size-increase'),
-    opacityDecrease: findOne(toolbar, node => node.dataset.fabricPilotAction === 'opacity-decrease'),
-    opacityIncrease: findOne(toolbar, node => node.dataset.fabricPilotAction === 'opacity-increase')
+    sizeField: findOne(toolbar, node =>
+      node.className === 'mpv-fabric-pilot-field' &&
+      findOne(node, child => child.dataset?.fabricPilotSetting === 'size') !== null)
   };
 }
 
@@ -8870,17 +8883,29 @@ test('brush settings expose the familiar bounded palette without mutating the sc
   assert.equal(controls.sizeInput.step, '1');
   assert.equal(controls.sizeInput.value, '3');
   assert.equal(controls.sizeInput.tabIndex, -1);
-  assert.equal(controls.sizeInput.getAttribute('aria-label'), '브러시 크기');
+  assert.equal(controls.sizeInput.getAttribute('aria-label'), '크기');
   assert.equal(controls.opacityInput.min, '10');
   assert.equal(controls.opacityInput.max, '100');
   assert.equal(controls.opacityInput.step, '1');
   assert.equal(controls.opacityInput.value, '100');
   assert.equal(controls.opacityInput.tabIndex, -1);
-  assert.equal(controls.opacityInput.getAttribute('aria-label'), '브러시 불투명도');
-  assert.equal(controls.sizeDecrease.getAttribute('aria-label'), '브러시 크기 1px 줄이기');
-  assert.equal(controls.sizeIncrease.getAttribute('aria-label'), '브러시 크기 1px 늘리기');
-  assert.equal(controls.opacityDecrease.getAttribute('aria-label'), '브러시 불투명도 1% 줄이기');
-  assert.equal(controls.opacityIncrease.getAttribute('aria-label'), '브러시 불투명도 1% 늘리기');
+  assert.equal(controls.opacityInput.getAttribute('aria-label'), '불투명도');
+  // 목업(§0.3 시안)에는 -/+ 스텝 버튼이 없다. 트랙보다 버튼이 커 보이던 원인이다.
+  // ±1 정밀 조절은 [ / ] 단축키와 Alt 드래그가 맡는다.
+  for (const action of ['size-decrease', 'size-increase', 'opacity-decrease', 'opacity-increase']) {
+    assert.equal(
+      findOne(root, node => node.dataset.fabricPilotAction === action),
+      null,
+      `${action} 스텝 버튼은 목업에 없다`
+    );
+  }
+  // 필드는 라벨과 수치를 한 줄에 두고 그 아래 트랙을 둔다.
+  assert.ok(controls.sizeField, '크기 필드가 있다');
+  assert.equal(controls.sizeField.children.length, 2, '필드는 머리줄과 트랙 둘뿐이다');
+  assert.equal(controls.sizeField.children[0].className, 'mpv-fabric-pilot-field-top');
+  assert.equal(controls.sizeField.children[0].children[0].textContent, '크기');
+  assert.equal(controls.sizeField.children[0].children[1], controls.sizeOutput);
+  assert.equal(controls.sizeField.children[1], controls.sizeInput);
   assert.equal(controls.sizeOutput.textContent, '3px');
   assert.equal(controls.opacityOutput.textContent, '100%');
   for (const output of [controls.sizeOutput, controls.opacityOutput]) {
@@ -8914,32 +8939,33 @@ test('brush settings expose the familiar bounded palette without mutating the sc
   assert.equal(controls.sizePreview.style.background, '#ffd000');
   assert.equal(controls.sizePreview.style.opacity, '0.4');
 
-  controls.sizeDecrease.dispatch('click');
-  assert.equal(controls.sizeInput.value, '23');
-  controls.sizeIncrease.dispatch('click');
-  controls.sizeIncrease.dispatch('click');
-  assert.equal(controls.sizeInput.value, '25');
-  controls.opacityDecrease.dispatch('click');
-  assert.equal(controls.opacityInput.value, '39');
-  controls.opacityIncrease.dispatch('click');
-  controls.opacityIncrease.dispatch('click');
-  assert.equal(controls.opacityInput.value, '41');
+  // 트랙의 채운 길이는 값에 비례한다. 이 값을 안 넘기면 range 입력은 채움을
+  // 그리지 않아 트랙이 통째로 빈칸으로 보인다.
+  controls.sizeInput.value = '25';
+  controls.sizeInput.dispatch('input');
+  assert.equal(
+    controls.sizeInput.style.getPropertyValue('--fabric-range-fill'),
+    `${((25 - 1) / (50 - 1)) * 100}%`
+  );
+  controls.opacityInput.value = '55';
+  controls.opacityInput.dispatch('input');
+  assert.equal(
+    controls.opacityInput.style.getPropertyValue('--fabric-range-fill'),
+    `${((55 - 10) / (100 - 10)) * 100}%`
+  );
 
-  controls.sizeInput.value = '1';
+  // 경계 밖 값은 그대로 물리지 않는다.
+  controls.sizeInput.value = '0';
   controls.sizeInput.dispatch('input');
-  controls.sizeDecrease.dispatch('click');
   assert.equal(controls.sizeInput.value, '1');
-  controls.sizeInput.value = '50';
+  controls.sizeInput.value = '999';
   controls.sizeInput.dispatch('input');
-  controls.sizeIncrease.dispatch('click');
   assert.equal(controls.sizeInput.value, '50');
-  controls.opacityInput.value = '10';
+  controls.opacityInput.value = '0';
   controls.opacityInput.dispatch('input');
-  controls.opacityDecrease.dispatch('click');
   assert.equal(controls.opacityInput.value, '10');
-  controls.opacityInput.value = '100';
+  controls.opacityInput.value = '999';
   controls.opacityInput.dispatch('input');
-  controls.opacityIncrease.dispatch('click');
   assert.equal(controls.opacityInput.value, '100');
 
   controls.sizeInput.value = 'invalid';

--- a/scripts/tests/runtime-profile.test.js
+++ b/scripts/tests/runtime-profile.test.js
@@ -249,7 +249,7 @@ test('stable engine promotion uses the 2.3.0 beta release version consistently',
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
   const packageLock = JSON.parse(fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'));
 
-  assert.equal(packageJson.version, '2.6.2-beta');
-  assert.equal(packageLock.version, '2.6.2-beta');
-  assert.equal(packageLock.packages[''].version, '2.6.2-beta');
+  assert.equal(packageJson.version, '2.6.3-beta');
+  assert.equal(packageLock.version, '2.6.3-beta');
+  assert.equal(packageLock.packages[''].version, '2.6.3-beta');
 });


### PR DESCRIPTION
사용자 지적: "브러시 크기, 불투명도 버튼이 너무 멍청하게 큰 거 같은데, 목업처럼은 못 해?"

맞습니다. 40px 짜리 `−`/`+` 버튼 둘이 3px 트랙 양옆에 붙어 있으면 정작 조절하는
트랙보다 버튼이 커 보입니다.

## 목업 사양 (§0.3 시안, artifact `99a13417`)

```
라벨(10px 대문자 자간)  ·····························  수치(11px 등폭)
──────────── 3px 트랙 + 9px 원형 손잡이 ────────────
```

목업에는 `−`/`+` 버튼이 **없습니다.** 걷어냈습니다.

- range 입력을 목업 트랙 모양으로 다시 그립니다. 기본 렌더는 OS 위젯이라 팔레트와
  따로 놉니다(직전 라운드 스크롤바와 같은 이유).
- range 입력은 기본으로 **채운 부분을 그리지 않습니다.** 값 비율을
  `--fabric-range-fill` 로 넘겨 트랙 배경 그러데이션 경계로 씁니다.
  실측: 채움 `#a8a8a8` / 빈칸 `#424242`.
- 라벨을 `브러시 크기`→`크기` 등으로 줄였습니다. 섹션 이름이 이미 `브러시 설정`이라
  접두어가 중복이었습니다.

패널 높이 **303px → 253px**.

## 잃은 것

클릭 한 번에 ±1 씩 옮기던 수단. `[` / `]` 단축키와 Alt 드래그가 그대로 있고,
range 입력도 `step=1` 이라 트랙을 클릭하면 정수 값으로 바로 갑니다.

## 테스트

- 스텝 버튼 클릭 검증을 값 직접 조작으로 옮기고, 네 액션이 **더 이상 존재하지 않음**과
  필드 구조(머리줄+트랙 둘뿐, 라벨·수치 배치)를 단언합니다.
- 채움 비율 단언 신설 — **되돌려 실패 확인**(설정을 지우면 154번이 깨집니다).
- 가짜 DOM 3곳의 `style` 이 순수 객체라 `setProperty` 가 없었습니다. 런타임이 표준
  API 를 쓰므로 가짜 쪽을 표준에 맞췄습니다 — 안 그러면 `prepare()` 자체가 실패합니다.

25개 스위트 **2,284 pass / 0 fail**, Electron 레이아웃 2 pass. 버전 2.6.3-beta(세 파일 동시).

🤖 Generated with [Claude Code](https://claude.com/claude-code)